### PR TITLE
feat(serve): validate deployment stack and log durability mode on startup (swamp-club#1488)

### DIFF
--- a/integration/serve_ready_test.ts
+++ b/integration/serve_ready_test.ts
@@ -1,0 +1,210 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { dirname, fromFileUrl, join } from "@std/path";
+import { initializeTestRepo } from "./test_helpers.ts";
+
+const PROJECT_ROOT = join(dirname(fromFileUrl(import.meta.url)), "..");
+
+const CLI_LAUNCH_ARGS = [
+  "run",
+  "--config",
+  join(PROJECT_ROOT, "deno.json"),
+  "--unstable-bundle",
+  "--allow-read",
+  "--allow-write",
+  "--allow-env",
+  "--allow-run",
+  "--allow-sys",
+  "--allow-net",
+  join(PROJECT_ROOT, "main.ts"),
+];
+
+async function waitForLine(
+  stream: ReadableStream<Uint8Array>,
+  predicate: (line: string) => boolean,
+  timeoutMs: number,
+): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const start = Date.now();
+  try {
+    while (true) {
+      if (Date.now() - start > timeoutMs) {
+        throw new Error(
+          `timed out after ${timeoutMs}ms waiting for line; buffer was: ${buffer}`,
+        );
+      }
+      const { done, value } = await reader.read();
+      if (done) {
+        throw new Error(
+          `stream closed before predicate matched; buffer was: ${buffer}`,
+        );
+      }
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (predicate(line)) {
+          return line;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+Deno.test({
+  name: "swamp serve: /ready returns 200 and /health returns 200 after startup",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const repoDir = await Deno.makeTempDir({ prefix: "swamp-serve-ready-" });
+    try {
+      await initializeTestRepo(repoDir);
+
+      const cmd = new Deno.Command(Deno.execPath(), {
+        args: [
+          ...CLI_LAUNCH_ARGS,
+          "--json",
+          "serve",
+          "--port",
+          "0",
+          "--no-schedule",
+        ],
+        cwd: repoDir,
+        stdin: "null",
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const child = cmd.spawn();
+
+      try {
+        const listeningLine = await waitForLine(
+          child.stdout,
+          (line) => line.includes('"status":"listening"'),
+          15_000,
+        );
+
+        const listening = JSON.parse(listeningLine);
+        const port = listening.port;
+        const baseUrl = `http://127.0.0.1:${port}`;
+
+        assertEquals(typeof listening.mode, "string");
+
+        const readyRes = await fetch(`${baseUrl}/ready`);
+        assertEquals(readyRes.status, 200);
+        const readyBody = await readyRes.json();
+        assertEquals(readyBody.status, "ready");
+        assertEquals(typeof readyBody.mode, "string");
+
+        const healthRes = await fetch(`${baseUrl}/health`);
+        assertEquals(healthRes.status, 200);
+        const healthBody = await healthRes.json();
+        assertEquals(healthBody.status, "ok");
+
+        child.kill("SIGINT");
+        await Promise.race([
+          child.status,
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error("serve did not exit")), 6_000)
+          ),
+        ]);
+      } finally {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // Already dead
+        }
+        try {
+          await child.status;
+        } catch {
+          // Status already consumed
+        }
+      }
+    } finally {
+      await Deno.remove(repoDir, { recursive: true }).catch(() => {});
+    }
+  },
+});
+
+Deno.test({
+  name: "swamp serve: JSON listening event includes mode field",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const repoDir = await Deno.makeTempDir({
+      prefix: "swamp-serve-mode-json-",
+    });
+    try {
+      await initializeTestRepo(repoDir);
+
+      const cmd = new Deno.Command(Deno.execPath(), {
+        args: [
+          ...CLI_LAUNCH_ARGS,
+          "--json",
+          "serve",
+          "--port",
+          "0",
+          "--no-schedule",
+        ],
+        cwd: repoDir,
+        stdin: "null",
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const child = cmd.spawn();
+
+      try {
+        const listeningLine = await waitForLine(
+          child.stdout,
+          (line) => line.includes('"status":"listening"'),
+          15_000,
+        );
+
+        const listening = JSON.parse(listeningLine);
+        assertEquals(listening.mode, "local");
+
+        child.kill("SIGINT");
+        await Promise.race([
+          child.status,
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error("serve did not exit")), 6_000)
+          ),
+        ]);
+      } finally {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // Already dead
+        }
+        try {
+          await child.status;
+        } catch {
+          // Status already consumed
+        }
+      }
+    } finally {
+      await Deno.remove(repoDir, { recursive: true }).catch(() => {});
+    }
+  },
+});

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -160,6 +160,13 @@ import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
 import { requireAuthenticated, requireScope } from "../auth_context.ts";
 import { getAutoResolver } from "../../domain/extensions/auto_resolver_context.ts";
 import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
