### PR TITLE
feat(serve): move per-login token secrets from vault to encrypted control-plane store (swamp-club#1511)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1300,31 +1300,76 @@ export const serveCommand = new Command()
       );
     }
 
+    // Create the control-plane store — used for both the encrypted token
+    // secrets vault and downstream HA coordination (heartbeats, pending
+    // runs, etc). Created once and shared across all consumers.
+    const caps = syncService?.capabilities?.();
+    let controlPlaneStore: ControlPlaneStore;
+    if (caps?.controlPlane && syncService?.controlPlaneStore) {
+      controlPlaneStore = syncService.controlPlaneStore();
+      logger.info("Control-plane store: remote datastore");
+    } else {
+      controlPlaneStore = new FileSystemControlPlaneStore(
+        swampPath(resolvedRepoDir),
+      );
+      logger.info("Control-plane store: local filesystem fallback");
+    }
+
+    // Initialize the encrypted control-plane vault provider for serve-internal
+    // secrets (OAuth credentials, per-login token secrets). This replaces
+    // secrets in the user's vault (which is a poor fit for external backends
+    // like AWS SM) with an encrypted control-plane store that supports
+    // immediate deletion and has no per-secret cost.
+    const { ControlPlaneVaultProvider, TOKEN_SECRETS_VAULT_NAME } =
+      await import(
+        "../../domain/vaults/control_plane_vault_provider.ts"
+      );
+    const tokenSecretsProvider = new ControlPlaneVaultProvider(
+      controlPlaneStore,
+    );
+    await tokenSecretsProvider.initialize();
+    VaultService.registerGlobalProvider(
+      TOKEN_SECRETS_VAULT_NAME,
+      "control_plane",
+      tokenSecretsProvider,
+    );
+
     let oauthClientSecret = "";
     if (authConfig.mode === "oauth") {
-      const vaultService = await VaultService.fromRepository(
+      const oauthVaultService = await VaultService.fromRepository(
         resolvedRepoDir,
         { defaultVaultName: repoMarker?.defaultVault },
       );
-      const vaultNames = vaultService.getVaultNames();
-      if (vaultNames.length === 0) {
-        throw new UserError(
-          "oauth mode requires a vault — run 'swamp vault create local_encryption default' first",
-        );
-      }
-      const vaultName = vaultService.getDefaultVaultName() ?? vaultNames[0];
+      const userVaultName = oauthVaultService.getDefaultVaultName() ??
+        oauthVaultService.getVaultNames()[0];
       let credentials;
       try {
         credentials = await resolveOAuthClientCredentials(
           {
-            getVaultSecret: async (v, k) => {
+            getVaultSecret: async (_v, k) => {
               try {
-                return await vaultService.get(v, k, "serve:oauth-resolve");
+                return await oauthVaultService.get(
+                  TOKEN_SECRETS_VAULT_NAME,
+                  k,
+                  "serve:oauth-resolve",
+                );
               } catch {
+                if (userVaultName) {
+                  try {
+                    return await oauthVaultService.get(
+                      userVaultName,
+                      k,
+                      "serve:oauth-resolve",
+                    );
+                  } catch {
+                    return null;
+                  }
+                }
                 return null;
               }
             },
-            putVaultSecret: (v, k, val) => vaultService.put(v, k, val),
+            putVaultSecret: (_v, k, val) =>
+              oauthVaultService.put(TOKEN_SECRETS_VAULT_NAME, k, val),
             registerClient: async (providerUrl, signal) => {
               const { startDeviceGrant, pollForToken } = await import(
                 "../../serve/oauth_client.ts"
@@ -1425,7 +1470,7 @@ export const serveCommand = new Command()
             },
           },
           authConfig.oauthProvider,
-          vaultName,
+          TOKEN_SECRETS_VAULT_NAME,
           authConfig.oauthClientId,
           AbortSignal.timeout(300_000),
         );
@@ -1501,8 +1546,11 @@ export const serveCommand = new Command()
           }
         }
         await storeResolvedAdmins(
-          { putVaultSecret: (v, k, val) => vaultService.put(v, k, val) },
-          vaultName,
+          {
+            putVaultSecret: (_v, k, val) =>
+              oauthVaultService.put(TOKEN_SECRETS_VAULT_NAME, k, val),
+          },
+          TOKEN_SECRETS_VAULT_NAME,
           resolvedMap,
         );
       } else if (credentials.resolvedAdmins) {
@@ -1519,8 +1567,7 @@ export const serveCommand = new Command()
           } else {
             throw new UserError(
               `Admin '${admin}' not found in cached resolutions. ` +
-                "Clear stored credentials to re-register: " +
-                `swamp vault delete ${vaultName} oauth-client-id`,
+                "Restart serve without --oauth-client-id to re-register",
             );
           }
         }
@@ -1537,8 +1584,7 @@ export const serveCommand = new Command()
           } else {
             throw new UserError(
               `Allowed-user '${entry}' not found in cached resolutions. ` +
-                "Clear stored credentials to re-register: " +
-                `swamp vault delete ${vaultName} oauth-client-id`,
+                "Restart serve without --oauth-client-id to re-register",
             );
           }
         }
@@ -1546,7 +1592,7 @@ export const serveCommand = new Command()
         throw new UserError(
           "Cannot resolve usernames — no access token and no cached resolutions. " +
             "Clear stored credentials to re-register: " +
-            `swamp vault delete ${vaultName} oauth-client-id`,
+            `swamp vault delete ${TOKEN_SECRETS_VAULT_NAME} oauth-client-id`,
         );
       }
     }
@@ -1671,20 +1717,100 @@ export const serveCommand = new Command()
     // each process gets a unique ID that survives across reconnects.
     const instanceId = detachRuns ? crypto.randomUUID() : undefined;
 
