### PR TITLE
feat(provenance): expose bundle fingerprint in execution provenance (swamp-club#1498)

### DIFF
--- a/design/models.md
+++ b/design/models.md
@@ -309,6 +309,19 @@ workflow for orchestration.
 `triggeredBy: "model"`, `parentOutputId` pointing to the caller's output, and
 `callerExtension` for provenance tracking.
 
+### Execution Identity
+
+Every method execution records `bundleFingerprint` on `ExecutionProvenance` —
+the SHA-256 source fingerprint of the extension bundle that produced the output.
+This is the one piece of execution identity that only core can provide:
+`definitionHash` and `modelVersion` already cover the definition content and
+type version, but neither proves which _code_ actually ran.
+
+The field is optional — old outputs without it parse correctly, and built-in
+model types (which have no extension bundle) leave it undefined. A lifecycle
+consumer can persist the fingerprint alongside evidence and compare against the
+current invocation to determine whether an interrupted run can safely resume.
+
 ### Workflow Gate Control (`context.approveWorkflowGate`, `context.rejectWorkflowGate`)
 
 `context.approveWorkflowGate(options)` and `context.rejectWorkflowGate(options)`

--- a/src/domain/extensions/extension_loader.ts
+++ b/src/domain/extensions/extension_loader.ts
@@ -308,6 +308,13 @@ export class ExtensionLoader {
           continue;
         }
 
+        let fingerprint: string | undefined;
+        try {
+          fingerprint = await computeSourceFingerprint(absolutePath, baseDir);
+        } catch {
+          // Non-fatal — fingerprint is best-effort on cold load
+        }
+
         this.adapter.register(
           typeNormalized,
           validated,
@@ -319,6 +326,7 @@ export class ExtensionLoader {
               absolutePath,
               this.repoDir,
             ),
+            sourceFingerprint: fingerprint,
           },
         );
         result.loaded.push(file);
@@ -764,6 +772,7 @@ export class ExtensionLoader {
           entry.source_path,
           this.repoDir,
         ),
+        sourceFingerprint: entry.source_fingerprint || undefined,
       },
     );
   }
@@ -1022,7 +1031,13 @@ export class ExtensionLoader {
               absolutePath,
               this.repoDir,
             ),
+            sourceFingerprint: effectiveFingerprint,
           },
+        );
+      } else if (this.adapter.updateSourceFingerprint) {
+        this.adapter.updateSourceFingerprint(
+          typeNormalized,
+          effectiveFingerprint,
         );
       }
 

