### PR TITLE
fix(serve): persist OAuth token definitions and data to remote datastore

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1364,6 +1364,24 @@ export const serveCommand = new Command()
       );
     }
 
+    const tokenTypeDir = SERVER_TOKEN_MODEL_TYPE.toDirectoryPath();
+    const tokenSourceDir = join(modelsDir, tokenTypeDir);
+    const tokenMigrationResult = await migrateGrantDefinitions(
+      tokenSourceDir,
+      join(autoDefDir, tokenTypeDir),
+    );
+    if (tokenMigrationResult.moved > 0) {
+      logger
+        .info`Migrated ${tokenMigrationResult.moved} server-token definition(s) from models/ to auto-definitions/`;
+      await cleanupEmptyParentDirs(
+        join(tokenSourceDir, "_placeholder"),
+        modelsDir,
+      );
+      if (syncService) {
+        await syncService.pushChanged();
+      }
+    }
+
     const caps = syncService?.capabilities?.();
     const hasRemoteControlPlane = !!(caps?.controlPlane &&
       syncService?.controlPlaneStore);
@@ -2739,6 +2757,7 @@ export const serveCommand = new Command()
             resolvedRepoDir,
             repoContext,
             repoMarker?.defaultVault,
+            syncService,
           );
           const deviceAuthResponse = await handleDeviceAuth(
             req,

--- a/src/serve/device_auth_handler.ts
+++ b/src/serve/device_auth_handler.ts
@@ -41,6 +41,8 @@ import {
 import { createResourceWriter } from "../domain/models/data_writer.ts";
 import { VaultService } from "../domain/vaults/vault_service.ts";
 import { TOKEN_SECRETS_VAULT_NAME } from "../domain/vaults/control_plane_vault_provider.ts";
+import { YamlDefinitionRepository } from "../infrastructure/persistence/yaml_definition_repository.ts";
+import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
 
 const logger = getSwampLogger(["serve", "device-auth"]);
 
@@ -292,6 +294,7 @@ async function mintServerTokenImpl(
   repoDir: string,
   repoContext: RepositoryContext,
   defaultVault?: string,
+  syncService?: DatastoreSyncService,
 ): Promise<string> {
   const tokenName = `oauth-${crypto.randomUUID().slice(0, 8)}`;
   const secretKey = serverTokenSecretKey(tokenName);
@@ -311,7 +314,13 @@ async function mintServerTokenImpl(
       type: SERVER_TOKEN_MODEL_TYPE.normalized,
       name: tokenName,
     });
-    await defRepo.save(SERVER_TOKEN_MODEL_TYPE, def);
+    const autoDefRepo = new YamlDefinitionRepository(
+      repoDir,
+      repoContext.eventBus,
+      repoContext.autoDefinitionsDir,
+      false,
+    );
+    await autoDefRepo.save(SERVER_TOKEN_MODEL_TYPE, def);
   }
 
   const now = Date.now();
@@ -345,6 +354,11 @@ async function mintServerTokenImpl(
     tokenData as unknown as Record<string, unknown>,
   );
 
+  if (syncService) {
+    await syncService.markDirty();
+    await syncService.pushChanged();
+  }
+
   logger.info("Minted OAuth server token {name} for {principal}", {
     name: tokenName,
     principal: principalId,
@@ -363,6 +377,7 @@ export function createDeviceAuthDeps(
   repoDir: string,
   repoContext: RepositoryContext,
   defaultVault?: string,
+  syncService?: DatastoreSyncService,
 ): DeviceAuthDeps {
   return {
     authConfig,
@@ -389,6 +404,7 @@ export function createDeviceAuthDeps(
         rd,
         rc,
         defaultVault,
+        syncService,
       ),
     storeAccessToken: async (tokenName: string, accessToken: string) => {
       const vaultService = await VaultService.fromRepository(


### PR DESCRIPTION
## Summary

Fixes swamp-club#1528. OAuth server-token definitions were saved to `models/` (local filesystem) and token data was never pushed to S3, so authenticated users had to re-login after pod replacement.

**Root cause:** `mintServerTokenImpl` in `device_auth_handler.ts` wrote the token definition to the local `models/` directory and token data to the local cache, but never called `pushChanged()` on the sync service. On K8s pod replacement, the ephemeral cache was empty and `hydrateLocalCache` found nothing in S3 — the definition and data were never pushed there.

**Fix:**
- Save token definitions to `auto-definitions/` (datastore tier, synced to S3) instead of `models/` (local only)
- Call `markDirty()` + `pushChanged()` after minting so both the definition and token data are pushed to S3 immediately
- Add startup migration to move existing server-token definitions from `models/` → `auto-definitions/` (same pattern as the existing grant definition migration)
- Wire `syncService` through `createDeviceAuthDeps` to the mint function

**Reproduction:**
1. Init repo with S3 datastore (Minio)
2. Start serve with `--auth-mode oauth`
3. Authenticate via OAuth device flow
4. Kill serve, delete `~/.swamp/repos/<id>/` cache (simulates K8s pod replacement)
5. Restart serve → auth fails (before fix) / succeeds (after fix)

Verified end-to-end locally with Minio S3 backend.

## Test Plan

- [x] Existing token_auth_test.ts passes (21 tests)
- [x] Full test suite passes
- [x] Manual E2E: mint → kill → delete cache → restart → auth succeeds
- [x] Verified S3 bucket contains both `auto-definitions/swamp/server-token/<id>.yaml` and `data/swamp/server-token/<id>/token-main/`
- [x] Verified `hydrateLocalCache` pulls token data back on restart
- [x] Type check, lint, format all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNQpF4JuoVJnq5EnEpJ2hF