### PR TITLE
fix(serve): address adversarial review feedback on token secrets migration (swamp-club#1511)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1801,7 +1801,11 @@ export const serveCommand = new Command()
             SERVER_TOKEN_MODEL_TYPE,
             tokenName,
           );
-          if (!def) return;
+          if (!def) {
+            throw new Error(
+              `Definition not found for token '${tokenName}' — skipping migration`,
+            );
+          }
           const updated = {
             ...currentAttrs,
             vaultName: newVaultName,

--- a/src/domain/crypto/aes_gcm.ts
+++ b/src/domain/crypto/aes_gcm.ts
@@ -47,6 +47,9 @@ export async function aesGcmDecrypt(
   blob: EncryptedBlob,
   key: CryptoKey,
 ): Promise<string> {
+  if (blob.version !== 1) {
+    throw new Error(`Unsupported EncryptedBlob version: ${blob.version}`);
+  }
   const iv = base64ToArrayBuffer(blob.iv);
   const data = base64ToArrayBuffer(blob.data);
 


### PR DESCRIPTION
## Summary

- Throw from `updateTokenVaultName` when definition is missing, so the migration outer `catch` counts it as `failed` and skips vault cleanup — prevents orphaning secrets when a token data record exists but its definition was deleted
- Add version check to `aesGcmDecrypt` for forward compatibility — rejects unknown blob versions with a clear error instead of silently attempting decryption

Follow-up to #2061.

## Test Plan

- Existing migration tests pass (21 tests)
- Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8EJw9xUwpVxciP5sqERB3