### PR TITLE
fix(extensions): replace raw version-drift check with registry-based comparison (swamp-club#1367)

### DIFF
--- a/.claude/skills/swamp/references/extension-publish/references/publishing.md
+++ b/.claude/skills/swamp/references/extension-publish/references/publishing.md
@@ -356,6 +356,32 @@ change invalidates the entry by construction. The cache is a pure optimization:
 a cache miss falls back to fresh packaging. The cache is never load-bearing for
 correctness and can be deleted safely at any time.
 
+## Version-Drift Check
+
+An advisory (non-blocking) check that runs during `swamp extension push` and
+`--dry-run`. It compares current model versions against the last-published
+version in the registry to catch a common mistake:
+
+- **Model version bumped, manifest not** — one or more model `version` fields
+  changed compared to the published version but the manifest `version` did not.
+  The manifest version must be bumped whenever a model version changes so the
+  registry reflects that a new release is available.
+
+The check fetches the last-published version's metadata from the registry. This
+works on any machine with registry credentials — no local state is required.
+
+When the extension has never been published (first publish), the check reports
+that it cannot verify version drift rather than silently skipping. This is
+informational, not an error.
+
+The version-drift check is **not** run during `swamp extension fmt` — it
+requires registry access that the fmt command does not use.
+
+Manifest and model versions are independent — a multi-model extension can have
+each model at a different version. The check never requires model versions to
+match the manifest version. It only checks directionality: if a model version
+moved, the manifest version must also move.
+
 ## Push Workflow
 
 > **Before you push:** Your extension directory must be an initialized swamp
@@ -409,9 +435,14 @@ swamp extension push manifest.yaml --repo-dir /path/to/repo --json
 9. **Bundle TypeScript** — compiles each entry point (models, vaults, drivers,
    datastores) to standalone JS. Include files are not bundled. If a `deno.json`
    is present, the import map governs dependency resolution.
-10. **Version check** — verifies version doesn't already exist (offers to bump)
-11. **Build archive** — creates tar.gz with all content types and their bundles
-12. **Upload** — three-phase push: initiate, upload archive, confirm
+10. **Version-drift check** — advisory check comparing current model versions
+    against the last-published version in the registry. Warns when a model
+    version was bumped but the manifest `version` was not. If the extension has
+    never been published, reports that the check could not run rather than
+    silently skipping. See "Version-Drift Check" below.
+11. **Version check** — verifies version doesn't already exist (offers to bump)
+12. **Build archive** — creates tar.gz with all content types and their bundles
+13. **Upload** — three-phase push: initiate, upload archive, confirm
 
 ## Extension Formatting
 

--- a/src/cli/commands/extension_fmt.ts
+++ b/src/cli/commands/extension_fmt.ts
@@ -37,7 +37,6 @@ import {
   resolveExtensionFiles,
 } from "../resolve_extension_files.ts";
 import { UserError } from "../../domain/errors.ts";
-import { checkVersionConsistency } from "../../domain/extensions/extension_quality_checker.ts";
 
 interface ExtensionFmtOptions extends GlobalOptions {
   repoDir?: string;
@@ -85,7 +84,6 @@ export const extensionFmtCommand = new Command()
       outputMode: cliCtx.outputMode,
     });
     const {
-      manifest,
       allModelFiles,
       allVaultFiles,
       allDriverFiles,
@@ -121,16 +119,7 @@ export const extensionFmtCommand = new Command()
       renderer.handlers(),
     );
 
-    // 5. Check for version drift (advisory warning only)
-    const versionIssues = await checkVersionConsistency(
-      manifest.version,
-      allModelFiles,
-    );
-    if (versionIssues.length > 0) {
-      renderer.renderVersionDriftWarnings(versionIssues);
-    }
-
-    // 6. Throw if quality checks failed
+    // 5. Throw if quality checks failed
     if (!renderer.passed()) {
       throw new UserError(renderer.failureMessage());
     }

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -49,6 +49,7 @@ import {
 import type { SafetyIssue } from "../../domain/extensions/extension_safety_analyzer.ts";
 import {
   checkVersionConsistency,
+  type PublishedExtensionState,
   type QualityIssue,
 } from "../../domain/extensions/extension_quality_checker.ts";
 import type { DependencyTrustIssue } from "../../domain/extensions/extension_dependency_trust_checker.ts";
@@ -538,10 +539,38 @@ export const extensionPushCommand = new Command()
       }
     }
 
