### PR TITLE
fix(workflows): resolve evaluated prompt in workflow approvals (swamp-club#1521)

### DIFF
--- a/src/cli/commands/workflow_approvals.ts
+++ b/src/cli/commands/workflow_approvals.ts
@@ -43,6 +43,7 @@ import {
 import type { WorkflowApprovalsResponse } from "../../serve/protocol.ts";
 import type { WorkflowRunId } from "../../domain/workflows/workflow_id.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
+import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -120,15 +121,15 @@ export const workflowApprovalsCommand = withRemoteOptions(
     return;
   }
 
-  const { repoContext, datastoreConfig } = await requireInitializedRepoUnlocked(
-    {
+  const { repoDir, repoContext, datastoreConfig } =
+    await requireInitializedRepoUnlocked({
       repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
-    },
-  );
+    });
 
   const ctx = createLibSwampContext({ logger: cliCtx.logger });
   const runRepo = repoContext.workflowRunRepo;
+  const evaluatedRepo = new YamlEvaluatedWorkflowRepository(repoDir);
   const deps = createWorkflowApprovalsDeps(
     repoContext.workflowRepo,
     runRepo,
@@ -142,6 +143,7 @@ export const workflowApprovalsCommand = withRemoteOptions(
       );
       return runs.filter((r): r is WorkflowRun => r !== null);
     },
+    (workflowId) => evaluatedRepo.findById(workflowId),
   );
 
   let pending: PendingApproval[] = [];

--- a/src/libswamp/workflows/approvals.ts
+++ b/src/libswamp/workflows/approvals.ts
@@ -21,11 +21,13 @@ import type {
   WorkflowRepository,
   WorkflowRunRepository,
 } from "../../domain/workflows/repositories.ts";
+import type { Workflow } from "../../domain/workflows/workflow.ts";
 import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import { evaluateApprovalTimeout } from "../../domain/workflows/approval_timeout.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
+import { getLogger } from "@logtape/logtape";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 
 export interface PendingApproval {
@@ -52,6 +54,9 @@ export interface WorkflowApprovalsDeps {
   findSuspendedRuns?: (
     workflowId: WorkflowId,
   ) => Promise<WorkflowRun[]>;
+  findEvaluatedWorkflow?: (
+    workflowId: WorkflowId,
+  ) => Promise<Workflow | null>;
 }
 
 export function createWorkflowApprovalsDeps(
@@ -60,8 +65,11 @@ export function createWorkflowApprovalsDeps(
   findSuspendedRuns?: (
     workflowId: WorkflowId,
   ) => Promise<WorkflowRun[]>,
+  findEvaluatedWorkflow?: (
+    workflowId: WorkflowId,
+  ) => Promise<Workflow | null>,
 ): WorkflowApprovalsDeps {
-  return { workflowRepo, runRepo, findSuspendedRuns };
+  return { workflowRepo, runRepo, findSuspendedRuns, findEvaluatedWorkflow };
 }
 
 export async function* workflowApprovals(
@@ -74,6 +82,7 @@ export async function* workflowApprovals(
     (async function* () {
       yield { kind: "resolving" };
 
+      const logger = getLogger(["swamp", "workflow", "approvals"]);
       const workflows = await deps.workflowRepo.findAll();
       const pending: PendingApproval[] = [];
 
@@ -81,6 +90,9 @@ export async function* workflowApprovals(
         const runs = deps.findSuspendedRuns
           ? await deps.findSuspendedRuns(workflow.id)
           : await deps.runRepo.findAllByWorkflowId(workflow.id);
+
+        let evaluatedWorkflow: Workflow | null | undefined;
+
         for (const run of runs) {
           if (run.status !== "suspended") continue;
           const waiting = run.findWaitingApprovalStep();
@@ -99,9 +111,32 @@ export async function* workflowApprovals(
           );
           if (timeout?.expired) continue;
 
-          const prompt = taskData && taskData.type === "manual_approval"
-            ? taskData.prompt
-            : undefined;
+          if (evaluatedWorkflow === undefined && deps.findEvaluatedWorkflow) {
+            try {
+              evaluatedWorkflow = await deps.findEvaluatedWorkflow(
+                workflow.id,
+              );
+            } catch {
+              logger
+                .warn`Failed to load evaluated workflow for ${workflow.name}, using raw definition`;
+              evaluatedWorkflow = null;
+            }
+          }
+
+          let prompt: string | undefined;
+          if (evaluatedWorkflow) {
+            const evalTaskData = evaluatedWorkflow.jobs
+              .find((j) => j.name === waiting.jobName)?.steps
+              .find((s) => s.name === waiting.stepName)?.task.data;
+            prompt = evalTaskData?.type === "manual_approval"
+              ? evalTaskData.prompt
+              : undefined;
+          }
+          if (!prompt) {
+            prompt = taskData?.type === "manual_approval"
+              ? taskData.prompt
+              : undefined;
+          }
 
           pending.push({
             workflowName: workflow.name,

--- a/src/libswamp/workflows/approvals_test.ts
+++ b/src/libswamp/workflows/approvals_test.ts
@@ -36,11 +36,12 @@ function makeWorkflow(overrides?: {
   name?: string;
   stepType?: string;
   timeout?: number;
+  prompt?: string;
 }): Workflow {
   const stepTask = overrides?.stepType === "manual_approval"
     ? {
       type: "manual_approval" as const,
-      prompt: "Approve deployment",
+      prompt: overrides?.prompt ?? "Approve deployment",
       timeout: overrides?.timeout,
     }
     : { type: "model_method" as const, modelIdOrName: "m", methodName: "run" };
@@ -98,6 +99,7 @@ function makeRun(overrides?: {
 function makeDeps(
   workflows: Workflow[],
   runsByWorkflow: Map<string, WorkflowRun[]>,
+  evaluatedWorkflows?: Map<string, Workflow>,
 ): WorkflowApprovalsDeps {
   return {
     workflowRepo: {
@@ -107,6 +109,10 @@ function makeDeps(
       findAllByWorkflowId: (id: WorkflowId) =>
         Promise.resolve(runsByWorkflow.get(id as string) ?? []),
     } as WorkflowApprovalsDeps["runRepo"],
+    findEvaluatedWorkflow: evaluatedWorkflows
+      ? (id: WorkflowId) =>
+        Promise.resolve(evaluatedWorkflows.get(id as string) ?? null)
+      : undefined,
   };
 }
 
@@ -212,5 +218,66 @@ Deno.test("workflowApprovals: filters out expired approval timeouts", async () =
   const completed = events.find((e) => e.kind === "completed");
   if (completed?.kind === "completed") {
     assertEquals(completed.data.approvals.length, 0);
+  }
+});
+
+Deno.test("workflowApprovals: returns evaluated prompt when evaluated workflow exists", async () => {
+  const wf = makeWorkflow({ stepType: "manual_approval" });
+  const evaluatedWf = makeWorkflow({
+    stepType: "manual_approval",
+    prompt: "Approve deployment to production v2.0",
+  });
+  const run = makeRun({ id: "run-eval" });
+  const evaluatedWorkflows = new Map([[WF_ID as string, evaluatedWf]]);
+  const deps = makeDeps(
+    [wf],
+    new Map([[WF_ID as string, [run]]]),
+    evaluatedWorkflows,
+  );
+  const events = await collect<WorkflowApprovalsEvent>(
+    workflowApprovals(ctx, deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.approvals.length, 1);
+    assertEquals(
+      completed.data.approvals[0].prompt,
+      "Approve deployment to production v2.0",
+    );
+  }
+});
+
+Deno.test("workflowApprovals: falls back to raw prompt when no evaluated workflow exists", async () => {
+  const wf = makeWorkflow({ stepType: "manual_approval" });
+  const run = makeRun({ id: "run-fallback" });
+  const evaluatedWorkflows = new Map<string, Workflow>();
+  const deps = makeDeps(
+    [wf],
+    new Map([[WF_ID as string, [run]]]),
+    evaluatedWorkflows,
+  );
+  const events = await collect<WorkflowApprovalsEvent>(
+    workflowApprovals(ctx, deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.approvals.length, 1);
+    assertEquals(completed.data.approvals[0].prompt, "Approve deployment");
+  }
+});
+
+Deno.test("workflowApprovals: falls back to raw prompt when findEvaluatedWorkflow throws", async () => {
+  const wf = makeWorkflow({ stepType: "manual_approval" });
+  const run = makeRun({ id: "run-error" });
+  const deps = makeDeps([wf], new Map([[WF_ID as string, [run]]]));
+  deps.findEvaluatedWorkflow = () =>
+    Promise.reject(new Error("Corrupted YAML"));
+  const events = await collect<WorkflowApprovalsEvent>(
+    workflowApprovals(ctx, deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.approvals.length, 1);
+    assertEquals(completed.data.approvals[0].prompt, "Approve deployment");
   }
 });

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -87,6 +87,7 @@ import {
   extractTraceContext,
   runWithParentTrace,
 } from "../../infrastructure/tracing/mod.ts";
+import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
 import { RunEventBuffer } from "../run_event_buffer.ts";
 import {
   deleteActiveRun,
@@ -373,6 +374,7 @@ export async function handleWorkflowApprovals(
   try {
     const libCtx = createLibSwampContext();
     const runRepo = ctx.repoContext.workflowRunRepo;
+    const evaluatedRepo = new YamlEvaluatedWorkflowRepository(ctx.repoDir);
     const deps = createWorkflowApprovalsDeps(
       ctx.repoContext.workflowRepo,
       runRepo,
@@ -386,6 +388,7 @@ export async function handleWorkflowApprovals(
         );
         return runs.filter((r): r is WorkflowRun => r !== null);
       },
+      (workflowId) => evaluatedRepo.findById(workflowId),
     );
 
     let result: Record<string, unknown> | undefined;


### PR DESCRIPTION
## Summary

- `swamp workflow approvals` was reading the `manual_approval` prompt from the raw workflow definition YAML (`workflows/`), which contains unevaluated `${{ }}` template expressions
- Now looks up the evaluated workflow from `.swamp/workflows-evaluated/` and reads the resolved prompt, falling back to the raw definition when no evaluated workflow exists or the file is unreadable
- Wired up `YamlEvaluatedWorkflowRepository` in both the CLI command and server handler

Fixes swamp-club#1521

## Test Plan

- Added unit tests for evaluated prompt resolution, fallback when no evaluated workflow exists, and fallback when `findEvaluatedWorkflow` throws
- Reproduced the bug in a scratch repo: `swamp workflow approvals` showed `${{ inputs.version }}`; after the fix it shows the resolved value (e.g. `9.9.9`)
- Verified both `--json` and log output modes
- All existing tests pass (`deno run test`)
- Type checking, linting, and formatting pass