### PR TITLE
fix(serve): close five security vulnerabilities in serve HA and vault subsystems

### DIFF
--- a/design/workflow.md
+++ b/design/workflow.md
@@ -523,8 +523,12 @@ The `webhook` namespace exposes:
 - `webhook.body` — the request body, parsed as JSON when the payload is valid
   JSON, otherwise the raw string.
 - `webhook.headers` — request headers as a map of lowercased names to values.
-  The active scheme's signature header is excluded (e.g. `x-hub-signature-256`
-  for github, `stripe-signature` for stripe — see schemes below).
+  The active scheme's signature header and sensitive credential headers are
+  excluded. Redacted headers include authentication (`authorization`,
+  `proxy-authorization`, `cookie`), proxy credentials
+  (`x-amzn-oidc-accesstoken`, `x-goog-iap-jwt-assertion`,
+  `cf-access-jwt-assertion`, `x-forwarded-client-cert`), and any header
+  ending in `-token` or `-secret`.
 - `webhook.route` — the matched webhook route (e.g. `/hooks/linear`).
 
 The signature scheme is selected per endpoint on the `--webhook` flag:
@@ -556,10 +560,10 @@ and the run does not start. The `webhook` namespace is available only inside
 `trigger.inputs`; the rest of the workflow reads the extracted values as normal
 inputs (`${{ inputs.identifier }}`).
 
-**Security:** `webhook.headers` values are not redacted (the same caveat as the
-`env` namespace). If a workflow maps one into a model attribute it is stored in
-`.swamp/data/` and visible in `swamp data get` output — avoid forwarding
-sensitive headers.
+**Security:** Sensitive headers (authentication, proxy credentials, and headers
+ending in `-token` or `-secret`) are redacted before the payload is persisted or
+exposed to workflow expressions. Provider event headers (e.g. `x-github-event`,
+`content-type`) are preserved.
 
 ## Jobs
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -76,7 +76,11 @@ import {
   resolveTrustedCollectives,
   ScheduledExecutionService,
 } from "../../libswamp/mod.ts";
