### PR TITLE
fix(tls): surface diagnostic hint for UnknownIssuer certificate errors (swamp-club#1518)

### DIFF
--- a/src/presentation/output/error_output.ts
+++ b/src/presentation/output/error_output.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { ValidationError } from "@cliffy/command";
-import { bold, red } from "@std/fmt/colors";
+import { bold, dim, red, yellow } from "@std/fmt/colors";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
 import { DuplicateTypeUserError } from "../../domain/extensions/duplicate_type_user_error.ts";
@@ -95,6 +95,34 @@ export function exitCodeForError(error: unknown): number {
 }
 
 /**
+ * Returns a TLS diagnostic hint if the error message indicates an
+ * `UnknownIssuer` TLS failure, or `undefined` otherwise. Compiled Deno
+ * binaries use `rustls-native-certs` / `deno_native_certs` which read
+ * static keychain entries on macOS — they do not use the OS's full trust
+ * evaluation (`SecTrustEvaluateWithError`), so roots distributed via
+ * Apple's OTA trust updates are invisible. This hint guides users to the
+ * existing `SSL_CERT_FILE` workaround.
+ */
+export function tlsErrorHint(message: string): string | undefined {
+  if (
+    !message.includes("UnknownIssuer") &&
+    !message.includes("invalid peer certificate")
+  ) {
+    return undefined;
+  }
+  return [
+    "The TLS certificate was rejected because its root CA is not in Deno's trust store.",
+    "On macOS, Deno does not use the operating system's full certificate trust",
+    "evaluation, so some certificates trusted by curl and browsers are not recognized.",
+    "",
+    "Workaround: set SSL_CERT_FILE to a PEM file containing the missing root CA:",
+    "  export SSL_CERT_FILE=/path/to/root-ca.pem",
+    "",
+    "This is a known Deno limitation — see https://github.com/denoland/deno/issues/36402",
+  ].join("\n");
+}
+
+/**
  * Renders an error to the user.
  *
  * In JSON mode this is the SINGLE emitter for fatal output: it writes
@@ -107,8 +135,13 @@ export function renderError(error: unknown, outputMode?: OutputMode): void {
   const err = error instanceof Error ? error : new Error(String(error));
 
   if (outputMode === "json") {
+    const json = buildErrorJson(err);
+    const hint = tlsErrorHint(err.message);
+    if (hint) {
+      json.hint = hint;
+    }
     // deno-lint-ignore no-console
-    console.error(JSON.stringify(buildErrorJson(err), null, 2));
+    console.error(JSON.stringify(json, null, 2));
     return;
   }
 
@@ -118,5 +151,10 @@ export function renderError(error: unknown, outputMode?: OutputMode): void {
     logger.fatal("Error: {message}", { message: err.message });
   } else {
     logger.fatal("{error}", { error: err });
+  }
+
+  const hint = tlsErrorHint(err.message);
+  if (hint) {
+    console.error(`\n${yellow(bold("Hint:"))} ${dim(hint)}`);
   }
 }

--- a/src/presentation/output/error_output_test.ts
+++ b/src/presentation/output/error_output_test.ts
@@ -24,6 +24,7 @@ import {
   buildErrorJson,
   exitCodeForError,
   renderError,
+  tlsErrorHint,
 } from "./error_output.ts";
 import { UserError } from "../../domain/errors.ts";
 import { LockTimeoutError } from "../../domain/datastore/distributed_lock.ts";
@@ -483,4 +484,86 @@ Deno.test("buildErrorJson: LockTimeoutError includes code field", () => {
   const result = buildErrorJson(err);
   assertEquals(result.code, "lock_timeout");
   assertStringIncludes(result.error as string, "timed out after 60000ms");
+});
+
+// ============================================================================
+// tlsErrorHint tests (issue #1518)
+// ============================================================================
+
+Deno.test("tlsErrorHint: returns hint for UnknownIssuer error", () => {
+  const hint = tlsErrorHint(
+    "error sending request for url (https://fw.example.com/api/): client error (Connect): invalid peer certificate: UnknownIssuer",
+  );
+  assertEquals(hint !== undefined, true);
+  assertStringIncludes(hint!, "SSL_CERT_FILE");
+  assertStringIncludes(hint!, "root CA");
+});
+
+Deno.test("tlsErrorHint: returns hint for invalid peer certificate error", () => {
+  const hint = tlsErrorHint("invalid peer certificate: something");
+  assertEquals(hint !== undefined, true);
+  assertStringIncludes(hint!, "SSL_CERT_FILE");
+});
+
+Deno.test("tlsErrorHint: returns undefined for unrelated errors", () => {
+  assertEquals(tlsErrorHint("connection refused"), undefined);
+  assertEquals(tlsErrorHint("Model not found"), undefined);
+  assertEquals(tlsErrorHint("timeout"), undefined);
+});
+
+Deno.test("renderError: log mode appends TLS hint for UnknownIssuer", () => {
+  const logs: string[] = [];
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => logs.push(args.join(" "));
+
+  try {
+    renderError(
+      new UserError(
+        "error sending request: invalid peer certificate: UnknownIssuer",
+      ),
+    );
+
+    assertEquals(logs.length, 2);
+    assertStringIncludes(logs[0], "UnknownIssuer");
+    assertStringIncludes(logs[1], "Hint:");
+    assertStringIncludes(logs[1], "SSL_CERT_FILE");
+  } finally {
+    console.error = originalError;
+  }
+});
+
+Deno.test("renderError: json mode includes hint field for UnknownIssuer", () => {
+  const stderrLogs: string[] = [];
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => stderrLogs.push(args.join(" "));
+
+  try {
+    renderError(
+      new UserError(
+        "error sending request: invalid peer certificate: UnknownIssuer",
+      ),
+      "json",
+    );
+
+    assertEquals(stderrLogs.length, 1);
+    const parsed = JSON.parse(stderrLogs[0]);
+    assertStringIncludes(parsed.hint, "SSL_CERT_FILE");
+    assertStringIncludes(parsed.hint, "root CA");
+  } finally {
+    console.error = originalError;
+  }
+});
+
+Deno.test("renderError: no TLS hint for non-TLS errors", () => {
+  const logs: string[] = [];
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => logs.push(args.join(" "));
+
+  try {
+    renderError(new UserError("Model not found"));
+    assertEquals(logs.length, 1);
+    assertEquals(logs[0].includes("Hint:"), false);
+  } finally {
+    console.error = originalError;
+  }
 });


### PR DESCRIPTION
## Summary

- Adds a diagnostic hint to `renderError` that detects `UnknownIssuer` / `invalid peer certificate` TLS failures and explains the Deno limitation with the `SSL_CERT_FILE` workaround
- In log mode: appends a yellow `Hint:` block after the error
- In JSON mode: adds a `hint` field to the error JSON

Closes swamp-club#1518.

### Root cause

Deno's `deno_native_certs` on macOS uses `SecTrustSettingsCopyCertificates` to read static keychain entries. It does not use the OS's full trust evaluation (`SecTrustEvaluateWithError`), so roots distributed via Apple's OTA trust updates — like ISRG Root YR — are not recognized.

swamp already sets `DENO_TLS_CA_STORE=system,mozilla` at startup, but this doesn't help for OTA-distributed roots. Filed upstream as denoland/deno#36402.

### Related

- denoland/deno#36402 — upstream issue
- swamp-club#1520 — docs update for `tls-and-proxies.md`

## Test plan

- [x] `tlsErrorHint` returns hint for `UnknownIssuer` and `invalid peer certificate` messages
- [x] `tlsErrorHint` returns `undefined` for unrelated errors
- [x] `renderError` appends hint in log mode for TLS errors
- [x] `renderError` includes `hint` field in JSON mode for TLS errors
- [x] No hint for non-TLS errors (no regression)
- [x] Verified output from compiled binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)