### PR TITLE
feat(serve): read serve configuration from YAML config file

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -77,6 +77,11 @@ import {
   ScheduledExecutionService,
 } from "../../libswamp/mod.ts";
 import { parseWebhookFlag, WebhookService } from "../../serve/webhook.ts";
+import {
+  loadServeConfig,
+  mergeServeOptions,
+  parseExplicitFlags,
+} from "../../serve/serve_config.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { ActiveRunRegistry } from "../../serve/active_run_registry.ts";
@@ -284,6 +289,9 @@ export function validateWebSocketOrigin(
 
 export function collectServeExtraArgs(options: AnyOptions): string[] {
   const args: string[] = [];
+  if (options.config) {
+    args.push("--config", options.config as string);
+  }
   if (options.schedule === false) {
     args.push("--no-schedule");
   }
@@ -448,6 +456,10 @@ const daemonEnableCommand = new Command()
   .option(
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option(
+    "--config <path:string>",
+    "Path to serve config file (default: .swamp/serve.yaml)",
   )
   .option("--port <port:number>", "Port for the daemon to listen on", {
     default: 9090,
@@ -868,6 +880,10 @@ export const serveCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
+  .option(
+    "--config <path:string>",
+    "Path to serve config file (default: .swamp/serve.yaml)",
+  )
   .option("--port <port:number>", "Port to listen on", { default: 9090 })
   .option("--host <host:string>", "Host to bind to", { default: "127.0.0.1" })
   .option("--no-schedule", "Disable scheduled workflow execution")
@@ -1028,14 +1044,21 @@ export const serveCommand = new Command()
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["serve"]);
     const repoDir = resolveRepoDir(options.repoDir as string | undefined);
-    const port = options.port as number;
-    const host = options.host as string;
     const isJson = ctx.outputMode === "json";
 
-    const certFile = (options.certFile as string | undefined) ??
-      Deno.env.get("SWAMP_SERVE_CERT_FILE") ?? undefined;
-    const keyFile = (options.keyFile as string | undefined) ??
-      Deno.env.get("SWAMP_SERVE_KEY_FILE") ?? undefined;
+    // Load config file and merge with CLI flags (four-level priority:
+    // CLI flag > env var > config file > default)
+    const configFile = loadServeConfig(
+      options.config as string | undefined,
+      repoDir,
+    );
+    const explicitFlags = parseExplicitFlags(Deno.args);
+    const merged = mergeServeOptions(configFile, options, explicitFlags);
+
+    const port = merged.port;
+    const host = merged.host;
+    const certFile = merged.certFile;
+    const keyFile = merged.keyFile;
 
     if ((certFile && !keyFile) || (!certFile && keyFile)) {
       throw new Error(
@@ -1050,10 +1073,9 @@ export const serveCommand = new Command()
       key = await Deno.readTextFile(keyFile);
     }
     const tlsEnabled = cert !== undefined;
-    const trustProxy = options.trustProxy === true;
+    const trustProxy = merged.trustProxy;
 
-    const wsIdleTimeoutRaw = (options.wsIdleTimeout as string | undefined) ??
-      Deno.env.get("SWAMP_WS_IDLE_TIMEOUT") ?? undefined;
+    const wsIdleTimeoutRaw = merged.wsIdleTimeout;
     let wsIdleTimeoutSeconds: number | undefined;
     if (wsIdleTimeoutRaw !== undefined) {
       if (wsIdleTimeoutRaw === "0") {
@@ -1065,8 +1087,7 @@ export const serveCommand = new Command()
       }
     }
 
-    const queueTimeoutRaw = (options.queueTimeout as string | undefined) ??
-      Deno.env.get("SWAMP_QUEUE_TIMEOUT") ?? undefined;
+    const queueTimeoutRaw = merged.queueTimeout;
     let queueTimeoutMs: number | undefined;
     if (queueTimeoutRaw !== undefined) {
       const normalized = queueTimeoutRaw.trim().replace(/^0[smhdw].*$/i, "0");
@@ -1075,35 +1096,30 @@ export const serveCommand = new Command()
         : parseTimeout(queueTimeoutRaw, "--queue-timeout");
     }
 
-    const heartbeatIntervalRaw =
-      (options.heartbeatInterval as string | undefined) ??
-        Deno.env.get("SWAMP_HEARTBEAT_INTERVAL");
+    const heartbeatIntervalRaw = merged.heartbeatInterval;
     const heartbeatIntervalMs = heartbeatIntervalRaw !== undefined
       ? parseTimeout(heartbeatIntervalRaw, "--heartbeat-interval")
       : undefined;
 
-    const staleTtlRaw = (options.staleTtl as string | undefined) ??
-      Deno.env.get("SWAMP_STALE_TTL");
+    const staleTtlRaw = merged.staleTtl;
     const staleTtlMs = staleTtlRaw !== undefined
       ? parseTimeout(staleTtlRaw, "--stale-ttl")
       : undefined;
 
-    const reconciliationIntervalRaw =
-      (options.reconciliationInterval as string | undefined) ??
-        Deno.env.get("SWAMP_RECONCILIATION_INTERVAL");
+    const reconciliationIntervalRaw = merged.reconciliationInterval;
     const reconciliationIntervalMs = reconciliationIntervalRaw !== undefined
       ? parseTimeout(reconciliationIntervalRaw, "--reconciliation-interval")
       : undefined;
 
     const authConfig = buildServeAuthConfig({
-      authMode: options.authMode as string | undefined,
-      admins: options.admins as string | undefined,
-      allowedCollectives: options.allowedCollectives as string | undefined,
-      allowedUsers: options.allowedUsers as string | undefined,
-      oauthProvider: options.oauthProvider as string | undefined,
-      oauthClientId: options.oauthClientId as string | undefined,
-      groupsField: options.groupsField as string | undefined,
-      restrictedModelTypes: options.restrictedModelTypes as string | undefined,
+      authMode: merged.authMode,
+      admins: merged.admins,
+      allowedCollectives: merged.allowedCollectives,
+      allowedUsers: merged.allowedUsers,
+      oauthProvider: merged.oauthProvider,
+      oauthClientId: merged.oauthClientId,
+      groupsField: merged.groupsField,
+      restrictedModelTypes: merged.restrictedModelTypes,
     });
 
     if (authConfig.mode === "none" && authConfig.admins.length > 0) {
@@ -1138,8 +1154,7 @@ export const serveCommand = new Command()
 
     assertOffLoopbackSecurity(host, tlsEnabled, authConfig.mode);
 
-    const trustedHostsRaw = (options.trustedHosts as string | undefined) ??
-      Deno.env.get("SWAMP_TRUSTED_HOSTS") ?? undefined;
+    const trustedHostsRaw = merged.trustedHosts;
     const trustedHosts = trustedHostsRaw
       ? trustedHostsRaw.split(",").map((h) => h.trim()).filter((h) =>
         h.length > 0
@@ -1197,8 +1212,7 @@ export const serveCommand = new Command()
       bundles: bundleRegistry,
       queueTimeoutMs,
     });
-    const verifyOnEnroll = options.verifyOnEnroll === true ||
-      Deno.env.get("SWAMP_VERIFY_ON_ENROLL") === "true";
+    const verifyOnEnroll = merged.verifyOnEnroll;
     const workerGateway = new WorkerGateway({
       repoDir: resolvedRepoDir,
       repoContext,
@@ -1254,7 +1268,7 @@ export const serveCommand = new Command()
       reportRegistry.ensureLoaded(),
     ]);
 
-    const grantReloadMode = options.grantReload as string;
+    const grantReloadMode = merged.grantReload;
     if (grantReloadMode !== "manual" && grantReloadMode !== "auto") {
       throw new UserError(
         `Invalid --grant-reload value "${grantReloadMode}": must be "manual" or "auto"`,
@@ -1613,7 +1627,7 @@ export const serveCommand = new Command()
     });
 
     const cancelRegistry = new RunCancelRegistry();
-    const detachRuns = options.detachRuns === true;
+    const detachRuns = merged.detachRuns;
     const activeRunRegistry = detachRuns ? new ActiveRunRegistry() : undefined;
 
     if (!detachRuns) {
@@ -1754,8 +1768,8 @@ export const serveCommand = new Command()
       };
 
     const ac = new AbortController();
-    const enableSchedule = options.schedule !== false;
-    const webhookFlags: string[] = options.webhook ?? [];
+    const enableSchedule = merged.schedule;
+    const webhookFlags: string[] = merged.webhook ?? [];
 
     // Start scheduled execution service if enabled
     let scheduledExecution: ScheduledExecutionService | null = null;
@@ -1901,9 +1915,7 @@ export const serveCommand = new Command()
     let collectiveRefreshService:
       | import("../../serve/collective_refresh_service.ts").CollectiveRefreshService
       | null = null;
-    const groupRefreshRaw =
-      (options.groupRefreshInterval as string | undefined) ??
-        Deno.env.get("SWAMP_GROUP_REFRESH_INTERVAL") ?? undefined;
+    const groupRefreshRaw = merged.groupRefreshInterval;
 
     const DEFAULT_GROUP_REFRESH_MS = 4 * 60 * 60 * 1000;
     let groupRefreshMs = DEFAULT_GROUP_REFRESH_MS;
@@ -2065,8 +2077,11 @@ export const serveCommand = new Command()
 
     // Parse and initialize webhook endpoints
     let webhookService: WebhookService | null = null;
-    if (webhookFlags.length > 0) {
-      const endpoints = webhookFlags.map(parseWebhookFlag);
+    const webhookEndpoints = webhookFlags.length > 0
+      ? webhookFlags.map(parseWebhookFlag)
+      : merged.webhookEndpoints ?? [];
+    if (webhookEndpoints.length > 0) {
+      const endpoints = webhookEndpoints;
       webhookService = new WebhookService({
         repoDir: resolvedRepoDir,
         repoContext,
@@ -2468,7 +2483,7 @@ export const serveCommand = new Command()
     );
 
     // Hot-reload: PID file + SIGHUP handler
-    const hotReload = options.hotReload === true;
+    const hotReload = merged.hotReload;
     const pidPath = hotReload ? swampPath(resolvedRepoDir, "serve.pid") : null;
 
     if (hotReload && pidPath) {

--- a/src/serve/mod.ts
+++ b/src/serve/mod.ts
@@ -40,3 +40,14 @@ export {
   type WebhookEventHandler,
   WebhookService,
 } from "./webhook.ts";
+export {
+  type EnvLookup,
+  loadServeConfig,
+  type MergedServeOptions,
+  mergeServeOptions,
+  parseExplicitFlags,
+  parseWebhookConfig,
+  SERVE_ENV_MAP,
+  type ServeConfigFile,
+  type WebhookConfigEntry,
+} from "./serve_config.ts";

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -1,0 +1,725 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { parse as parseYaml } from "@std/yaml";
+import { join } from "@std/path";
+import { UserError } from "../domain/errors.ts";
+import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+import { resolveSecret, type WebhookEndpoint } from "./webhook.ts";
+import { WEBHOOK_SCHEMES, type WebhookScheme } from "./webhook_verifiers.ts";
+import type { VerifierConfig } from "./webhook_verifiers.ts";
+
+const logger = getSwampLogger(["serve", "config"]);
+
+// ── Env Var Map ───────────────────────────────────────────────────────
+
+export const SERVE_ENV_MAP: Readonly<Record<string, string>> = {
+  certFile: "SWAMP_SERVE_CERT_FILE",
+  keyFile: "SWAMP_SERVE_KEY_FILE",
+  wsIdleTimeout: "SWAMP_WS_IDLE_TIMEOUT",
+  queueTimeout: "SWAMP_QUEUE_TIMEOUT",
+  verifyOnEnroll: "SWAMP_VERIFY_ON_ENROLL",
+  trustedHosts: "SWAMP_TRUSTED_HOSTS",
+  heartbeatInterval: "SWAMP_HEARTBEAT_INTERVAL",
+  staleTtl: "SWAMP_STALE_TTL",
+  reconciliationInterval: "SWAMP_RECONCILIATION_INTERVAL",
+  groupRefreshInterval: "SWAMP_GROUP_REFRESH_INTERVAL",
+};
+
+// ── Webhook Config Types ──────────────────────────────────────────────
+
+export interface WebhookConfigEntry {
+  readonly route: string;
+  readonly workflow: string;
+  readonly secret: string;
+  readonly scheme?: string;
+  readonly header?: string;
+  readonly prefix?: string;
+}
+
+// ── Config File Shape ─────────────────────────────────────────────────
+
+export interface ServeConfigFile {
+  port?: number;
+  host?: string;
+  auth?: {
+    mode?: string;
+    admins?: string[];
+    "allowed-collectives"?: string[];
+    "allowed-users"?: string[];
+    "oauth-provider"?: string;
+    "oauth-client-id"?: string;
+    "groups-field"?: string;
+    "restricted-model-types"?: string[];
+    "group-refresh-interval"?: string;
+  };
+  tls?: {
+    "cert-file"?: string;
+    "key-file"?: string;
+  };
+  webhooks?: WebhookConfigEntry[];
+  schedule?: boolean;
+  "hot-reload"?: boolean;
+  "detach-runs"?: boolean;
+  "trust-proxy"?: boolean;
+  "trusted-hosts"?: string[];
+  "grant-reload"?: string;
+  "ws-idle-timeout"?: string;
+  "queue-timeout"?: string;
+  "verify-on-enroll"?: boolean;
+  "heartbeat-interval"?: string;
+  "stale-ttl"?: string;
+  "reconciliation-interval"?: string;
+}
+
+// ── Known Keys ────────────────────────────────────────────────────────
+
+const KNOWN_TOP_LEVEL_KEYS = new Set([
+  "port",
+  "host",
+  "auth",
+  "tls",
+  "webhooks",
+  "schedule",
+  "hot-reload",
+  "detach-runs",
+  "trust-proxy",
+  "trusted-hosts",
+  "grant-reload",
+  "ws-idle-timeout",
+  "queue-timeout",
+  "verify-on-enroll",
+  "heartbeat-interval",
+  "stale-ttl",
+  "reconciliation-interval",
+]);
+
+const KNOWN_AUTH_KEYS = new Set([
+  "mode",
+  "admins",
+  "allowed-collectives",
+  "allowed-users",
+  "oauth-provider",
+  "oauth-client-id",
+  "groups-field",
+  "restricted-model-types",
+  "group-refresh-interval",
+]);
+
+const KNOWN_TLS_KEYS = new Set([
+  "cert-file",
+  "key-file",
+]);
+
+// ── Config Loading ────────────────────────────────────────────────────
+
+const DEFAULT_CONFIG_PATH = ".swamp/serve.yaml";
+
+export function loadServeConfig(
+  configPath: string | undefined,
+  repoDir: string,
+): ServeConfigFile | null {
+  const path = configPath ?? join(repoDir, DEFAULT_CONFIG_PATH);
+  const isExplicit = configPath !== undefined;
+
+  let content: string;
+  try {
+    content = Deno.readTextFileSync(path);
+  } catch (cause) {
+    if (cause instanceof Deno.errors.NotFound) {
+      if (isExplicit) {
+        throw new UserError(
+          `Serve config file not found: ${path}`,
+        );
+      }
+      return null;
+    }
+    throw new UserError(
+      `Failed to read serve config file ${path}: ${cause}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(content);
+  } catch (cause) {
+    throw new UserError(
+      `Invalid YAML in serve config file ${path}: ${cause}`,
+    );
+  }
+
+  if (parsed === null || parsed === undefined) {
+    return null;
+  }
+
+  if (typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new UserError(
+      `Serve config file ${path} must be a YAML mapping, got ${
+        Array.isArray(parsed) ? "array" : typeof parsed
+      }`,
+    );
+  }
+
+  const raw = parsed as Record<string, unknown>;
+
+  warnUnknownKeys(raw, KNOWN_TOP_LEVEL_KEYS, path, "");
+  if (raw.auth && typeof raw.auth === "object" && !Array.isArray(raw.auth)) {
+    warnUnknownKeys(
+      raw.auth as Record<string, unknown>,
+      KNOWN_AUTH_KEYS,
+      path,
+      "auth.",
+    );
+  }
+  if (raw.tls && typeof raw.tls === "object" && !Array.isArray(raw.tls)) {
+    warnUnknownKeys(
+      raw.tls as Record<string, unknown>,
+      KNOWN_TLS_KEYS,
+      path,
+      "tls.",
+    );
+  }
+
+  validateConfigValues(raw, path);
+
+  return raw as unknown as ServeConfigFile;
+}
+
+function warnUnknownKeys(
+  obj: Record<string, unknown>,
+  known: ReadonlySet<string>,
+  path: string,
+  prefix: string,
+): void {
+  for (const key of Object.keys(obj)) {
+    if (!known.has(key)) {
+      logger.warn(
+        "Unknown key {key} in serve config file {path} — ignoring",
+        { key: `${prefix}${key}`, path },
+      );
+    }
+  }
+}
+
+function validateConfigValues(
+  raw: Record<string, unknown>,
+  path: string,
+): void {
+  if (raw.port !== undefined) {
+    if (typeof raw.port !== "number" || !Number.isInteger(raw.port)) {
+      throw new UserError(
+        `Invalid port in ${path}: expected integer, got ${
+          JSON.stringify(raw.port)
+        }`,
+      );
+    }
+    if (raw.port < 1 || raw.port > 65535) {
+      throw new UserError(
+        `Invalid port in ${path}: must be between 1 and 65535, got ${raw.port}`,
+      );
+    }
+  }
+
+  if (raw.host !== undefined && typeof raw.host !== "string") {
+    throw new UserError(
+      `Invalid host in ${path}: expected string, got ${typeof raw.host}`,
+    );
+  }
+
+  if (raw.schedule !== undefined && typeof raw.schedule !== "boolean") {
+    throw new UserError(
+      `Invalid schedule in ${path}: expected boolean, got ${typeof raw
+        .schedule}`,
+    );
+  }
+
+  if (
+    raw["hot-reload"] !== undefined && typeof raw["hot-reload"] !== "boolean"
+  ) {
+    throw new UserError(
+      `Invalid hot-reload in ${path}: expected boolean, got ${typeof raw[
+        "hot-reload"
+      ]}`,
+    );
+  }
+
+  if (
+    raw["detach-runs"] !== undefined && typeof raw["detach-runs"] !== "boolean"
+  ) {
+    throw new UserError(
+      `Invalid detach-runs in ${path}: expected boolean, got ${typeof raw[
+        "detach-runs"
+      ]}`,
+    );
+  }
+
+  if (
+    raw["trust-proxy"] !== undefined && typeof raw["trust-proxy"] !== "boolean"
+  ) {
+    throw new UserError(
+      `Invalid trust-proxy in ${path}: expected boolean, got ${typeof raw[
+        "trust-proxy"
+      ]}`,
+    );
+  }
+
+  if (
+    raw["verify-on-enroll"] !== undefined &&
+    typeof raw["verify-on-enroll"] !== "boolean"
+  ) {
+    throw new UserError(
+      `Invalid verify-on-enroll in ${path}: expected boolean, got ${typeof raw[
+        "verify-on-enroll"
+      ]}`,
+    );
+  }
+
+  if (raw.webhooks !== undefined) {
+    if (!Array.isArray(raw.webhooks)) {
+      throw new UserError(
+        `Invalid webhooks in ${path}: expected array, got ${typeof raw
+          .webhooks}`,
+      );
+    }
+    for (let i = 0; i < raw.webhooks.length; i++) {
+      validateWebhookEntry(raw.webhooks[i], path, i);
+    }
+  }
+
+  if (raw["trusted-hosts"] !== undefined) {
+    if (!Array.isArray(raw["trusted-hosts"])) {
+      throw new UserError(
+        `Invalid trusted-hosts in ${path}: expected array of strings, got ${typeof raw[
+          "trusted-hosts"
+        ]}`,
+      );
+    }
+  }
+}
+
+function validateWebhookEntry(
+  entry: unknown,
+  path: string,
+  index: number,
+): void {
+  if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+    throw new UserError(
+      `Invalid webhook at index ${index} in ${path}: expected object`,
+    );
+  }
+  const obj = entry as Record<string, unknown>;
+  if (typeof obj.route !== "string" || !obj.route) {
+    throw new UserError(
+      `Invalid webhook at index ${index} in ${path}: route is required and must be a string`,
+    );
+  }
+  if (!obj.route.startsWith("/")) {
+    throw new UserError(
+      `Invalid webhook at index ${index} in ${path}: route must start with '/', got '${obj.route}'`,
+    );
+  }
+  if (typeof obj.workflow !== "string" || !obj.workflow) {
+    throw new UserError(
+      `Invalid webhook at index ${index} in ${path}: workflow is required and must be a string`,
+    );
+  }
+  if (typeof obj.secret !== "string" || !obj.secret) {
+    throw new UserError(
+      `Invalid webhook at index ${index} in ${path}: secret is required and must be a string`,
+    );
+  }
+  if (obj.scheme !== undefined) {
+    if (
+      typeof obj.scheme !== "string" ||
+      !(WEBHOOK_SCHEMES as readonly string[]).includes(obj.scheme)
+    ) {
+      throw new UserError(
+        `Invalid webhook at index ${index} in ${path}: scheme must be one of ${
+          WEBHOOK_SCHEMES.join(", ")
+        }, got '${obj.scheme}'`,
+      );
+    }
+    if (obj.scheme === "generic" && typeof obj.header !== "string") {
+      throw new UserError(
+        `Invalid webhook at index ${index} in ${path}: generic scheme requires a header name`,
+      );
+    }
+  }
+}
+
+// ── Webhook Config to WebhookEndpoint ─────────────────────────────────
+
+export function parseWebhookConfig(entry: WebhookConfigEntry): WebhookEndpoint {
+  const secret = resolveSecret(entry.secret);
+  const scheme = (entry.scheme ?? "github") as WebhookScheme;
+
+  let verifier: VerifierConfig;
+  if (scheme === "generic") {
+    verifier = {
+      scheme: "generic",
+      header: entry.header!,
+      prefix: entry.prefix ?? "",
+    };
+  } else {
+    verifier = { scheme };
+  }
+
+  return {
+    route: entry.route,
+    workflowIdOrName: entry.workflow,
+    secret,
+    verifier,
+  };
+}
+
+// ── Explicit Flag Detection ───────────────────────────────────────────
+
+export function parseExplicitFlags(args: readonly string[]): Set<string> {
+  const flags = new Set<string>();
+  for (const arg of args) {
+    if (!arg.startsWith("--")) continue;
+
+    let flagName: string;
+    const eqIndex = arg.indexOf("=");
+    if (eqIndex !== -1) {
+      flagName = arg.slice(2, eqIndex);
+    } else {
+      flagName = arg.slice(2);
+    }
+
+    if (flagName.startsWith("no-")) {
+      flags.add(flagName.slice(3));
+      flags.add(flagName);
+    }
+
+    flags.add(flagName);
+  }
+  return flags;
+}
+
+// kebab-case flag name → camelCase option name
+function kebabToCamel(s: string): string {
+  return s.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+// ── Merge Logic ───────────────────────────────────────────────────────
+
+export type EnvLookup = (name: string) => string | undefined;
+
+export interface MergedServeOptions {
+  port: number;
+  host: string;
+  schedule: boolean;
+  certFile?: string;
+  keyFile?: string;
+  grantReload: string;
+  webhook?: string[];
+  webhookEndpoints?: WebhookEndpoint[];
+  authMode: string;
+  admins?: string;
+  allowedCollectives?: string;
+  allowedUsers?: string;
+  oauthProvider?: string;
+  oauthClientId?: string;
+  groupsField?: string;
+  restrictedModelTypes?: string;
+  groupRefreshInterval?: string;
+  trustProxy: boolean;
+  wsIdleTimeout?: string;
+  queueTimeout?: string;
+  verifyOnEnroll: boolean;
+  trustedHosts?: string;
+  detachRuns: boolean;
+  heartbeatInterval?: string;
+  staleTtl?: string;
+  reconciliationInterval?: string;
+  hotReload: boolean;
+}
+
+export function mergeServeOptions(
+  config: ServeConfigFile | null,
+  cliOptions: Record<string, unknown>,
+  explicitFlags: ReadonlySet<string>,
+  envLookup: EnvLookup = (name) => Deno.env.get(name),
+): MergedServeOptions {
+  function resolve<T>(
+    flagName: string,
+    cliValue: T,
+    configValue: T | undefined,
+    defaultValue: T,
+  ): T {
+    if (explicitFlags.has(flagName)) {
+      return cliValue;
+    }
+
+    const envVarName = SERVE_ENV_MAP[kebabToCamel(flagName)];
+    if (envVarName) {
+      const envValue = envLookup(envVarName);
+      if (envValue !== undefined) {
+        return envValue as unknown as T;
+      }
+    }
+
+    if (configValue !== undefined) {
+      return configValue;
+    }
+
+    return defaultValue;
+  }
+
+  function resolveBoolean(
+    flagName: string,
+    cliValue: boolean,
+    configValue: boolean | undefined,
+    defaultValue: boolean,
+  ): boolean {
+    if (explicitFlags.has(flagName)) {
+      return cliValue;
+    }
+
+    const envVarName = SERVE_ENV_MAP[kebabToCamel(flagName)];
+    if (envVarName) {
+      const envValue = envLookup(envVarName);
+      if (envValue !== undefined) {
+        return envValue === "true" || envValue === "1";
+      }
+    }
+
+    if (configValue !== undefined) {
+      return configValue;
+    }
+
+    return defaultValue;
+  }
+
+  const port = resolve<number>(
+    "port",
+    cliOptions.port as number,
+    config?.port,
+    9090,
+  );
+
+  const host = resolve<string>(
+    "host",
+    cliOptions.host as string,
+    config?.host,
+    "127.0.0.1",
+  );
+
+  const schedule = resolveBoolean(
+    "schedule",
+    cliOptions.schedule as boolean,
+    config?.schedule,
+    true,
+  );
+
+  const certFile = resolve<string | undefined>(
+    "cert-file",
+    cliOptions.certFile as string | undefined,
+    config?.tls?.["cert-file"],
+    undefined,
+  );
+
+  const keyFile = resolve<string | undefined>(
+    "key-file",
+    cliOptions.keyFile as string | undefined,
+    config?.tls?.["key-file"],
+    undefined,
+  );
+
+  const grantReload = resolve<string>(
+    "grant-reload",
+    cliOptions.grantReload as string,
+    config?.["grant-reload"],
+    "manual",
+  );
+
+  const authMode = resolve<string>(
+    "auth-mode",
+    cliOptions.authMode as string,
+    config?.auth?.mode,
+    "none",
+  );
+
+  const admins = resolve<string | undefined>(
+    "admins",
+    cliOptions.admins as string | undefined,
+    config?.auth?.admins?.join(","),
+    undefined,
+  );
+
+  const allowedCollectives = resolve<string | undefined>(
+    "allowed-collectives",
+    cliOptions.allowedCollectives as string | undefined,
+    config?.auth?.["allowed-collectives"]?.join(","),
+    undefined,
+  );
+
+  const allowedUsers = resolve<string | undefined>(
+    "allowed-users",
+    cliOptions.allowedUsers as string | undefined,
+    config?.auth?.["allowed-users"]?.join(","),
+    undefined,
+  );
+
+  const oauthProvider = resolve<string | undefined>(
+    "oauth-provider",
+    cliOptions.oauthProvider as string | undefined,
+    config?.auth?.["oauth-provider"],
+    undefined,
+  );
+
+  const oauthClientId = resolve<string | undefined>(
+    "oauth-client-id",
+    cliOptions.oauthClientId as string | undefined,
+    config?.auth?.["oauth-client-id"],
+    undefined,
+  );
+
+  const groupsField = resolve<string | undefined>(
+    "groups-field",
+    cliOptions.groupsField as string | undefined,
+    config?.auth?.["groups-field"],
+    undefined,
+  );
+
+  const restrictedModelTypes = resolve<string | undefined>(
+    "restricted-model-types",
+    cliOptions.restrictedModelTypes as string | undefined,
+    config?.auth?.["restricted-model-types"]?.join(","),
+    undefined,
+  );
+
+  const groupRefreshInterval = resolve<string | undefined>(
+    "group-refresh-interval",
+    cliOptions.groupRefreshInterval as string | undefined,
+    config?.auth?.["group-refresh-interval"],
+    undefined,
+  );
+
+  const trustProxy = resolveBoolean(
+    "trust-proxy",
+    cliOptions.trustProxy as boolean,
+    config?.["trust-proxy"],
+    false,
+  );
+
+  const wsIdleTimeout = resolve<string | undefined>(
+    "ws-idle-timeout",
+    cliOptions.wsIdleTimeout as string | undefined,
+    config?.["ws-idle-timeout"],
+    undefined,
+  );
+
+  const queueTimeout = resolve<string | undefined>(
+    "queue-timeout",
+    cliOptions.queueTimeout as string | undefined,
+    config?.["queue-timeout"],
+    undefined,
+  );
+
+  const verifyOnEnroll = resolveBoolean(
+    "verify-on-enroll",
+    cliOptions.verifyOnEnroll as boolean,
+    config?.["verify-on-enroll"],
+    false,
+  );
+
+  const trustedHosts = resolve<string | undefined>(
+    "trusted-hosts",
+    cliOptions.trustedHosts as string | undefined,
+    config?.["trusted-hosts"]?.join(","),
+    undefined,
+  );
+
+  const detachRuns = resolveBoolean(
+    "detach-runs",
+    cliOptions.detachRuns as boolean,
+    config?.["detach-runs"],
+    false,
+  );
+
+  const heartbeatInterval = resolve<string | undefined>(
+    "heartbeat-interval",
+    cliOptions.heartbeatInterval as string | undefined,
+    config?.["heartbeat-interval"],
+    undefined,
+  );
+
+  const staleTtl = resolve<string | undefined>(
+    "stale-ttl",
+    cliOptions.staleTtl as string | undefined,
+    config?.["stale-ttl"],
+    undefined,
+  );
+
+  const reconciliationInterval = resolve<string | undefined>(
+    "reconciliation-interval",
+    cliOptions.reconciliationInterval as string | undefined,
+    config?.["reconciliation-interval"],
+    undefined,
+  );
+
+  const hotReload = resolveBoolean(
+    "hot-reload",
+    cliOptions.hotReload as boolean,
+    config?.["hot-reload"],
+    false,
+  );
+
+  // Webhooks: CLI --webhook flags replace config file webhooks entirely
+  let webhook: string[] | undefined;
+  let webhookEndpoints: WebhookEndpoint[] | undefined;
+
+  if (explicitFlags.has("webhook")) {
+    webhook = cliOptions.webhook as string[] | undefined;
+  } else if (config?.webhooks && config.webhooks.length > 0) {
+    webhookEndpoints = config.webhooks.map(parseWebhookConfig);
+  }
+
+  return {
+    port,
+    host,
+    schedule,
+    certFile,
+    keyFile,
+    grantReload,
+    webhook,
+    webhookEndpoints,
+    authMode,
+    admins,
+    allowedCollectives,
+    allowedUsers,
+    oauthProvider,
+    oauthClientId,
+    groupsField,
+    restrictedModelTypes,
+    groupRefreshInterval,
+    trustProxy,
+    wsIdleTimeout,
+    queueTimeout,
+    verifyOnEnroll,
+    trustedHosts,
+    detachRuns,
+    heartbeatInterval,
+    staleTtl,
+    reconciliationInterval,
+    hotReload,
+  };
+}

--- a/src/serve/serve_config_test.ts
+++ b/src/serve/serve_config_test.ts
@@ -1,0 +1,523 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertNotEquals, assertThrows } from "@std/assert";
+import { stringify as stringifyYaml } from "@std/yaml";
+import { join } from "@std/path";
+import { initializeLogging } from "../infrastructure/logging/logger.ts";
+import {
+  loadServeConfig,
+  mergeServeOptions,
+  parseExplicitFlags,
+  parseWebhookConfig,
+  type ServeConfigFile,
+  type WebhookConfigEntry,
+} from "./serve_config.ts";
+
+await initializeLogging({});
+
+function withTempDir(fn: (dir: string) => void): void {
+  const dir = Deno.makeTempDirSync();
+  try {
+    fn(dir);
+  } finally {
+    try {
+      Deno.removeSync(dir, { recursive: true });
+    } catch { /* Windows EBUSY */ }
+  }
+}
+
+function writeConfig(dir: string, config: Record<string, unknown>): string {
+  const swampDir = join(dir, ".swamp");
+  Deno.mkdirSync(swampDir, { recursive: true });
+  const path = join(swampDir, "serve.yaml");
+  Deno.writeTextFileSync(path, stringifyYaml(config));
+  return path;
+}
+
+Deno.test("loadServeConfig: parses valid full config with all fields", () => {
+  withTempDir((dir) => {
+    writeConfig(dir, {
+      port: 8080,
+      host: "0.0.0.0",
+      auth: {
+        mode: "token",
+        admins: ["user:admin-1"],
+        "allowed-collectives": ["engineering"],
+        "allowed-users": ["alice"],
+        "restricted-model-types": ["command/shell"],
+        "group-refresh-interval": "2h",
+      },
+      tls: {
+        "cert-file": "/etc/swamp/server.crt",
+        "key-file": "/etc/swamp/server.key",
+      },
+      webhooks: [
+        {
+          route: "/hooks/ci",
+          workflow: "deploy",
+          secret: "my-secret",
+          scheme: "github",
+        },
+      ],
+      schedule: true,
+      "hot-reload": false,
+      "detach-runs": true,
+      "trust-proxy": true,
+      "trusted-hosts": ["host.docker.internal"],
+      "grant-reload": "auto",
+      "ws-idle-timeout": "2m",
+      "queue-timeout": "5m",
+      "verify-on-enroll": true,
+      "heartbeat-interval": "30s",
+      "stale-ttl": "90s",
+      "reconciliation-interval": "60s",
+    });
+
+    const config = loadServeConfig(undefined, dir);
+    assertNotEquals(config, null);
+    assertEquals(config!.port, 8080);
+    assertEquals(config!.host, "0.0.0.0");
+    assertEquals(config!.auth?.mode, "token");
+    assertEquals(config!.auth?.admins, ["user:admin-1"]);
+    assertEquals(config!.tls?.["cert-file"], "/etc/swamp/server.crt");
+    assertEquals(config!.webhooks?.length, 1);
+    assertEquals(config!.webhooks?.[0].route, "/hooks/ci");
+    assertEquals(config!["detach-runs"], true);
+    assertEquals(config!["trust-proxy"], true);
+    assertEquals(config!["trusted-hosts"], ["host.docker.internal"]);
+  });
+});
+
+Deno.test("loadServeConfig: parses minimal config (just port)", () => {
+  withTempDir((dir) => {
+    writeConfig(dir, { port: 3000 });
+    const config = loadServeConfig(undefined, dir);
+    assertNotEquals(config, null);
+    assertEquals(config!.port, 3000);
+    assertEquals(config!.host, undefined);
+    assertEquals(config!.auth, undefined);
+  });
+});
+
+Deno.test("loadServeConfig: missing config at default location returns null", () => {
+  withTempDir((dir) => {
+    const config = loadServeConfig(undefined, dir);
+    assertEquals(config, null);
+  });
+});
+
+Deno.test("loadServeConfig: missing config with explicit --config is an error", () => {
+  assertThrows(
+    () => loadServeConfig("/nonexistent/path.yaml", "/tmp"),
+    Error,
+    "Serve config file not found",
+  );
+});
+
+Deno.test("loadServeConfig: invalid YAML produces clear error", () => {
+  withTempDir((dir) => {
+    const swampDir = join(dir, ".swamp");
+    Deno.mkdirSync(swampDir, { recursive: true });
+    Deno.writeTextFileSync(
+      join(swampDir, "serve.yaml"),
+      "port: [invalid: yaml: {",
+    );
+    assertThrows(
+      () => loadServeConfig(undefined, dir),
+      Error,
+      "Invalid YAML",
+    );
+  });
+});
+
+Deno.test("loadServeConfig: unknown keys produce warning but parsing succeeds", () => {
+  withTempDir((dir) => {
+    writeConfig(dir, {
+      port: 9090,
+      "unknown-key": "value",
+      "another-unknown": 42,
+    });
+    const config = loadServeConfig(undefined, dir);
+    assertNotEquals(config, null);
+    assertEquals(config!.port, 9090);
+  });
+});
+
+Deno.test("loadServeConfig: invalid port produces error", () => {
+  withTempDir((dir) => {
+    writeConfig(dir, { port: 99999 });
+    assertThrows(
+      () => loadServeConfig(undefined, dir),
+      Error,
+      "must be between 1 and 65535",
+    );
+  });
+});
+
+Deno.test("loadServeConfig: non-integer port produces error", () => {
+  withTempDir((dir) => {
+    writeConfig(dir, { port: "not-a-number" });
+    assertThrows(
+      () => loadServeConfig(undefined, dir),
+      Error,
+      "expected integer",
+    );
+  });
+});
+
+Deno.test("loadServeConfig: array config file produces error", () => {
+  withTempDir((dir) => {
+    const swampDir = join(dir, ".swamp");
+    Deno.mkdirSync(swampDir, { recursive: true });
+    Deno.writeTextFileSync(join(swampDir, "serve.yaml"), "- item1\n- item2\n");
+    assertThrows(
+      () => loadServeConfig(undefined, dir),
+      Error,
+      "must be a YAML mapping",
+    );
+  });
+});
+
+Deno.test("loadServeConfig: webhook missing route produces error", () => {
+  withTempDir((dir) => {
+    writeConfig(dir, {
+      webhooks: [{ workflow: "deploy", secret: "s" }],
+    });
+    assertThrows(
+      () => loadServeConfig(undefined, dir),
+      Error,
+      "route is required",
+    );
+  });
+});
+
+Deno.test("loadServeConfig: webhook route not starting with / produces error", () => {
+  withTempDir((dir) => {
+    writeConfig(dir, {
+      webhooks: [{
+        route: "hooks/ci",
+        workflow: "deploy",
+        secret: "s",
+      }],
+    });
+    assertThrows(
+      () => loadServeConfig(undefined, dir),
+      Error,
+      "must start with '/'",
+    );
+  });
+});
+
+Deno.test("loadServeConfig: webhook with invalid scheme produces error", () => {
+  withTempDir((dir) => {
+    writeConfig(dir, {
+      webhooks: [{
+        route: "/hooks/ci",
+        workflow: "deploy",
+        secret: "s",
+        scheme: "invalid",
+      }],
+    });
+    assertThrows(
+      () => loadServeConfig(undefined, dir),
+      Error,
+      "scheme must be one of",
+    );
+  });
+});
+
+Deno.test("loadServeConfig: webhook generic scheme without header produces error", () => {
+  withTempDir((dir) => {
+    writeConfig(dir, {
+      webhooks: [{
+        route: "/hooks/ci",
+        workflow: "deploy",
+        secret: "s",
+        scheme: "generic",
+      }],
+    });
+    assertThrows(
+      () => loadServeConfig(undefined, dir),
+      Error,
+      "generic scheme requires a header name",
+    );
+  });
+});
+
+Deno.test("loadServeConfig: empty file returns null", () => {
+  withTempDir((dir) => {
+    const swampDir = join(dir, ".swamp");
+    Deno.mkdirSync(swampDir, { recursive: true });
+    Deno.writeTextFileSync(join(swampDir, "serve.yaml"), "");
+    const config = loadServeConfig(undefined, dir);
+    assertEquals(config, null);
+  });
+});
+
+Deno.test("parseWebhookConfig: parses github scheme webhook", () => {
+  const entry: WebhookConfigEntry = {
+    route: "/hooks/ci",
+    workflow: "deploy-pipeline",
+    secret: "my-secret",
+  };
+  const endpoint = parseWebhookConfig(entry);
+  assertEquals(endpoint.route, "/hooks/ci");
+  assertEquals(endpoint.workflowIdOrName, "deploy-pipeline");
+  assertEquals(endpoint.secret, "my-secret");
+  assertEquals(endpoint.verifier, { scheme: "github" });
+});
+
+Deno.test("parseWebhookConfig: parses linear scheme webhook", () => {
+  const entry: WebhookConfigEntry = {
+    route: "/hooks/linear",
+    workflow: "triage",
+    secret: "linear-secret",
+    scheme: "linear",
+  };
+  const endpoint = parseWebhookConfig(entry);
+  assertEquals(endpoint.verifier, { scheme: "linear" });
+});
+
+Deno.test("parseWebhookConfig: parses generic scheme with header and prefix", () => {
+  const entry: WebhookConfigEntry = {
+    route: "/hooks/custom",
+    workflow: "process",
+    secret: "generic-secret",
+    scheme: "generic",
+    header: "X-Signature",
+    prefix: "sha256=",
+  };
+  const endpoint = parseWebhookConfig(entry);
+  assertEquals(endpoint.verifier, {
+    scheme: "generic",
+    header: "X-Signature",
+    prefix: "sha256=",
+  });
+});
+
+// ── parseExplicitFlags ────────────────────────────────────────────────
+
+Deno.test("parseExplicitFlags: detects simple flags", () => {
+  const flags = parseExplicitFlags(["--port", "9090", "--host", "0.0.0.0"]);
+  assertEquals(flags.has("port"), true);
+  assertEquals(flags.has("host"), true);
+  assertEquals(flags.has("auth-mode"), false);
+});
+
+Deno.test("parseExplicitFlags: handles --flag=value form", () => {
+  const flags = parseExplicitFlags(["--port=9090"]);
+  assertEquals(flags.has("port"), true);
+});
+
+Deno.test("parseExplicitFlags: handles --no-flag negation", () => {
+  const flags = parseExplicitFlags(["--no-schedule"]);
+  assertEquals(flags.has("schedule"), true);
+  assertEquals(flags.has("no-schedule"), true);
+});
+
+Deno.test("parseExplicitFlags: ignores non-flag args", () => {
+  const flags = parseExplicitFlags(["serve", "9090", "-v"]);
+  assertEquals(flags.size, 0);
+});
+
+// ── mergeServeOptions ─────────────────────────────────────────────────
+
+Deno.test("mergeServeOptions: CLI flag wins over env var and config file", () => {
+  const config: ServeConfigFile = { port: 3000 };
+  const cliOptions = { port: 8080 };
+  const explicitFlags = new Set(["port"]);
+  const envLookup = () => undefined;
+
+  const merged = mergeServeOptions(
+    config,
+    cliOptions,
+    explicitFlags,
+    envLookup,
+  );
+  assertEquals(merged.port, 8080);
+});
+
+Deno.test("mergeServeOptions: env var wins over config file when CLI not explicit", () => {
+  const config: ServeConfigFile = {
+    tls: { "cert-file": "/from/config.crt" },
+  };
+  const cliOptions = {};
+  const explicitFlags = new Set<string>();
+  const envLookup = (name: string) =>
+    name === "SWAMP_SERVE_CERT_FILE" ? "/from/env.crt" : undefined;
+
+  const merged = mergeServeOptions(
+    config,
+    cliOptions,
+    explicitFlags,
+    envLookup,
+  );
+  assertEquals(merged.certFile, "/from/env.crt");
+});
+
+Deno.test("mergeServeOptions: config file wins over default when neither CLI nor env var set", () => {
+  const config: ServeConfigFile = { port: 3000, host: "0.0.0.0" };
+  const cliOptions = { port: 9090, host: "127.0.0.1" };
+  const explicitFlags = new Set<string>();
+  const envLookup = () => undefined;
+
+  const merged = mergeServeOptions(
+    config,
+    cliOptions,
+    explicitFlags,
+    envLookup,
+  );
+  assertEquals(merged.port, 3000);
+  assertEquals(merged.host, "0.0.0.0");
+});
+
+Deno.test("mergeServeOptions: defaults used when no config and no explicit flags", () => {
+  const cliOptions = { port: 9090, host: "127.0.0.1" };
+  const explicitFlags = new Set<string>();
+  const envLookup = () => undefined;
+
+  const merged = mergeServeOptions(null, cliOptions, explicitFlags, envLookup);
+  assertEquals(merged.port, 9090);
+  assertEquals(merged.host, "127.0.0.1");
+  assertEquals(merged.schedule, true);
+  assertEquals(merged.trustProxy, false);
+  assertEquals(merged.detachRuns, false);
+  assertEquals(merged.hotReload, false);
+});
+
+Deno.test("mergeServeOptions: auth config arrays converted to comma-separated strings", () => {
+  const config: ServeConfigFile = {
+    auth: {
+      mode: "oauth",
+      admins: ["alice", "bob"],
+      "allowed-collectives": ["eng", "ops"],
+      "allowed-users": ["carol"],
+      "restricted-model-types": ["command/shell", "command/exec"],
+    },
+  };
+  const cliOptions = {};
+  const explicitFlags = new Set<string>();
+  const envLookup = () => undefined;
+
+  const merged = mergeServeOptions(
+    config,
+    cliOptions,
+    explicitFlags,
+    envLookup,
+  );
+  assertEquals(merged.authMode, "oauth");
+  assertEquals(merged.admins, "alice,bob");
+  assertEquals(merged.allowedCollectives, "eng,ops");
+  assertEquals(merged.allowedUsers, "carol");
+  assertEquals(merged.restrictedModelTypes, "command/shell,command/exec");
+});
+
+Deno.test("mergeServeOptions: CLI webhooks replace config webhooks", () => {
+  const config: ServeConfigFile = {
+    webhooks: [{
+      route: "/hooks/config",
+      workflow: "config-wf",
+      secret: "config-secret",
+    }],
+  };
+  const cliOptions = { webhook: ["/hooks/cli:cli-wf:cli-secret"] };
+  const explicitFlags = new Set(["webhook"]);
+  const envLookup = () => undefined;
+
+  const merged = mergeServeOptions(
+    config,
+    cliOptions,
+    explicitFlags,
+    envLookup,
+  );
+  assertEquals(merged.webhook, ["/hooks/cli:cli-wf:cli-secret"]);
+  assertEquals(merged.webhookEndpoints, undefined);
+});
+
+Deno.test("mergeServeOptions: config webhooks used when no CLI webhooks", () => {
+  const config: ServeConfigFile = {
+    webhooks: [{
+      route: "/hooks/config",
+      workflow: "config-wf",
+      secret: "config-secret",
+    }],
+  };
+  const cliOptions = {};
+  const explicitFlags = new Set<string>();
+  const envLookup = () => undefined;
+
+  const merged = mergeServeOptions(
+    config,
+    cliOptions,
+    explicitFlags,
+    envLookup,
+  );
+  assertEquals(merged.webhook, undefined);
+  assertNotEquals(merged.webhookEndpoints, undefined);
+  assertEquals(merged.webhookEndpoints!.length, 1);
+  assertEquals(merged.webhookEndpoints![0].route, "/hooks/config");
+  assertEquals(merged.webhookEndpoints![0].workflowIdOrName, "config-wf");
+});
+
+Deno.test("mergeServeOptions: env var fallback works with no config file (backwards compat)", () => {
+  const cliOptions = {};
+  const explicitFlags = new Set<string>();
+  const envLookup = (name: string) => {
+    if (name === "SWAMP_SERVE_CERT_FILE") return "/env/cert.pem";
+    if (name === "SWAMP_SERVE_KEY_FILE") return "/env/key.pem";
+    if (name === "SWAMP_WS_IDLE_TIMEOUT") return "60";
+    return undefined;
+  };
+
+  const merged = mergeServeOptions(null, cliOptions, explicitFlags, envLookup);
+  assertEquals(merged.certFile, "/env/cert.pem");
+  assertEquals(merged.keyFile, "/env/key.pem");
+  assertEquals(merged.wsIdleTimeout, "60");
+});
+
+Deno.test("mergeServeOptions: boolean env var handling for verify-on-enroll", () => {
+  const cliOptions = {};
+  const explicitFlags = new Set<string>();
+  const envLookup = (name: string) =>
+    name === "SWAMP_VERIFY_ON_ENROLL" ? "true" : undefined;
+
+  const merged = mergeServeOptions(null, cliOptions, explicitFlags, envLookup);
+  assertEquals(merged.verifyOnEnroll, true);
+});
+
+Deno.test("mergeServeOptions: trusted-hosts config array joined to comma string", () => {
+  const config: ServeConfigFile = {
+    "trusted-hosts": ["host.docker.internal", "host.minikube.internal"],
+  };
+  const cliOptions = {};
+  const explicitFlags = new Set<string>();
+  const envLookup = () => undefined;
+
+  const merged = mergeServeOptions(
+    config,
+    cliOptions,
+    explicitFlags,
+    envLookup,
+  );
+  assertEquals(
+    merged.trustedHosts,
+    "host.docker.internal,host.minikube.internal",
+  );
+});


### PR DESCRIPTION
## Summary

- Add `.swamp/serve.yaml` config file support for `swamp serve` — operators can version-control their serve configuration instead of managing long CLI flag chains
- New `--config <path>` flag to specify an alternate config file location
- Four-level resolution priority: **CLI flag > env var > config file > default**
- Structured YAML webhook format as an alternative to the colon-delimited CLI string
- Unknown config keys warn but don't fail (forward compatibility)
- 31 unit tests covering config parsing, four-level merge priority, webhook formats, flag detection, and edge cases

Closes swamp-club#1517

### Config file example

```yaml
port: 9090
host: 0.0.0.0

auth:
  mode: token
  admins:
    - "user:admin-token-name"

tls:
  cert-file: /etc/swamp/server.crt
  key-file: /etc/swamp/server.key

webhooks:
  - route: /hooks/ci
    workflow: deploy-pipeline
    secret: "@env=WEBHOOK_SECRET"

schedule: true
detach-runs: true
```

### Documentation gap

The `swamp-club/swamp-club` repo has issues disabled, so a docs issue could not be filed. The following manual pages need updating:
- `content/manual/reference/swamp-serve.md` — config file format, `--config` flag, resolution priority
- `content/manual/how-to/swamp-serve.md` — production deployment with config files

UAT gap filed: swamp-club/swamp-uat#336

## Test plan

- [x] `deno fmt --check` — clean
- [x] `deno lint` — clean
- [x] `deno run test` — 9790 passed, 0 failed
- [x] `deno run compile` — binary compiles
- [x] Binary verification (18 scenarios):
  - No config file (backwards compat) → default port 9090
  - Config at `.swamp/serve.yaml` → port from config
  - CLI `--port` overrides config port
  - Explicit `--config /path` → reads custom path
  - `--config` with missing file → hard error
  - Invalid YAML → clear parse error
  - Unknown keys → warnings + successful start
  - Invalid port → field-level error
  - `schedule: false` from config → no scheduler
  - Env var overrides config (proved both directions with invalid/valid values)
  - Auth mode + admins from config
  - Webhook structured format from config
  - CLI `--webhook` replaces config webhooks
  - Generic scheme webhook from config
  - Empty config file → defaults
  - `detach-runs` + `hot-reload` from config

🤖 Generated with [Claude Code](https://claude.com/claude-code)