-import { parseWebhookFlag, WebhookService } from "../../serve/webhook.ts";
+import {
+  isSensitiveHeader,
+  parseWebhookFlag,
+  WebhookService,
+} from "../../serve/webhook.ts";
 import {
   loadServeConfig,
   mergeServeOptions,
@@ -384,6 +388,7 @@ export async function reapOrphanedWorkflowRuns(
   save: (workflowId: WorkflowId, run: WorkflowRun) => Promise<void>,
   trackerLookup: (runId: string) => { status: string } | null,
   isDeadFn: (pid: number) => boolean = isProcessDead,
+  localInstanceId?: string,
 ): Promise<ReapResult> {
   let reaped = 0;
   let skipped = 0;
@@ -415,7 +420,26 @@ export async function reapOrphanedWorkflowRuns(
       continue;
     }
 
-    // Not in tracker (legacy run) — fall back to PID check
+    // Not in tracker — check instanceId before falling back to PID check.
+    // A run with a foreign instanceId belongs to another instance and must
+    // not be PID-checked against the local process table.
+    if (
+      localInstanceId && run.instanceId &&
+      run.instanceId !== localInstanceId
+    ) {
+      logger.info(
+        "Skipping workflow run {runId} (workflow: {workflowName}) — belongs to remote instance {instanceId}",
+        {
+          runId: run.id,
+          workflowName: run.workflowName,
+          instanceId: run.instanceId,
+        },
+      );
+      skipped++;
+      continue;
+    }
+
+    // Legacy run or same-instance run — fall back to PID check
     const pid = run.pid;
     if (pid !== undefined && !isDeadFn(pid)) {
       logger.info(
@@ -1339,20 +1363,7 @@ export const serveCommand = new Command()
       );
     }
 
-    // Create the control-plane store — used for both the encrypted token
-    // secrets vault and downstream HA coordination (heartbeats, pending
-    // runs, etc). Created once and shared across all consumers.
     const caps = syncService?.capabilities?.();
-    let controlPlaneStore: ControlPlaneStore;
-    if (caps?.controlPlane && syncService?.controlPlaneStore) {
-      controlPlaneStore = syncService.controlPlaneStore();
-      logger.info("Control-plane store: remote datastore");
-    } else {
-      controlPlaneStore = new FileSystemControlPlaneStore(
-        swampPath(resolvedRepoDir),
-      );
-      logger.info("Control-plane store: local filesystem fallback");
-    }
     const hasRemoteControlPlane = !!(caps?.controlPlane &&
       syncService?.controlPlaneStore);
 
@@ -1393,6 +1404,98 @@ export const serveCommand = new Command()
       logger.info(
         "HA: detached runs, pending-run durability (no remote control-plane — heartbeat and reconciliation disabled)",
       );
+    }
+
+    // Bind namespace and migrate control-plane records before creating the
+    // store that all downstream consumers share. The S3/GCS extensions
+    // capture controlPrefixPath at controlPlaneStore() construction time
+    // for list(), so the store must be created after namespace binding.
+    const serveNamespace = isCustomDatastoreConfig(datastoreConfig)
+      ? datastoreConfig.namespace
+      : undefined;
+    const MIGRATION_SENTINEL = "migration/root-import-complete";
+    if (hasRemoteControlPlane && syncService) {
+      // Migration: if a namespace is configured, read root control-plane
+      // records before binding so the pre-namespace path is addressable.
+      // After binding, the extension's get/put/delete resolve to the
+      // namespaced path — root keys are no longer addressable — so we
+      // use a sentinel to skip re-migration on subsequent boots.
+      const rootRecords = new Map<string, Uint8Array>();
+      if (serveNamespace) {
+        const rootStore = syncService.controlPlaneStore!();
+        for (
+          const prefix of [
+            "token-secrets/",
+            "pending-runs/",
+            "heartbeats/",
+            "active-runs/",
+            "fire-records/",
+            "claims/",
+          ]
+        ) {
+          try {
+            const keys = await rootStore.list(prefix);
+            for (const key of keys) {
+              const data = await rootStore.get(key);
+              if (data) rootRecords.set(key, new Uint8Array(data));
+            }
+          } catch (err) {
+            logger.warn(
+              "Failed to read root control-plane records under {prefix}: {error}",
+              {
+                prefix,
+                error: err instanceof Error ? err.message : String(err),
+              },
+            );
+            throw err;
+          }
+        }
+      }
+
+      await hydrateLocalCache({
+        syncService,
+        catalogInvalidate: () => repoContext.catalogStore.invalidate(),
+        signal: AbortSignal.timeout(60_000),
+        namespace: serveNamespace,
+      });
+
+      if (serveNamespace && rootRecords.size > 0) {
+        const namespacedStore = syncService.controlPlaneStore!();
+        const sentinel = await namespacedStore.get(MIGRATION_SENTINEL);
+        if (!sentinel) {
+          let migrated = 0;
+          for (const [key, data] of rootRecords) {
+            const existing = await namespacedStore.get(key);
+            if (!existing) {
+              await namespacedStore.put(key, data);
+              migrated++;
+            }
+          }
+          await namespacedStore.put(
+            MIGRATION_SENTINEL,
+            new TextEncoder().encode(new Date().toISOString()),
+          );
+          if (migrated > 0) {
+            logger.info(
+              "Migrated {count} control-plane record(s) from root to namespace {namespace}",
+              { count: migrated, namespace: serveNamespace },
+            );
+          }
+        }
+      }
+    }
+
+    // Create the control-plane store AFTER namespace binding so the S3/GCS
+    // extension's list() prefix is correctly scoped.
+    let controlPlaneStore: ControlPlaneStore;
+    if (hasRemoteControlPlane && syncService?.controlPlaneStore) {
+      controlPlaneStore = syncService.controlPlaneStore();
+      logger.info("Control-plane store: remote datastore");
+    } else {
+      controlPlaneStore = new FileSystemControlPlaneStore(
+        swampPath(resolvedRepoDir),
+      );
+      logger.info("Control-plane store: local filesystem fallback");
     }
 
     // Initialize the encrypted control-plane vault provider for serve-internal
@@ -1883,19 +1986,20 @@ export const serveCommand = new Command()
 
     let heartbeatService: InstanceHeartbeatService | undefined;
 
-    if (hasRemoteControlPlane && syncService) {
-      await hydrateLocalCache({
-        syncService,
-        catalogInvalidate: () => repoContext.catalogStore.invalidate(),
-        signal: AbortSignal.timeout(60_000),
-      });
-    }
-
     // Reap stale runs via the SQLite tracker (heartbeat + PID liveness).
     // This handles both model-method and workflow runs registered with the tracker.
     const runTracker = RunTrackerStore.fromSwampDir(
       swampPath(resolvedRepoDir),
     );
+    const scrubbedHeaders = runTracker.scrubPendingRunHeaders(
+      isSensitiveHeader,
+    );
+    if (scrubbedHeaders > 0) {
+      logger.info(
+        "Scrubbed sensitive headers from {count} existing pending run(s)",
+        { count: scrubbedHeaders },
+      );
+    }
     const reapedRuns = runTracker.reapStaleRuns(DEFAULT_STALE_TTL_MS);
     for (const run of reapedRuns) {
       logger.warn`Reaped stale ${run.runKind} run ${run.id} (${
@@ -1924,6 +2028,7 @@ export const serveCommand = new Command()
         return tracked ? { status: tracked.status } : null;
       },
       isProcessDead,
+      instanceId,
     );
 
     const swept = await sweepStaleRecords({
@@ -2918,11 +3023,24 @@ export const serveCommand = new Command()
       }
     }
 
+    const configuredWebhookWorkflows = new Set(
+      webhookEndpoints.map((e) => e.workflowIdOrName),
+    );
+    const configuredWebhookRoutes = new Set(
+      webhookEndpoints.map((e) => e.route),
+    );
+    const allWorkflows = await repoContext.workflowRepo.findAll();
+    const configuredCronWorkflows = new Set(
+      allWorkflows.filter((w) => w.schedule).map((w) => w.name),
+    );
     const replayed = await replayPendingRuns({
       runTracker,
       webhookService: webhookService ?? undefined,
       scheduledExecution: scheduledExecution ?? undefined,
       controlPlaneStore,
+      configuredWebhookWorkflows,
+      configuredWebhookRoutes,
+      configuredCronWorkflows,
     });
     if (replayed > 0) {
       logger.info`Replayed ${replayed} pending run(s) from previous process`;

--- a/src/cli/commands/serve_test.ts
+++ b/src/cli/commands/serve_test.ts
@@ -402,6 +402,7 @@ function makeRun(
     status?: RunStatus;
     pid?: number;
     id?: string;
+    instanceId?: string;
   } = {},
 ): WorkflowRun {
   return WorkflowRun.fromData({
@@ -411,6 +412,7 @@ function makeRun(
     status: overrides.status ?? "running",
     startedAt: "2026-07-20T20:00:00.000Z",
     pid: overrides.pid,
+    instanceId: overrides.instanceId,
     jobs: [{
       jobName: "main",
       status: "running",
@@ -577,4 +579,84 @@ Deno.test("reapOrphanedWorkflowRuns: mixed scenario with tracker and legacy runs
   assertEquals(legacyNoPid.status, "failed");
   assertEquals(succeededRun.status, "succeeded");
   assertEquals(saved.length, 3);
+});
+
+Deno.test("reapOrphanedWorkflowRuns: skips run with foreign instanceId when tracker miss", async () => {
+  const run = makeRun({ pid: 42, instanceId: "remote-1" });
+  const saved: string[] = [];
+  const result = await reapOrphanedWorkflowRuns(
+    [{ run, workflowId: WORKFLOW_ID }],
+    (_wid, r) => {
+      saved.push(r.id);
+      return Promise.resolve();
+    },
+    noTracker,
+    () => {
+      throw new Error("should not check PID for foreign instance");
+    },
+    "local-1",
+  );
+  assertEquals(result.reaped, 0);
+  assertEquals(result.skipped, 1);
+  assertEquals(run.status, "running");
+  assertEquals(saved.length, 0);
+});
+
+Deno.test("reapOrphanedWorkflowRuns: reaps run with matching instanceId when tracker miss and PID dead", async () => {
+  const run = makeRun({ pid: 42, instanceId: "local-1" });
+  const saved: string[] = [];
+  const result = await reapOrphanedWorkflowRuns(
+    [{ run, workflowId: WORKFLOW_ID }],
+    (_wid, r) => {
+      saved.push(r.id);
+      return Promise.resolve();
+    },
+    noTracker,
+    (_pid) => true, // PID is dead
+    "local-1",
+  );
+  assertEquals(result.reaped, 1);
+  assertEquals(result.skipped, 0);
+  assertEquals(run.status, "failed");
+  assertEquals(saved.length, 1);
+});
+
+Deno.test("reapOrphanedWorkflowRuns: reaps run with no instanceId when tracker miss and PID dead", async () => {
+  const run = makeRun({ pid: 42 }); // no instanceId — legacy run
+  const saved: string[] = [];
+  const result = await reapOrphanedWorkflowRuns(
+    [{ run, workflowId: WORKFLOW_ID }],
+    (_wid, r) => {
+      saved.push(r.id);
+      return Promise.resolve();
+    },
+    noTracker,
+    (_pid) => true, // PID is dead
+    "local-1",
+  );
+  assertEquals(result.reaped, 1);
+  assertEquals(result.skipped, 0);
+  assertEquals(run.status, "failed");
+  assertEquals(saved.length, 1);
+});
+
+Deno.test("reapOrphanedWorkflowRuns: reaps run with foreign instanceId when tracker reports stale", async () => {
+  const run = makeRun({ pid: 42, instanceId: "remote-1" });
+  const saved: string[] = [];
+  const result = await reapOrphanedWorkflowRuns(
+    [{ run, workflowId: WORKFLOW_ID }],
+    (_wid, r) => {
+      saved.push(r.id);
+      return Promise.resolve();
+    },
+    trackerReaped, // tracker says stale — overrides instanceId check
+    () => {
+      throw new Error("should not check PID when tracker confirms stale");
+    },
+    "local-1",
+  );
+  assertEquals(result.reaped, 1);
+  assertEquals(result.skipped, 0);
+  assertEquals(run.status, "failed");
+  assertEquals(saved.length, 1);
 });

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -430,9 +430,18 @@ export async function processSensitiveResourceData(
     );
   }
 
+  const userVaultNames = vaultNames.filter((n) => !n.startsWith("_"));
+
   for (const { field, originalValue } of fieldsWithValues) {
     const targetVault = field.vaultName ?? spec.vaultName ??
-      vaultService.getDefaultVaultName() ?? vaultNames[0];
+      vaultService.getDefaultVaultName() ?? userVaultNames[0] ?? vaultNames[0];
+
+    if (targetVault.startsWith("_")) {
+      throw new Error(
+        `Cannot store sensitive field '${field.path}': vault '${targetVault}' is reserved for internal use`,
+      );
+    }
+
     const vaultKey = field.vaultKey ??
       sanitizeVaultKey(
         `${modelType.normalized}/${modelId}/${methodName}/${specName}/${instanceName}/${field.path}`,

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -1925,6 +1925,48 @@ Deno.test("processSensitiveResourceData: falls back to vaultNames[0] when no def
   assertStringIncludes(data.secret as string, "'alpha-vault'");
 });
 
+Deno.test("processSensitiveResourceData: throws when target vault name starts with underscore", async () => {
+  const spec: ResourceOutputSpec = {
+    schema: z.object({
+      secret: z.string().meta({
+        sensitive: true,
+        vaultName: "_token-secrets",
+      }),
+    }),
+    lifetime: "infinite",
+    garbageCollection: 10,
+  };
+
+  const data: Record<string, unknown> = { secret: "my-secret" };
+  const vaultService = new VaultService();
+  vaultService.registerVault({
+    name: "_token-secrets",
+    type: "mock",
+    config: {},
+  });
+  vaultService.registerVault({
+    name: "user-vault",
+    type: "mock",
+    config: {},
+  });
+
+  await assertRejects(
+    () =>
+      processSensitiveResourceData(
+        data,
+        spec,
+        vaultService,
+        modelType,
+        modelId,
+        "create",
+        "creds",
+        "main",
+      ),
+    Error,
+    "reserved for internal use",
+  );
+});
+
 // --- createResourceWriter attributes tests ---
 
 Deno.test("createResourceWriter: resource handle includes attributes from written data", async () => {

--- a/src/infrastructure/persistence/run_tracker_store.ts
+++ b/src/infrastructure/persistence/run_tracker_store.ts
@@ -410,6 +410,42 @@ export class RunTrackerStore implements RunTrackerRepository {
     this.db.prepare("DELETE FROM pending_runs WHERE id = ?").run(id);
   }
 
+  scrubPendingRunHeaders(
+    isSensitive: (header: string) => boolean,
+  ): number {
+    const rows = this.db.prepare(
+      "SELECT id, payload FROM pending_runs WHERE payload IS NOT NULL",
+    ).all() as unknown as { id: string; payload: string }[];
+    let scrubbed = 0;
+    const update = this.db.prepare(
+      "UPDATE pending_runs SET payload = ? WHERE id = ?",
+    );
+    for (const row of rows) {
+      try {
+        const parsed = JSON.parse(row.payload);
+        if (
+          !parsed || typeof parsed !== "object" ||
+          typeof parsed.headers !== "object" || parsed.headers === null
+        ) continue;
+        const headers = parsed.headers as Record<string, string>;
+        let changed = false;
+        for (const name of Object.keys(headers)) {
+          if (isSensitive(name)) {
+            delete headers[name];
+            changed = true;
+          }
+        }
+        if (changed) {
+          update.run(JSON.stringify(parsed), row.id);
+          scrubbed++;
+        }
+      } catch {
+        // Corrupt payload — leave it for replay to discard
+      }
+    }
+    return scrubbed;
+  }
+
   findAllPendingRuns(): PendingRunEntry[] {
     const rows = this.db.prepare(
       "SELECT * FROM pending_runs ORDER BY created_at ASC",

--- a/src/infrastructure/persistence/run_tracker_store_test.ts
+++ b/src/infrastructure/persistence/run_tracker_store_test.ts
@@ -22,6 +22,7 @@ import { join } from "@std/path";
 import { hostname } from "node:os";
 import { ActiveRun } from "../../domain/models/active_run.ts";
 import { type PendingRunEntry, RunTrackerStore } from "./run_tracker_store.ts";
+import { isSensitiveHeader } from "../../serve/webhook.ts";
 
 function makeTempDbPath(): string {
   const dir = Deno.makeTempDirSync({ prefix: "swamp-run-tracker-test-" });
@@ -551,6 +552,57 @@ Deno.test("RunTrackerStore: register stores null initiatedBy for ghost runs", ()
 
     const found = store.findById("ghost-run");
     assertEquals(found?.initiatedBy, null);
+  } finally {
+    store.close();
+  }
+});
+
+// ── scrubPendingRunHeaders tests ─────────────────────────────────────
+
+Deno.test("scrubPendingRunHeaders: strips sensitive headers from pending run payloads", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const payload = JSON.stringify({
+      headers: {
+        authorization: "Bearer secret",
+        "x-github-event": "push",
+        cookie: "session=abc",
+      },
+    });
+    store.enqueuePendingRun(makePendingRun({ id: "pr-scrub-1", payload }));
+
+    const scrubbed = store.scrubPendingRunHeaders(isSensitiveHeader);
+    assertEquals(scrubbed, 1);
+
+    const found = store.findAllPendingRuns();
+    assertEquals(found.length, 1);
+    const updatedPayload = JSON.parse(found[0].payload!);
+    assertEquals(updatedPayload.headers, { "x-github-event": "push" });
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("scrubPendingRunHeaders: leaves rows with no headers unchanged", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const payload = JSON.stringify({ body: {} });
+    store.enqueuePendingRun(makePendingRun({ id: "pr-no-headers", payload }));
+
+    const scrubbed = store.scrubPendingRunHeaders(isSensitiveHeader);
+    assertEquals(scrubbed, 0);
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("scrubPendingRunHeaders: handles null payload gracefully", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    store.enqueuePendingRun(makePendingRun({ id: "pr-null-payload" }));
+
+    const scrubbed = store.scrubPendingRunHeaders(isSensitiveHeader);
+    assertEquals(scrubbed, 0);
   } finally {
     store.close();
   }

--- a/src/serve/boot_reconciliation.ts
+++ b/src/serve/boot_reconciliation.ts
@@ -38,6 +38,7 @@ import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_se
 import { InstanceHeartbeatService } from "./instance_heartbeat.ts";
 import { cleanupActiveRunsForInstance } from "./active_run_tracker.ts";
 import type { PendingRunEntry } from "../infrastructure/persistence/run_tracker_store.ts";
+import { isSensitiveHeader } from "./webhook.ts";
 
 const logger = getSwampLogger(["serve", "boot-reconciliation"]);
 
@@ -66,6 +67,7 @@ export interface HydrateLocalCacheDeps {
   syncService: DatastoreSyncService;
   catalogInvalidate: () => void;
   signal?: AbortSignal;
+  namespace?: string;
 }
 
 export interface HydrateResult {
@@ -77,7 +79,10 @@ export async function hydrateLocalCache(
 ): Promise<HydrateResult> {
   logger.info("Hydrating local cache from remote datastore");
   try {
-    const pulled = await deps.syncService.pullChanged({ signal: deps.signal });
+    const pulled = await deps.syncService.pullChanged({
+      signal: deps.signal,
+      ...(deps.namespace ? { namespace: deps.namespace } : {}),
+    });
     const count = typeof pulled === "number" ? pulled : 0;
     if (count > 0) {
       logger.info`Pulled ${count} file(s) from remote datastore`;
@@ -223,6 +228,9 @@ export interface ReplayPendingRunsDeps {
   scheduledExecution?:
     import("../libswamp/workflows/scheduled_execution.ts").ScheduledExecutionService;
   controlPlaneStore?: ControlPlaneStore;
+  configuredWebhookWorkflows: ReadonlySet<string>;
+  configuredWebhookRoutes: ReadonlySet<string>;
+  configuredCronWorkflows: ReadonlySet<string>;
 }
 
 export async function replayPendingRuns(
@@ -232,7 +240,10 @@ export async function replayPendingRuns(
 
   // Merge remote entries from the control-plane store when available.
   // Remote entries that already exist locally (by id) are skipped.
+  // Track the source key for remote entries so discard deletes the
+  // actual key, not a key reconstructed from the entry's own id.
   const pending: PendingRunEntry[] = [...localPending];
+  const remoteSourceKeys = new Map<string, string>();
   if (deps.controlPlaneStore) {
     try {
       const remoteKeys = await deps.controlPlaneStore.list("pending-runs/");
@@ -281,6 +292,7 @@ export async function replayPendingRuns(
         }
         if (!localIds.has(entry.id)) {
           pending.push(entry);
+          remoteSourceKeys.set(entry.id, key);
           logger
             .debug`Merged remote pending run ${entry.id} for ${entry.workflowIdOrName}`;
         }
@@ -298,10 +310,47 @@ export async function replayPendingRuns(
   logger
     .debug`Replaying ${pending.length} pending run(s) from previous process`;
 
+  const discardEntry = async (
+    id: string,
+    reason: string,
+  ): Promise<void> => {
+    logger.warn`Discarding pending run ${id}: ${reason}`;
+    deps.runTracker.deletePendingRun(id);
+    if (deps.controlPlaneStore) {
+      const cpKey = remoteSourceKeys.get(id) ?? `pending-runs/${id}`;
+      await deps.controlPlaneStore.delete(cpKey).catch(
+        (err: unknown) => {
+          logger.warn(
+            "Control-plane delete failed for discarded entry {id}: {error}",
+            {
+              id,
+              error: err instanceof Error ? err.message : String(err),
+            },
+          );
+        },
+      );
+    }
+  };
+
   let replayed = 0;
   for (const entry of pending) {
     try {
       if (entry.source === "webhook" && deps.webhookService) {
+        if (!deps.configuredWebhookWorkflows.has(entry.workflowIdOrName)) {
+          await discardEntry(
+            entry.id,
+            `workflow '${entry.workflowIdOrName}' is not a configured webhook endpoint`,
+          );
+          continue;
+        }
+        const entryRoute = entry.route ?? "";
+        if (entryRoute && !deps.configuredWebhookRoutes.has(entryRoute)) {
+          await discardEntry(
+            entry.id,
+            `route '${entryRoute}' is not a configured webhook endpoint`,
+          );
+          continue;
+        }
         let parsed: Record<string, unknown> = {};
         if (entry.payload) {
           try {
@@ -310,35 +359,25 @@ export async function replayPendingRuns(
               parsed = raw as Record<string, unknown>;
             }
           } catch {
-            logger
-              .warn`Discarding pending run ${entry.id}: corrupt payload`;
-            deps.runTracker.deletePendingRun(entry.id);
-            if (deps.controlPlaneStore) {
-              await deps.controlPlaneStore.delete(
-                `pending-runs/${entry.id}`,
-              ).catch((err: unknown) => {
-                logger.warn(
-                  "Control-plane delete failed for discarded entry {id}: {error}",
-                  {
-                    id: entry.id,
-                    error: err instanceof Error ? err.message : String(err),
-                  },
-                );
-              });
-            }
+            await discardEntry(entry.id, "corrupt payload");
             continue;
+          }
+        }
+        const rawHeaders = (parsed.headers ?? {}) as Record<string, string>;
+        const redactedHeaders: Record<string, string> = {};
+        for (const [name, value] of Object.entries(rawHeaders)) {
+          if (!isSensitiveHeader(name)) {
+            redactedHeaders[name] = value;
           }
         }
         deps.webhookService.enqueueForReplay({
           pendingRunId: entry.id,
           workflowIdOrName: entry.workflowIdOrName,
-          route: entry.route ?? "",
+          route: entryRoute,
           payload: {
             body: parsed.body ?? null,
-            headers: (parsed.headers ?? {}) as Record<string, string>,
-            route: typeof parsed.route === "string"
-              ? parsed.route
-              : (entry.route ?? ""),
+            headers: redactedHeaders,
+            route: typeof parsed.route === "string" ? parsed.route : entryRoute,
           },
           traceparent: entry.traceparent,
           tracestate: entry.tracestate,
@@ -347,6 +386,13 @@ export async function replayPendingRuns(
         logger
           .info`Replayed pending webhook run for ${entry.workflowIdOrName}`;
       } else if (entry.source === "cron" && deps.scheduledExecution) {
+        if (!deps.configuredCronWorkflows.has(entry.workflowIdOrName)) {
+          await discardEntry(
+            entry.id,
+            `workflow '${entry.workflowIdOrName}' is not a configured scheduled workflow`,
+          );
+          continue;
+        }
         deps.scheduledExecution.enqueueForReplay({
           pendingRunId: entry.id,
           workflowIdOrName: entry.workflowIdOrName,

--- a/src/serve/boot_reconciliation_test.ts
+++ b/src/serve/boot_reconciliation_test.ts
@@ -381,7 +381,13 @@ interface ReplayedCron {
 
 function createReplayHarness(
   pending: PendingRunEntry[],
-  opts: { hasWebhook?: boolean; hasCron?: boolean } = {},
+  opts: {
+    hasWebhook?: boolean;
+    hasCron?: boolean;
+    configuredWebhookWorkflows?: ReadonlySet<string>;
+    configuredWebhookRoutes?: ReadonlySet<string>;
+    configuredCronWorkflows?: ReadonlySet<string>;
+  } = {},
 ) {
   const deleted: string[] = [];
   const webhookReplays: ReplayedWebhook[] = [];
@@ -404,10 +410,32 @@ function createReplayHarness(
     } as unknown as ReplayPendingRunsDeps["scheduledExecution"]
     : undefined;
 
+  // Default to permissive sets that accept anything — individual tests
+  // override when they need to exercise the filter logic.
+  const configuredWebhookWorkflows = opts.configuredWebhookWorkflows ??
+    new Set(
+      pending.filter((e) => e.source === "webhook").map((e) =>
+        e.workflowIdOrName
+      ),
+    );
+  const configuredWebhookRoutes = opts.configuredWebhookRoutes ??
+    new Set(
+      pending.filter((e) => e.source === "webhook" && e.route).map((e) =>
+        e.route!
+      ),
+    );
+  const configuredCronWorkflows = opts.configuredCronWorkflows ??
+    new Set(
+      pending.filter((e) => e.source === "cron").map((e) => e.workflowIdOrName),
+    );
+
   const deps: ReplayPendingRunsDeps = {
     runTracker,
     webhookService,
     scheduledExecution,
+    configuredWebhookWorkflows,
+    configuredWebhookRoutes,
+    configuredCronWorkflows,
   };
 
   return {
@@ -535,6 +563,117 @@ Deno.test("replayPendingRuns: webhook with no payload uses empty object", async 
   assertEquals(h.webhookReplays.length, 1);
 });
 
+Deno.test("replayPendingRuns: discards webhook entry with unconfigured workflow", async () => {
+  const h = createReplayHarness(
+    [{
+      id: "pr-unconfigured-wf",
+      source: "webhook",
+      workflowIdOrName: "unknown-workflow",
+      payload: JSON.stringify({ body: null, headers: {} }),
+      route: "/hooks/deploy",
+      createdAt: "2026-01-01T00:00:00Z",
+    }],
+    {
+      configuredWebhookWorkflows: new Set(["my-workflow"]),
+      configuredWebhookRoutes: new Set(["/hooks/deploy"]),
+    },
+  );
+
+  const count = await replayPendingRuns(h.deps);
+
+  assertEquals(count, 0);
+  assertEquals(h.webhookReplays.length, 0);
+  assertEquals(h.deleted, ["pr-unconfigured-wf"]);
+});
+
+Deno.test("replayPendingRuns: discards webhook entry with unconfigured route", async () => {
+  const h = createReplayHarness(
+    [{
+      id: "pr-unconfigured-route",
+      source: "webhook",
+      workflowIdOrName: "deploy-flow",
+      payload: JSON.stringify({ body: null, headers: {} }),
+      route: "/unknown",
+      createdAt: "2026-01-01T00:00:00Z",
+    }],
+    {
+      configuredWebhookWorkflows: new Set(["deploy-flow"]),
+      configuredWebhookRoutes: new Set(["/hooks/github"]),
+    },
+  );
+
+  const count = await replayPendingRuns(h.deps);
+
+  assertEquals(count, 0);
+  assertEquals(h.webhookReplays.length, 0);
+  assertEquals(h.deleted, ["pr-unconfigured-route"]);
+});
+
+Deno.test("replayPendingRuns: discards cron entry with unconfigured workflow", async () => {
+  const h = createReplayHarness(
+    [{
+      id: "pr-unconfigured-cron",
+      source: "cron",
+      workflowIdOrName: "unknown",
+      createdAt: "2026-01-01T00:00:00Z",
+    }],
+    {
+      configuredCronWorkflows: new Set(["my-scheduled"]),
+    },
+  );
+
+  const count = await replayPendingRuns(h.deps);
+
+  assertEquals(count, 0);
+  assertEquals(h.cronReplays.length, 0);
+  assertEquals(h.deleted, ["pr-unconfigured-cron"]);
+});
+
+Deno.test("replayPendingRuns: replays valid webhook entry when workflow is configured", async () => {
+  const h = createReplayHarness(
+    [{
+      id: "pr-valid-wh",
+      source: "webhook",
+      workflowIdOrName: "deploy-flow",
+      payload: JSON.stringify({ body: { ref: "main" }, headers: {} }),
+      route: "/hooks/deploy",
+      createdAt: "2026-01-01T00:00:00Z",
+    }],
+    {
+      configuredWebhookWorkflows: new Set(["deploy-flow"]),
+      configuredWebhookRoutes: new Set(["/hooks/deploy"]),
+    },
+  );
+
+  const count = await replayPendingRuns(h.deps);
+
+  assertEquals(count, 1);
+  assertEquals(h.webhookReplays.length, 1);
+  assertEquals(h.webhookReplays[0].workflowIdOrName, "deploy-flow");
+  assertEquals(h.webhookReplays[0].pendingRunId, "pr-valid-wh");
+});
+
+Deno.test("replayPendingRuns: replays valid cron entry when workflow is configured", async () => {
+  const h = createReplayHarness(
+    [{
+      id: "pr-valid-cron",
+      source: "cron",
+      workflowIdOrName: "nightly-sync",
+      createdAt: "2026-01-01T00:00:00Z",
+    }],
+    {
+      configuredCronWorkflows: new Set(["nightly-sync"]),
+    },
+  );
+
+  const count = await replayPendingRuns(h.deps);
+
+  assertEquals(count, 1);
+  assertEquals(h.cronReplays.length, 1);
+  assertEquals(h.cronReplays[0].workflowIdOrName, "nightly-sync");
+  assertEquals(h.cronReplays[0].pendingRunId, "pr-valid-cron");
+});
+
 Deno.test("sweepStaleRecords: sweeps all three model types together", async () => {
   const h = createHarness(
     new Map([
@@ -620,7 +759,10 @@ Deno.test("replayPendingRuns: merges remote-only entries into replay", async () 
   const controlPlaneStore = createInMemoryControlPlaneStore({
     "pending-runs/remote-1": remoteEntry,
   });
-  const h = createReplayHarness([]);
+  const h = createReplayHarness([], {
+    configuredWebhookWorkflows: new Set(["remote-flow"]),
+    configuredWebhookRoutes: new Set(["/hooks/remote"]),
+  });
   h.deps.controlPlaneStore = controlPlaneStore;
 
   const count = await replayPendingRuns(h.deps);
@@ -641,7 +783,9 @@ Deno.test("replayPendingRuns: deduplicates local and remote entries by id", asyn
     "pending-runs/dup-1": sharedEntry,
   });
   // Local also has the same entry
-  const h = createReplayHarness([sharedEntry]);
+  const h = createReplayHarness([sharedEntry], {
+    configuredCronWorkflows: new Set(["shared-flow"]),
+  });
   h.deps.controlPlaneStore = controlPlaneStore;
 
   const count = await replayPendingRuns(h.deps);

--- a/src/serve/capability_service.ts
+++ b/src/serve/capability_service.ts
@@ -73,10 +73,19 @@ import {
 } from "../domain/models/worker/enrollment_token_model.ts";
 import { WORKER_MODEL_TYPE } from "../domain/models/worker/worker_model.ts";
 import { STEP_LEASE_MODEL_TYPE } from "../domain/models/worker/step_lease_model.ts";
+import { TOKEN_SECRETS_VAULT_NAME } from "../domain/vaults/control_plane_vault_provider.ts";
+
+const DENIED_VAULT_NAMES: ReadonlySet<string> = new Set([
+  TOKEN_SECRETS_VAULT_NAME,
+]);
 
 const DENIED_SECRET_KEY_PREFIXES: readonly string[] = [
   SERVER_TOKEN_SECRET_KEY_PREFIX,
   WORKER_TOKEN_SECRET_KEY_PREFIX,
+  "oauth-client-secret",
+  "oauth-access-token-",
+  "oauth-bootstrap-access-token",
+  "oauth-resolved-admins",
 ];
 
 const DENIED_QUERY_MODEL_TYPES: readonly string[] = [
@@ -347,6 +356,14 @@ export class CapabilityService {
     return { deleted: true };
   }
 
+  #assertVaultNotDenied(vaultName: string, verb: string): void {
+    if (DENIED_VAULT_NAMES.has(vaultName)) {
+      throw new Error(
+        `${verb}: access denied — reserved vault '${vaultName}' is not accessible from dispatched methods`,
+      );
+    }
+  }
+
   #assertSecretKeyNotDenied(secretKey: string, verb: string): void {
     const normalized = secretKey.toLowerCase();
     if (DENIED_SECRET_KEY_PREFIXES.some((p) => normalized.startsWith(p))) {
@@ -379,6 +396,8 @@ export class CapabilityService {
     workerName: string,
     params: ResolveSecretParams & { dispatchId?: string },
   ): Promise<{ value: unknown }> {
+    this.#assertVaultNotDenied(params.vaultName, "resolveSecret");
+    this.#assertSecretKeyNotDenied(params.secretKey, "resolveSecret");
     if (this.#dispatches) {
       const dispatch = this.#resolveDispatch(
         workerName,
@@ -390,7 +409,6 @@ export class CapabilityService {
           `resolveSecret: worker '${workerName}' has no active dispatch`,
         );
       }
-      this.#assertSecretKeyNotDenied(params.secretKey, "resolveSecret");
       this.#assertSecretInAllowlist(
         dispatch,
         params.vaultName,
@@ -418,6 +436,8 @@ export class CapabilityService {
     workerName: string,
     params: PutSecretParams & { dispatchId?: string },
   ): Promise<{ ok: boolean }> {
+    this.#assertVaultNotDenied(params.vaultName, "putSecret");
+    this.#assertSecretKeyNotDenied(params.secretKey, "putSecret");
     if (this.#dispatches) {
       const dispatch = this.#resolveDispatch(
         workerName,
@@ -429,7 +449,6 @@ export class CapabilityService {
           `putSecret: worker '${workerName}' has no active dispatch`,
         );
       }
-      this.#assertSecretKeyNotDenied(params.secretKey, "putSecret");
     }
     const vault = await this.#vault();
     if (params.deleteAnnotation) {

--- a/src/serve/capability_service_test.ts
+++ b/src/serve/capability_service_test.ts
@@ -551,3 +551,59 @@ Deno.test("putSecret: passes without dispatch registry (no scoping)", async () =
   });
   assertEquals(result.ok, true);
 });
+
+// ── reserved vault name tests (hoisted guards) ──────────────────────────
+
+Deno.test("resolveSecret: rejects _token-secrets vault name", async () => {
+  const service = createService(undefined);
+  await assertRejects(
+    () =>
+      service.resolveSecret("worker-1", {
+        vaultName: "_token-secrets",
+        secretKey: "some-key",
+      }),
+    Error,
+    "reserved vault",
+  );
+});
+
+Deno.test("putSecret: rejects _token-secrets vault name", async () => {
+  const service = createService(undefined);
+  await assertRejects(
+    () =>
+      service.putSecret("worker-1", {
+        vaultName: "_token-secrets",
+        secretKey: "some-key",
+        secretValue: "val",
+      }),
+    Error,
+    "reserved vault",
+  );
+});
+
+Deno.test("resolveSecret: rejects oauth-access-token- prefixed keys", async () => {
+  const service = createService(undefined);
+  await assertRejects(
+    () =>
+      service.resolveSecret("worker-1", {
+        vaultName: "default",
+        secretKey: "oauth-access-token-github",
+      }),
+    Error,
+    "infrastructure secrets",
+  );
+});
+
+Deno.test("putSecret: rejects oauth-client-secret key", async () => {
+  const service = createService(undefined);
+  await assertRejects(
+    () =>
+      service.putSecret("worker-1", {
+        vaultName: "default",
+        secretKey: "oauth-client-secret",
+        secretValue: "evil",
+      }),
+    Error,
+    "infrastructure secrets",
+  );
+});

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -129,6 +129,7 @@ import {
   send,
   sendError,
 } from "./shared.ts";
+import { isReservedVaultName } from "./vault_handlers.ts";
 
 export async function handleWorkerList(
   socket: WebSocket,
@@ -1067,6 +1068,16 @@ export async function handleVaultMigrate(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  if (isReservedVaultName(payload.vaultName)) {
+    sendError(
+      socket,
+      requestId,
+      "forbidden",
+      `Vault '${payload.vaultName}' is reserved for internal use`,
+    );
+    return;
+  }
+
   if (
     !authorizeOrReject(socket, requestId, principal, "admin", {
       kind: "model",

--- a/src/serve/handlers/vault_handlers.ts
+++ b/src/serve/handlers/vault_handlers.ts
@@ -63,6 +63,27 @@ import {
   sendError,
 } from "./shared.ts";
 
+export function isReservedVaultName(name: string): boolean {
+  return name.startsWith("_");
+}
+
+function rejectReservedVault(
+  socket: WebSocket,
+  requestId: string,
+  vaultName: string,
+): boolean {
+  if (isReservedVaultName(vaultName)) {
+    sendError(
+      socket,
+      requestId,
+      "forbidden",
+      `Vault '${vaultName}' is reserved for internal use`,
+    );
+    return true;
+  }
+  return false;
+}
+
 export async function handleVaultGet(
   socket: WebSocket,
   ctx: ConnectionContext,
@@ -126,6 +147,8 @@ export async function handleVaultPut(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  if (rejectReservedVault(socket, requestId, payload.vaultName)) return;
+
   if (payload.refreshFrom !== undefined || payload.clearRefresh) {
     if (
       !authorizeOrReject(socket, requestId, principal, "admin", {
@@ -236,6 +259,8 @@ export async function handleVaultDelete(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  if (rejectReservedVault(socket, requestId, payload.vaultName)) return;
+
   if (
     !authorizeOrReject(socket, requestId, principal, "write", {
       kind: "data",
@@ -412,6 +437,8 @@ export async function handleVaultInspect(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  if (rejectReservedVault(socket, requestId, payload.vaultName)) return;
+
   if (
     !authorizeOrReject(socket, requestId, principal, "read", {
       kind: "data",
@@ -467,6 +494,11 @@ export async function handleVaultListKeys(
   principal: Principal | null,
   payload?: VaultListKeysPayload,
 ): Promise<void> {
+  if (
+    payload?.vaultName &&
+    rejectReservedVault(socket, requestId, payload.vaultName)
+  ) return;
+
   if (
     !authorizeOrReject(socket, requestId, principal, "read", {
       kind: "data",
@@ -571,6 +603,8 @@ export async function handleVaultAnnotate(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  if (rejectReservedVault(socket, requestId, payload.vaultName)) return;
+
   if (
     !authorizeOrReject(socket, requestId, principal, "write", {
       kind: "data",

--- a/src/serve/handlers/vault_handlers_test.ts
+++ b/src/serve/handlers/vault_handlers_test.ts
@@ -1,0 +1,39 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { isReservedVaultName } from "./vault_handlers.ts";
+
+Deno.test("isReservedVaultName: returns true for _token-secrets", () => {
+  assertEquals(isReservedVaultName("_token-secrets"), true);
+});
+
+Deno.test("isReservedVaultName: returns true for _any-underscore-prefix", () => {
+  assertEquals(isReservedVaultName("_any-underscore-prefix"), true);
+});
+
+Deno.test("isReservedVaultName: returns false for normal vault names", () => {
+  assertEquals(isReservedVaultName("default"), false);
+  assertEquals(isReservedVaultName("my-vault"), false);
+  assertEquals(isReservedVaultName("production"), false);
+});
+
+Deno.test("isReservedVaultName: returns false for empty string", () => {
+  assertEquals(isReservedVaultName(""), false);
+});

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -46,12 +46,39 @@ const logger = getSwampLogger(["serve", "webhook"]);
 /** Default signature header — used by the github scheme. */
 const SIGNATURE_HEADER = "x-hub-signature-256";
 
+const REDACTED_HEADERS: ReadonlySet<string> = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "set-cookie",
+  "x-api-key",
+  "x-auth-token",
+  "x-hub-signature",
+  "x-shopify-hmac-sha256",
+  "x-amzn-oidc-accesstoken",
+  "x-amzn-oidc-data",
+  "x-goog-iap-jwt-assertion",
+  "cf-access-jwt-assertion",
+  "x-forwarded-client-cert",
+]);
+
+const REDACTED_HEADER_SUFFIXES: readonly string[] = [
+  "-token",
+  "-secret",
+];
+
+export function isSensitiveHeader(name: string): boolean {
+  const lower = name.toLowerCase();
+  if (REDACTED_HEADERS.has(lower)) return true;
+  return REDACTED_HEADER_SUFFIXES.some((suffix) => lower.endsWith(suffix));
+}
+
 /**
  * Builds the {@link WebhookPayload} exposed to a workflow's `trigger.inputs`
  * CEL expressions from a verified request. The body is JSON-parsed when
  * possible, falling back to the raw UTF-8 string for non-JSON payloads. Header
- * names are lowercased and the signature header is dropped so it can never leak
- * into workflow inputs.
+ * names are lowercased; the signature header and sensitive credential headers
+ * are dropped so they can never leak into workflow inputs or persistent storage.
  */
 export function buildWebhookPayload(
   body: Uint8Array,
@@ -72,6 +99,7 @@ export function buildWebhookPayload(
   for (const [name, value] of headers) {
     const lower = name.toLowerCase();
     if (lower === excluded) continue;
+    if (isSensitiveHeader(lower)) continue;
     exposedHeaders[lower] = value;
   }
 

--- a/src/serve/webhook_test.ts
+++ b/src/serve/webhook_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import {
   buildWebhookPayload,
+  isSensitiveHeader,
   parseWebhookFlag,
   resolveSecret,
   WebhookService,
@@ -371,4 +372,178 @@ Deno.test("listEndpoints: includes scheme from each endpoint verifier", () => {
   assertEquals(infos[0].scheme, "github");
   assertEquals(infos[1].scheme, "stripe");
   assertEquals(infos[2].scheme, "generic");
+});
+
+// ── buildWebhookPayload header redaction ─────────────────────────────
+
+Deno.test("buildWebhookPayload: strips authorization header", () => {
+  const headers = new Headers({
+    "Authorization": "Bearer secret-token",
+    "Content-Type": "application/json",
+  });
+  const payload = buildWebhookPayload(
+    new TextEncoder().encode("{}"),
+    headers,
+    "/test",
+  );
+  assertEquals("authorization" in payload.headers, false);
+  assertEquals(payload.headers["content-type"], "application/json");
+});
+
+Deno.test("buildWebhookPayload: strips proxy-authorization header", () => {
+  const headers = new Headers({
+    "Proxy-Authorization": "Basic dXNlcjpwYXNz",
+    "Content-Type": "application/json",
+  });
+  const payload = buildWebhookPayload(
+    new TextEncoder().encode("{}"),
+    headers,
+    "/test",
+  );
+  assertEquals("proxy-authorization" in payload.headers, false);
+  assertEquals(payload.headers["content-type"], "application/json");
+});
+
+Deno.test("buildWebhookPayload: strips cookie header", () => {
+  const headers = new Headers({
+    "Cookie": "session=abc123",
+    "Content-Type": "application/json",
+  });
+  const payload = buildWebhookPayload(
+    new TextEncoder().encode("{}"),
+    headers,
+    "/test",
+  );
+  assertEquals("cookie" in payload.headers, false);
+  assertEquals(payload.headers["content-type"], "application/json");
+});
+
+Deno.test("buildWebhookPayload: strips x-api-key header", () => {
+  const headers = new Headers({
+    "X-Api-Key": "key-12345",
+    "Content-Type": "application/json",
+  });
+  const payload = buildWebhookPayload(
+    new TextEncoder().encode("{}"),
+    headers,
+    "/test",
+  );
+  assertEquals("x-api-key" in payload.headers, false);
+  assertEquals(payload.headers["content-type"], "application/json");
+});
+
+Deno.test("buildWebhookPayload: strips x-amzn-oidc-accesstoken header", () => {
+  const headers = new Headers({
+    "X-Amzn-Oidc-Accesstoken": "eyJhbGciOi...",
+    "Content-Type": "application/json",
+  });
+  const payload = buildWebhookPayload(
+    new TextEncoder().encode("{}"),
+    headers,
+    "/test",
+  );
+  assertEquals("x-amzn-oidc-accesstoken" in payload.headers, false);
+  assertEquals(payload.headers["content-type"], "application/json");
+});
+
+Deno.test("buildWebhookPayload: strips headers with -token suffix", () => {
+  const headers = new Headers({
+    "X-Custom-Token": "tok_abc",
+    "Content-Type": "application/json",
+  });
+  const payload = buildWebhookPayload(
+    new TextEncoder().encode("{}"),
+    headers,
+    "/test",
+  );
+  assertEquals("x-custom-token" in payload.headers, false);
+  assertEquals(payload.headers["content-type"], "application/json");
+});
+
+Deno.test("buildWebhookPayload: strips headers with -secret suffix", () => {
+  const headers = new Headers({
+    "X-Custom-Secret": "s3cret",
+    "Content-Type": "application/json",
+  });
+  const payload = buildWebhookPayload(
+    new TextEncoder().encode("{}"),
+    headers,
+    "/test",
+  );
+  assertEquals("x-custom-secret" in payload.headers, false);
+  assertEquals(payload.headers["content-type"], "application/json");
+});
+
+Deno.test("buildWebhookPayload: preserves standard event headers", () => {
+  const headers = new Headers({
+    "X-GitHub-Event": "push",
+    "Content-Type": "application/json",
+    "X-GitHub-Delivery": "72d3162e-cc78-11e3-81ab-4c9367dc0958",
+  });
+  const payload = buildWebhookPayload(
+    new TextEncoder().encode("{}"),
+    headers,
+    "/test",
+  );
+  assertEquals(payload.headers["x-github-event"], "push");
+  assertEquals(payload.headers["content-type"], "application/json");
+  assertEquals(
+    payload.headers["x-github-delivery"],
+    "72d3162e-cc78-11e3-81ab-4c9367dc0958",
+  );
+});
+
+Deno.test("buildWebhookPayload: preserves idempotency-key header", () => {
+  const headers = new Headers({
+    "Idempotency-Key": "unique-key-123",
+    "Content-Type": "application/json",
+  });
+  const payload = buildWebhookPayload(
+    new TextEncoder().encode("{}"),
+    headers,
+    "/test",
+  );
+  assertEquals(payload.headers["idempotency-key"], "unique-key-123");
+});
+
+// ── isSensitiveHeader ────────────────────────────────────────────────
+
+Deno.test("isSensitiveHeader: returns true for known sensitive headers", () => {
+  const sensitiveHeaders = [
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+    "set-cookie",
+    "x-api-key",
+    "x-auth-token",
+    "x-hub-signature",
+    "x-shopify-hmac-sha256",
+    "x-amzn-oidc-accesstoken",
+    "x-amzn-oidc-data",
+    "x-goog-iap-jwt-assertion",
+    "cf-access-jwt-assertion",
+    "x-forwarded-client-cert",
+  ];
+  for (const header of sensitiveHeaders) {
+    assertEquals(
+      isSensitiveHeader(header),
+      true,
+      `expected ${header} to be sensitive`,
+    );
+  }
+});
+
+Deno.test("isSensitiveHeader: returns false for safe headers", () => {
+  const safeHeaders = [
+    "content-type",
+    "x-github-event",
+    "idempotency-key",
+  ];
+  for (const header of safeHeaders) {
+    assertEquals(
+      isSensitiveHeader(header),
+      false,
+      `expected ${header} to be safe`,
+    );
+  }
 });


### PR DESCRIPTION
## Summary

Fixes five security vulnerabilities identified in serve's HA coordination, vault handling, webhook persistence, and boot reconciliation subsystems.

### 1. CRITICAL — Vault-write escalates to token impersonation
- Reject underscore-prefixed vault names in client vault handlers (`handleVaultPut`, `handleVaultDelete`, `handleVaultListKeys`, `handleVaultInspect`, `handleVaultAnnotate`, `handleVaultMigrate`)
- Add `DENIED_VAULT_NAMES` set in capability service as primary control; extend `DENIED_SECRET_KEY_PREFIXES` with OAuth key prefixes as defense-in-depth
- Guard `processSensitiveResourceData` in `data_writer.ts` — the real write path for model-authored vault writes
- Hoist vault name and key denials outside `if (this.#dispatches)` so they're unconditional

### 2. HIGH — Control-plane ignores namespace, breaking tenant isolation
- Pass namespace to `hydrateLocalCache` so the S3/GCS extension's `bindNamespace` activates correctly
- Acquire `controlPlaneStore()` **after** hydration so `list()` captures the namespaced prefix (the extension captures `controlPrefixPath` at construction time)
- One-time migration: read root-path records before binding, copy to namespaced path after binding, write sentinel to prevent re-migration; root records left intact for rollback safety

### 3. HIGH — Boot reap kills live remote-instance runs
- Add `localInstanceId` parameter to `reapOrphanedWorkflowRuns`
- Gate the PID fallback on instanceId mismatch — placed **after** tracker miss, not before, so this machine's own crashed runs from a previous boot are still reaped correctly
- Log skipped remote runs with run ID and instance ID for diagnosability

### 4. HIGH — Webhook headers persisted unredacted
- Add denylist of sensitive headers (auth, proxy credentials, provider-specific) plus `-token`/`-secret` suffix rules
- Scrub existing SQLite `pending_runs` rows at boot via `scrubPendingRunHeaders`
- Redact headers from stored payloads during replay
- Update `design/workflow.md` to reflect the new behavior

### 5. HIGH — Boot replay executes unvalidated workflows
- Validate webhook and cron entries against configured endpoint/schedule sets (all three sets are **required** on `ReplayPendingRunsDeps` — omission is a compile error)
- Validate `route` against configured webhook routes
- Track remote source keys via `remoteSourceKeys` map so `discardEntry` deletes by the actual listed key, not a reconstructed one

## Test Plan

- 28 new unit tests covering all five fixes: vault name rejection, capability denials, header redaction, instanceId boot reap, replay validation
- Integration-tested with minio as remote datastore:
  - Fresh namespaced deployment: control-plane keys at `{namespace}/_control/`, not root
  - Key persistence across restarts: `Loaded existing token encryption key`
  - Root→namespace migration: records migrated, sentinel written, key reused
  - Sentinel prevents re-migration on subsequent boots
  - Two-instance HA: separate heartbeats, shared encryption key, no false reaping
  - OAuth flow: full device-grant bootstrap with swamp-club.com
- `deno check` ✓ `deno lint` ✓ `deno fmt` ✓ `deno run test` (9869 passed) ✓ `deno run compile` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)