-    // Probe the sync service for control-plane capability and create a
-    // control-plane store. Falls back to a filesystem-based store when the
-    // datastore extension doesn't advertise controlPlane.
-    let controlPlaneStore: ControlPlaneStore | undefined;
-    if (detachRuns) {
-      const caps = syncService?.capabilities?.();
-      if (caps?.controlPlane && syncService?.controlPlaneStore) {
-        controlPlaneStore = syncService.controlPlaneStore();
-        logger.info("Control-plane store: remote datastore");
-      } else {
-        controlPlaneStore = new FileSystemControlPlaneStore(
-          swampPath(resolvedRepoDir),
-        );
-        logger.info("Control-plane store: local filesystem fallback");
+    // Migrate existing vault-backed token secrets to the encrypted
+    // control-plane store. Runs before auth middleware accepts tokens.
+    if (authConfig.mode === "oauth") {
+      const { migrateTokenSecrets } = await import(
+        "../../serve/token_secret_migration.ts"
+      );
+      const { createResourceWriter } = await import(
+        "../../domain/models/data_writer.ts"
+      );
+      const migrationVaultService = await VaultService.fromRepository(
+        resolvedRepoDir,
+        { defaultVaultName: repoMarker?.defaultVault },
+      );
+      await migrateTokenSecrets({
+        tokenSecretsVaultName: TOKEN_SECRETS_VAULT_NAME,
+        vaultService: migrationVaultService,
+        dataQueryService: repoContext.dataQueryService,
+        updateTokenVaultName: async (tokenName, newVaultName, currentAttrs) => {
+          const def = await repoContext.definitionRepo.findByName(
+            SERVER_TOKEN_MODEL_TYPE,
+            tokenName,
+          );
+          if (!def) return;
+          const updated = {
+            ...currentAttrs,
+            vaultName: newVaultName,
+          };
+          const { writeResource } = createResourceWriter(
+            repoContext.unifiedDataRepo,
+            SERVER_TOKEN_MODEL_TYPE,
+            def.id,
+            serverTokenModel.resources!,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            tokenName,
+          );
+          await writeResource(
+            "token",
+            "token-main",
+            updated as Record<string, unknown>,
+          );
+        },
+      });
+
+      // Migrate OAuth bootstrap secrets from the user's vault to
+      // _token-secrets. These are fixed-name keys that were previously
+      // stored in the user's vault during first-time OAuth setup.
+      const {
+        OAUTH_CLIENT_ID_KEY,
+        OAUTH_CLIENT_SECRET_KEY,
+        OAUTH_BOOTSTRAP_ACCESS_TOKEN_KEY,
+        OAUTH_RESOLVED_ADMINS_KEY,
+      } = await import("../../serve/oauth_registration.ts");
+      const userVaultForMigration =
+        migrationVaultService.getDefaultVaultName() ??
+          migrationVaultService.getVaultNames().find((n) =>
+            n !== TOKEN_SECRETS_VAULT_NAME
+          );
+      if (userVaultForMigration) {
+        for (
+          const key of [
+            OAUTH_CLIENT_ID_KEY,
+            OAUTH_CLIENT_SECRET_KEY,
+            OAUTH_BOOTSTRAP_ACCESS_TOKEN_KEY,
+            OAUTH_RESOLVED_ADMINS_KEY,
+          ]
+        ) {
+          try {
+            const existing = await migrationVaultService.get(
+              TOKEN_SECRETS_VAULT_NAME,
+              key,
+              "serve:oauth-migration",
+            );
+            if (existing) continue;
+          } catch { /* not in _token-secrets yet */ }
+          try {
+            const value = await migrationVaultService.get(
+              userVaultForMigration,
+              key,
+              "serve:oauth-migration",
+            );
+            await migrationVaultService.put(
+              TOKEN_SECRETS_VAULT_NAME,
+              key,
+              value,
+            );
+            logger.info(
+              "Migrated OAuth secret {key} from vault to control-plane store",
+              { key },
+            );
+          } catch { /* key doesn't exist in old vault — skip */ }
+        }
       }
     }
 
@@ -1950,13 +2076,10 @@ export const serveCommand = new Command()
         resolvedRepoDir,
         { defaultVaultName: repoMarker?.defaultVault },
       );
-      const vaultNames = vaultService.getVaultNames();
-      if (vaultNames.length === 0) {
-        throw new UserError(
-          "group refresh requires a vault — run 'swamp vault create local_encryption default' first",
+      const userVaultName = vaultService.getDefaultVaultName() ??
+        vaultService.getVaultNames().find((n) =>
+          n !== TOKEN_SECRETS_VAULT_NAME
         );
-      }
-      const vaultName = vaultService.getDefaultVaultName() ?? vaultNames[0];
 
       const {
         CollectiveRefreshService,
@@ -1997,11 +2120,22 @@ export const serveCommand = new Command()
         getAccessToken: async (tokenName) => {
           try {
             return await vaultService.get(
-              vaultName,
+              TOKEN_SECRETS_VAULT_NAME,
               oauthAccessTokenKey(tokenName),
               "serve:group-refresh",
             );
           } catch {
+            if (userVaultName) {
+              try {
+                return await vaultService.get(
+                  userVaultName,
+                  oauthAccessTokenKey(tokenName),
+                  "serve:group-refresh",
+                );
+              } catch {
+                return null;
+              }
+            }
             return null;
           }
         },

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1341,7 +1341,9 @@ export const serveCommand = new Command()
         { defaultVaultName: repoMarker?.defaultVault },
       );
       const userVaultName = oauthVaultService.getDefaultVaultName() ??
-        oauthVaultService.getVaultNames()[0];
+        oauthVaultService.getVaultNames().find((n) =>
+          n !== TOKEN_SECRETS_VAULT_NAME
+        );
       let credentials;
       try {
         credentials = await resolveOAuthClientCredentials(
@@ -1591,8 +1593,7 @@ export const serveCommand = new Command()
       } else {
         throw new UserError(
           "Cannot resolve usernames — no access token and no cached resolutions. " +
-            "Clear stored credentials to re-register: " +
-            `swamp vault delete ${TOKEN_SECRETS_VAULT_NAME} oauth-client-id`,
+            "Restart serve without --oauth-client-id to re-register",
         );
       }
     }
@@ -1805,6 +1806,13 @@ export const serveCommand = new Command()
               key,
               value,
             );
+            if (
+              typeof migrationVaultService.supportsDelete === "function" &&
+              migrationVaultService.supportsDelete(userVaultForMigration)
+            ) {
+              await migrationVaultService.delete(userVaultForMigration, key)
+                .catch(() => {});
+            }
             logger.info(
               "Migrated OAuth secret {key} from vault to control-plane store",
               { key },

--- a/src/domain/crypto/aes_gcm.ts
+++ b/src/domain/crypto/aes_gcm.ts
@@ -1,0 +1,101 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export interface EncryptedBlob {
+  iv: string;
+  data: string;
+  version: number;
+}
+
+export async function aesGcmEncrypt(
+  plaintext: string,
+  key: CryptoKey,
+): Promise<EncryptedBlob> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const encoded = new TextEncoder().encode(plaintext);
+
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    encoded,
+  );
+
+  return {
+    iv: arrayBufferToBase64(iv),
+    data: arrayBufferToBase64(ciphertext),
+    version: 1,
+  };
+}
+
+export async function aesGcmDecrypt(
+  blob: EncryptedBlob,
+  key: CryptoKey,
+): Promise<string> {
+  const iv = base64ToArrayBuffer(blob.iv);
+  const data = base64ToArrayBuffer(blob.data);
+
+  const decrypted = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv },
+    key,
+    data,
+  );
+
+  return new TextDecoder().decode(decrypted);
+}
+
+export async function generateAesKey(): Promise<CryptoKey> {
+  return await crypto.subtle.generateKey(
+    { name: "AES-GCM", length: 256 },
+    true,
+    ["encrypt", "decrypt"],
+  );
+}
+
+export async function exportAesKey(key: CryptoKey): Promise<Uint8Array> {
+  const raw = await crypto.subtle.exportKey("raw", key);
+  return new Uint8Array(raw);
+}
+
+export async function importAesKey(raw: Uint8Array): Promise<CryptoKey> {
+  return await crypto.subtle.importKey(
+    "raw",
+    raw.buffer as ArrayBuffer,
+    { name: "AES-GCM", length: 256 },
+    true,
+    ["encrypt", "decrypt"],
+  );
+}
+
+export function arrayBufferToBase64(buffer: ArrayBuffer | Uint8Array): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+export function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}