+import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
+import {
+  type DatastoreClassification,
+  resolveDeploymentMode,
+  type VaultClassification,
+} from "../../domain/serve/deployment_mode.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -1276,6 +1283,58 @@ export const serveCommand = new Command()
       reportRegistry.ensureLoaded(),
     ]);
 
+    // Probe deployment stack and resolve durability mode.
+    const datastoreClass: DatastoreClassification =
+      isCustomDatastoreConfig(datastoreConfig)
+        ? {
+          kind: "remote",
+          type: datastoreConfig.type,
+          hasControlPlane: !!syncService?.capabilities?.().controlPlane,
+        }
+        : { kind: "filesystem" };
+
+    let vaultClass: VaultClassification = { kind: "none" };
+    try {
+      const vaultRepo = new YamlVaultConfigRepository(resolvedRepoDir);
+      const vaults = await vaultRepo.findAll();
+      if (vaults.length > 0) {
+        const remoteVault = vaults.find((v) => v.type !== "local_encryption");
+        vaultClass = remoteVault
+          ? { kind: "remote", type: remoteVault.type }
+          : { kind: "local" };
+      }
+    } catch {
+      // No vaults directory or unreadable — treat as "none"
+    }
+
+    const deploymentMode = resolveDeploymentMode(datastoreClass, vaultClass);
+
+    if (datastoreClass.kind === "remote") {
+      const cpLabel = datastoreClass.hasControlPlane
+        ? "available"
+        : "not available";
+      logger.info(
+        `Datastore: ${datastoreClass.type} (control-plane: ${cpLabel})`,
+      );
+    } else {
+      logger.info("Datastore: filesystem");
+    }
+    if (vaultClass.kind === "remote") {
+      logger.info(`Vault: ${vaultClass.type}`);
+    }
+    for (const warning of deploymentMode.warnings) {
+      logger.warn(warning);
+    }
+    if (deploymentMode.mode === "durable") {
+      logger.info("Mode: durable — runs survive instance replacement");
+    } else if (deploymentMode.mode === "durable (limited)") {
+      logger.info(
+        "Mode: durable (limited) — runs survive but secret-dependent workflows may fail",
+      );
+    } else {
+      logger.info("Mode: local — runs survive process restart");
+    }
+
     const grantReloadMode = merged.grantReload;
     if (grantReloadMode !== "manual" && grantReloadMode !== "auto") {
       throw new UserError(
@@ -2166,6 +2225,8 @@ export const serveCommand = new Command()
       wsUpgradeOpts.idleTimeout = wsIdleTimeoutSeconds;
     }
 
+    let isReady = !detachRuns;
+
     const wsScheme = tlsEnabled ? "wss" : "ws";
     const server = Deno.serve(
       {
@@ -2183,6 +2244,7 @@ export const serveCommand = new Command()
               url: `${wsScheme}://${hostname}:${listenPort}`,
               schedulingEnabled: enableSchedule,
               detachRuns,
+              mode: deploymentMode.mode,
             }));
           } else {
             logger.info("WebSocket API server listening on {url}", {
@@ -2453,6 +2515,14 @@ export const serveCommand = new Command()
           return new Response(JSON.stringify(authInfo), {
             headers: { "content-type": "application/json" },
           });
+        }
+
+        // Readiness endpoint — returns 200 only after full startup
+        if (req.method === "GET" && new URL(req.url).pathname === "/ready") {
+          if (!isReady) {
+            return new Response("Service Unavailable", { status: 503 });
+          }
+          return Response.json({ status: "ready", mode: deploymentMode.mode });
         }
 
         // Health check endpoint
@@ -2815,6 +2885,9 @@ export const serveCommand = new Command()
         );
         Deno.unrefTimer(reaperTimer);
       }