--- a/src/domain/extensions/kind_adapter.ts
+++ b/src/domain/extensions/kind_adapter.ts
@@ -57,6 +57,7 @@ export interface RegistrationContext {
   denoRuntime: DenoRuntime;
   repoDir: string | null;
   extensionName?: string;
+  sourceFingerprint?: string;
 }
 
 export interface KindAdapter {
@@ -112,6 +113,11 @@ export interface KindAdapter {
   // lazy entries. Use for "should I skip the import?" checks (e.g.,
   // importAndRegisterBundle's early-return guard).
   isFullyLoaded(typeNormalized: string): boolean;
+
+  updateSourceFingerprint?(
+    typeNormalized: string,
+    fingerprint: string,
+  ): void;
 
   validateNamespace?(rawType: string): string | undefined;
 

--- a/src/domain/extensions/model_kind_adapter.ts
+++ b/src/domain/extensions/model_kind_adapter.ts
@@ -458,6 +458,7 @@ export const modelKindAdapter: KindAdapter = {
       context.repoDir,
     );
     modelDef.extensionName = context.extensionName;
+    modelDef.sourceFingerprint = context.sourceFingerprint;
 
     let bundlePromise: Promise<string> | undefined;
     modelDef.bundleSourceFactory = () => {
@@ -490,6 +491,13 @@ export const modelKindAdapter: KindAdapter = {
     });
   },
 
+  updateSourceFingerprint(typeNormalized: string, fingerprint: string): void {
+    const modelDef = modelRegistry.get(typeNormalized);
+    if (modelDef) {
+      modelDef.sourceFingerprint = fingerprint;
+    }
+  },
+
   promoteFromLazy(
     _typeNormalized: string,
     validated: Record<string, unknown>,
@@ -503,6 +511,7 @@ export const modelKindAdapter: KindAdapter = {
       context.repoDir,
     );
     modelDef.extensionName = context.extensionName;
+    modelDef.sourceFingerprint = context.sourceFingerprint;
 
     let bundlePromise: Promise<string> | undefined;
     modelDef.bundleSourceFactory = () => {

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -802,11 +802,13 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
             triggeredBy: context._invocationProvenance.triggeredBy,
             parentOutputId: context._invocationProvenance.parentOutputId,
             callerExtension: context._invocationProvenance.callerExtension,
+            bundleFingerprint: modelDef.sourceFingerprint,
           }
           : {
             definitionHash,
             modelVersion: modelDef.version,
             triggeredBy: "manual" as const,
+            bundleFingerprint: modelDef.sourceFingerprint,
           };
         output = ModelOutput.create({
           definitionId: currentDefinition.id,

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -876,6 +876,14 @@ export interface ModelDefinition<
    * authorization.
    */
   extensionName?: string;
+
+  /**
+   * SHA-256 fingerprint of the extension source that was bundled for this
+   * model type. Populated by the extension loader at registration time.
+   * Undefined for built-in types. Recorded in ExecutionProvenance so
+   * lifecycle consumers can verify which code bundle produced an output.
+   */
+  sourceFingerprint?: string;
 }
 
 /**

--- a/src/domain/models/model_output.ts
+++ b/src/domain/models/model_output.ts
@@ -79,6 +79,7 @@ export const ExecutionProvenanceSchema = z.object({
   parentOutputId: z.string().uuid().optional(),
   callerExtension: z.string().optional(),
   initiatedBy: z.string().optional(),
+  bundleFingerprint: z.string().optional(),
 });
 
 /**

--- a/src/domain/models/model_output_test.ts
+++ b/src/domain/models/model_output_test.ts
@@ -573,3 +573,48 @@ Deno.test("ModelOutput.isComplete: returns true for cancelled", () => {
 
   assertEquals(output.isComplete, true);
 });
+
+// bundleFingerprint provenance round-trip tests
+
+Deno.test("ModelOutput toData/fromData round-trips bundleFingerprint", () => {
+  const provenance: ExecutionProvenance = {
+    definitionHash: "hash123",
+    modelVersion: "2026.02.09.3",
+    triggeredBy: "manual",
+    bundleFingerprint: "sha256:deadbeef",
+  };
+  const output = ModelOutput.create({
+    definitionId: createDefinitionId(crypto.randomUUID()),
+    methodName: "create",
+    status: "running",
+    provenance,
+  });
+  output.markSucceeded();
+
+  const data = output.toData();
+  const restored = ModelOutput.fromData(data);
+
+  assertEquals(restored.provenance.bundleFingerprint, "sha256:deadbeef");
+});
+
+Deno.test("ModelOutput fromData: missing bundleFingerprint defaults to undefined", () => {
+  const data = {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    definitionId: "660e8400-e29b-41d4-a716-446655440000",
+    methodName: "create",
+    status: "succeeded" as const,
+    startedAt: "2023-01-01T00:00:00.000Z",
+    completedAt: "2023-01-01T00:00:05.000Z",
+    durationMs: 5000,
+    retryCount: 0,
+    provenance: {
+      definitionHash: "hash",
+      modelVersion: "2026.02.09.1",
+      triggeredBy: "manual" as const,
+    },
+  };
+
+  const output = ModelOutput.fromData(data);
+
+  assertEquals(output.provenance.bundleFingerprint, undefined);
+});

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -816,6 +816,7 @@ export class DefaultStepExecutor implements StepExecutor {
         workflowId: ctx.workflowId,
         workflowRunId: ctx.workflowRunId,
         stepName: ctx.stepName,
+        bundleFingerprint: modelDef.sourceFingerprint,
       },
     });
 

--- a/src/libswamp/models/output_get.ts
+++ b/src/libswamp/models/output_get.ts
@@ -46,6 +46,7 @@ export interface ProvenanceData {
   workflowId?: string;
   workflowRunId?: string;
   stepName?: string;
+  bundleFingerprint?: string;
 }
 
 /**

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -648,6 +648,7 @@ export async function* modelMethodRun(
               modelVersion: modelDef.version,
               triggeredBy: "manual",
               initiatedBy: input.initiatedBy,
+              bundleFingerprint: modelDef.sourceFingerprint,
             },
           });
           output.markRunning(Deno.pid);


### PR DESCRIPTION
## Summary

- Adds `bundleFingerprint` to `ExecutionProvenance` — the SHA-256 source
  fingerprint of the extension bundle that produced the output
- Stamps `sourceFingerprint` on `ModelDefinition` at registration time
  (same pattern as `extensionName`), making it available at all provenance
  construction sites
- Computes fingerprint on both cold-load (`loadFromPaths`) and indexed
  (`buildIndex`) paths so it's present from the very first run
- Surfaces in `ProvenanceData` for `swamp model output get` and JSON output
- Built-in types leave it `undefined`; old outputs without the field parse
  correctly

This is the one piece of execution identity that only core can provide —
`definitionHash` and `modelVersion` already cover definition content and
type version, but neither proves which *code* actually ran. A lifecycle
consumer can persist the fingerprint alongside evidence and compare against
the current invocation to determine whether an interrupted run can safely
resume.

Closes swamp-club#1498

## Test plan

- [x] `deno check` — clean (pre-existing bench file error only)
- [x] `deno lint` — clean
- [x] `deno fmt` — clean
- [x] `deno run test` — 9746 passed, 0 failed (1 pre-existing flaky)
- [x] `deno run compile` — binary compiles
- [x] E2E: shell model — `bundleFingerprint` absent (built-in, no bundle)
- [x] E2E: custom extension cold start — `bundleFingerprint` present on
  first run
- [x] E2E: custom extension warm start — same fingerprint, still present
- [x] E2E: different extension source — different fingerprint
- [x] E2E: old outputs without field — parse correctly (backwards compat)
- [x] Perf: 109 model types (@swamp/aws/ec2) — cold start 1.35s vs warm
  1.30s, ~50ms difference, negligible

🤖 Generated with [Claude Code](https://claude.com/claude-code)