### PR TITLE
feat(serve): add --grants-file flag to load external grants at startup

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -496,7 +496,7 @@ const daemonEnableCommand = new Command()
   )
   .option(
     "--grants-file <path:string>",
-    "Path to an external grants YAML file loaded at startup (env: SWAMP_GRANTS_FILE)",
+    "Path to an external grants YAML file loaded at startup",
   )
   .option(
     "--grant-reload <mode:string>",
@@ -1751,24 +1751,23 @@ export const serveCommand = new Command()
         : resolve(merged.grantsFile))
       : undefined;
     if (externalGrantsFilePath) {
-      const resolvedPath = externalGrantsFilePath;
       let content: string;
       try {
-        content = await Deno.readTextFile(resolvedPath);
+        content = await Deno.readTextFile(externalGrantsFilePath);
       } catch (cause) {
         if (cause instanceof Deno.errors.NotFound) {
           throw new UserError(
-            `External grants file not found: ${resolvedPath}`,
+            `External grants file not found: ${externalGrantsFilePath}`,
           );
         }
         throw new UserError(
-          `Failed to read external grants file ${resolvedPath}: ${cause}`,
+          `Failed to read external grants file ${externalGrantsFilePath}: ${cause}`,
         );
       }
 
       if (content.trim().length > 0) {
         const externalResult = parseGrantFile(
-          resolvedPath,
+          externalGrantsFilePath,
           content,
           validateGrantCondition,
         );
@@ -1785,12 +1784,12 @@ export const serveCommand = new Command()
             }`,
           );
         }
-        validEntries.set(resolvedPath, externalResult.entries);
+        validEntries.set(externalGrantsFilePath, externalResult.entries);
         logger
-          .info`Loaded ${externalResult.entries.length} grant(s) from external file ${resolvedPath}`;
+          .info`Loaded ${externalResult.entries.length} grant(s) from external file ${externalGrantsFilePath}`;
       } else {
         logger
-          .info`External grants file ${resolvedPath} is empty — no external grants added`;
+          .info`External grants file ${externalGrantsFilePath} is empty — no external grants added`;
       }
     }
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -119,6 +119,7 @@ import {
 } from "../../domain/access/admin_materializer.ts";
 import {
   collectErrors,
+  parseGrantFile,
   readGrantFiles,
 } from "../../domain/access/grant_file.ts";
 import { validateGrantCondition } from "../../infrastructure/cel/grant_condition_environment.ts";
@@ -300,6 +301,9 @@ export function collectServeExtraArgs(options: AnyOptions): string[] {
   }
   if (options.schedule === false) {
     args.push("--no-schedule");
+  }
+  if (options.grantsFile) {
+    args.push("--grants-file", options.grantsFile as string);
   }
   if (options.grantReload && options.grantReload !== "manual") {
     args.push("--grant-reload", options.grantReload as string);
@@ -489,6 +493,10 @@ const daemonEnableCommand = new Command()
   .option(
     "--key-file <path:string>",
     "Path to PEM-encoded TLS private key",
+  )
+  .option(
+    "--grants-file <path:string>",
+    "Path to an external grants YAML file loaded at startup (env: SWAMP_GRANTS_FILE)",
   )
   .option(
     "--grant-reload <mode:string>",
@@ -801,6 +809,10 @@ export const serveCommand = new Command()
   .option(
     "--key-file <path:string>",
     "Path to PEM-encoded TLS private key (env: SWAMP_SERVE_KEY_FILE)",
+  )
+  .option(
+    "--grants-file <path:string>",
+    "Path to an external grants YAML file loaded at startup (env: SWAMP_GRANTS_FILE)",
   )
   .option(
     "--grant-reload <mode:string>",
@@ -1733,6 +1745,55 @@ export const serveCommand = new Command()
       validEntries.set(filename, result.entries);
     }
 
+    const externalGrantsFilePath = merged.grantsFile
+      ? (isAbsolute(merged.grantsFile)
+        ? merged.grantsFile
+        : resolve(merged.grantsFile))
+      : undefined;
+    if (externalGrantsFilePath) {
+      const resolvedPath = externalGrantsFilePath;
+      let content: string;
+      try {
+        content = await Deno.readTextFile(resolvedPath);
+      } catch (cause) {
+        if (cause instanceof Deno.errors.NotFound) {
+          throw new UserError(
+            `External grants file not found: ${resolvedPath}`,
+          );
+        }
+        throw new UserError(
+          `Failed to read external grants file ${resolvedPath}: ${cause}`,
+        );
+      }
+
+      if (content.trim().length > 0) {
+        const externalResult = parseGrantFile(
+          resolvedPath,
+          content,
+          validateGrantCondition,
+        );
+        if (externalResult.errors.length > 0) {
+          const errorMessages = externalResult.errors.map((e) => {
+            const loc = e.entryIndex !== undefined
+              ? `${e.filename} entry ${e.entryIndex + 1}`
+              : e.filename;
+            return `  ${loc}: ${e.message}`;
+          });
+          throw new UserError(
+            `External grants file validation failed — refusing to start:\n${
+              errorMessages.join("\n")
+            }`,
+          );
+        }
+        validEntries.set(resolvedPath, externalResult.entries);
+        logger
+          .info`Loaded ${externalResult.entries.length} grant(s) from external file ${resolvedPath}`;
+      } else {
+        logger
+          .info`External grants file ${resolvedPath} is empty — no external grants added`;
+      }
+    }
+
     const fileGrantStore = createFileGrantStore(
       repoContext.definitionRepo,
       autoDefRepo,
@@ -1967,6 +2028,7 @@ export const serveCommand = new Command()
         defaultVault: repoMarker?.defaultVault,
         instanceId,
         staleTtlMs,
+        grantsFile: externalGrantsFilePath,
         hotReload: merged.hotReload,
       };
 

--- a/src/cli/commands/serve_daemon_test.ts
+++ b/src/cli/commands/serve_daemon_test.ts
@@ -128,6 +128,22 @@ Deno.test("collectServeExtraArgs: deprecated --detach-runs is not forwarded", ()
   assertEquals(args, []);
 });
 
+Deno.test("collectServeExtraArgs: includes --grants-file", () => {
+  const args = collectServeExtraArgs({
+    grantsFile: "/etc/swamp/grants.yaml",
+  });
+  assertEquals(args, ["--grants-file", "/etc/swamp/grants.yaml"]);
+});
+
+Deno.test("collectServeExtraArgs: skips --grants-file when not set", () => {
+  const args = collectServeExtraArgs({
+    schedule: true,
+    grantReload: "manual",
+    authMode: "none",
+  });
+  assertEquals(args, []);
+});
+
 Deno.test("collectServeExtraArgs: combines multiple flags", () => {
   const args = collectServeExtraArgs({
     schedule: false,

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -457,23 +457,21 @@ export async function handleAccessReload(
             validateGrantCondition,
           );
           if (externalResult.errors.length > 0) {
-            allErrors.push(...externalResult.errors);
+            allErrors.push(...externalResult.errors.map((e) => ({
+              ...e,
+              filename: "external-grants-file",
+            })));
           } else {
             validEntries.set(ctx.grantsFile, externalResult.entries);
           }
         }
       } catch (error) {
-        if (error instanceof Deno.errors.NotFound) {
-          allErrors.push({
-            filename: ctx.grantsFile,
-            message: "External grants file not found",
-          });
-        } else {
-          allErrors.push({
-            filename: ctx.grantsFile,
-            message: `Failed to read: ${error}`,
-          });
-        }
+        logger
+          .error`Failed to read external grants file ${ctx.grantsFile}: ${error}`;
+        allErrors.push({
+          filename: "external-grants-file",
+          message: "Failed to read external grants file",
+        });
       }
 
       if (allErrors.length > 0) {
@@ -511,10 +509,10 @@ export async function handleAccessReload(
 
     const fileResultList: AccessReloadFileResult[] = [];
     for (const [filename, perFile] of reconcileResult.perFile) {
-      const parsed = fileResults.get(filename);
+      const entries = validEntries.get(filename);
       fileResultList.push({
         filename,
-        entryCount: parsed?.entries.length ?? 0,
+        entryCount: entries?.length ?? 0,
         created: perFile.created,
         revoked: perFile.revoked,
         reactivated: perFile.reactivated,

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -32,6 +32,7 @@ import type {
 import {
   collectErrors,
   type GrantFileError,
+  parseGrantFile,
   readGrantFiles,
 } from "../../domain/access/grant_file.ts";
 import {
@@ -444,6 +445,50 @@ export async function handleAccessReload(
     >();
     for (const [filename, result] of fileResults) {
       validEntries.set(filename, result.entries);
+    }
+
+    if (ctx.grantsFile) {
+      try {
+        const content = await Deno.readTextFile(ctx.grantsFile);
+        if (content.trim().length > 0) {
+          const externalResult = parseGrantFile(
+            ctx.grantsFile,
+            content,
+            validateGrantCondition,
+          );
+          if (externalResult.errors.length > 0) {
+            allErrors.push(...externalResult.errors);
+          } else {
+            validEntries.set(ctx.grantsFile, externalResult.entries);
+          }
+        }
+      } catch (error) {
+        if (error instanceof Deno.errors.NotFound) {
+          allErrors.push({
+            filename: ctx.grantsFile,
+            message: "External grants file not found",
+          });
+        } else {
+          allErrors.push({
+            filename: ctx.grantsFile,
+            message: `Failed to read: ${error}`,
+          });
+        }
+      }
+
+      if (allErrors.length > 0) {
+        send(socket, {
+          type: "access.reload",
+          id: requestId,
+          payload: {
+            success: false,
+            grantCount: 0,
+            groupCount: 0,
+            errors: formatGrantFileErrors(allErrors),
+          },
+        });
+        return;
+      }
     }
 
     const autoDefDir = join(ctx.repoDir, ".swamp", "auto-definitions");

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -103,6 +103,8 @@ export interface ConnectionContext {
   instanceId?: string;
   /** Heartbeat stale TTL in ms — used by cross-instance run.attach fallback. */
   staleTtlMs?: number;
+  /** Resolved path to external grants file, if --grants-file was provided. */
+  grantsFile?: string;
   /** Whether --hot-reload is enabled — gates serve.reload over WebSocket. */
   hotReload?: boolean;
 }

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -32,6 +32,7 @@ const logger = getSwampLogger(["serve", "config"]);
 export const SERVE_ENV_MAP: Readonly<Record<string, string>> = {
   certFile: "SWAMP_SERVE_CERT_FILE",
   keyFile: "SWAMP_SERVE_KEY_FILE",
+  grantsFile: "SWAMP_GRANTS_FILE",
   wsIdleTimeout: "SWAMP_WS_IDLE_TIMEOUT",
   queueTimeout: "SWAMP_QUEUE_TIMEOUT",
   verifyOnEnroll: "SWAMP_VERIFY_ON_ENROLL",
@@ -79,6 +80,7 @@ export interface ServeConfigFile {
   "detach-runs"?: boolean;
   "trust-proxy"?: boolean;
   "trusted-hosts"?: string[];
+  "grants-file"?: string;
   "grant-reload"?: string;
   "ws-idle-timeout"?: string;
   "queue-timeout"?: string;
@@ -101,6 +103,7 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
   "detach-runs",
   "trust-proxy",
   "trusted-hosts",
+  "grants-file",
   "grant-reload",
   "ws-idle-timeout",
   "queue-timeout",
@@ -293,6 +296,7 @@ function validateConfigValues(
   }
 
   const stringFields: [string, unknown][] = [
+    ["grants-file", raw["grants-file"]],
     ["grant-reload", raw["grant-reload"]],
     ["ws-idle-timeout", raw["ws-idle-timeout"]],
     ["queue-timeout", raw["queue-timeout"]],
@@ -479,6 +483,7 @@ export interface MergedServeOptions {
   schedule: boolean;
   certFile?: string;
   keyFile?: string;
+  grantsFile?: string;
   grantReload: string;
   webhook?: string[];
   webhookEndpoints?: WebhookEndpoint[];
@@ -608,6 +613,13 @@ export function mergeServeOptions(
     "key-file",
     cliOptions.keyFile as string | undefined,
     config?.tls?.["key-file"],
+    undefined,
+  );
+
+  const grantsFile = resolveString(
+    "grants-file",
+    cliOptions.grantsFile as string | undefined,
+    config?.["grants-file"],
     undefined,
   );
 
@@ -767,6 +779,7 @@ export function mergeServeOptions(
     schedule,
     certFile,
     keyFile,
+    grantsFile,
     grantReload,
     webhook,
     webhookEndpoints,

--- a/src/serve/serve_config_test.ts
+++ b/src/serve/serve_config_test.ts
@@ -554,3 +554,80 @@ Deno.test("mergeServeOptions: trusted-hosts config array joined to comma string"
     "host.docker.internal,host.minikube.internal",
   );
 });
+
+// ── grants-file merge ─────────────────────────────────────────────────
+
+Deno.test("mergeServeOptions: grants-file CLI flag wins over config and env", () => {
+  const config: ServeConfigFile = { "grants-file": "/from/config.yaml" };
+  const cliOptions = { grantsFile: "/from/cli.yaml" };
+  const explicitFlags = new Set(["grants-file"]);
+  const envLookup = () => undefined;
+
+  const merged = mergeServeOptions(
+    config,
+    cliOptions,
+    explicitFlags,
+    envLookup,
+  );
+  assertEquals(merged.grantsFile, "/from/cli.yaml");
+});
+
+Deno.test("mergeServeOptions: grants-file env var wins over config when CLI not explicit", () => {
+  const config: ServeConfigFile = { "grants-file": "/from/config.yaml" };
+  const cliOptions = {};
+  const explicitFlags = new Set<string>();
+  const envLookup = (name: string) =>
+    name === "SWAMP_GRANTS_FILE" ? "/from/env.yaml" : undefined;
+
+  const merged = mergeServeOptions(
+    config,
+    cliOptions,
+    explicitFlags,
+    envLookup,
+  );
+  assertEquals(merged.grantsFile, "/from/env.yaml");
+});
+
+Deno.test("mergeServeOptions: grants-file from config when no CLI or env", () => {
+  const config: ServeConfigFile = { "grants-file": "/from/config.yaml" };
+  const cliOptions = {};
+  const explicitFlags = new Set<string>();
+  const envLookup = () => undefined;
+
+  const merged = mergeServeOptions(
+    config,
+    cliOptions,
+    explicitFlags,
+    envLookup,
+  );
+  assertEquals(merged.grantsFile, "/from/config.yaml");
+});
+
+Deno.test("mergeServeOptions: grants-file undefined when not specified anywhere", () => {
+  const cliOptions = {};
+  const explicitFlags = new Set<string>();
+  const envLookup = () => undefined;
+
+  const merged = mergeServeOptions(null, cliOptions, explicitFlags, envLookup);
+  assertEquals(merged.grantsFile, undefined);
+});
+
+Deno.test("loadServeConfig: grants-file field is parsed", () => {
+  withTempDir((dir) => {
+    writeConfig(dir, { "grants-file": "/etc/swamp/grants.yaml" });
+    const config = loadServeConfig(undefined, dir);
+    assertNotEquals(config, null);
+    assertEquals(config!["grants-file"], "/etc/swamp/grants.yaml");
+  });
+});
+
+Deno.test("loadServeConfig: non-string grants-file produces error", () => {
+  withTempDir((dir) => {
+    writeConfig(dir, { "grants-file": 42 });
+    assertThrows(
+      () => loadServeConfig(undefined, dir),
+      Error,
+      "expected string",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `--grants-file` flag to `swamp serve` that loads access grants from an external YAML file path at startup. This enables Kubernetes-native grant management where operators define grants in a ConfigMap, mount it into the container, and point serve at the mounted path.

Closes swamp-club#1530

## Problem

In a Kubernetes deployment, access grants are managed externally — defined in a ConfigMap, Helm values, or a GitOps repo — and mounted into the container at startup. Previously, swamp serve only read grants from the repo's `grants/` directory. There was no clean way to inject grants from outside the repo at container init time without either:

- Copying grant files into the repo directory during init (fragile, pollutes the repo)
- Running `swamp access grant create` commands before starting serve (extra init steps, race conditions)
- Baking grants into the container image (can't change without rebuild)

## Solution

### New configuration option

The external grants file path can be specified via three mechanisms (in merge priority order):

1. **CLI flag:** `swamp serve --grants-file /etc/swamp/grants.yaml`
2. **Environment variable:** `SWAMP_GRANTS_FILE=/etc/swamp/grants.yaml`
3. **serve.yaml config:** `grants-file: /etc/swamp/grants.yaml`

### Grants file format

Uses the same YAML format as existing grant files in `grants/`:

```yaml
grants:
  - subject: "idp-group:engineering"
    effect: allow
    actions: [run]
    resource: "workflow:*"
  - subject: "user:deploy-bot"
    effect: allow
    actions: [run, read]
    resource: "model:*"
```

### How it works

1. Serve starts and loads repo grants from `grants/` directory (existing behavior unchanged)
2. If `--grants-file` is specified, the external file is read and parsed via the existing `parseGrantFile()` function
3. External grant entries are merged into the reconciliation pipeline — the reconciler creates/revokes/reactivates grant model instances in the data store, tracked by source `file:<full-path>`
4. The `PolicySnapshotLoader` builds the in-memory snapshot from all active grants (repo + external)
5. On `access.reload`, the external file is re-read and re-reconciled alongside repo grants

### Startup behavior

- **File specified and valid:** grants loaded, logged, and reconciled
- **File specified but missing:** startup fails with `External grants file not found: <path>`
- **File specified but invalid YAML:** startup fails with `External grants file validation failed`
- **File specified but empty:** accepted — no external grants added (logged)
- **Flag not specified:** existing behavior unchanged

### Kubernetes use case

```yaml
# ConfigMap
apiVersion: v1
kind: ConfigMap
metadata:
  name: swamp-grants
data:
  grants.yaml: |
    grants:
      - subject: "idp-group:engineering"
        action: run
        resource: "workflow:*"

# Pod
containers:
  - name: swamp
    command: ["swamp", "serve", "--grants-file", "/etc/swamp/grants.yaml"]
    volumeMounts:
      - name: grants
        mountPath: /etc/swamp/grants.yaml
        subPath: grants.yaml
volumes:
  - name: grants
    configMap:
      name: swamp-grants
```

Kubernetes extracts the ConfigMap `data` keys into files at the mount path — swamp sees a plain YAML file, no ConfigMap-specific parsing needed.

### Source collision avoidance

External grant sources use the full resolved file path (e.g. `file:/etc/swamp/grants.yaml`) rather than just the basename, so they never collide with repo `grants/` directory filenames.

### What this does NOT include

- SIGHUP reload (stretch goal from the issue — deferred)
- Multiple `--grants-file` flags (operators can consolidate into one file)
- Grant management via API
- Grant priority or conflict resolution between sources

## Changes

| File | Change |
|------|--------|
| `src/serve/serve_config.ts` | Added `grants-file` to config interface, known keys, env map (`SWAMP_GRANTS_FILE`), merge options, and validation |
| `src/cli/commands/serve.ts` | Added `--grants-file` flag to both serve commands, startup loading logic, `parseGrantFile()` integration, `ConnectionContext` wiring, `collectServeExtraArgs` forwarding |
| `src/serve/handlers/shared.ts` | Added `grantsFile` field to `ConnectionContext` |
| `src/serve/handlers/access_handlers.ts` | Extended `access.reload` handler to re-read external grants file |
| `src/serve/serve_config_test.ts` | 6 new tests: merge priority (CLI > env > config), config parsing, validation |
| `src/cli/commands/serve_daemon_test.ts` | 2 new tests: `collectServeExtraArgs` with/without `--grants-file` |

## Test plan

- [x] **Unit tests:** 8 new tests covering config merge priority, env var fallback, config file parsing, validation, and daemon arg forwarding — all passing
- [x] **Full test suite:** 9890 tests pass, 0 failures
- [x] **Local E2E with compiled binary:**
  - Serve starts with `--grants-file`, grants appear in `access grant list` with correct source
  - Missing file -> startup fails with clear error
  - Invalid YAML -> startup fails with clear error
  - Empty file -> startup succeeds, no external grants added
  - Grants coexist with repo grants and admin grants
  - `access.reload` re-reads the external file
- [x] **Minikube E2E:** deployed pod with ConfigMap-mounted `grants.yaml` at `/etc/swamp/grants.yaml`, confirmed serve loaded 2 grants from the mounted path
- [ ] File documentation issue in swamp-club/swamp-club for reference docs