+
+      isReady = true;
+      logger.info("Startup complete — /ready is now serving 200");
     }
 
     await server.finished;

--- a/src/domain/serve/deployment_mode.ts
+++ b/src/domain/serve/deployment_mode.ts
@@ -1,0 +1,74 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export type DeploymentMode = "local" | "durable" | "durable (limited)";
+
+export type DatastoreClassification =
+  | { readonly kind: "filesystem" }
+  | {
+    readonly kind: "remote";
+    readonly type: string;
+    readonly hasControlPlane: boolean;
+  };
+
+export type VaultClassification =
+  | { readonly kind: "none" }
+  | { readonly kind: "local" }
+  | { readonly kind: "remote"; readonly type: string };
+
+export interface DeploymentModeResult {
+  readonly mode: DeploymentMode;
+  readonly warnings: readonly string[];
+}
+
+export function resolveDeploymentMode(
+  datastore: DatastoreClassification,
+  vault: VaultClassification,
+): DeploymentModeResult {
+  if (datastore.kind === "filesystem") {
+    return { mode: "local", warnings: [] };
+  }
+
+  if (!datastore.hasControlPlane) {
+    return {
+      mode: "local",
+      warnings: [
+        `Update ${datastore.type} for cross-machine durability`,
+      ],
+    };
+  }
+
+  const warnings: string[] = [];
+
+  if (vault.kind === "none") {
+    warnings.push(
+      "No vault configured — workflows requiring secrets will fail after instance replacement",
+    );
+    return { mode: "durable", warnings };
+  }
+
+  if (vault.kind === "local") {
+    warnings.push(
+      "Vault is file-based — secrets will not be available after instance replacement",
+    );
+    return { mode: "durable (limited)", warnings };
+  }
+
+  return { mode: "durable", warnings: [] };
+}