--- a/src/domain/crypto/aes_gcm.ts
+++ b/src/domain/crypto/aes_gcm.ts
@@ -75,7 +75,10 @@ export async function exportAesKey(key: CryptoKey): Promise<Uint8Array> {
 export async function importAesKey(raw: Uint8Array): Promise<CryptoKey> {
   return await crypto.subtle.importKey(
     "raw",
-    raw.buffer as ArrayBuffer,
+    raw.buffer.slice(
+      raw.byteOffset,
+      raw.byteOffset + raw.byteLength,
+    ) as ArrayBuffer,
     { name: "AES-GCM", length: 256 },
     true,
     ["encrypt", "decrypt"],

--- a/src/domain/crypto/aes_gcm_test.ts
+++ b/src/domain/crypto/aes_gcm_test.ts
@@ -1,0 +1,109 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertNotEquals } from "@std/assert";
+import {
+  aesGcmDecrypt,
+  aesGcmEncrypt,
+  arrayBufferToBase64,
+  base64ToArrayBuffer,
+  exportAesKey,
+  generateAesKey,
+  importAesKey,
+} from "./aes_gcm.ts";
+
+Deno.test("aesGcmEncrypt: round-trips plaintext through encrypt and decrypt", async () => {
+  const key = await generateAesKey();
+  const plaintext = "hello world secret value";
+
+  const blob = await aesGcmEncrypt(plaintext, key);
+  const decrypted = await aesGcmDecrypt(blob, key);
+
+  assertEquals(decrypted, plaintext);
+});
+
+Deno.test("aesGcmEncrypt: produces distinct IVs per call", async () => {
+  const key = await generateAesKey();
+  const plaintext = "same value";
+
+  const blob1 = await aesGcmEncrypt(plaintext, key);
+  const blob2 = await aesGcmEncrypt(plaintext, key);
+
+  assertNotEquals(blob1.iv, blob2.iv);
+});
+
+Deno.test("aesGcmEncrypt: produces distinct ciphertext per call", async () => {
+  const key = await generateAesKey();
+  const plaintext = "same value";
+
+  const blob1 = await aesGcmEncrypt(plaintext, key);
+  const blob2 = await aesGcmEncrypt(plaintext, key);
+
+  assertNotEquals(blob1.data, blob2.data);
+});
+
+Deno.test("aesGcmDecrypt: fails with wrong key", async () => {
+  const key1 = await generateAesKey();
+  const key2 = await generateAesKey();
+  const plaintext = "secret";
+
+  const blob = await aesGcmEncrypt(plaintext, key1);
+
+  let threw = false;
+  try {
+    await aesGcmDecrypt(blob, key2);
+  } catch {
+    threw = true;
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("aesGcmEncrypt: handles empty string", async () => {
+  const key = await generateAesKey();
+  const blob = await aesGcmEncrypt("", key);
+  const decrypted = await aesGcmDecrypt(blob, key);
+  assertEquals(decrypted, "");
+});
+
+Deno.test("aesGcmEncrypt: handles unicode content", async () => {
+  const key = await generateAesKey();
+  const plaintext = "hello \u{1F30D} wörld \u{1F389}";
+  const blob = await aesGcmEncrypt(plaintext, key);
+  const decrypted = await aesGcmDecrypt(blob, key);
+  assertEquals(decrypted, plaintext);
+});
+
+Deno.test("generateAesKey: exports and re-imports a key that still works", async () => {
+  const original = await generateAesKey();
+  const exported = await exportAesKey(original);
+  assertEquals(exported.byteLength, 32);
+
+  const reimported = await importAesKey(exported);
+  const plaintext = "round-trip through export/import";
+  const blob = await aesGcmEncrypt(plaintext, original);
+  const decrypted = await aesGcmDecrypt(blob, reimported);
+  assertEquals(decrypted, plaintext);
+});
+
+Deno.test("arrayBufferToBase64: round-trips through base64ToArrayBuffer", () => {
+  const original = new Uint8Array([0, 1, 2, 127, 128, 255]);
+  const b64 = arrayBufferToBase64(original);
+  const restored = new Uint8Array(base64ToArrayBuffer(b64));
+  assertEquals(restored, original);
+});

--- a/src/domain/vaults/control_plane_vault_provider.ts
+++ b/src/domain/vaults/control_plane_vault_provider.ts
@@ -1,0 +1,146 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ControlPlaneStore } from "../datastore/control_plane_store.ts";
+import type { VaultDeleteProvider, VaultProvider } from "./vault_provider.ts";
+import {
+  aesGcmDecrypt,
+  aesGcmEncrypt,
+  type EncryptedBlob,
+  exportAesKey,
+  generateAesKey,
+  importAesKey,
+} from "../crypto/aes_gcm.ts";
+import { getLogger } from "@logtape/logtape";
+
+const logger = getLogger(["vaults", "control-plane"]);
+
+export const TOKEN_SECRETS_VAULT_NAME = "_token-secrets";
+
+const ENCRYPTION_KEY_PATH = "token-secrets/encryption-key";
+const SECRET_PREFIX = "token-secrets/values/";
+
+export class ControlPlaneVaultProvider
+  implements VaultProvider, VaultDeleteProvider {
+  readonly #store: ControlPlaneStore;
+  #key: CryptoKey | undefined;
+
+  constructor(store: ControlPlaneStore) {
+    this.#store = store;
+  }
+
+  async initialize(): Promise<void> {
+    this.#key = await this.#bootstrapKey();
+  }
+
+  getName(): string {
+    return TOKEN_SECRETS_VAULT_NAME;
+  }
+
+  async get(secretKey: string): Promise<string> {
+    const key = this.#requireKey();
+    const data = await this.#store.get(`${SECRET_PREFIX}${secretKey}`);
+    if (data === null) {
+      throw new Error(
+        `Secret '${secretKey}' not found in ${TOKEN_SECRETS_VAULT_NAME}`,
+      );
+    }
+    const blob: EncryptedBlob = JSON.parse(new TextDecoder().decode(data));
+    return await aesGcmDecrypt(blob, key);
+  }
+
+  async put(secretKey: string, secretValue: string): Promise<void> {
+    const key = this.#requireKey();
+    const blob = await aesGcmEncrypt(secretValue, key);
+    const encoded = new TextEncoder().encode(JSON.stringify(blob));
+    await this.#store.put(`${SECRET_PREFIX}${secretKey}`, encoded);
+  }
+
+  async delete(secretKey: string): Promise<void> {
+    await this.#store.delete(`${SECRET_PREFIX}${secretKey}`);
+  }
+
+  async list(): Promise<string[]> {
+    const keys = await this.#store.list(SECRET_PREFIX);
+    return keys.map((k) => k.slice(SECRET_PREFIX.length));
+  }
+
+  #requireKey(): CryptoKey {
+    if (!this.#key) {
+      throw new Error(
+        "ControlPlaneVaultProvider not initialized — call initialize() first",
+      );
+    }
+    return this.#key;
+  }
+
+  async #bootstrapKey(): Promise<CryptoKey> {
+    const existing = await this.#store.get(ENCRYPTION_KEY_PATH);
+    if (existing) {
+      logger.debug`Loaded existing token encryption key`;
+      return await importAesKey(new Uint8Array(existing));
+    }
+
+    const newKey = await generateAesKey();
+    const exported = await exportAesKey(newKey);
+
+    if (this.#store.putIfAbsent) {
+      const won = await this.#store.putIfAbsent(ENCRYPTION_KEY_PATH, exported);
+      if (won) {
+        logger.info`Generated new token encryption key`;
+        return newKey;
+      }
+      const theirs = await this.#store.get(ENCRYPTION_KEY_PATH);
+      if (!theirs) {
+        throw new Error(
+          "Token encryption key disappeared after putIfAbsent race",
+        );
+      }
+      logger.debug`Using token encryption key from another instance`;
+      return await importAesKey(new Uint8Array(theirs));
+    }
+
+    await this.#store.put(ENCRYPTION_KEY_PATH, exported);
+    const readBack = await this.#store.get(ENCRYPTION_KEY_PATH);
+    if (!readBack) {
+      throw new Error("Token encryption key missing after write");
+    }
+    const readBackBytes = new Uint8Array(readBack);
+    if (readBackBytes.length !== exported.length) {
+      logger
+        .warn`Token encryption key was overwritten by another instance, using theirs`;
+      return await importAesKey(readBackBytes);
+    }
+    let same = true;
+    for (let i = 0; i < exported.length; i++) {
+      if (readBackBytes[i] !== exported[i]) {
+        same = false;
+        break;
+      }
+    }
+    if (!same) {
+      logger
+        .warn`Token encryption key was overwritten by another instance, using theirs`;
+      return await importAesKey(readBackBytes);
+    }
+
+    logger.info`Generated new token encryption key (no putIfAbsent support)`;
+    return newKey;
+  }
+}

--- a/src/domain/vaults/control_plane_vault_provider.ts
+++ b/src/domain/vaults/control_plane_vault_provider.ts
@@ -116,6 +116,9 @@ export class ControlPlaneVaultProvider
       return await importAesKey(new Uint8Array(theirs));
     }
 
+    // Fallback for stores without putIfAbsent. Safe for single-instance
+    // deployments. Multi-instance deployments MUST use a store that
+    // implements putIfAbsent (FileSystemControlPlaneStore and S3 both do).
     await this.#store.put(ENCRYPTION_KEY_PATH, exported);
     const readBack = await this.#store.get(ENCRYPTION_KEY_PATH);
     if (!readBack) {

--- a/src/domain/vaults/control_plane_vault_provider_test.ts
+++ b/src/domain/vaults/control_plane_vault_provider_test.ts
@@ -1,0 +1,142 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import type { ControlPlaneStore } from "../datastore/control_plane_store.ts";
+import {
+  ControlPlaneVaultProvider,
+  TOKEN_SECRETS_VAULT_NAME,
+} from "./control_plane_vault_provider.ts";
+
+await initializeLogging({});
+
+function createMockStore(): ControlPlaneStore {
+  const data = new Map<string, Uint8Array>();
+  return {
+    put(key: string, value: Uint8Array): Promise<void> {
+      data.set(key, new Uint8Array(value));
+      return Promise.resolve();
+    },
+    putIfAbsent(key: string, value: Uint8Array): Promise<boolean> {
+      if (data.has(key)) return Promise.resolve(false);
+      data.set(key, new Uint8Array(value));
+      return Promise.resolve(true);
+    },
+    get(key: string): Promise<Uint8Array | null> {
+      return Promise.resolve(data.get(key) ?? null);
+    },
+    delete(key: string): Promise<void> {
+      data.delete(key);
+      return Promise.resolve();
+    },
+    list(prefix: string): Promise<string[]> {
+      return Promise.resolve(
+        [...data.keys()].filter((k) => k.startsWith(prefix)),
+      );
+    },
+  };
+}
+
+Deno.test("ControlPlaneVaultProvider: getName returns the vault name constant", async () => {
+  const provider = new ControlPlaneVaultProvider(createMockStore());
+  await provider.initialize();
+  assertEquals(provider.getName(), TOKEN_SECRETS_VAULT_NAME);
+});
+
+Deno.test("ControlPlaneVaultProvider: round-trips a secret through put and get", async () => {
+  const provider = new ControlPlaneVaultProvider(createMockStore());
+  await provider.initialize();
+
+  await provider.put("my-key", "my-secret");
+  const result = await provider.get("my-key");
+  assertEquals(result, "my-secret");
+});
+
+Deno.test("ControlPlaneVaultProvider: get throws for missing secret", async () => {
+  const provider = new ControlPlaneVaultProvider(createMockStore());
+  await provider.initialize();
+
+  await assertRejects(
+    () => provider.get("nonexistent"),
+    Error,
+    "not found",
+  );
+});
+
+Deno.test("ControlPlaneVaultProvider: delete removes a secret", async () => {
+  const provider = new ControlPlaneVaultProvider(createMockStore());
+  await provider.initialize();
+
+  await provider.put("to-delete", "value");
+  assertEquals(await provider.get("to-delete"), "value");
+
+  await provider.delete("to-delete");
+  await assertRejects(() => provider.get("to-delete"), Error, "not found");
+});
+
+Deno.test("ControlPlaneVaultProvider: list returns stored keys", async () => {
+  const provider = new ControlPlaneVaultProvider(createMockStore());
+  await provider.initialize();
+
+  await provider.put("key-a", "val-a");
+  await provider.put("key-b", "val-b");
+
+  const keys = await provider.list();
+  assertEquals(keys.sort(), ["key-a", "key-b"]);
+});
+
+Deno.test("ControlPlaneVaultProvider: two instances share the same encryption key", async () => {
+  const store = createMockStore();
+
+  const p1 = new ControlPlaneVaultProvider(store);
+  await p1.initialize();
+
+  const p2 = new ControlPlaneVaultProvider(store);
+  await p2.initialize();
+
+  await p1.put("shared-key", "shared-secret");
+  assertEquals(await p2.get("shared-key"), "shared-secret");
+});
+
+Deno.test("ControlPlaneVaultProvider: throws if not initialized", async () => {
+  const provider = new ControlPlaneVaultProvider(createMockStore());
+
+  await assertRejects(
+    () => provider.get("any-key"),
+    Error,
+    "not initialized",
+  );
+});
+
+Deno.test("ControlPlaneVaultProvider: works without putIfAbsent", async () => {
+  const store = createMockStore();
+  const storeWithoutPIA: ControlPlaneStore = {
+    put: store.put.bind(store),
+    get: store.get.bind(store),
+    delete: store.delete.bind(store),
+    list: store.list.bind(store),
+  };
+
+  const provider = new ControlPlaneVaultProvider(storeWithoutPIA);
+  await provider.initialize();
+
+  await provider.put("key", "value");
+  assertEquals(await provider.get("key"), "value");
+});

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -70,10 +70,6 @@ export class VaultService {
     VaultService.#globalProviders.set(name, { type, provider });
   }
 
-  static clearGlobalProviders(): void {
-    VaultService.#globalProviders.clear();
-  }
-
   private readonly providers = new Map<string, VaultProvider>();
   private readonly vaultTypes = new Map<string, string>();
   private readonly auditFlags = new Map<string, boolean>();
@@ -214,18 +210,6 @@ export class VaultService {
     if (config.auditReads) {
       this.auditFlags.set(config.name, true);
     }
-  }
-
-  /**
-   * Registers a pre-built vault provider instance directly.
-   */
-  registerProvider(
-    name: string,
-    type: string,
-    provider: VaultProvider,
-  ): void {
-    this.providers.set(name, provider);
-    this.vaultTypes.set(name, type);
   }
 
   /**

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -57,6 +57,23 @@ export interface VaultRefreshOptions {
  * Service for managing vault providers and resolving vault operations.
  */
 export class VaultService {
+  static readonly #globalProviders = new Map<
+    string,
+    { type: string; provider: VaultProvider }
+  >();
+
+  static registerGlobalProvider(
+    name: string,
+    type: string,
+    provider: VaultProvider,
+  ): void {
+    VaultService.#globalProviders.set(name, { type, provider });
+  }
+
+  static clearGlobalProviders(): void {
+    VaultService.#globalProviders.clear();
+  }
+
   private readonly providers = new Map<string, VaultProvider>();
   private readonly vaultTypes = new Map<string, string>();
   private readonly auditFlags = new Map<string, boolean>();
@@ -161,6 +178,12 @@ export class VaultService {
         }
       }
     }
+    for (const [name, { type, provider }] of VaultService.#globalProviders) {
+      if (!vaultService.providers.has(name)) {
+        vaultService.providers.set(name, provider);
+        vaultService.vaultTypes.set(name, type);
+      }
+    }
     vaultService.ensureDefaultVaults();
     if (vaultService.hasAnyAuditEnabled()) {
       vaultService.setAuditRepository(
@@ -191,6 +214,18 @@ export class VaultService {
     if (config.auditReads) {
       this.auditFlags.set(config.name, true);
     }
+  }
+
+  /**
+   * Registers a pre-built vault provider instance directly.
+   */
+  registerProvider(
+    name: string,
+    type: string,
+    provider: VaultProvider,
+  ): void {
+    this.providers.set(name, provider);
+    this.vaultTypes.set(name, type);
   }
 
   /**

--- a/src/serve/collective_refresh_service_test.ts
+++ b/src/serve/collective_refresh_service_test.ts
@@ -268,3 +268,60 @@ Deno.test("CollectiveRefreshService: keeps collectives and groups separate", asy
   assertEquals(storedCollectives, ["coll-a", "coll-b"]);
   assertEquals(storedGroups, ["group-x", "group-y"]);
 });
+
+Deno.test("CollectiveRefreshService: works with fallback getAccessToken (simulates _token-secrets → user vault fallback)", async () => {
+  let accessTokenCalls = 0;
+  const deps = makeMockDeps({
+    listActiveTokens: () =>
+      Promise.resolve([
+        {
+          name: "tok-migrated",
+          principalId: "user:u1",
+          collectives: ["old"],
+          groups: [],
+        },
+      ]),
+    getAccessToken: (_tokenName: string): Promise<string | null> => {
+      accessTokenCalls++;
+      return Promise.resolve("fallback-access-token");
+    },
+    getUserInfo: () =>
+      Promise.resolve({
+        sub: "u1",
+        email: "u1@example.com",
+        collectives: ["new"],
+        groups: [],
+      }),
+  });
+
+  const svc = new CollectiveRefreshService(deps);
+  svc.start();
+  await new Promise((r) => setTimeout(r, 200));
+  await svc.dispose();
+
+  assertEquals(accessTokenCalls, 1);
+  assertEquals(deps.updatedTokens.get("tok-migrated"), ["new"]);
+});
+
+Deno.test("CollectiveRefreshService: skips token when getAccessToken returns null", async () => {
+  const deps = makeMockDeps({
+    listActiveTokens: () =>
+      Promise.resolve([
+        {
+          name: "tok-no-access",
+          principalId: "user:u1",
+          collectives: ["existing"],
+          groups: [],
+        },
+      ]),
+    getAccessToken: (): Promise<string | null> => Promise.resolve(null),
+  });
+
+  const svc = new CollectiveRefreshService(deps);
+  svc.start();
+  await new Promise((r) => setTimeout(r, 200));
+  await svc.dispose();
+
+  assertEquals(deps.updatedTokens.size, 0);
+  assertEquals(deps.revokedTokens.length, 0);
+});

--- a/src/serve/device_auth_handler.ts
+++ b/src/serve/device_auth_handler.ts
@@ -40,6 +40,7 @@ import {
 } from "../domain/models/access/server_token_model.ts";
 import { createResourceWriter } from "../domain/models/data_writer.ts";
 import { VaultService } from "../domain/vaults/vault_service.ts";
+import { TOKEN_SECRETS_VAULT_NAME } from "../domain/vaults/control_plane_vault_provider.ts";
 
 const logger = getSwampLogger(["serve", "device-auth"]);
 
@@ -300,14 +301,7 @@ async function mintServerTokenImpl(
     repoDir,
     { defaultVaultName: defaultVault },
   );
-  const vaultNames = vaultService.getVaultNames();
-  if (vaultNames.length === 0) {
-    throw new Error(
-      "No vaults configured — create one with: swamp vault create local_encryption default",
-    );
-  }
-  const vaultName = vaultService.getDefaultVaultName() ?? vaultNames[0];
-
+  const vaultName = TOKEN_SECRETS_VAULT_NAME;
   await vaultService.put(vaultName, secretKey, plaintext);
 
   const defRepo = repoContext.definitionRepo;
@@ -401,10 +395,8 @@ export function createDeviceAuthDeps(
         repoDir,
         { defaultVaultName: defaultVault },
       );
-      const vaultNames = vaultService.getVaultNames();
-      if (vaultNames.length === 0) return;
       await vaultService.put(
-        vaultService.getDefaultVaultName() ?? vaultNames[0],
+        TOKEN_SECRETS_VAULT_NAME,
         oauthAccessTokenKey(tokenName),
         accessToken,
       );

--- a/src/serve/token_secret_migration.ts
+++ b/src/serve/token_secret_migration.ts
@@ -1,0 +1,140 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+import type { VaultService } from "../domain/vaults/vault_service.ts";
+import type { DataQueryService } from "../domain/data/data_query_service.ts";
+import {
+  SERVER_TOKEN_MODEL_TYPE,
+  ServerTokenSchema,
+  serverTokenSecretKey,
+} from "../domain/models/access/server_token_model.ts";
+import { TOKEN_SECRETS_VAULT_NAME } from "../domain/vaults/control_plane_vault_provider.ts";
+
+const logger = getSwampLogger(["serve", "token-migration"]);
+
+export interface TokenSecretMigrationDeps {
+  tokenSecretsVaultName: string;
+  vaultService: VaultService;
+  dataQueryService: DataQueryService;
+  updateTokenVaultName: (
+    tokenName: string,
+    newVaultName: string,
+    currentAttrs: Record<string, unknown>,
+  ) => Promise<void>;
+}
+
+export async function migrateTokenSecrets(
+  deps: TokenSecretMigrationDeps,
+): Promise<{ migrated: number; skipped: number; failed: number }> {
+  const records = await deps.dataQueryService.query(
+    `modelType == "${SERVER_TOKEN_MODEL_TYPE.normalized}" && name == "token-main"`,
+    { loadAttributes: true },
+  );
+
+  let migrated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const record of records) {
+    const rawAttrs = (record as { attributes?: Record<string, unknown> })
+      .attributes;
+    if (!rawAttrs) continue;
+    const parsed = ServerTokenSchema.safeParse(rawAttrs);
+    if (!parsed.success) continue;
+
+    const token = parsed.data;
+    if (token.vaultName === TOKEN_SECRETS_VAULT_NAME) {
+      skipped++;
+      continue;
+    }
+
+    try {
+      const secretKey = serverTokenSecretKey(token.name);
+      const oauthKey = `oauth-access-token-${token.name}`;
+
+      let serverSecret: string;
+      try {
+        serverSecret = await deps.vaultService.get(
+          token.vaultName,
+          token.secretKey,
+          "serve:token-migration",
+        );
+      } catch {
+        logger
+          .warn`Token secret missing from vault for ${token.name}, skipping`;
+        skipped++;
+        continue;
+      }
+
+      await deps.vaultService.put(
+        deps.tokenSecretsVaultName,
+        secretKey,
+        serverSecret,
+      );
+
+      try {
+        const oauthSecret = await deps.vaultService.get(
+          token.vaultName,
+          oauthKey,
+          "serve:token-migration",
+        );
+        await deps.vaultService.put(
+          deps.tokenSecretsVaultName,
+          oauthKey,
+          oauthSecret,
+        );
+      } catch {
+        logger
+          .debug`OAuth access token not found for ${token.name}, skipping OAuth key migration`;
+      }
+
+      await deps.updateTokenVaultName(
+        token.name,
+        deps.tokenSecretsVaultName,
+        rawAttrs,
+      );
+
+      if (
+        typeof deps.vaultService.supportsDelete === "function" &&
+        deps.vaultService.supportsDelete(token.vaultName)
+      ) {
+        await deps.vaultService.delete(token.vaultName, token.secretKey)
+          .catch(() => {});
+        await deps.vaultService.delete(token.vaultName, oauthKey)
+          .catch(() => {});
+      }
+
+      migrated++;
+      logger.info`Migrated token secrets for ${token.name}`;
+    } catch (err) {
+      failed++;
+      logger.warn`Failed to migrate token ${token.name}: ${
+        err instanceof Error ? err.message : String(err)
+      }`;
+    }
+  }
+
+  if (migrated > 0 || failed > 0) {
+    logger
+      .info`Token secret migration complete: ${migrated} migrated, ${skipped} skipped, ${failed} failed`;
+  }
+
+  return { migrated, skipped, failed };
+}

--- a/src/serve/token_secret_migration_test.ts
+++ b/src/serve/token_secret_migration_test.ts
@@ -1,0 +1,270 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../infrastructure/logging/logger.ts";
+import type { TokenSecretMigrationDeps } from "./token_secret_migration.ts";
+import { migrateTokenSecrets } from "./token_secret_migration.ts";
+import { TOKEN_SECRETS_VAULT_NAME } from "../domain/vaults/control_plane_vault_provider.ts";
+
+await initializeLogging({});
+
+function createMockVault(): {
+  secrets: Map<string, Map<string, string>>;
+  vaultService: TokenSecretMigrationDeps["vaultService"];
+} {
+  const secrets = new Map<string, Map<string, string>>();
+  return {
+    secrets,
+    vaultService: {
+      get(
+        vaultName: string,
+        key: string,
+        _caller?: string,
+      ): Promise<string> {
+        const vault = secrets.get(vaultName);
+        if (!vault || !vault.has(key)) {
+          return Promise.reject(
+            new Error(`Secret '${key}' not found in vault '${vaultName}'`),
+          );
+        }
+        return Promise.resolve(vault.get(key)!);
+      },
+      put(vaultName: string, key: string, value: string): Promise<void> {
+        if (!secrets.has(vaultName)) secrets.set(vaultName, new Map());
+        secrets.get(vaultName)!.set(key, value);
+        return Promise.resolve();
+      },
+      supportsDelete(_vaultName: string): boolean {
+        return true;
+      },
+      delete(vaultName: string, key: string): Promise<void> {
+        secrets.get(vaultName)?.delete(key);
+        return Promise.resolve();
+      },
+    } as TokenSecretMigrationDeps["vaultService"],
+  };
+}
+
+function createMockDataQuery(
+  records: Record<string, unknown>[],
+): TokenSecretMigrationDeps["dataQueryService"] {
+  return {
+    query(
+      _predicate: string,
+      _options?: Record<string, unknown>,
+    ): Promise<unknown[]> {
+      return Promise.resolve(records);
+    },
+  } as TokenSecretMigrationDeps["dataQueryService"];
+}
+
+Deno.test("migrateTokenSecrets: migrates a vault-backed token to _token-secrets", async () => {
+  const { secrets, vaultService } = createMockVault();
+  secrets.set(
+    "user-vault",
+    new Map([
+      ["server-token-oauth-abc", "secret-value"],
+      ["oauth-access-token-oauth-abc", "oauth-token-value"],
+    ]),
+  );
+
+  const records = [{
+    attributes: {
+      name: "oauth-abc",
+      state: "active",
+      vaultName: "user-vault",
+      secretKey: "server-token-oauth-abc",
+      principalId: "user:123",
+      principalEmail: "u@example.com",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2026-02-01T00:00:00.000Z",
+    },
+  }];
+
+  const updatedRecords: { name: string; vault: string }[] = [];
+
+  const result = await migrateTokenSecrets({
+    tokenSecretsVaultName: TOKEN_SECRETS_VAULT_NAME,
+    vaultService,
+    dataQueryService: createMockDataQuery(records),
+    updateTokenVaultName: (name, vault, _attrs) => {
+      updatedRecords.push({ name, vault });
+      return Promise.resolve();
+    },
+  });
+
+  assertEquals(result.migrated, 1);
+  assertEquals(result.skipped, 0);
+  assertEquals(result.failed, 0);
+
+  assertEquals(
+    secrets.get(TOKEN_SECRETS_VAULT_NAME)?.get("server-token-oauth-abc"),
+    "secret-value",
+  );
+  assertEquals(
+    secrets.get(TOKEN_SECRETS_VAULT_NAME)?.get(
+      "oauth-access-token-oauth-abc",
+    ),
+    "oauth-token-value",
+  );
+
+  assertEquals(updatedRecords.length, 1);
+  assertEquals(updatedRecords[0].name, "oauth-abc");
+  assertEquals(updatedRecords[0].vault, TOKEN_SECRETS_VAULT_NAME);
+
+  assertEquals(secrets.get("user-vault")?.has("server-token-oauth-abc"), false);
+  assertEquals(
+    secrets.get("user-vault")?.has("oauth-access-token-oauth-abc"),
+    false,
+  );
+});
+
+Deno.test("migrateTokenSecrets: skips tokens already in _token-secrets", async () => {
+  const { vaultService } = createMockVault();
+  const records = [{
+    attributes: {
+      name: "oauth-abc",
+      state: "active",
+      vaultName: TOKEN_SECRETS_VAULT_NAME,
+      secretKey: "server-token-oauth-abc",
+      principalId: "user:123",
+      principalEmail: "u@example.com",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2026-02-01T00:00:00.000Z",
+    },
+  }];
+
+  const result = await migrateTokenSecrets({
+    tokenSecretsVaultName: TOKEN_SECRETS_VAULT_NAME,
+    vaultService,
+    dataQueryService: createMockDataQuery(records),
+    updateTokenVaultName: () => Promise.resolve(),
+  });
+
+  assertEquals(result.migrated, 0);
+  assertEquals(result.skipped, 1);
+});
+
+Deno.test("migrateTokenSecrets: skips token when vault secret is missing", async () => {
+  const { vaultService } = createMockVault();
+  const records = [{
+    attributes: {
+      name: "oauth-abc",
+      state: "active",
+      vaultName: "user-vault",
+      secretKey: "server-token-oauth-abc",
+      principalId: "user:123",
+      principalEmail: "u@example.com",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2026-02-01T00:00:00.000Z",
+    },
+  }];
+
+  const result = await migrateTokenSecrets({
+    tokenSecretsVaultName: TOKEN_SECRETS_VAULT_NAME,
+    vaultService,
+    dataQueryService: createMockDataQuery(records),
+    updateTokenVaultName: () => Promise.resolve(),
+  });
+
+  assertEquals(result.migrated, 0);
+  assertEquals(result.skipped, 1);
+});
+
+Deno.test("migrateTokenSecrets: migrates server token even when OAuth access token is missing", async () => {
+  const { secrets, vaultService } = createMockVault();
+  secrets.set(
+    "user-vault",
+    new Map([["server-token-oauth-abc", "secret-value"]]),
+  );
+
+  const records = [{
+    attributes: {
+      name: "oauth-abc",
+      state: "active",
+      vaultName: "user-vault",
+      secretKey: "server-token-oauth-abc",
+      principalId: "user:123",
+      principalEmail: "u@example.com",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2026-02-01T00:00:00.000Z",
+    },
+  }];
+
+  const result = await migrateTokenSecrets({
+    tokenSecretsVaultName: TOKEN_SECRETS_VAULT_NAME,
+    vaultService,
+    dataQueryService: createMockDataQuery(records),
+    updateTokenVaultName: () => Promise.resolve(),
+  });
+
+  assertEquals(result.migrated, 1);
+  assertEquals(
+    secrets.get(TOKEN_SECRETS_VAULT_NAME)?.get("server-token-oauth-abc"),
+    "secret-value",
+  );
+});
+
+Deno.test("migrateTokenSecrets: continues on per-token failure", async () => {
+  const { secrets, vaultService } = createMockVault();
+  secrets.set(
+    "user-vault",
+    new Map([
+      ["server-token-oauth-good", "good-secret"],
+    ]),
+  );
+
+  const records = [
+    {
+      attributes: {
+        name: "oauth-bad",
+        state: "active",
+        vaultName: "user-vault",
+        secretKey: "server-token-oauth-bad",
+        principalId: "user:123",
+        principalEmail: "u@example.com",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        expiresAt: "2026-02-01T00:00:00.000Z",
+      },
+    },
+    {
+      attributes: {
+        name: "oauth-good",
+        state: "active",
+        vaultName: "user-vault",
+        secretKey: "server-token-oauth-good",
+        principalId: "user:456",
+        principalEmail: "u2@example.com",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        expiresAt: "2026-02-01T00:00:00.000Z",
+      },
+    },
+  ];
+
+  const result = await migrateTokenSecrets({
+    tokenSecretsVaultName: TOKEN_SECRETS_VAULT_NAME,
+    vaultService,
+    dataQueryService: createMockDataQuery(records),
+    updateTokenVaultName: () => Promise.resolve(),
+  });
+
+  assertEquals(result.migrated, 1);
+  assertEquals(result.skipped, 1);
+});


### PR DESCRIPTION
## Summary

- Introduces `ControlPlaneVaultProvider` — an internal `VaultProvider` implementation that encrypts secrets with AES-256-GCM and stores them in the control-plane store (S3 for remote datastores, filesystem for local). Registered globally via `VaultService.registerGlobalProvider()` so every `VaultService.fromRepository()` call automatically includes it.
- New OAuth logins store both token secrets (`server-token-oauth-*`, `oauth-access-token-oauth-*`) and bootstrap credentials (`oauth-client-id`, `oauth-client-secret`, `oauth-bootstrap-access-token`, `oauth-resolved-admins`) in the `_token-secrets` vault instead of the user's configured vault.
- On serve startup, existing secrets are migrated from the user's vault to the control-plane store. Migration is idempotent, per-token crash-safe, and tolerates missing OAuth access tokens.
- Serve no longer requires a user vault for OAuth mode — a datastore alone is sufficient.

Fixes swamp-club#1511

## Test Plan

- 23 new unit tests: AES-256-GCM crypto (8), ControlPlaneVaultProvider (8), migration (5), collective refresh fallback (2)
- Full test suite: 9824 passed, 0 failed, 0 regressions (baseline: 9801)
- E2E verified with ministack (AWS SM + S3):
  - Old binary mints tokens in AWS SM → new binary migrates all 6 secrets → commands work through serve
  - Idempotent restart skips migration
  - New login goes straight to `_token-secrets`
  - Serve starts with no vault (datastore only)
  - Non-HA local filesystem serve works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8EJw9xUwpVxciP5sqERB3