### PR TITLE
fix(serve): align token migration log and add markDirty before push

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1251,12 +1251,13 @@ export const serveCommand = new Command()
     );
     if (tokenMigrationResult.moved > 0) {
       logger
-        .info`Migrated ${tokenMigrationResult.moved} server-token definition(s) from models/ to auto-definitions/`;
+        .info`Migrated ${tokenMigrationResult.moved} server-token definition(s) from models/ to .swamp/auto-definitions/`;
       await cleanupEmptyParentDirs(
         join(tokenSourceDir, "_placeholder"),
         modelsDir,
       );
       if (syncService) {
+        await syncService.markDirty();
         await syncService.pushChanged();
       }
     }


### PR DESCRIPTION
## Summary

Review feedback followup for #2071 (swamp-club#1528).

- Align token migration log message to say `.swamp/auto-definitions/` matching the grant migration message format
- Add `markDirty()` before `pushChanged()` in the startup migration block for consistency with the mint path — safe today (first push always full-walks) but cheap insurance if the code moves later

## Test Plan

- [x] Type check, lint, format pass
- No behavioral change — log message cosmetic fix and defensive `markDirty()` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNQpF4JuoVJnq5EnEpJ2hF