### PR TITLE
feat(serve): add --server support to serve reload

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -1110,13 +1110,20 @@ nginx pattern.
 
 1. Start serve with `swamp serve --hot-reload`
 2. Push updated extension code, pull it (`swamp extension pull @name --force`)
-3. Run `swamp serve reload` — reads `.swamp/serve.pid`, sends SIGHUP
+3. Trigger a reload:
+   - **Local**: `swamp serve reload` — reads `.swamp/serve.pid`, sends SIGHUP
+   - **Remote**: `swamp serve reload --server wss://host:port` — sends a
+     `serve.reload` WebSocket request (requires admin authorization)
 4. Serve reloads all pulled extension types. In-flight requests complete on old
    code; new requests use new code.
 
 ### Mechanism
 
-On SIGHUP, `reloadPulledExtensions()` performs a READ-ONLY scan:
+Both the SIGHUP signal handler and the `serve.reload` WebSocket handler call the
+same shared `performServeReload()` function in `src/serve/extension_reload.ts`.
+A module-level reloading guard prevents concurrent reloads from either trigger.
+
+`reloadPulledExtensions()` performs a READ-ONLY scan:
 
 1. Opens a fresh `ExtensionCatalogStore` (reads `_extension_catalog.db`)
 2. Reads the lockfile via `LockfileRepository` for extension names/versions

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -73,7 +73,6 @@ import {
 import { groupCommandAction } from "../group_action.ts";
 import {
   normalizeFireTime,
-  resolveTrustedCollectives,
   ScheduledExecutionService,
 } from "../../libswamp/mod.ts";
 import {
@@ -97,19 +96,18 @@ import { RunCancelRegistry } from "../../serve/run_cancel_registry.ts";
 import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
 import { reportRegistry } from "../../domain/reports/report_registry.ts";
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
-import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
 import {
-  incrementReloadGeneration,
-  LockfileRepository,
-} from "../../libswamp/mod.ts";
-import { removeAttachedExtensionsForType } from "../../domain/extensions/model_kind_adapter.ts";
+  isReloading,
+  performServeReload,
+} from "../../serve/extension_reload.ts";
 import {
-  extensionKindToKindDir,
-} from "../../domain/extensions/source_failure_recorder.ts";
-import { computeSourceFingerprint } from "../../domain/extensions/bundle_freshness.ts";
-import { bundleExtension } from "../../domain/models/bundle.ts";
-import { EmbeddedDenoRuntime } from "../../infrastructure/runtime/embedded_deno_runtime.ts";
-import { ModelType } from "../../domain/models/model_type.ts";
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+} from "../remote_run.ts";
+import { validateServerRepoExclusivity } from "./access_helpers.ts";
+import type { ServeReloadResponse } from "../../serve/protocol.ts";
+import { createServeReloadRenderer } from "../../presentation/renderers/serve_reload.ts";
 import {
   type PolicyReloadMode,
   PolicySnapshotLoader,
@@ -131,7 +129,7 @@ import {
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { GRANT_MODEL_TYPE } from "../../domain/models/access/grant_model.ts";
 import { cleanupEmptyParentDirs } from "../../infrastructure/persistence/directory_cleanup.ts";
-import { dirname, isAbsolute, join, resolve } from "@std/path";
+import { isAbsolute, join, resolve } from "@std/path";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
 import {
   RepoMarkerRepository,
@@ -142,7 +140,6 @@ import {
   RunTrackerStore,
 } from "../../infrastructure/persistence/run_tracker_store.ts";
 import { swampPath } from "../../infrastructure/persistence/paths.ts";
-import { canonicalizePath } from "../../infrastructure/persistence/canonicalize_path.ts";
 import { DefaultDatastorePathResolver } from "../../infrastructure/persistence/default_datastore_path_resolver.ts";
 import {
   cleanupExpiredClaims,
@@ -162,8 +159,6 @@ import {
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
 import { requireAuthenticated, requireScope } from "../auth_context.ts";
-import { getAutoResolver } from "../../domain/extensions/auto_resolver_context.ts";
-import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
 import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
 import {
@@ -668,182 +663,66 @@ const daemonStatusCommand = new Command()
     renderDaemonStatus(status, ctx.outputMode, toServiceMode(mode));
   });
 
-async function reloadPulledExtensions(
-  repoDir: string,
-  lockfilePath: string,
-): Promise<number> {
-  incrementReloadGeneration();
-
-  const catalogDbPath = swampPath(repoDir, "_extension_catalog.db");
-
-  const catalog = new ExtensionCatalogStore(catalogDbPath);
-  try {
-    const lockfile = await LockfileRepository.create(lockfilePath);
-    const entries = lockfile.getAllEntries();
-
-    // Re-bundle only sources whose fingerprint changed since the catalog
-    // was last written. Unchanged sources keep their existing bundle and
-    // skip the expensive deno-bundle subprocess.
-    // Query by source_path prefix instead of extension_name — the
-    // source_path PK always reflects the pulled-extensions directory
-    // layout, even when extension_name is empty (swamp-club#1149).
-    const pulledRoot = join(repoDir, ".swamp", "pulled-extensions");
-    const rebundled = new Set<string>();
-    let denoRuntime: EmbeddedDenoRuntime | undefined;
-    let denoPath: string | undefined;
-    for (const [extName] of Object.entries(entries)) {
-      const sourcePrefix = canonicalizePath(
-        join(pulledRoot, extName) + "/",
-      );
-      const allRows = catalog.findBySourcePathPrefix(sourcePrefix);
-      for (const row of allRows) {
-        if (
-          !row.source_path || !row.bundle_path ||
-          rebundled.has(row.source_path)
-        ) continue;
-        try {
-          const kindDir = extensionKindToKindDir(
-            row.kind as Parameters<typeof extensionKindToKindDir>[0],
-          );
-          const baseDir = join(pulledRoot, extName, kindDir);
-          const currentFp = await computeSourceFingerprint(
-            row.source_path,
-            baseDir,
-          );
-          if (currentFp === row.source_fingerprint) continue;
-          if (!denoRuntime) {
-            denoRuntime = new EmbeddedDenoRuntime();
-          }
-          if (!denoPath) {
-            denoPath = await denoRuntime.ensureDeno();
-          }
-          const js = await bundleExtension(row.source_path, denoPath, {
-            env: denoRuntime.getDenoEnv(),
-          });
-          await Deno.mkdir(dirname(row.bundle_path), { recursive: true });
-          await Deno.writeTextFile(row.bundle_path, js);
-          catalog.updateSourceFingerprint(row.source_path, currentFp);
-          rebundled.add(row.source_path);
-        } catch (err) {
-          logger.warn(
-            "Hot-reload: failed to re-bundle {path}, keeping old bundle: {error}",
-            {
-              path: row.source_path,
-              error: err instanceof Error ? err.message : String(err),
-            },
-          );
-        }
-      }
-    }
-
-    let reloadedCount = 0;
-    for (const [name] of Object.entries(entries)) {
-      const sourcePrefix = canonicalizePath(
-        join(pulledRoot, name) + "/",
-      );
-      const rows = catalog.findBySourcePathPrefix(sourcePrefix);
-      if (rows.length === 0) continue;
-
-      for (const row of rows) {
-        if (!row.type_normalized) continue;
-        try {
-          const kind = row.kind;
-
-          if (kind === "model") {
-            modelRegistry.invalidateType(row.type_normalized);
-            removeAttachedExtensionsForType(row.type_normalized);
-            modelRegistry.registerLazy({
-              type: ModelType.create(row.type_normalized),
-              bundlePath: row.bundle_path,
-              sourcePath: row.source_path,
-              version: row.version,
-              sourceFingerprint: row.source_fingerprint,
-            });
-            await modelRegistry.ensureTypeLoaded(row.type_normalized);
-            reloadedCount++;
-          } else if (kind === "vault") {
-            vaultTypeRegistry.invalidateType(row.type_normalized);
-            vaultTypeRegistry.registerLazy({
-              type: row.type_normalized,
-              bundlePath: row.bundle_path,
-              sourcePath: row.source_path,
-              version: row.version,
-            });
-            await vaultTypeRegistry.ensureTypeLoaded(row.type_normalized);
-            reloadedCount++;
-          } else if (kind === "datastore") {
-            datastoreTypeRegistry.invalidateType(row.type_normalized);
-            datastoreTypeRegistry.registerLazy({
-              type: row.type_normalized,
-              bundlePath: row.bundle_path,
-              sourcePath: row.source_path,
-              version: row.version,
-            });
-            await datastoreTypeRegistry.ensureTypeLoaded(row.type_normalized);
-            reloadedCount++;
-          } else if (kind === "report") {
-            reportRegistry.invalidateType(row.type_normalized);
-            reportRegistry.registerLazy({
-              type: row.type_normalized,
-              bundlePath: row.bundle_path,
-              sourcePath: row.source_path,
-              version: row.version,
-            });
-            await reportRegistry.ensureTypeLoaded(row.type_normalized);
-            reloadedCount++;
-          }
-        } catch (err) {
-          logger.warn(
-            "Failed to reload type {type} from {extension}: {error}",
-            {
-              type: row.type_normalized,
-              extension: name,
-              error: err instanceof Error ? err.message : String(err),
-            },
-          );
-        }
-      }
-    }
-    return reloadedCount;
-  } finally {
-    catalog.close();
-  }
-}
-
-async function reloadTrustedCollectives(
-  repoDir: string,
-): Promise<void> {
-  const markerRepo = new RepoMarkerRepository();
-  const marker = await markerRepo.read(RepoPath.create(repoDir));
-
-  let authCollectives: string[] | undefined;
-  try {
-    const authRepo = new AuthRepository();
-    const creds = await authRepo.load();
-    authCollectives = creds?.collectives;
-  } catch {
-    // Auth file unreadable — continue without membership collectives
-  }
-
-  const collectives = resolveTrustedCollectives(marker, authCollectives);
-  const resolver = getAutoResolver();
-  if (resolver) {
-    resolver.updateAllowedCollectives(collectives);
-  }
-}
-
 const reloadCommand = new Command()
   .name("reload")
   .description(
     "Reload pulled extension bundles and refresh the trust list on a running serve process.\n\n" +
-      "Reads .swamp/serve.pid and sends SIGHUP to trigger hot-reload. " +
-      "Requires the serve process to be running with --hot-reload.",
+      "With --server, sends a serve.reload request over WebSocket. " +
+      "Without --server, reads .swamp/serve.pid and sends SIGHUP locally. " +
+      "The local path requires the serve process to be running with --hot-reload.",
   )
+  .example(
+    "Reload on a remote server",
+    "swamp serve reload --server wss://swamp.acme.internal:9090",
+  )
+  .example("Reload locally", "swamp serve reload")
   .option(
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
-  .action(async (options: AnyOptions) => {
+  .option(
+    "--server <url:string>",
+    "Reload extensions on a 'swamp serve' server instead of locally (env: SWAMP_SERVE_URL)",
+  )
+  .option(
+    "--token <token:string>",
+    "Server token (falls back to stored credential)",
+  )
+  .action(async function (options: AnyOptions) {
+    const server = resolveServeUrl(options.server as string | undefined);
+
+    validateServerRepoExclusivity(
+      server,
+      options.repoDir as string | undefined,
+    );
+
+    const ctx = createContext(options as GlobalOptions, ["serve", "reload"]);
+    const renderer = createServeReloadRenderer(ctx.outputMode);
+
+    if (server) {
+      const token = await resolveServerToken(
+        server,
+        options.token as string | undefined,
+      );
+
+      const response = await requestServerResponse<ServeReloadResponse>(
+        { server, ...(token ? { token } : {}) },
+        { type: "serve.reload" },
+      );
+
+      if (!response.success) {
+        renderer.render({
+          success: false,
+          reloadedCount: 0,
+          errors: response.errors,
+        });
+        throw new UserError("Extension reload failed on the server");
+      }
+
+      renderer.render(response);
+      return;
+    }
+
     const repoDir = resolveRepoDir(options.repoDir as string | undefined);
     const pidPath = swampPath(repoDir, "serve.pid");
 
@@ -2824,39 +2703,26 @@ export const serveCommand = new Command()
       await Deno.writeTextFile(pidPath, String(Deno.pid));
       logger.info`Hot-reload enabled, PID file written to ${pidPath}`;
 
-      let reloading = false;
       Deno.addSignalListener("SIGHUP", () => {
-        if (reloading) {
+        if (isReloading()) {
           logger.warn("Hot-reload already in progress, ignoring SIGHUP");
           return;
         }
-        reloading = true;
         logger.info("SIGHUP received, reloading pulled extensions...");
-        reloadPulledExtensions(resolvedRepoDir, extensionLockfilePath)
-          .then(async (count) => {
-            logger.info`Hot-reloaded ${count} type(s)`;
-            try {
-              await reloadTrustedCollectives(resolvedRepoDir);
-              logger.info("Trust list refreshed from .swamp.yaml");
-            } catch (err) {
-              logger.warn(
-                "Failed to refresh trust list, keeping current config: {error}",
-                {
-                  error: err instanceof Error ? err.message : String(err),
-                },
-              );
+        performServeReload(resolvedRepoDir, extensionLockfilePath)
+          .then((result) => {
+            if (result.success) {
+              logger.info`Hot-reloaded ${result.reloadedCount} type(s)`;
+              if (result.errors.length > 0) {
+                for (const err of result.errors) {
+                  logger.warn`${err}`;
+                }
+              }
+            } else {
+              for (const err of result.errors) {
+                logger.error`${err}`;
+              }
             }
-          })
-          .catch((err) => {
-            logger.error(
-              "Hot-reload failed, continuing with old code: {error}",
-              {
-                error: err instanceof Error ? err.message : String(err),
-              },
-            );
-          })
-          .finally(() => {
-            reloading = false;
           });
       });
     }

--- a/src/presentation/renderers/serve_reload.ts
+++ b/src/presentation/renderers/serve_reload.ts
@@ -1,0 +1,66 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { OutputMode } from "../output/output.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import type { ServeReloadResponse } from "../../serve/protocol.ts";
+
+const logger = getSwampLogger(["serve", "reload"]);
+
+export interface ServeReloadRenderer {
+  render(result: ServeReloadResponse): void;
+}
+
+class LogServeReloadRenderer implements ServeReloadRenderer {
+  render(result: ServeReloadResponse): void {
+    if (!result.success) {
+      logger.error`Extension reload failed`;
+      for (const error of result.errors) {
+        logger.error`${error}`;
+      }
+      return;
+    }
+
+    logger.info`Reloaded ${result.reloadedCount} extension type(s)`;
+
+    if (result.errors.length > 0) {
+      for (const error of result.errors) {
+        logger.warn`${error}`;
+      }
+    }
+  }
+}
+
+class JsonServeReloadRenderer implements ServeReloadRenderer {
+  render(result: ServeReloadResponse): void {
+    writeOutput(JSON.stringify(result, null, 2));
+  }
+}
+
+export function createServeReloadRenderer(
+  mode: OutputMode,
+): ServeReloadRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonServeReloadRenderer();
+    case "log":
+      return new LogServeReloadRenderer();
+  }
+}

--- a/src/presentation/renderers/serve_reload_test.ts
+++ b/src/presentation/renderers/serve_reload_test.ts
@@ -1,0 +1,77 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { assertStringIncludes } from "@std/assert";
+import { createServeReloadRenderer } from "./serve_reload.ts";
+import type { ServeReloadResponse } from "../../serve/protocol.ts";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+await initializeLogging({});
+
+function captureRender(
+  mode: "log" | "json",
+  result: ServeReloadResponse,
+): string[] {
+  const renderer = createServeReloadRenderer(mode);
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.render(result);
+  } finally {
+    console.log = origLog;
+  }
+  return output;
+}
+
+Deno.test("createServeReloadRenderer: returns renderer for log mode", () => {
+  const renderer = createServeReloadRenderer("log");
+  assertEquals(typeof renderer.render, "function");
+});
+
+Deno.test("createServeReloadRenderer: returns renderer for json mode", () => {
+  const renderer = createServeReloadRenderer("json");
+  assertEquals(typeof renderer.render, "function");
+});
+
+Deno.test("serveReloadRenderer json: outputs full result as JSON", () => {
+  const result: ServeReloadResponse = {
+    success: true,
+    reloadedCount: 5,
+    errors: [],
+  };
+  const output = captureRender("json", result);
+  const parsed = JSON.parse(output.join(""));
+  assertEquals(parsed.success, true);
+  assertEquals(parsed.reloadedCount, 5);
+  assertEquals(parsed.errors, []);
+});
+
+Deno.test("serveReloadRenderer json: includes errors on failure", () => {
+  const result: ServeReloadResponse = {
+    success: false,
+    reloadedCount: 0,
+    errors: ["Reload already in progress"],
+  };
+  const output = captureRender("json", result);
+  const parsed = JSON.parse(output.join(""));
+  assertEquals(parsed.success, false);
+  assertStringIncludes(parsed.errors[0], "already in progress");
+});

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -113,6 +113,7 @@ import {
   handleExtensionUpdate,
   handleRunDoctor,
   handleRunHistory,
+  handleServeReload,
   handleVaultMigrate,
   handleWorkerList,
   handleWorkerQueueList,
@@ -227,6 +228,11 @@ const AccessCanIRequestSchema = z.object({
 
 const AccessReloadRequestSchema = z.object({
   type: z.literal("access.reload"),
+  id: z.string().min(1).max(256),
+});
+
+const ServeReloadRequestSchema = z.object({
+  type: z.literal("serve.reload"),
   id: z.string().min(1).max(256),
 });
 
@@ -878,6 +884,7 @@ const ServerRequestSchema = z.discriminatedUnion("type", [
   AccessCheckRequestSchema,
   AccessCanIRequestSchema,
   AccessReloadRequestSchema,
+  ServeReloadRequestSchema,
   DataGetRequestSchema,
   DataQueryRequestSchema,
   DataListRequestSchema,
@@ -1157,6 +1164,9 @@ export function handleMessage(
       break;
     case "access.reload":
       task = handleAccessReload(socket, ctx, request.id, principal);
+      break;
+    case "serve.reload":
+      task = handleServeReload(socket, ctx, request.id, principal);
       break;
     case "data.get":
       task = handleDataGet(

--- a/src/serve/extension_reload.ts
+++ b/src/serve/extension_reload.ts
@@ -1,0 +1,279 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { dirname, isAbsolute, join, resolve } from "@std/path";
+import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+import { modelRegistry } from "../domain/models/model.ts";
+import { vaultTypeRegistry } from "../domain/vaults/vault_type_registry.ts";
+import { reportRegistry } from "../domain/reports/report_registry.ts";
+import { datastoreTypeRegistry } from "../domain/datastore/datastore_type_registry.ts";
+import { ExtensionCatalogStore } from "../infrastructure/persistence/extension_catalog_store.ts";
+import {
+  incrementReloadGeneration,
+  LockfileRepository,
+} from "../libswamp/mod.ts";
+import { removeAttachedExtensionsForType } from "../domain/extensions/model_kind_adapter.ts";
+import { extensionKindToKindDir } from "../domain/extensions/source_failure_recorder.ts";
+import { computeSourceFingerprint } from "../domain/extensions/bundle_freshness.ts";
+import { bundleExtension } from "../domain/models/bundle.ts";
+import { EmbeddedDenoRuntime } from "../infrastructure/runtime/embedded_deno_runtime.ts";
+import { ModelType } from "../domain/models/model_type.ts";
+import { swampPath } from "../infrastructure/persistence/paths.ts";
+import { canonicalizePath } from "../infrastructure/persistence/canonicalize_path.ts";
+import {
+  type RepoMarkerData,
+  RepoMarkerRepository,
+} from "../infrastructure/persistence/repo_marker_repository.ts";
+import { RepoPath } from "../domain/repo/repo_path.ts";
+import { getAutoResolver } from "../domain/extensions/auto_resolver_context.ts";
+import { AuthRepository } from "../infrastructure/persistence/auth_repository.ts";
+import { resolveTrustedCollectives } from "../libswamp/mod.ts";
+import { resolveModelsDir } from "../cli/resolve_models_dir.ts";
+
+const logger = getSwampLogger(["serve", "reload"]);
+
+let reloading = false;
+
+export function isReloading(): boolean {
+  return reloading;
+}
+
+export async function reloadPulledExtensions(
+  repoDir: string,
+  lockfilePath: string,
+): Promise<number> {
+  incrementReloadGeneration();
+
+  const catalogDbPath = swampPath(repoDir, "_extension_catalog.db");
+
+  const catalog = new ExtensionCatalogStore(catalogDbPath);
+  try {
+    const lockfile = await LockfileRepository.create(lockfilePath);
+    const entries = lockfile.getAllEntries();
+
+    const pulledRoot = join(repoDir, ".swamp", "pulled-extensions");
+    const rebundled = new Set<string>();
+    let denoRuntime: EmbeddedDenoRuntime | undefined;
+    let denoPath: string | undefined;
+    for (const [extName] of Object.entries(entries)) {
+      const sourcePrefix = canonicalizePath(
+        join(pulledRoot, extName) + "/",
+      );
+      const allRows = catalog.findBySourcePathPrefix(sourcePrefix);
+      for (const row of allRows) {
+        if (
+          !row.source_path || !row.bundle_path ||
+          rebundled.has(row.source_path)
+        ) continue;
+        try {
+          const kindDir = extensionKindToKindDir(
+            row.kind as Parameters<typeof extensionKindToKindDir>[0],
+          );
+          const baseDir = join(pulledRoot, extName, kindDir);
+          const currentFp = await computeSourceFingerprint(
+            row.source_path,
+            baseDir,
+          );
+          if (currentFp === row.source_fingerprint) continue;
+          if (!denoRuntime) {
+            denoRuntime = new EmbeddedDenoRuntime();
+          }
+          if (!denoPath) {
+            denoPath = await denoRuntime.ensureDeno();
+          }
+          const js = await bundleExtension(row.source_path, denoPath, {
+            env: denoRuntime.getDenoEnv(),
+          });
+          await Deno.mkdir(dirname(row.bundle_path), { recursive: true });
+          await Deno.writeTextFile(row.bundle_path, js);
+          catalog.updateSourceFingerprint(row.source_path, currentFp);
+          rebundled.add(row.source_path);
+        } catch (err) {
+          logger.warn(
+            "Hot-reload: failed to re-bundle {path}, keeping old bundle: {error}",
+            {
+              path: row.source_path,
+              error: err instanceof Error ? err.message : String(err),
+            },
+          );
+        }
+      }
+    }
+
+    let reloadedCount = 0;
+    for (const [name] of Object.entries(entries)) {
+      const sourcePrefix = canonicalizePath(
+        join(pulledRoot, name) + "/",
+      );
+      const rows = catalog.findBySourcePathPrefix(sourcePrefix);
+      if (rows.length === 0) continue;
+
+      for (const row of rows) {
+        if (!row.type_normalized) continue;
+        try {
+          const kind = row.kind;
+
+          if (kind === "model") {
+            modelRegistry.invalidateType(row.type_normalized);
+            removeAttachedExtensionsForType(row.type_normalized);
+            modelRegistry.registerLazy({
+              type: ModelType.create(row.type_normalized),
+              bundlePath: row.bundle_path,
+              sourcePath: row.source_path,
+              version: row.version,
+              sourceFingerprint: row.source_fingerprint,
+            });
+            await modelRegistry.ensureTypeLoaded(row.type_normalized);
+            reloadedCount++;
+          } else if (kind === "vault") {
+            vaultTypeRegistry.invalidateType(row.type_normalized);
+            vaultTypeRegistry.registerLazy({
+              type: row.type_normalized,
+              bundlePath: row.bundle_path,
+              sourcePath: row.source_path,
+              version: row.version,
+            });
+            await vaultTypeRegistry.ensureTypeLoaded(row.type_normalized);
+            reloadedCount++;
+          } else if (kind === "datastore") {
+            datastoreTypeRegistry.invalidateType(row.type_normalized);
+            datastoreTypeRegistry.registerLazy({
+              type: row.type_normalized,
+              bundlePath: row.bundle_path,
+              sourcePath: row.source_path,
+              version: row.version,
+            });
+            await datastoreTypeRegistry.ensureTypeLoaded(row.type_normalized);
+            reloadedCount++;
+          } else if (kind === "report") {
+            reportRegistry.invalidateType(row.type_normalized);
+            reportRegistry.registerLazy({
+              type: row.type_normalized,
+              bundlePath: row.bundle_path,
+              sourcePath: row.source_path,
+              version: row.version,
+            });
+            await reportRegistry.ensureTypeLoaded(row.type_normalized);
+            reloadedCount++;
+          }
+        } catch (err) {
+          logger.warn(
+            "Failed to reload type {type} from {extension}: {error}",
+            {
+              type: row.type_normalized,
+              extension: name,
+              error: err instanceof Error ? err.message : String(err),
+            },
+          );
+        }
+      }
+    }
+    return reloadedCount;
+  } finally {
+    catalog.close();
+  }
+}
+
+export async function reloadTrustedCollectives(
+  repoDir: string,
+): Promise<void> {
+  const markerRepo = new RepoMarkerRepository();
+  const marker = await markerRepo.read(RepoPath.create(repoDir));
+
+  let authCollectives: string[] | undefined;
+  try {
+    const authRepo = new AuthRepository();
+    const creds = await authRepo.load();
+    authCollectives = creds?.collectives;
+  } catch {
+    // Auth file unreadable — continue without membership collectives
+  }
+
+  const collectives = resolveTrustedCollectives(marker, authCollectives);
+  const resolver = getAutoResolver();
+  if (resolver) {
+    resolver.updateAllowedCollectives(collectives);
+  }
+}
+
+export async function resolveLockfilePath(
+  repoDir: string,
+): Promise<string> {
+  let marker: RepoMarkerData | null = null;
+  try {
+    const markerRepo = new RepoMarkerRepository();
+    marker = await markerRepo.read(RepoPath.create(repoDir));
+  } catch {
+    // Not in a swamp repo or marker unreadable — resolveModelsDir(null) returns the default
+  }
+  const modelsDir = resolveModelsDir(marker);
+  return join(
+    isAbsolute(modelsDir) ? modelsDir : resolve(repoDir, modelsDir),
+    "upstream_extensions.json",
+  );
+}
+
+export interface ServeReloadResult {
+  success: boolean;
+  reloadedCount: number;
+  errors: string[];
+}
+
+export async function performServeReload(
+  repoDir: string,
+  lockfilePath: string,
+): Promise<ServeReloadResult> {
+  if (reloading) {
+    return {
+      success: false,
+      reloadedCount: 0,
+      errors: ["Reload already in progress"],
+    };
+  }
+
+  reloading = true;
+  const errors: string[] = [];
+  let reloadedCount = 0;
+
+  try {
+    reloadedCount = await reloadPulledExtensions(repoDir, lockfilePath);
+
+    try {
+      await reloadTrustedCollectives(repoDir);
+    } catch (err) {
+      errors.push(
+        "Failed to refresh trust list: " +
+          (err instanceof Error ? err.message : String(err)),
+      );
+    }
+
+    return { success: true, reloadedCount, errors };
+  } catch (err) {
+    return {
+      success: false,
+      reloadedCount: 0,
+      errors: [
+        "Hot-reload failed: " +
+        (err instanceof Error ? err.message : String(err)),
+      ],
+    };
+  } finally {
+    reloading = false;
+  }
+}

--- a/src/serve/extension_reload_test.ts
+++ b/src/serve/extension_reload_test.ts
@@ -1,0 +1,25 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { isReloading } from "./extension_reload.ts";
+
+Deno.test("isReloading: returns false when no reload is in progress", () => {
+  assertEquals(isReloading(), false);
+});

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -129,6 +129,10 @@ import {
   send,
   sendError,
 } from "./shared.ts";
+import {
+  performServeReload,
+  resolveLockfilePath,
+} from "../extension_reload.ts";
 import { isReservedVaultName } from "./vault_handlers.ts";
 
 export async function handleWorkerList(
@@ -1689,5 +1693,34 @@ export async function handleAuditTimeline(
   } catch (error) {
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "audit_timeline_failed", message);
+  }
+}
+
+export async function handleServeReload(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "admin", {
+      kind: "access",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const lockfilePath = await resolveLockfilePath(ctx.repoDir);
+    const result = await performServeReload(ctx.repoDir, lockfilePath);
+
+    send(socket, {
+      type: "serve.reload",
+      id: requestId,
+      payload: result,
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "serve_reload_failed", message);
   }
 }

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -463,6 +463,7 @@ export type ServerRequest =
   | { type: "access.check"; id: string; payload: AccessCheckPayload }
   | { type: "access.can-i"; id: string; payload: AccessCanIPayload }
   | { type: "access.reload"; id: string }
+  | { type: "serve.reload"; id: string }
   | { type: "data.get"; id: string; payload: DataGetPayload }
   | { type: "data.query"; id: string; payload: DataQueryPayload }
   | { type: "data.list"; id: string; payload: DataListPayload }
@@ -695,6 +696,12 @@ export interface AccessReloadResponse {
   filesProcessed?: number;
   fileResults?: AccessReloadFileResult[];
   errors?: string[];
+}
+
+export interface ServeReloadResponse {
+  success: boolean;
+  reloadedCount: number;
+  errors: string[];
 }
 
 export interface DataGetResponse {
@@ -1031,6 +1038,7 @@ export type ServerMessage =
   | { type: "access.check"; id: string; payload: AccessCheckResponse }
   | { type: "access.can-i"; id: string; payload: AccessCanIResponse }
   | { type: "access.reload"; id: string; payload: AccessReloadResponse }
+  | { type: "serve.reload"; id: string; payload: ServeReloadResponse }
   | { type: "data.get"; id: string; payload: DataGetResponse }
   | { type: "data.query"; id: string; payload: DataQueryResponse }
   | { type: "data.list"; id: string; payload: DataListResponse }


### PR DESCRIPTION
## Summary

Closes swamp-club#1532.

- Adds `--server`/`--token` options to `swamp serve reload` so remote users can trigger extension reloads via WebSocket (`serve.reload` message type) instead of requiring local SIGHUP access
- Extracts `reloadPulledExtensions()` and `reloadTrustedCollectives()` from `serve.ts` into `src/serve/extension_reload.ts` with a shared concurrency guard, used by both the SIGHUP signal handler and the new WebSocket handler
- Follows the established `access reload` pattern: admin authorization, request-response over WebSocket, renderer for both log and JSON output modes

## Test Plan

- [x] `deno check` — all modified files type-check clean
- [x] `deno lint` / `deno fmt` — pass
- [x] `deno run test` — 9878 tests pass, 0 failures
- [x] `deno run compile` — binary compiles
- [x] End-to-end: created scratch repo, pulled `@swamp/aws/s3`, started `swamp serve --hot-reload`, verified local SIGHUP reload still works, verified `swamp serve reload --server ws://localhost:<port>` reloads 10 extension types, verified `--json` output mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)