### PR TITLE
fix(workflows): use parent workflow name in nested suspend/approve hints

### DIFF
--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -224,7 +224,9 @@ class ConsoleWorkflowRunRenderer implements WorkflowRunRenderer {
       validating_inputs: () => {},
       evaluating_workflow: () => {},
       started: (e) => {
-        this.workflowName = e.workflowName;
+        if (!this.pipe) {
+          this.workflowName = e.workflowName;
+        }
         const jobNames = [...e.jobs.map((j) => j.id), "system"];
         this.pipe = new PipeWriter(jobNames);
         setSystemPipeWidth(this.pipe.maxWidth);

--- a/src/presentation/renderers/workflow_run_test.ts
+++ b/src/presentation/renderers/workflow_run_test.ts
@@ -382,6 +382,72 @@ Deno.test("ConsoleWorkflowRunRenderer: suspended workflow shows step ID and appr
   assertStringIncludes(output, "swamp workflow resume test-pipeline");
 });
 
+Deno.test("ConsoleWorkflowRunRenderer: nested workflow started event does not corrupt parent name in suspend hints", async () => {
+  const renderer = createWorkflowRunRenderer("log", {
+    workflowName: "parent-workflow",
+  });
+  const events: WorkflowRunEvent[] = [
+    { kind: "validating_inputs" },
+    { kind: "evaluating_workflow" },
+    {
+      kind: "started",
+      runId: "run-1",
+      workflowName: "parent-workflow",
+      jobs: [
+        { id: "run-child", stepCount: 1, dependsOn: [] },
+        {
+          id: "gate-after-child",
+          stepCount: 1,
+          dependsOn: ["run-child"],
+        },
+      ],
+    },
+    { kind: "job_started", jobId: "run-child" },
+    {
+      kind: "started",
+      runId: "child-run-1",
+      workflowName: "child-workflow",
+      jobs: [{ id: "child-job", stepCount: 1, dependsOn: [] }],
+    },
+    {
+      kind: "completed",
+      run: makeRunView("succeeded"),
+    },
+    { kind: "job_started", jobId: "gate-after-child" },
+    {
+      kind: "approval_requested",
+      runId: "run-1",
+      jobId: "gate-after-child",
+      stepId: "approve-the-thing",
+      prompt: "PARENT gate",
+    },
+    {
+      kind: "suspended",
+      run: makeRunView("succeeded"),
+      jobId: "gate-after-child",
+      stepId: "approve-the-thing",
+      prompt: "PARENT gate",
+    },
+  ];
+  const lines = await captureOutputAsync(async () => {
+    await consumeStream(toStream(events), renderer.handlers());
+  });
+  const output = lines.join("\n");
+  assertStringIncludes(
+    output,
+    "swamp workflow approve parent-workflow approve-the-thing",
+  );
+  assertStringIncludes(
+    output,
+    "swamp workflow reject parent-workflow approve-the-thing",
+  );
+  assertStringIncludes(output, "swamp workflow resume parent-workflow");
+  assertStringIncludes(
+    output,
+    "awaiting approval on step approve-the-thing",
+  );
+});
+
 Deno.test("ConsoleWorkflowRunRenderer: cancelled run sets workflowFailed()", async () => {
   const renderer = createWorkflowRunRenderer("log", {
     workflowName: "test-pipeline",


### PR DESCRIPTION
## Summary

- When a parent workflow runs a child via a `type: workflow` step and then
  suspends at its own `manual_approval` gate, the suspend banner and
  approve/reject/resume hints incorrectly named the child workflow instead
  of the parent — producing unusable commands
- Guard the `workflowName` assignment in the renderer's `started` handler
  to only apply on the first event (the parent's), preventing child
  workflow names from overwriting it
- Add test covering the nested workflow scenario

Fixes swamp-club#1522

## Test Plan

- [x] Unit test: nested workflow `started` event does not corrupt parent
  name in suspend/approve/reject/resume hints
- [x] Reproduction: created scratch-parent/scratch-child workflows in
  `/tmp/swamp-repro-issue-1522`, verified all hints now reference
  `scratch-parent` instead of `scratch-child`
- [x] Existing suspend test still passes (single-workflow case)
- [x] Full test suite passes (`deno run test`)
- [x] Type check, lint, and format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)