### PR TITLE
fix(serve): address review feedback on deployment mode validation (#2058)

### DIFF
--- a/integration/serve_ready_test.ts
+++ b/integration/serve_ready_test.ts
@@ -94,7 +94,7 @@ Deno.test({
         cwd: repoDir,
         stdin: "null",
         stdout: "piped",
-        stderr: "piped",
+        stderr: "null",
       });
       const child = cmd.spawn();
 
@@ -170,7 +170,7 @@ Deno.test({
         cwd: repoDir,
         stdin: "null",
         stdout: "piped",
-        stderr: "piped",
+        stderr: "null",
       });
       const child = cmd.spawn();
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1303,8 +1303,10 @@ export const serveCommand = new Command()
           ? { kind: "remote", type: remoteVault.type }
           : { kind: "local" };
       }
-    } catch {
-      // No vaults directory or unreadable — treat as "none"
+    } catch (e: unknown) {
+      logger.warn("Could not probe vault configuration: {error}", {
+        error: e instanceof Error ? e.message : String(e),
+      });
     }
 
     const deploymentMode = resolveDeploymentMode(datastoreClass, vaultClass);
@@ -2520,7 +2522,7 @@ export const serveCommand = new Command()
         // Readiness endpoint — returns 200 only after full startup
         if (req.method === "GET" && new URL(req.url).pathname === "/ready") {
           if (!isReady) {
-            return new Response("Service Unavailable", { status: 503 });
+            return Response.json({ status: "not_ready" }, { status: 503 });
           }
           return Response.json({ status: "ready", mode: deploymentMode.mode });
         }


### PR DESCRIPTION
## Summary

- Vault probe catch block now logs a warning instead of silently swallowing errors — prevents corrupt vault YAML from producing wrong deployment mode with no indication
- `/ready` 503 response returns JSON `{"status":"not_ready"}` instead of plain text, so clients can unconditionally parse the body
- Integration test stderr changed from `"piped"` to `"null"` to avoid potential pipe-buffer deadlock

Follow-up to #2058 addressing automated review feedback.

## Test Plan

- All 10 existing tests pass (8 unit + 2 integration)
- `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)