-    // 6c. Version-drift check (advisory warning only)
+    // 6d. Version-drift check (advisory warning only)
+    // Fetch the last-published version from the registry to compare
+    // model versions. Best-effort — if credentials are unavailable or
+    // the extension has never been published, we tell the user.
+    let published: PublishedExtensionState | undefined;
+    try {
+      const creds = await prepareDeps.loadCredentials();
+      if (creds) {
+        const latestDetail = await prepareDeps.getLatestVersionDetail(
+          creds.serverUrl,
+          manifest.name,
+          creds.apiKey,
+        );
+        if (latestDetail) {
+          published = {
+            manifestVersion: latestDetail.version,
+            models: (latestDetail.contentMetadata?.models ?? []).map((m) => ({
+              fileName: m.fileName,
+              version: m.version,
+            })),
+          };
+        }
+      }
+    } catch {
+      cliCtx.logger
+        .debug`Failed to fetch published version for drift check (continuing)`;
+    }
+
     const versionIssues = await checkVersionConsistency(
       prepared.manifest.version,
       allModelFiles,
+      published,
     );
     if (versionIssues.length > 0) {
       renderer.renderVersionDriftWarnings(versionIssues);

--- a/src/domain/extensions/extension_package_cache.ts
+++ b/src/domain/extensions/extension_package_cache.ts
@@ -174,11 +174,15 @@ function normalizeToForwardSlash(p: string): string {
   return SEPARATOR === "\\" ? p.replaceAll("\\", "/") : p;
 }
 
+export async function computeFileContentHash(path: string): Promise<string> {
+  const bytes = await Deno.readFile(path);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return `sha256:${encodeHex(new Uint8Array(digest))}`;
+}
+
 async function readFileIfExists(path: string): Promise<string> {
   try {
-    const bytes = await Deno.readFile(path);
-    const digest = await crypto.subtle.digest("SHA-256", bytes);
-    return `sha256:${encodeHex(new Uint8Array(digest))}`;
+    return await computeFileContentHash(path);
   } catch (error) {
     if (error instanceof Deno.errors.NotFound) {
       return "missing";

--- a/src/domain/extensions/extension_quality_checker.ts
+++ b/src/domain/extensions/extension_quality_checker.ts
@@ -320,12 +320,50 @@ export async function checkExtensionQuality(
   };
 }
 
-/** Advisory check — warns on manifest/model version mismatch but never blocks. */
+/** Published model metadata from the registry. */
+export interface PublishedModelVersion {
+  fileName: string;
+  version: string;
+}
+
+/** Published extension state from the registry. */
+export interface PublishedExtensionState {
+  manifestVersion: string;
+  models: PublishedModelVersion[];
+}
+
+/**
+ * Advisory check — warns on version drift but never blocks.
+ *
+ * Compares current model versions against the registry's last-published
+ * version. Warns when a model version moved but the manifest version
+ * did not.
+ *
+ * When no published state is available (first publish), tells the user
+ * rather than silently skipping.
+ */
 export async function checkVersionConsistency(
   manifestVersion: string,
   modelFiles: string[],
+  published?: PublishedExtensionState,
 ): Promise<QualityIssue[]> {
+  if (modelFiles.length === 0) return [];
+
+  if (!published) {
+    return [{
+      check: "version-drift",
+      output: "unable to check for version drift — no previously published " +
+        "version found in the registry (this is expected on first publish)",
+    }];
+  }
+
+  const publishedByFile = new Map<string, string>();
+  for (const m of published.models) {
+    publishedByFile.set(m.fileName, m.version);
+  }
+
   const issues: QualityIssue[] = [];
+  let anyModelVersionBumped = false;
 
   for (const file of modelFiles) {
     let content: string;
@@ -344,15 +382,24 @@ export async function checkVersionConsistency(
     const modelVersion = extractModelVersion(content);
     if (!modelVersion) continue;
 
-    if (modelVersion !== manifestVersion) {
-      issues.push({
-        check: "version-drift",
-        output:
-          `${basename(file)}: model version "${modelVersion}" differs from ` +
-          `manifest version "${manifestVersion}" ` +
-          `(update the model's version field to align)`,
-      });
+    const publishedVersion = publishedByFile.get(basename(file));
+    if (!publishedVersion) continue;
+
+    if (modelVersion !== publishedVersion) {
+      anyModelVersionBumped = true;
     }
+  }
+
+  if (
+    anyModelVersionBumped &&
+    manifestVersion === published.manifestVersion
+  ) {
+    issues.push({
+      check: "version-drift",
+      output:
+        `manifest version "${manifestVersion}" was not bumped but one or ` +
+        `more model versions changed (bump the manifest version)`,
+    });
   }
 
   return issues;

--- a/src/domain/extensions/extension_quality_checker_test.ts
+++ b/src/domain/extensions/extension_quality_checker_test.ts
@@ -23,6 +23,7 @@ import {
   checkExtensionQuality,
   checkUpgradeChainConsistency,
   checkVersionConsistency,
+  type PublishedExtensionState,
   stripCommentsAndStrings,
 } from "./extension_quality_checker.ts";
 
@@ -408,75 +409,155 @@ Deno.test("stripCommentsAndStrings blanks template literal text", () => {
 
 // ── checkVersionConsistency tests ────────────────────────────────────
 
-Deno.test("checkVersionConsistency: matching versions produce no issues", async () => {
+Deno.test("checkVersionConsistency: informs user when no published state", async () => {
   await withTempFiles(
     {
       "model.ts":
         'export const model = {\n  version: "2026.05.22.1",\n  type: "test",\n};\n',
     },
     async (_dir, paths) => {
-      const issues = await checkVersionConsistency("2026.05.22.1", paths);
-      assertEquals(issues, []);
+      const issues = await checkVersionConsistency(
+        "2026.05.22.1",
+        paths,
+      );
+      assertEquals(issues.length, 1);
+      assertEquals(issues[0].check, "version-drift");
+      assertStringIncludes(issues[0].output, "unable to check");
+      assertStringIncludes(issues[0].output, "no previously published");
     },
   );
 });
 
-Deno.test("checkVersionConsistency: earlier version literal does not cause false positive", async () => {
-  await withTempFiles(
-    {
-      "card.ts":
-        'const SCHEMA_TEMPLATE = { version: "1.0.0" };\n\nexport const model = {\n  version: "2026.05.22.1",\n  type: "test",\n};\n',
-    },
-    async (_dir, paths) => {
-      const issues = await checkVersionConsistency("2026.05.22.1", paths);
-      assertEquals(issues, []);
-    },
-  );
-});
-
-Deno.test("checkVersionConsistency: mismatched version reports drift", async () => {
+Deno.test("checkVersionConsistency: no warning when versions match published", async () => {
   await withTempFiles(
     {
       "model.ts":
-        'export const model = {\n  version: "2026.03.01.1",\n  type: "test",\n};\n',
+        'export const model = {\n  version: "2026.05.22.1",\n  type: "test",\n};\n',
     },
     async (_dir, paths) => {
-      const issues = await checkVersionConsistency("2026.05.22.1", paths);
-      assertEquals(issues.length, 1);
-      assertEquals(issues[0].check, "version-drift");
-      assertStringIncludes(issues[0].output, "2026.03.01.1");
-      assertStringIncludes(issues[0].output, "2026.05.22.1");
+      const published: PublishedExtensionState = {
+        manifestVersion: "2026.05.22.1",
+        models: [{ fileName: "model.ts", version: "2026.05.22.1" }],
+      };
+      const issues = await checkVersionConsistency(
+        "2026.05.22.1",
+        paths,
+        published,
+      );
+      assertEquals(issues, []);
     },
   );
 });
 
-Deno.test("checkVersionConsistency: multiple models with mixed versions", async () => {
+Deno.test("checkVersionConsistency: warns when model version bumped but manifest not", async () => {
+  await withTempFiles(
+    {
+      "model.ts":
+        'export const model = {\n  version: "2026.06.01.1",\n  type: "test",\n};\n',
+    },
+    async (_dir, paths) => {
+      const published: PublishedExtensionState = {
+        manifestVersion: "2026.05.22.1",
+        models: [{ fileName: "model.ts", version: "2026.05.22.1" }],
+      };
+      const issues = await checkVersionConsistency(
+        "2026.05.22.1",
+        paths,
+        published,
+      );
+      assertEquals(issues.length, 1);
+      assertStringIncludes(issues[0].output, "manifest version");
+      assertStringIncludes(issues[0].output, "was not bumped");
+    },
+  );
+});
+
+Deno.test("checkVersionConsistency: no warning when both model and manifest bumped", async () => {
+  await withTempFiles(
+    {
+      "model.ts":
+        'export const model = {\n  version: "2026.06.01.1",\n  type: "test",\n};\n',
+    },
+    async (_dir, paths) => {
+      const published: PublishedExtensionState = {
+        manifestVersion: "2026.05.22.1",
+        models: [{ fileName: "model.ts", version: "2026.05.22.1" }],
+      };
+      const issues = await checkVersionConsistency(
+        "2026.06.01.1",
+        paths,
+        published,
+      );
+      assertEquals(issues, []);
+    },
+  );
+});
+
+Deno.test("checkVersionConsistency: multi-model only detects drift on bumped model", async () => {
   await withTempFiles(
     {
       "model_a.ts":
         'export const model = {\n  version: "2026.05.22.1",\n  type: "a",\n};\n',
       "model_b.ts":
-        'export const model = {\n  version: "2026.04.10.2",\n  type: "b",\n};\n',
-      "model_c.ts":
-        'export const model = {\n  version: "2026.05.22.1",\n  type: "c",\n};\n',
+        'export const model = {\n  version: "2026.06.01.1",\n  type: "b",\n};\n',
     },
     async (_dir, paths) => {
-      const issues = await checkVersionConsistency("2026.05.22.1", paths);
+      const published: PublishedExtensionState = {
+        manifestVersion: "2026.05.22.1",
+        models: [
+          { fileName: "model_a.ts", version: "2026.05.22.1" },
+          { fileName: "model_b.ts", version: "2026.04.10.2" },
+        ],
+      };
+      const issues = await checkVersionConsistency(
+        "2026.05.22.1",
+        paths,
+        published,
+      );
       assertEquals(issues.length, 1);
-      assertEquals(issues[0].check, "version-drift");
-      assertStringIncludes(issues[0].output, "model_b.ts");
+      assertStringIncludes(issues[0].output, "manifest version");
+      assertStringIncludes(issues[0].output, "was not bumped");
     },
   );
 });
 
-Deno.test("checkVersionConsistency: files without version export are skipped", async () => {
+Deno.test("checkVersionConsistency: metadata-only release produces no warnings", async () => {
   await withTempFiles(
     {
-      "helpers.ts":
-        "export function add(a: number, b: number): number {\n  return a + b;\n}\n",
+      "model.ts":
+        'export const model = {\n  version: "2026.05.22.1",\n  type: "test",\n};\n',
     },
     async (_dir, paths) => {
-      const issues = await checkVersionConsistency("2026.05.22.1", paths);
+      const published: PublishedExtensionState = {
+        manifestVersion: "2026.05.22.1",
+        models: [{ fileName: "model.ts", version: "2026.05.22.1" }],
+      };
+      const issues = await checkVersionConsistency(
+        "2026.06.01.1",
+        paths,
+        published,
+      );
+      assertEquals(issues, []);
+    },
+  );
+});
+
+Deno.test("checkVersionConsistency: new model not in published state is ignored", async () => {
+  await withTempFiles(
+    {
+      "model.ts":
+        'export const model = {\n  version: "2026.06.01.1",\n  type: "test",\n};\n',
+    },
+    async (_dir, paths) => {
+      const published: PublishedExtensionState = {
+        manifestVersion: "2026.05.22.1",
+        models: [],
+      };
+      const issues = await checkVersionConsistency(
+        "2026.05.22.1",
+        paths,
+        published,
+      );
       assertEquals(issues, []);
     },
   );
@@ -488,10 +569,35 @@ Deno.test("checkVersionConsistency: empty file list produces no issues", async (
 });
 
 Deno.test("checkVersionConsistency: nonexistent files are skipped", async () => {
-  const issues = await checkVersionConsistency("2026.05.22.1", [
-    "/tmp/does-not-exist-12345.ts",
-  ]);
+  const issues = await checkVersionConsistency(
+    "2026.05.22.1",
+    ["/tmp/does-not-exist-12345.ts"],
+    {
+      manifestVersion: "2026.05.22.1",
+      models: [],
+    },
+  );
   assertEquals(issues, []);
+});
+
+Deno.test("checkVersionConsistency: files without version export are skipped", async () => {
+  await withTempFiles(
+    {
+      "helpers.ts":
+        "export function add(a: number, b: number): number {\n  return a + b;\n}\n",
+    },
+    async (_dir, paths) => {
+      const issues = await checkVersionConsistency(
+        "2026.05.22.1",
+        paths,
+        {
+          manifestVersion: "2026.05.22.1",
+          models: [],
+        },
+      );
+      assertEquals(issues, []);
+    },
+  );
 });
 
 // ── checkUpgradeChainConsistency tests ─────────────────────────────

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -291,6 +291,11 @@ export interface ExtensionPushPrepareDeps {
     name: string,
     apiKey: string,
   ) => Promise<{ version: string } | null>;
+  getLatestVersionDetail: (
+    serverUrl: string,
+    name: string,
+    apiKey: string,
+  ) => Promise<LatestVersionDetail | null>;
 }
 
 /** Metadata sent during push phases. */
@@ -341,7 +346,10 @@ import {
   getCollectives,
   SwampClubClient,
 } from "../../infrastructure/http/swamp_club_client.ts";
-import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
+import {
+  ExtensionApiClient,
+  type LatestVersionDetail,
+} from "../../infrastructure/http/extension_api_client.ts";
 import type { ClientIdentity } from "../../infrastructure/http/client_identity.ts";
 import { analyzeExtensionSafety } from "../../domain/extensions/extension_safety_analyzer.ts";
 import {
@@ -396,6 +404,10 @@ export function createExtensionPushPrepareDeps(
       const result = await client.getLatestVersion(name, apiKey);
       if (!result) return null;
       return { version: result.version };
+    },
+    getLatestVersionDetail: async (serverUrl, name, apiKey) => {
+      const client = new ExtensionApiClient(serverUrl, identity);
+      return await client.getLatestVersionDetail(name, apiKey);
     },
   };
 }

--- a/src/libswamp/extensions/push_pull_roundtrip_test.ts
+++ b/src/libswamp/extensions/push_pull_roundtrip_test.ts
@@ -95,6 +95,7 @@ function makePrepareDeps(
     ensureDenoPath: () => Promise.resolve("/usr/bin/deno"),
     getDenoEnv: () => Deno.env.toObject(),
     getLatestVersion: () => Promise.resolve(null),
+    getLatestVersionDetail: () => Promise.resolve(null),
     ...overrides,
   };
 }

--- a/src/libswamp/extensions/push_test.ts
+++ b/src/libswamp/extensions/push_test.ts
@@ -126,6 +126,7 @@ function makePrepareDeps(
     ensureDenoPath: () => Promise.resolve("/usr/bin/deno"),
     getDenoEnv: () => Deno.env.toObject(),
     getLatestVersion: () => Promise.resolve(null),
+    getLatestVersionDetail: () => Promise.resolve(null),
     ...overrides,
   };
 }

--- a/src/presentation/renderers/extension_fmt.ts
+++ b/src/presentation/renderers/extension_fmt.ts
@@ -22,7 +22,6 @@ import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
 import {
   qualityCheckLabel,
-  type QualityIssue,
 } from "../../domain/extensions/extension_quality_checker.ts";
 import { UserError } from "../../domain/errors.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
@@ -31,7 +30,6 @@ import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 export interface ExtensionFmtRenderer extends Renderer<ExtensionFmtEvent> {
   passed(): boolean;
   failureMessage(): string;
-  renderVersionDriftWarnings(warnings: QualityIssue[]): void;
 }
 
 class LogExtensionFmtRenderer implements ExtensionFmtRenderer {
@@ -90,14 +88,6 @@ class LogExtensionFmtRenderer implements ExtensionFmtRenderer {
         throw new UserError(e.error.message);
       },
     };
-  }
-
-  renderVersionDriftWarnings(warnings: QualityIssue[]): void {
-    const logger = getSwampLogger(["extension", "fmt"]);
-    logger.warn`Version drift warnings (non-blocking):`;
-    for (const w of warnings) {
-      logger.warn`  ${w.output}`;
-    }
   }
 }
 
@@ -159,12 +149,6 @@ class JsonExtensionFmtRenderer implements ExtensionFmtRenderer {
         throw new UserError(e.error.message);
       },
     };
-  }
-
-  renderVersionDriftWarnings(warnings: QualityIssue[]): void {
-    console.log(
-      JSON.stringify({ versionDriftWarnings: warnings }, null, 2),
-    );
   }
 }
 


### PR DESCRIPTION
## Summary

- Replace the raw string-equality version-drift check (`modelVersion !== manifestVersion`) with a registry-based check that fetches the last-published version's model metadata via `getLatestVersionDetail`
- Warn only when a model version moved compared to the published version but the manifest version did not — the actual bug the check should catch
- Remove version-drift from `extension fmt` (no registry context available)
- First-publish extensions get an honest "unable to check" message instead of a silent skip
- Document the version-drift check in the extension publishing skill guide

Fixes swamp-club#1367

### What changed

| File | Change |
|------|--------|
| `extension_quality_checker.ts` | Rewrote `checkVersionConsistency` to accept `PublishedExtensionState` from registry instead of raw manifest version comparison |
| `extension_push.ts` | Calls `prepareDeps.getLatestVersionDetail` to fetch published model versions; removed local cache sidecar |
| `push.ts` (libswamp) | Added `getLatestVersionDetail` to `ExtensionPushPrepareDeps` interface and factory |
| `extension_fmt.ts` | Removed version-drift check (no registry context) |
| `extension_fmt.ts` renderer | Removed `renderVersionDriftWarnings` from interface and implementations |
| `extension_package_cache.ts` | Extracted `computeFileContentHash` as public utility; reverted `CachedPackageMetadata` to original shape |
| `publishing.md` (skill) | Added Version-Drift Check section documenting the registry-based behavior |
| Test files | Rewrote tests for registry-based approach; added mock `getLatestVersionDetail` to test deps |

### False positives eliminated

1. **Multi-model manifests** — untouched models with different versions no longer trigger warnings
2. **Metadata-only releases** — bumping manifest version without model changes is clean

## Test plan

- [x] Unit tests: 10 test cases covering no published state, versions matching, model bumped without manifest, both bumped, multi-model drift, metadata-only release, new model, empty list, nonexistent files, no-version files
- [x] Full test suite: 9817 tests pass
- [x] Manual verification against real registry (`@swamp/issue-lifecycle`): confirmed drift detection works on a fresh machine with zero local state
- [x] Manual verification of first-publish case: honest informational message

🤖 Generated with [Claude Code](https://claude.com/claude-code)