### PR TITLE
feat(vault): add --label flag to vault put for secret governance

### DIFF
--- a/packages/client/protocol.ts
+++ b/packages/client/protocol.ts
@@ -243,6 +243,7 @@ export interface VaultPutPayload {
   refreshFrom?: string;
   refreshTtlMs?: number;
   clearRefresh?: boolean;
+  tags?: Record<string, string>;
 }
 
 export interface VaultDeletePayload {

--- a/packages/client/protocol.ts
+++ b/packages/client/protocol.ts
@@ -243,7 +243,7 @@ export interface VaultPutPayload {
   refreshFrom?: string;
   refreshTtlMs?: number;
   clearRefresh?: boolean;
-  tags?: Record<string, string>;
+  labels?: Record<string, string>;
 }
 
 export interface VaultDeletePayload {

--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -55,6 +55,7 @@ import {
 } from "../remote_run.ts";
 import type { VaultPutResponse } from "../../serve/protocol.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { parseLabels } from "./vault_annotate.ts";
 
 const vaultLogger = getSwampLogger(["vault", "put"]);
 
@@ -166,6 +167,10 @@ When using --server, the value must be passed as a positional argument or KEY=VA
       "Remove refresh hook from a secret",
       "swamp vault put my-vault GCP_TOKEN --clear-refresh",
     )
+    .example(
+      "Store with tags",
+      "swamp vault put my-vault API_KEY=sk-123 --tag owner=platform-team --tag env=prod",
+    )
     .option(
       "--repo-dir <dir:string>",
       "Repository directory (env: SWAMP_REPO_DIR)",
@@ -186,6 +191,11 @@ When using --server, the value must be passed as a positional argument or KEY=VA
     .option(
       "--clear-refresh",
       "Remove the refresh hook from this secret",
+    )
+    .option(
+      "--tag <tag:string>",
+      "Attach a metadata tag to the secret (key=value, repeatable)",
+      { collect: true },
     ),
 ).action(async function (
   options: AnyOptions,
@@ -270,6 +280,7 @@ When using --server, the value must be passed as a positional argument or KEY=VA
           refreshFrom: options.refreshFrom as string | undefined,
           refreshTtlMs,
           clearRefresh: options.clearRefresh as boolean | undefined,
+          tags: parseLabels(options.tag as string[] | undefined),
         },
       },
     );
@@ -392,6 +403,7 @@ When using --server, the value must be passed as a positional argument or KEY=VA
         refreshFrom: options.refreshFrom,
         refreshTtlMs,
         clearRefresh: options.clearRefresh,
+        tags: parseLabels(options.tag as string[] | undefined),
       }),
       renderer.handlers(),
     );

--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -168,8 +168,8 @@ When using --server, the value must be passed as a positional argument or KEY=VA
       "swamp vault put my-vault GCP_TOKEN --clear-refresh",
     )
     .example(
-      "Store with tags",
-      "swamp vault put my-vault API_KEY=sk-123 --tag owner=platform-team --tag env=prod",
+      "Store with labels",
+      "swamp vault put my-vault API_KEY=sk-123 --label owner=platform-team --label env=prod",
     )
     .option(
       "--repo-dir <dir:string>",
@@ -193,8 +193,8 @@ When using --server, the value must be passed as a positional argument or KEY=VA
       "Remove the refresh hook from this secret",
     )
     .option(
-      "--tag <tag:string>",
-      "Attach a metadata tag to the secret (key=value, repeatable)",
+      "--label <label:string>",
+      "Attach a metadata label to the secret (key=value, repeatable)",
       { collect: true },
     ),
 ).action(async function (
@@ -280,7 +280,7 @@ When using --server, the value must be passed as a positional argument or KEY=VA
           refreshFrom: options.refreshFrom as string | undefined,
           refreshTtlMs,
           clearRefresh: options.clearRefresh as boolean | undefined,
-          tags: parseLabels(options.tag as string[] | undefined),
+          tags: parseLabels(options.label as string[] | undefined),
         },
       },
     );
@@ -403,7 +403,7 @@ When using --server, the value must be passed as a positional argument or KEY=VA
         refreshFrom: options.refreshFrom,
         refreshTtlMs,
         clearRefresh: options.clearRefresh,
