### PR TITLE
fix(serve): audit-log failed reload attempts and fix test name

### DIFF
--- a/src/serve/extension_reload_test.ts
+++ b/src/serve/extension_reload_test.ts
@@ -76,7 +76,7 @@ Deno.test("performServeReload: returns zero count for empty lockfile", async () 
   }
 });
 
-Deno.test("performServeReload: reloading guard resets after completion", async () => {
+Deno.test("performServeReload: resets isReloading flag after failure", async () => {
   assertEquals(isReloading(), false);
   const tmpDir = await Deno.makeTempDir();
   try {

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -494,6 +494,7 @@ export async function handleAccessReload(
       },
     });
   } catch (error) {
+    logger.error`Access policy reload failed (requested by ${who}): ${error}`;
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "access_reload_failed", message);
   }

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -1739,6 +1739,7 @@ export async function handleServeReload(
       payload: result,
     });
   } catch (error) {
+    logger.error`Extension reload failed (requested by ${who}): ${error}`;
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "serve_reload_failed", message);
   }


### PR DESCRIPTION
## Summary

Addresses two minor items from the adversarial review on #2072:

- **Audit-log failed reloads** — the `catch` blocks in `handleServeReload` and `handleAccessReload` now log the principal and error before sending the error response, so operators have a server-side record of all reload attempts (not just successful ones)
- **Rename misleading test** — `performServeReload: reloading guard resets after completion` → `performServeReload: resets isReloading flag after failure` to accurately describe what the test verifies

## Test Plan

- [x] `deno check` / `deno lint` / `deno fmt` — clean
- [x] Affected tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)