--- a/src/domain/serve/deployment_mode_test.ts
+++ b/src/domain/serve/deployment_mode_test.ts
@@ -1,0 +1,116 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  type DatastoreClassification,
+  resolveDeploymentMode,
+  type VaultClassification,
+} from "./deployment_mode.ts";
+
+const FILESYSTEM: DatastoreClassification = { kind: "filesystem" };
+const REMOTE_NO_CP: DatastoreClassification = {
+  kind: "remote",
+  type: "@swamp/s3-datastore",
+  hasControlPlane: false,
+};
+const REMOTE_CP: DatastoreClassification = {
+  kind: "remote",
+  type: "@swamp/s3-datastore",
+  hasControlPlane: true,
+};
+
+const VAULT_NONE: VaultClassification = { kind: "none" };
+const VAULT_LOCAL: VaultClassification = { kind: "local" };
+const VAULT_REMOTE: VaultClassification = {
+  kind: "remote",
+  type: "@swamp/aws-sm-vault",
+};
+
+// Scenario 1: filesystem + none/local vault → local, no warnings
+Deno.test("resolveDeploymentMode: filesystem datastore with no vault returns local", () => {
+  const result = resolveDeploymentMode(FILESYSTEM, VAULT_NONE);
+  assertEquals(result.mode, "local");
+  assertEquals(result.warnings, []);
+});
+
+// Scenario 2: filesystem + remote vault → local, no warnings
+Deno.test("resolveDeploymentMode: filesystem datastore with remote vault returns local", () => {
+  const result = resolveDeploymentMode(FILESYSTEM, VAULT_REMOTE);
+  assertEquals(result.mode, "local");
+  assertEquals(result.warnings, []);
+});
+
+// Scenario 3: remote without control-plane → local, warns to update extension
+Deno.test("resolveDeploymentMode: remote datastore without control-plane returns local with warning", () => {
+  const result = resolveDeploymentMode(REMOTE_NO_CP, VAULT_REMOTE);
+  assertEquals(result.mode, "local");
+  assertEquals(result.warnings.length, 1);
+  assertEquals(
+    result.warnings[0],
+    "Update @swamp/s3-datastore for cross-machine durability",
+  );
+});
+
+// Scenario 4: remote with control-plane + no vault → durable, warns about missing vault
+Deno.test("resolveDeploymentMode: remote datastore with control-plane and no vault returns durable with warning", () => {
+  const result = resolveDeploymentMode(REMOTE_CP, VAULT_NONE);
+  assertEquals(result.mode, "durable");
+  assertEquals(result.warnings.length, 1);
+  assertEquals(
+    result.warnings[0],
+    "No vault configured — workflows requiring secrets will fail after instance replacement",
+  );
+});
+
+// Scenario 5: remote with control-plane + local vault → durable (limited), warns about file-based secrets
+Deno.test("resolveDeploymentMode: remote datastore with control-plane and local vault returns durable limited", () => {
+  const result = resolveDeploymentMode(REMOTE_CP, VAULT_LOCAL);
+  assertEquals(result.mode, "durable (limited)");
+  assertEquals(result.warnings.length, 1);
+  assertEquals(
+    result.warnings[0],
+    "Vault is file-based — secrets will not be available after instance replacement",
+  );
+});
+
+// Scenario 6: remote with control-plane + remote vault → durable, no warnings
+Deno.test("resolveDeploymentMode: remote datastore with control-plane and remote vault returns durable", () => {
+  const result = resolveDeploymentMode(REMOTE_CP, VAULT_REMOTE);
+  assertEquals(result.mode, "durable");
+  assertEquals(result.warnings, []);
+});
+
+// Edge: filesystem + local vault → still local, no warnings
+Deno.test("resolveDeploymentMode: filesystem datastore with local vault returns local", () => {
+  const result = resolveDeploymentMode(FILESYSTEM, VAULT_LOCAL);
+  assertEquals(result.mode, "local");
+  assertEquals(result.warnings, []);
+});
+
+// Edge: remote without control-plane + no vault → local with extension warning only
+Deno.test("resolveDeploymentMode: remote datastore without control-plane and no vault returns local with warning", () => {
+  const result = resolveDeploymentMode(REMOTE_NO_CP, VAULT_NONE);
+  assertEquals(result.mode, "local");
+  assertEquals(result.warnings.length, 1);
+  assertEquals(
+    result.warnings[0],
+    "Update @swamp/s3-datastore for cross-machine durability",
+  );
+});


### PR DESCRIPTION
## Summary

- On startup, serve probes its deployment stack (datastore type, control-plane capability, vault type) and resolves a durability mode (`local` / `durable` / `durable (limited)`)
- Logs the resolved mode and warns about mismatches (e.g., remote datastore with file-based vault, missing control-plane support)
- Adds a `/ready` endpoint that returns 503 during startup and 200 once fully initialized (reconciliation, replay, heartbeat all complete)
- Includes the `mode` field in the JSON listening event output

Closes swamp-club#1488

## Test Plan

- Unit tests: 8 tests covering all 6 mode resolution scenarios plus edge cases
- Integration tests: 2 tests verifying `/ready` returns 200, `/health` returns 200, and JSON listening event includes `mode` field
- Manual binary testing: compiled binary, ran `swamp serve` with filesystem datastore (no vault, local vault), verified log output matches issue spec exactly
- Verified `/ready` and `/health` endpoint responses with `curl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)