-        tags: parseLabels(options.tag as string[] | undefined),
+        tags: parseLabels(options.label as string[] | undefined),
       }),
       renderer.handlers(),
     );

--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -280,12 +280,18 @@ When using --server, the value must be passed as a positional argument or KEY=VA
           refreshFrom: options.refreshFrom as string | undefined,
           refreshTtlMs,
           clearRefresh: options.clearRefresh as boolean | undefined,
-          tags: parseLabels(options.label as string[] | undefined),
+          labels: parseLabels(options.label as string[] | undefined),
         },
       },
     );
     const renderer = createVaultPutRenderer(cliCtx.outputMode);
-    renderer.handlers().completed({
+    const handlers = renderer.handlers();
+    if (response.warnings) {
+      for (const message of response.warnings) {
+        handlers.warning({ kind: "warning", message });
+      }
+    }
+    handlers.completed({
       kind: "completed",
       data: response.data as unknown as VaultPutData,
     });

--- a/src/libswamp/vaults/put.ts
+++ b/src/libswamp/vaults/put.ts
@@ -50,7 +50,7 @@ export interface VaultPutData {
   vaultType: string;
   overwritten: boolean;
   timestamp: string;
-  tags?: Record<string, string> | null;
+  labels?: Record<string, string> | null;
 }
 
 export type VaultPutEvent =
@@ -226,7 +226,7 @@ export async function* vaultPut(
       await deps.putSecret(input.vaultName, input.key, input.value);
       ctx.logger.debug`Secret stored successfully`;
 
-      let appliedTags: Record<string, string> | undefined;
+      let appliedLabels: Record<string, string> | undefined;
       if (input.tags && Object.keys(input.tags).length > 0) {
         try {
           const supportsAnno = await deps.supportsAnnotations(input.vaultName);
@@ -239,7 +239,7 @@ export async function* vaultPut(
               ? existing.merge({ labels: input.tags })
               : VaultAnnotation.create({ labels: input.tags });
             await deps.putAnnotation(input.vaultName, input.key, annotation);
-            appliedTags = input.tags;
+            appliedLabels = input.tags;
             ctx.logger.debug`Labels stored as annotations`;
           } else {
             yield {
@@ -303,10 +303,10 @@ export async function* vaultPut(
           vaultType: config.type,
           overwritten: input.overwritten,
           timestamp: new Date().toISOString(),
-          ...(appliedTags
-            ? { tags: appliedTags }
+          ...(appliedLabels
+            ? { labels: appliedLabels }
             : input.tags && Object.keys(input.tags).length > 0
-            ? { tags: null }
+            ? { labels: null }
             : {}),
         },
       };

--- a/src/libswamp/vaults/put.ts
+++ b/src/libswamp/vaults/put.ts
@@ -25,6 +25,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound } from "../errors.ts";
 import { RefreshHook } from "../../domain/vaults/refresh_hook.ts";
+import { VaultAnnotation } from "../../domain/vaults/vault_annotation.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Minimal vault config shape needed by the generator. */
@@ -49,6 +50,7 @@ export interface VaultPutData {
   vaultType: string;
   overwritten: boolean;
   timestamp: string;
+  tags?: Record<string, string>;
 }
 
 export type VaultPutEvent =
@@ -66,6 +68,7 @@ export interface VaultPutInput {
   refreshFrom?: string;
   refreshTtlMs?: number;
   clearRefresh?: boolean;
+  tags?: Record<string, string>;
 }
 
 /** Dependencies for the vault put operation. */
@@ -87,6 +90,16 @@ export interface VaultPutDeps {
   ) => Promise<void>;
   deleteRefreshHook: (vaultName: string, key: string) => Promise<void>;
   supportsRefreshHooks: (vaultName: string) => Promise<boolean>;
+  supportsAnnotations: (vaultName: string) => Promise<boolean>;
+  getAnnotation: (
+    vaultName: string,
+    key: string,
+  ) => Promise<VaultAnnotation | null>;
+  putAnnotation: (
+    vaultName: string,
+    key: string,
+    annotation: VaultAnnotation,
+  ) => Promise<void>;
 }
 
 /** Wires real infrastructure into VaultPutDeps. */
@@ -139,6 +152,18 @@ export function createVaultPutDeps(
     supportsRefreshHooks: async (vaultName) => {
       const svc = await getVaultService();
       return svc.supportsRefreshHooks(vaultName);
+    },
+    supportsAnnotations: async (vaultName) => {
+      const svc = await getVaultService();
+      return svc.supportsAnnotations(vaultName);
+    },
+    getAnnotation: async (vaultName, key) => {
+      const svc = await getVaultService();
+      return svc.getAnnotation(vaultName, key);
+    },
+    putAnnotation: async (vaultName, key, annotation) => {
+      const svc = await getVaultService();
+      await svc.putAnnotation(vaultName, key, annotation);
     },
   };
 }
@@ -201,6 +226,39 @@ export async function* vaultPut(
       await deps.putSecret(input.vaultName, input.key, input.value);
       ctx.logger.debug`Secret stored successfully`;
 
+      let appliedTags: Record<string, string> | undefined;
+      if (input.tags && Object.keys(input.tags).length > 0) {
+        const supportsAnno = await deps.supportsAnnotations(input.vaultName);
+        if (supportsAnno) {
+          try {
+            const existing = await deps.getAnnotation(
+              input.vaultName,
+              input.key,
+            );
+            const annotation = existing
+              ? existing.merge({ labels: input.tags })
+              : VaultAnnotation.create({ labels: input.tags });
+            await deps.putAnnotation(input.vaultName, input.key, annotation);
+            appliedTags = input.tags;
+            ctx.logger.debug`Tags stored as annotations`;
+          } catch (error) {
+            const message = error instanceof Error
+              ? error.message
+              : String(error);
+            yield {
+              kind: "warning",
+              message: `Secret stored but tagging failed: ${message}`,
+            };
+          }
+        } else {
+          yield {
+            kind: "warning",
+            message:
+              `Vault '${input.vaultName}' does not support annotations — --tag was ignored`,
+          };
+        }
+      }
+
       if (input.clearRefresh) {
         const supportsHooks = await deps.supportsRefreshHooks(
           input.vaultName,
@@ -245,6 +303,7 @@ export async function* vaultPut(
           vaultType: config.type,
           overwritten: input.overwritten,
           timestamp: new Date().toISOString(),
+          ...(appliedTags ? { tags: appliedTags } : {}),
         },
       };
     })(),

--- a/src/libswamp/vaults/put.ts
+++ b/src/libswamp/vaults/put.ts
@@ -228,9 +228,9 @@ export async function* vaultPut(
 
       let appliedTags: Record<string, string> | undefined;
       if (input.tags && Object.keys(input.tags).length > 0) {
-        const supportsAnno = await deps.supportsAnnotations(input.vaultName);
-        if (supportsAnno) {
-          try {
+        try {
+          const supportsAnno = await deps.supportsAnnotations(input.vaultName);
+          if (supportsAnno) {
             const existing = await deps.getAnnotation(
               input.vaultName,
               input.key,
@@ -240,21 +240,21 @@ export async function* vaultPut(
               : VaultAnnotation.create({ labels: input.tags });
             await deps.putAnnotation(input.vaultName, input.key, annotation);
             appliedTags = input.tags;
-            ctx.logger.debug`Tags stored as annotations`;
-          } catch (error) {
-            const message = error instanceof Error
-              ? error.message
-              : String(error);
+            ctx.logger.debug`Labels stored as annotations`;
+          } else {
             yield {
               kind: "warning",
-              message: `Secret stored but tagging failed: ${message}`,
+              message:
+                `Vault '${input.vaultName}' does not support annotations — labels were ignored`,
             };
           }
-        } else {
+        } catch (error) {
+          const message = error instanceof Error
+            ? error.message
+            : String(error);
           yield {
             kind: "warning",
-            message:
-              `Vault '${input.vaultName}' does not support annotations — --tag was ignored`,
+            message: `Secret stored but labeling failed: ${message}`,
           };
         }
       }

--- a/src/libswamp/vaults/put.ts
+++ b/src/libswamp/vaults/put.ts
@@ -50,7 +50,7 @@ export interface VaultPutData {
   vaultType: string;
   overwritten: boolean;
   timestamp: string;
-  tags?: Record<string, string>;
+  tags?: Record<string, string> | null;
 }
 
 export type VaultPutEvent =
@@ -303,7 +303,11 @@ export async function* vaultPut(
           vaultType: config.type,
           overwritten: input.overwritten,
           timestamp: new Date().toISOString(),
-          ...(appliedTags ? { tags: appliedTags } : {}),
+          ...(appliedTags
+            ? { tags: appliedTags }
+            : input.tags && Object.keys(input.tags).length > 0
+            ? { tags: null }
+            : {}),
         },
       };
     })(),

--- a/src/libswamp/vaults/put_test.ts
+++ b/src/libswamp/vaults/put_test.ts
@@ -322,6 +322,7 @@ Deno.test("vaultPut: yields warning when annotations not supported and tags prov
   >;
   assertEquals(warning !== undefined, true);
   assertStringIncludes(warning.message, "does not support annotations");
+  assertStringIncludes(warning.message, "labels were ignored");
 });
 
 Deno.test("vaultPut: yields warning but completes when annotation fails", async () => {
@@ -346,7 +347,7 @@ Deno.test("vaultPut: yields warning but completes when annotation fails", async 
     { kind: "warning" }
   >;
   assertEquals(warning !== undefined, true);
-  assertStringIncludes(warning.message, "tagging failed");
+  assertStringIncludes(warning.message, "labeling failed");
 
   const completed = events.find((e) => e.kind === "completed");
   assertEquals(completed !== undefined, true);

--- a/src/libswamp/vaults/put_test.ts
+++ b/src/libswamp/vaults/put_test.ts
@@ -17,10 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import type { RefreshHook } from "../../domain/vaults/refresh_hook.ts";
+import { VaultAnnotation } from "../../domain/vaults/vault_annotation.ts";
 import {
   vaultPut,
   type VaultPutDeps,
@@ -39,6 +40,9 @@ function makeDeps(overrides: Partial<VaultPutDeps> = {}): VaultPutDeps {
     putRefreshHook: () => Promise.resolve(),
     deleteRefreshHook: () => Promise.resolve(),
     supportsRefreshHooks: () => Promise.resolve(false),
+    supportsAnnotations: () => Promise.resolve(false),
+    getAnnotation: () => Promise.resolve(null),
+    putAnnotation: () => Promise.resolve(),
     ...overrides,
   };
 }
@@ -231,4 +235,146 @@ Deno.test("vaultPut: clearRefresh no-ops when provider does not support hooks", 
   );
 
   assertEquals(deleted, false);
+});
+
+Deno.test("vaultPut: stores tags as annotation when provider supports annotations", async () => {
+  let storedAnnotation: VaultAnnotation | null = null;
+  const deps = makeDeps({
+    supportsAnnotations: () => Promise.resolve(true),
+    getAnnotation: () => Promise.resolve(null),
+    putAnnotation: (_vault, _key, annotation) => {
+      storedAnnotation = annotation;
+      return Promise.resolve();
+    },
+  });
+
+  const events = await collect<VaultPutEvent>(
+    vaultPut(createLibSwampContext(), deps, {
+      vaultName: "my-vault",
+      key: "API_KEY",
+      value: "secret123",
+      overwritten: false,
+      tags: { owner: "platform-team", env: "prod" },
+    }),
+  );
+
+  assertEquals(storedAnnotation !== null, true);
+  assertEquals(storedAnnotation!.labels["owner"], "platform-team");
+  assertEquals(storedAnnotation!.labels["env"], "prod");
+
+  const completed = events.find((e) => e.kind === "completed") as Extract<
+    VaultPutEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.tags, { owner: "platform-team", env: "prod" });
+});
+
+Deno.test("vaultPut: merges tags with existing annotation on overwrite", async () => {
+  let storedAnnotation: VaultAnnotation | null = null;
+  const existing = VaultAnnotation.create({
+    labels: { existing: "value", owner: "old-team" },
+    notes: "keep me",
+  });
+  const deps = makeDeps({
+    supportsAnnotations: () => Promise.resolve(true),
+    getAnnotation: () => Promise.resolve(existing),
+    putAnnotation: (_vault, _key, annotation) => {
+      storedAnnotation = annotation;
+      return Promise.resolve();
+    },
+  });
+
+  await collect<VaultPutEvent>(
+    vaultPut(createLibSwampContext(), deps, {
+      vaultName: "my-vault",
+      key: "API_KEY",
+      value: "secret123",
+      overwritten: true,
+      tags: { owner: "new-team", env: "prod" },
+    }),
+  );
+
+  assertEquals(storedAnnotation !== null, true);
+  assertEquals(storedAnnotation!.labels["existing"], "value");
+  assertEquals(storedAnnotation!.labels["owner"], "new-team");
+  assertEquals(storedAnnotation!.labels["env"], "prod");
+  assertEquals(storedAnnotation!.notes, "keep me");
+});
+
+Deno.test("vaultPut: yields warning when annotations not supported and tags provided", async () => {
+  const deps = makeDeps({
+    supportsAnnotations: () => Promise.resolve(false),
+  });
+
+  const events = await collect<VaultPutEvent>(
+    vaultPut(createLibSwampContext(), deps, {
+      vaultName: "my-vault",
+      key: "API_KEY",
+      value: "secret123",
+      overwritten: false,
+      tags: { owner: "team" },
+    }),
+  );
+
+  const warning = events.find((e) => e.kind === "warning") as Extract<
+    VaultPutEvent,
+    { kind: "warning" }
+  >;
+  assertEquals(warning !== undefined, true);
+  assertStringIncludes(warning.message, "does not support annotations");
+});
+
+Deno.test("vaultPut: yields warning but completes when annotation fails", async () => {
+  const deps = makeDeps({
+    supportsAnnotations: () => Promise.resolve(true),
+    getAnnotation: () => Promise.resolve(null),
+    putAnnotation: () => Promise.reject(new Error("annotation write failed")),
+  });
+
+  const events = await collect<VaultPutEvent>(
+    vaultPut(createLibSwampContext(), deps, {
+      vaultName: "my-vault",
+      key: "API_KEY",
+      value: "secret123",
+      overwritten: false,
+      tags: { owner: "team" },
+    }),
+  );
+
+  const warning = events.find((e) => e.kind === "warning") as Extract<
+    VaultPutEvent,
+    { kind: "warning" }
+  >;
+  assertEquals(warning !== undefined, true);
+  assertStringIncludes(warning.message, "tagging failed");
+
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed !== undefined, true);
+});
+
+Deno.test("vaultPut: skips annotation when tags is empty", async () => {
+  let annotationCalled = false;
+  const deps = makeDeps({
+    supportsAnnotations: () => {
+      annotationCalled = true;
+      return Promise.resolve(true);
+    },
+  });
+
+  const events = await collect<VaultPutEvent>(
+    vaultPut(createLibSwampContext(), deps, {
+      vaultName: "my-vault",
+      key: "API_KEY",
+      value: "secret123",
+      overwritten: false,
+      tags: {},
+    }),
+  );
+
+  assertEquals(annotationCalled, false);
+  const completed = events.find((e) => e.kind === "completed") as Extract<
+    VaultPutEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.tags, undefined);
 });

--- a/src/libswamp/vaults/put_test.ts
+++ b/src/libswamp/vaults/put_test.ts
@@ -266,7 +266,7 @@ Deno.test("vaultPut: stores tags as annotation when provider supports annotation
     VaultPutEvent,
     { kind: "completed" }
   >;
-  assertEquals(completed.data.tags, { owner: "platform-team", env: "prod" });
+  assertEquals(completed.data.labels, { owner: "platform-team", env: "prod" });
 });
 
 Deno.test("vaultPut: merges tags with existing annotation on overwrite", async () => {
@@ -377,5 +377,5 @@ Deno.test("vaultPut: skips annotation when tags is empty", async () => {
     VaultPutEvent,
     { kind: "completed" }
   >;
-  assertEquals(completed.data.tags, undefined);
+  assertEquals(completed.data.labels, undefined);
 });

--- a/src/presentation/renderers/vault_put.ts
+++ b/src/presentation/renderers/vault_put.ts
@@ -29,11 +29,12 @@ class LogVaultPutRenderer implements Renderer<VaultPutEvent> {
     return {
       storing: () => {},
       completed: (e) => {
-        const tags = e.data.tags;
-        if (tags && Object.keys(tags).length > 0) {
-          const keys = Object.keys(tags).join(", ");
+        const labels = e.data.labels;
+        if (labels && Object.keys(labels).length > 0) {
+          const pairs = Object.entries(labels).map(([k, v]) => `${k}=${v}`)
+            .join(", ");
           logger
-            .info`Stored secret ${e.data.secretKey} in vault ${e.data.vaultName} with labels: ${keys}`;
+            .info`Stored secret ${e.data.secretKey} in vault ${e.data.vaultName} with labels: ${pairs}`;
         } else {
           logger
             .info`Stored secret ${e.data.secretKey} in vault ${e.data.vaultName}`;

--- a/src/presentation/renderers/vault_put.ts
+++ b/src/presentation/renderers/vault_put.ts
@@ -29,10 +29,11 @@ class LogVaultPutRenderer implements Renderer<VaultPutEvent> {
     return {
       storing: () => {},
       completed: (e) => {
-        const tagCount = e.data.tags ? Object.keys(e.data.tags).length : 0;
-        if (tagCount > 0) {
+        const labelCount = e.data.tags ? Object.keys(e.data.tags).length : 0;
+        if (labelCount > 0) {
+          const noun = labelCount === 1 ? "label" : "labels";
           logger
-            .info`Stored secret ${e.data.secretKey} in vault ${e.data.vaultName} with ${tagCount} tag(s)`;
+            .info`Stored secret ${e.data.secretKey} in vault ${e.data.vaultName} with ${labelCount} ${noun}`;
         } else {
           logger
             .info`Stored secret ${e.data.secretKey} in vault ${e.data.vaultName}`;

--- a/src/presentation/renderers/vault_put.ts
+++ b/src/presentation/renderers/vault_put.ts
@@ -29,8 +29,14 @@ class LogVaultPutRenderer implements Renderer<VaultPutEvent> {
     return {
       storing: () => {},
       completed: (e) => {
-        logger
-          .info`Stored secret ${e.data.secretKey} in vault ${e.data.vaultName}`;
+        const tagCount = e.data.tags ? Object.keys(e.data.tags).length : 0;
+        if (tagCount > 0) {
+          logger
+            .info`Stored secret ${e.data.secretKey} in vault ${e.data.vaultName} with ${tagCount} tag(s)`;
+        } else {
+          logger
+            .info`Stored secret ${e.data.secretKey} in vault ${e.data.vaultName}`;
+        }
       },
       warning: (e) => {
         logger.warn`${e.message}`;

--- a/src/presentation/renderers/vault_put.ts
+++ b/src/presentation/renderers/vault_put.ts
@@ -29,11 +29,11 @@ class LogVaultPutRenderer implements Renderer<VaultPutEvent> {
     return {
       storing: () => {},
       completed: (e) => {
-        const labelCount = e.data.tags ? Object.keys(e.data.tags).length : 0;
-        if (labelCount > 0) {
-          const noun = labelCount === 1 ? "label" : "labels";
+        const tags = e.data.tags;
+        if (tags && Object.keys(tags).length > 0) {
+          const keys = Object.keys(tags).join(", ");
           logger
-            .info`Stored secret ${e.data.secretKey} in vault ${e.data.vaultName} with ${labelCount} ${noun}`;
+            .info`Stored secret ${e.data.secretKey} in vault ${e.data.vaultName} with labels: ${keys}`;
         } else {
           logger
             .info`Stored secret ${e.data.secretKey} in vault ${e.data.vaultName}`;

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -374,6 +374,7 @@ const VaultPutRequestSchema = z.object({
     refreshFrom: z.string().optional(),
     refreshTtlMs: z.number().optional(),
     clearRefresh: z.boolean().optional(),
+    tags: z.record(z.string(), z.string()).optional(),
   }),
 });
 

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -374,7 +374,7 @@ const VaultPutRequestSchema = z.object({
     refreshFrom: z.string().optional(),
     refreshTtlMs: z.number().optional(),
     clearRefresh: z.boolean().optional(),
-    tags: z.record(z.string(), z.string()).optional(),
+    labels: z.record(z.string().min(1), z.string()).optional(),
   }),
 });
 

--- a/src/serve/handlers/vault_handlers.ts
+++ b/src/serve/handlers/vault_handlers.ts
@@ -217,7 +217,7 @@ export async function handleVaultPut(
         refreshFrom: payload.refreshFrom,
         refreshTtlMs: payload.refreshTtlMs,
         clearRefresh: payload.clearRefresh,
-        tags: payload.tags,
+        tags: payload.labels,
       }),
       {
         storing: () => {},

--- a/src/serve/handlers/vault_handlers.ts
+++ b/src/serve/handlers/vault_handlers.ts
@@ -216,6 +216,7 @@ export async function handleVaultPut(
         refreshFrom: payload.refreshFrom,
         refreshTtlMs: payload.refreshTtlMs,
         clearRefresh: payload.clearRefresh,
+        tags: payload.tags,
       }),
       {
         storing: () => {},

--- a/src/serve/handlers/vault_handlers.ts
+++ b/src/serve/handlers/vault_handlers.ts
@@ -207,6 +207,7 @@ export async function handleVaultPut(
     }
 
     let result: Record<string, unknown> | undefined;
+    const warnings: string[] = [];
     await consumeStream(
       vaultPut(libCtx, deps, {
         vaultName: payload.vaultName,
@@ -220,7 +221,9 @@ export async function handleVaultPut(
       }),
       {
         storing: () => {},
-        warning: () => {},
+        warning: (e) => {
+          warnings.push(e.message);
+        },
         completed: (e) => {
           result = e.data as unknown as Record<string, unknown>;
         },
@@ -238,7 +241,10 @@ export async function handleVaultPut(
     send(socket, {
       type: "vault.put",
       id: requestId,
-      payload: { data: result ?? {} },
+      payload: {
+        data: result ?? {},
+        ...(warnings.length > 0 ? { warnings } : {}),
+      },
     });
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -137,7 +137,7 @@ export interface VaultPutPayload {
   refreshFrom?: string;
   refreshTtlMs?: number;
   clearRefresh?: boolean;
-  tags?: Record<string, string>;
+  labels?: Record<string, string>;
 }
 
 export interface VaultDeletePayload {
@@ -835,6 +835,7 @@ export interface VaultGetResponse {
 
 export interface VaultPutResponse {
   data: Record<string, unknown>;
+  warnings?: string[];
 }
 
 export interface VaultDeleteResponse {

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -137,6 +137,7 @@ export interface VaultPutPayload {
   refreshFrom?: string;
   refreshTtlMs?: number;
   clearRefresh?: boolean;
+  tags?: Record<string, string>;
 }
 
 export interface VaultDeletePayload {


### PR DESCRIPTION
## Summary

- Adds a repeatable `--label key=value` flag to `swamp vault put` so labels can be set atomically with the secret in a single command
- Labels are stored as annotation labels via `putAnnotation` after `put` succeeds — same mechanism as `vault annotate --label`, visible through `vault inspect`
- Existing annotations are preserved and merged on overwrite
- Labels are best-effort: the secret is stored even if annotation fails (warning emitted)
- Providers without annotation support get a clear warning when `--label` is used
- Works through `--server` (remote) path — optional `labels` field added to `VaultPutPayload`, warnings forwarded to client

## Motivation

Organizations with governance requirements need to label secrets with metadata (owner, environment, classification, rotation schedule). Today this requires two commands (`vault put` then `vault annotate`), leaving the secret unlabeled between calls. This is a problem in CI pipelines and for customers whose cloud IAM policies require tags at creation time.

## Follow-up issues

- #2076 — Extension providers (AWS SM, Azure KV) to pass labels through to native `CreateSecret`/`setSecret` calls for IAM tag-on-create policies
- #2077 — Documentation update for `--label` flag
- swamp-club/swamp-uat#337 — UAT coverage

## Test plan

- 5 new unit tests for the libswamp `vaultPut` generator (labels stored, merge on overwrite, unsupported warning, failure warning, empty labels skip)
- All existing tests pass
- E2E verified against **local encryption** vault: put with labels, merge on overwrite, JSON output, inspect visibility
- E2E verified against **AWS SM via ministack**: put with labels, inspect, JSON output, merge on overwrite, verified native AWS tags via `aws secretsmanager describe-secret`

Closes #1529