### PR TITLE
fix(serve): address review feedback on HA auto-detection (#2067)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -536,7 +536,8 @@ const daemonEnableCommand = new Command()
   )
   .option(
     "--detach-runs",
-    "Deprecated — HA mode is now detected automatically. Accepted for backwards compatibility.",
+    "Deprecated — HA mode is now detected automatically based on your datastore configuration. " +
+      "This flag is accepted for backwards compatibility but has no effect.",
   )
   .option(
     "--heartbeat-interval <duration:string>",


### PR DESCRIPTION
## Summary

- Aligned `daemon enable --detach-runs` help text to match the main `serve --detach-runs` description — was missing "based on your datastore configuration" and "but has no effect"
- Updated docs issue #2065 with behavioral change notes for `/ready` 503 window and `detachRuns: true` JSON field

Follow-up to #2067 (swamp-club#1505).