### PR TITLE
feat(serve): add --server support to 23 CLI commands

### DIFF
--- a/src/cli/commands/access_token_list.ts
+++ b/src/cli/commands/access_token_list.ts
@@ -30,50 +30,76 @@ import {
   createLibSwampContext,
   createServerTokenListDeps,
   serverTokenList,
+  type ServerTokenListData,
   type ServerTokenListEvent,
   withDefaults,
 } from "../../libswamp/mod.ts";
 import { renderServerTokenList } from "../../presentation/output/access_token_output.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { AccessTokenListResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const accessTokenListCommand = new Command()
-  .name("list")
-  .description(
-    "List server tokens: state, principal, expiry, and last use",
-  )
-  .example("List all tokens", "swamp access token list")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .action(async function (options: AnyOptions) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "access",
-      "token",
-      "list",
-    ]);
+export const accessTokenListCommand = withRemoteOptions(
+  new Command()
+    .name("list")
+    .description(
+      "List server tokens: state, principal, expiry, and last use",
+    )
+    .example("List all tokens", "swamp access token list")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    ),
+).action(async function (options: AnyOptions) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "access",
+    "token",
+    "list",
+  ]);
 
-    const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: cliCtx.outputMode,
-    });
-
-    const libCtx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createServerTokenListDeps(repoContext.dataQueryService);
-
-    await consumeStream(
-      serverTokenList(libCtx, deps),
-      withDefaults<ServerTokenListEvent>({
-        completed: (event) => {
-          renderServerTokenList(event.data, cliCtx.outputMode);
-        },
-        error: (event) => {
-          throw new UserError(event.error.message);
-        },
-      }),
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
     );
+    const response = await requestServerResponse<AccessTokenListResponse>(
+      { server, token },
+      { type: "access.token.list", payload: {} },
+    );
+    renderServerTokenList(
+      response.data as unknown as ServerTokenListData,
+      cliCtx.outputMode,
+    );
+    return;
+  }
 
-    cliCtx.logger.debug("Server token list command completed");
+  const { repoContext } = await requireInitializedRepoReadOnly({
+    repoDir: resolveRepoDir(options.repoDir),
+    outputMode: cliCtx.outputMode,
   });
+
+  const libCtx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = createServerTokenListDeps(repoContext.dataQueryService);
+
+  await consumeStream(
+    serverTokenList(libCtx, deps),
+    withDefaults<ServerTokenListEvent>({
+      completed: (event) => {
+        renderServerTokenList(event.data, cliCtx.outputMode);
+      },
+      error: (event) => {
+        throw new UserError(event.error.message);
+      },
+    }),
+  );
+
+  cliCtx.logger.debug("Server token list command completed");
+});

--- a/src/cli/commands/access_token_revoke.ts
+++ b/src/cli/commands/access_token_revoke.ts
@@ -39,98 +39,123 @@ import {
   withDefaults,
 } from "../../libswamp/mod.ts";
 import { renderServerTokenRevoke } from "../../presentation/output/access_token_output.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { AccessTokenRevokeResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const accessTokenRevokeCommand = new Command()
-  .name("revoke")
-  .description("Invalidate a server token before it expires")
-  .example("Revoke a token", "swamp access token revoke adam-token")
-  .arguments("<name:string>")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .action(async function (options: AnyOptions, name: string) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "access",
-      "token",
-      "revoke",
-    ]);
+export const accessTokenRevokeCommand = withRemoteOptions(
+  new Command()
+    .name("revoke")
+    .description("Invalidate a server token before it expires")
+    .example("Revoke a token", "swamp access token revoke adam-token")
+    .arguments("<name:string>")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    ),
+).action(async function (options: AnyOptions, name: string) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "access",
+    "token",
+    "revoke",
+  ]);
 
-    const { repoDir, repoContext, datastoreConfig, syncService } =
-      await requireInitializedRepoUnlocked({
-        repoDir: resolveRepoDir(options.repoDir),
-        outputMode: cliCtx.outputMode,
-      });
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
+    );
+    const response = await requestServerResponse<AccessTokenRevokeResponse>(
+      { server, token },
+      { type: "access.token.revoke", payload: { name } },
+    );
+    renderServerTokenRevoke(
+      response.data as unknown as ServerTokenRevokeData,
+      cliCtx.outputMode,
+    );
+    return;
+  }
 
-    cliCtx.logger.debug`Revoking server token ${name}`;
+  const { repoDir, repoContext, datastoreConfig, syncService } =
+    await requireInitializedRepoUnlocked({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    });
 
-    const libCtx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = await createServerTokenRevokeDeps(
-      libCtx,
+  cliCtx.logger.debug`Revoking server token ${name}`;
+
+  const libCtx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = await createServerTokenRevokeDeps(
+    libCtx,
+    repoDir,
+    repoContext,
+  );
+
+  const preResult = await findDefinitionByIdOrName(
+    repoContext.definitionRepo,
+    name,
+  );
+  let flushModelLocks: (() => Promise<void>) | null = null;
+  if (preResult) {
+    const lockResult = await acquireModelLocks(
+      datastoreConfig,
+      [
+        {
+          modelType: preResult.type.normalized,
+          modelId: preResult.definition.id,
+        },
+      ],
       repoDir,
-      repoContext,
+      syncService,
+      repoContext.catalogStore,
     );
+    if (lockResult.synced) repoContext.catalogStore.invalidate();
+    flushModelLocks = lockResult.flush;
+  }
 
-    const preResult = await findDefinitionByIdOrName(
-      repoContext.definitionRepo,
-      name,
+  try {
+    let data: ServerTokenRevokeData | undefined;
+    await consumeStream(
+      serverTokenRevoke(libCtx, deps, { name }),
+      withDefaults<ServerTokenRevokeEvent>({
+        completed: (event) => {
+          data = event.data;
+        },
+        error: (event) => {
+          throw new UserError(event.error.message);
+        },
+      }),
     );
-    let flushModelLocks: (() => Promise<void>) | null = null;
-    if (preResult) {
-      const lockResult = await acquireModelLocks(
-        datastoreConfig,
-        [
-          {
-            modelType: preResult.type.normalized,
-            modelId: preResult.definition.id,
-          },
-        ],
-        repoDir,
-        syncService,
-        repoContext.catalogStore,
+    if (data === undefined) {
+      throw new UserError(
+        `Revoking token '${name}' ended without completing`,
       );
-      if (lockResult.synced) repoContext.catalogStore.invalidate();
-      flushModelLocks = lockResult.flush;
     }
-
-    try {
-      let data: ServerTokenRevokeData | undefined;
-      await consumeStream(
-        serverTokenRevoke(libCtx, deps, { name }),
-        withDefaults<ServerTokenRevokeEvent>({
-          completed: (event) => {
-            data = event.data;
+    renderServerTokenRevoke(data, cliCtx.outputMode);
+  } finally {
+    if (flushModelLocks) {
+      try {
+        await flushModelLocks();
+      } catch (releaseError) {
+        cliCtx.logger.warn(
+          "Failed to release locks during cleanup: {error}",
+          {
+            error: releaseError instanceof Error
+              ? releaseError.message
+              : String(releaseError),
           },
-          error: (event) => {
-            throw new UserError(event.error.message);
-          },
-        }),
-      );
-      if (data === undefined) {
-        throw new UserError(
-          `Revoking token '${name}' ended without completing`,
         );
       }
-      renderServerTokenRevoke(data, cliCtx.outputMode);
-    } finally {
-      if (flushModelLocks) {
-        try {
-          await flushModelLocks();
-        } catch (releaseError) {
-          cliCtx.logger.warn(
-            "Failed to release locks during cleanup: {error}",
-            {
-              error: releaseError instanceof Error
-                ? releaseError.message
-                : String(releaseError),
-            },
-          );
-        }
-      }
     }
+  }
 
-    cliCtx.logger.debug("Server token revoke command completed");
-  });
+  cliCtx.logger.debug("Server token revoke command completed");
+});

--- a/src/cli/commands/access_token_rotate.ts
+++ b/src/cli/commands/access_token_rotate.ts
@@ -40,131 +40,163 @@ import {
   withDefaults,
 } from "../../libswamp/mod.ts";
 import { renderServerTokenRotate } from "../../presentation/output/access_token_output.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { AccessTokenRotateResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
 const DEFAULT_DURATION = "30d";
 
-export const accessTokenRotateCommand = new Command()
-  .name("rotate")
-  .description(
-    "Revoke an existing token and mint a replacement with the same name and principal",
-  )
-  .example(
-    "Rotate a compromised token",
-    "swamp access token rotate sarah-token",
-  )
-  .example(
-    "Rotate with custom duration",
-    "swamp access token rotate sarah-token --duration 7d",
-  )
-  .arguments("<name:string>")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .option(
-    "--duration <duration:string>",
-    "Lifetime for the new token (e.g. 30m, 1h, 24h, 7d, 30d)",
-    { default: DEFAULT_DURATION },
-  )
-  .option(
-    "--vault <vault:string>",
-    "Vault that stores the token plaintext (defaults to the vault from the existing token)",
-  )
-  .action(async function (options: AnyOptions, name: string) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "access",
-      "token",
-      "rotate",
-    ]);
+export const accessTokenRotateCommand = withRemoteOptions(
+  new Command()
+    .name("rotate")
+    .description(
+      "Revoke an existing token and mint a replacement with the same name and principal",
+    )
+    .example(
+      "Rotate a compromised token",
+      "swamp access token rotate sarah-token",
+    )
+    .example(
+      "Rotate with custom duration",
+      "swamp access token rotate sarah-token --duration 7d",
+    )
+    .arguments("<name:string>")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option(
+      "--duration <duration:string>",
+      "Lifetime for the new token (e.g. 30m, 1h, 24h, 7d, 30d)",
+      { default: DEFAULT_DURATION },
+    )
+    .option(
+      "--vault <vault:string>",
+      "Vault that stores the token plaintext (defaults to the vault from the existing token)",
+    ),
+).action(async function (options: AnyOptions, name: string) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "access",
+    "token",
+    "rotate",
+  ]);
 
-    const durationMs = parseDuration(options.duration as string);
-    if (durationMs <= 0) {
-      throw new UserError(
-        `Invalid --duration value "${options.duration}": must be positive`,
-      );
-    }
-
-    const { repoDir, repoContext, datastoreConfig, syncService } =
-      await requireInitializedRepoUnlocked({
-        repoDir: resolveRepoDir(options.repoDir),
-        outputMode: cliCtx.outputMode,
-      });
-
-    cliCtx.logger.debug`Rotating server token ${name}`;
-
-    const libCtx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = await createServerTokenRotateDeps(
-      libCtx,
-      repoDir,
-      repoContext,
+  const durationMs = parseDuration(options.duration as string);
+  if (durationMs <= 0) {
+    throw new UserError(
+      `Invalid --duration value "${options.duration}": must be positive`,
     );
+  }
 
-    const preResult = await findDefinitionByIdOrName(
-      repoContext.definitionRepo,
-      name,
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
     );
-    if (!preResult) {
-      throw new UserError(
-        `Server token '${name}' not found. ` +
-          "Use 'swamp access token list' to see existing tokens.",
-      );
-    }
-
-    const lockResult = await acquireModelLocks(
-      datastoreConfig,
-      [
-        {
-          modelType: preResult.type.normalized,
-          modelId: preResult.definition.id,
-        },
-      ],
-      repoDir,
-      syncService,
-      repoContext.catalogStore,
-    );
-    if (lockResult.synced) repoContext.catalogStore.invalidate();
-    const flushModelLocks = lockResult.flush;
-
-    try {
-      let data: ServerTokenRotateData | undefined;
-      await consumeStream(
-        serverTokenRotate(libCtx, deps, {
+    const response = await requestServerResponse<AccessTokenRotateResponse>(
+      { server, token },
+      {
+        type: "access.token.rotate",
+        payload: {
           name,
           durationMs,
           vaultName: options.vault as string | undefined,
-        }),
-        withDefaults<ServerTokenRotateEvent>({
-          completed: (event) => {
-            data = event.data;
-          },
-          error: (event) => {
-            throw new UserError(event.error.message);
-          },
-        }),
-      );
-      if (data === undefined) {
-        throw new UserError(
-          `Rotating token '${name}' ended without completing`,
-        );
-      }
-      renderServerTokenRotate(data, cliCtx.outputMode);
-    } finally {
-      try {
-        await flushModelLocks();
-      } catch (releaseError) {
-        cliCtx.logger.warn(
-          "Failed to release locks during cleanup: {error}",
-          {
-            error: releaseError instanceof Error
-              ? releaseError.message
-              : String(releaseError),
-          },
-        );
-      }
-    }
+        },
+      },
+    );
+    renderServerTokenRotate(
+      response.data as unknown as ServerTokenRotateData,
+      cliCtx.outputMode,
+    );
+    return;
+  }
 
-    cliCtx.logger.debug("Server token rotate command completed");
-  });
+  const { repoDir, repoContext, datastoreConfig, syncService } =
+    await requireInitializedRepoUnlocked({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    });
+
+  cliCtx.logger.debug`Rotating server token ${name}`;
+
+  const libCtx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = await createServerTokenRotateDeps(
+    libCtx,
+    repoDir,
+    repoContext,
+  );
+
+  const preResult = await findDefinitionByIdOrName(
+    repoContext.definitionRepo,
+    name,
+  );
+  if (!preResult) {
+    throw new UserError(
+      `Server token '${name}' not found. ` +
+        "Use 'swamp access token list' to see existing tokens.",
+    );
+  }
+
+  const lockResult = await acquireModelLocks(
+    datastoreConfig,
+    [
+      {
+        modelType: preResult.type.normalized,
+        modelId: preResult.definition.id,
+      },
+    ],
+    repoDir,
+    syncService,
+    repoContext.catalogStore,
+  );
+  if (lockResult.synced) repoContext.catalogStore.invalidate();
+  const flushModelLocks = lockResult.flush;
+
+  try {
+    let data: ServerTokenRotateData | undefined;
+    await consumeStream(
+      serverTokenRotate(libCtx, deps, {
+        name,
+        durationMs,
+        vaultName: options.vault as string | undefined,
+      }),
+      withDefaults<ServerTokenRotateEvent>({
+        completed: (event) => {
+          data = event.data;
+        },
+        error: (event) => {
+          throw new UserError(event.error.message);
+        },
+      }),
+    );
+    if (data === undefined) {
+      throw new UserError(
+        `Rotating token '${name}' ended without completing`,
+      );
+    }
+    renderServerTokenRotate(data, cliCtx.outputMode);
+  } finally {
+    try {
+      await flushModelLocks();
+    } catch (releaseError) {
+      cliCtx.logger.warn(
+        "Failed to release locks during cleanup: {error}",
+        {
+          error: releaseError instanceof Error
+            ? releaseError.message
+            : String(releaseError),
+        },
+      );
+    }
+  }
+
+  cliCtx.logger.debug("Server token rotate command completed");
+});

--- a/src/cli/commands/data_gc.ts
+++ b/src/cli/commands/data_gc.ts
@@ -23,6 +23,7 @@ import {
   createDataGcDeps,
   createLibSwampContext,
   dataGc,
+  type DataGcData,
   dataGcPreview,
 } from "../../libswamp/mod.ts";
 import {
@@ -40,71 +41,100 @@ import {
   requireInitializedRepoReadOnly,
 } from "../repo_context.ts";
 import { promptConfirmation } from "../prompt_helpers.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { DataGcResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const dataGcCommand = new Command()
-  .name("gc")
-  .description("Run garbage collection on data (lifecycle and versions)")
-  .example("Preview what would be collected", "swamp data gc --dry-run")
-  .example("Run garbage collection", "swamp data gc --force")
-  .example(
-    "Run non-interactively in JSON mode (no prompt, structured output)",
-    "swamp data gc --json",
-  )
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .option("--dry-run", "Show what would be deleted without deleting")
-  .option("-y, --yes", "Skip confirmation prompt")
-  .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
-  .action(async function (options: AnyOptions) {
-    const cliCtx = createContext(options as GlobalOptions, ["data", "gc"]);
+export const dataGcCommand = withRemoteOptions(
+  new Command()
+    .name("gc")
+    .description("Run garbage collection on data (lifecycle and versions)")
+    .example("Preview what would be collected", "swamp data gc --dry-run")
+    .example("Run garbage collection", "swamp data gc --force")
+    .example(
+      "Run non-interactively in JSON mode (no prompt, structured output)",
+      "swamp data gc --json",
+    )
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option("--dry-run", "Show what would be deleted without deleting")
+    .option("-y, --yes", "Skip confirmation prompt")
+    .option("-f, --force", "Skip confirmation prompt (alias for --yes)"),
+).action(async function (options: AnyOptions) {
+  const cliCtx = createContext(options as GlobalOptions, ["data", "gc"]);
 
-    const repoOpts = {
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: cliCtx.outputMode,
-    };
-    const { repoDir, repoContext, datastoreResolver } = options.dryRun
-      ? await requireInitializedRepoReadOnly(repoOpts)
-      : await requireInitializedRepo(repoOpts);
-
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createDataGcDeps(
-      repoDir,
-      datastoreResolver,
-      repoContext.markDirty,
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
     );
+    const response = await requestServerResponse<DataGcResponse>(
+      { server, token },
+      {
+        type: "data.gc",
+        payload: { dryRun: !!options.dryRun },
+      },
+    );
+    const renderer = createDataGcRenderer(cliCtx.outputMode);
+    renderer.handlers().completed({
+      kind: "completed",
+      data: response.data as unknown as DataGcData,
+    });
+    return;
+  }
 
-    // Phase 1: Preview + Prompt (only in interactive mode without --force and not dry-run)
+  const repoOpts = {
+    repoDir: resolveRepoDir(options.repoDir),
+    outputMode: cliCtx.outputMode,
+  };
+  const { repoDir, repoContext, datastoreResolver } = options.dryRun
+    ? await requireInitializedRepoReadOnly(repoOpts)
+    : await requireInitializedRepo(repoOpts);
+
+  const ctx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = createDataGcDeps(
+    repoDir,
+    datastoreResolver,
+    repoContext.markDirty,
+  );
+
+  // Phase 1: Preview + Prompt (only in interactive mode without --force and not dry-run)
+  if (
+    cliCtx.outputMode === "log" && !options.yes && !options.force &&
+    !options.dryRun
+  ) {
+    const preview = await dataGcPreview(ctx, deps);
     if (
-      cliCtx.outputMode === "log" && !options.yes && !options.force &&
-      !options.dryRun
+      preview.items.length === 0 && preview.versionGcItems.length === 0
     ) {
-      const preview = await dataGcPreview(ctx, deps);
-      if (
-        preview.items.length === 0 && preview.versionGcItems.length === 0
-      ) {
-        console.log("Nothing to clean up.");
-        return;
-      }
-
-      renderDataGcPreview(preview, cliCtx.outputMode);
-      const confirmed = await promptConfirmation(
-        "Proceed with garbage collection?",
-      );
-      if (!confirmed) {
-        renderDataGcCancelled(cliCtx.outputMode);
-        return;
-      }
+      console.log("Nothing to clean up.");
+      return;
     }
 
-    // Phase 2: Execute GC
-    const renderer = createDataGcRenderer(cliCtx.outputMode);
-    await consumeStream(
-      dataGc(ctx, deps, { dryRun: !!options.dryRun }),
-      renderer.handlers(),
+    renderDataGcPreview(preview, cliCtx.outputMode);
+    const confirmed = await promptConfirmation(
+      "Proceed with garbage collection?",
     );
-  });
+    if (!confirmed) {
+      renderDataGcCancelled(cliCtx.outputMode);
+      return;
+    }
+  }
+
+  // Phase 2: Execute GC
+  const renderer = createDataGcRenderer(cliCtx.outputMode);
+  await consumeStream(
+    dataGc(ctx, deps, { dryRun: !!options.dryRun }),
+    renderer.handlers(),
+  );
+});

--- a/src/cli/commands/data_prune.ts
+++ b/src/cli/commands/data_prune.ts
@@ -23,6 +23,7 @@ import {
   createDataPruneDeps,
   createLibSwampContext,
   dataPrune,
+  type DataPruneData,
   dataPrunePreview,
 } from "../../libswamp/mod.ts";
 import {
@@ -40,77 +41,106 @@ import {
   requireInitializedRepoReadOnly,
 } from "../repo_context.ts";
 import { promptConfirmation } from "../prompt_helpers.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { DataPruneResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const dataPruneCommand = new Command()
-  .name("prune")
-  .description(
-    "Reclaim orphaned data whose owning model definition no longer exists.\n" +
-      "Unlike `data gc` (which enforces each model's declared lifetime and\n" +
-      "version-cap), prune removes data left behind when a model definition is\n" +
-      "deleted or migrated away. Deletion is irreversible; use --dry-run first.",
-  )
-  .example(
-    "Preview orphaned data that would be reclaimed",
-    "swamp data prune --dry-run",
-  )
-  .example("Reclaim orphaned data", "swamp data prune --force")
-  .example(
-    "Run non-interactively in JSON mode (no prompt, structured output)",
-    "swamp data prune --json",
-  )
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .option("--dry-run", "Show what would be reclaimed without deleting")
-  .option("-y, --yes", "Skip confirmation prompt")
-  .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
-  .action(async function (options: AnyOptions) {
-    const cliCtx = createContext(options as GlobalOptions, ["data", "prune"]);
+export const dataPruneCommand = withRemoteOptions(
+  new Command()
+    .name("prune")
+    .description(
+      "Reclaim orphaned data whose owning model definition no longer exists.\n" +
+        "Unlike `data gc` (which enforces each model's declared lifetime and\n" +
+        "version-cap), prune removes data left behind when a model definition is\n" +
+        "deleted or migrated away. Deletion is irreversible; use --dry-run first.",
+    )
+    .example(
+      "Preview orphaned data that would be reclaimed",
+      "swamp data prune --dry-run",
+    )
+    .example("Reclaim orphaned data", "swamp data prune --force")
+    .example(
+      "Run non-interactively in JSON mode (no prompt, structured output)",
+      "swamp data prune --json",
+    )
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option("--dry-run", "Show what would be reclaimed without deleting")
+    .option("-y, --yes", "Skip confirmation prompt")
+    .option("-f, --force", "Skip confirmation prompt (alias for --yes)"),
+).action(async function (options: AnyOptions) {
+  const cliCtx = createContext(options as GlobalOptions, ["data", "prune"]);
 
-    const repoOpts = {
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: cliCtx.outputMode,
-    };
-    const { repoDir, repoContext, datastoreResolver } = options.dryRun
-      ? await requireInitializedRepoReadOnly(repoOpts)
-      : await requireInitializedRepo(repoOpts);
-
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createDataPruneDeps(
-      repoDir,
-      datastoreResolver,
-      repoContext.unifiedDataRepo,
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
     );
+    const response = await requestServerResponse<DataPruneResponse>(
+      { server, token },
+      {
+        type: "data.prune",
+        payload: { dryRun: !!options.dryRun },
+      },
+    );
+    const renderer = createDataPruneRenderer(cliCtx.outputMode);
+    renderer.handlers().completed({
+      kind: "completed",
+      data: response.data as unknown as DataPruneData,
+    });
+    return;
+  }
 
-    // Phase 1: Preview + Prompt (only in interactive mode without --force and not dry-run)
-    if (
-      cliCtx.outputMode === "log" && !options.yes && !options.force &&
-      !options.dryRun
-    ) {
-      const preview = await dataPrunePreview(ctx, deps);
-      if (preview.items.length === 0) {
-        console.log("No orphaned data to reclaim.");
-        return;
-      }
+  const repoOpts = {
+    repoDir: resolveRepoDir(options.repoDir),
+    outputMode: cliCtx.outputMode,
+  };
+  const { repoDir, repoContext, datastoreResolver } = options.dryRun
+    ? await requireInitializedRepoReadOnly(repoOpts)
+    : await requireInitializedRepo(repoOpts);
 
-      renderDataPrunePreview(preview, cliCtx.outputMode);
-      const confirmed = await promptConfirmation(
-        "Reclaim this orphaned data?",
-      );
-      if (!confirmed) {
-        renderDataPruneCancelled(cliCtx.outputMode);
-        return;
-      }
+  const ctx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = createDataPruneDeps(
+    repoDir,
+    datastoreResolver,
+    repoContext.unifiedDataRepo,
+  );
+
+  // Phase 1: Preview + Prompt (only in interactive mode without --force and not dry-run)
+  if (
+    cliCtx.outputMode === "log" && !options.yes && !options.force &&
+    !options.dryRun
+  ) {
+    const preview = await dataPrunePreview(ctx, deps);
+    if (preview.items.length === 0) {
+      console.log("No orphaned data to reclaim.");
+      return;
     }
 
-    // Phase 2: Execute prune
-    const renderer = createDataPruneRenderer(cliCtx.outputMode);
-    await consumeStream(
-      dataPrune(ctx, deps, { dryRun: !!options.dryRun }),
-      renderer.handlers(),
+    renderDataPrunePreview(preview, cliCtx.outputMode);
+    const confirmed = await promptConfirmation(
+      "Reclaim this orphaned data?",
     );
-  });
+    if (!confirmed) {
+      renderDataPruneCancelled(cliCtx.outputMode);
+      return;
+    }
+  }
+
+  // Phase 2: Execute prune
+  const renderer = createDataPruneRenderer(cliCtx.outputMode);
+  await consumeStream(
+    dataPrune(ctx, deps, { dryRun: !!options.dryRun }),
+    renderer.handlers(),
+  );
+});

--- a/src/cli/commands/datastore_namespaces.ts
+++ b/src/cli/commands/datastore_namespaces.ts
@@ -22,6 +22,7 @@ import {
   consumeStream,
   createLibSwampContext,
   datastoreNamespaceList,
+  type NamespaceListData,
 } from "../../libswamp/mod.ts";
 import {
   createNamespaceListRenderer,
@@ -42,60 +43,94 @@ import {
 } from "../../domain/datastore/datastore_config.ts";
 import type { DatastoreProvider } from "../../domain/datastore/datastore_provider.ts";
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { DatastoreNamespaceListResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const datastoreNamespacesCommand = new Command()
-  .description("List all namespaces in the datastore")
-  .example("List namespaces", "swamp datastore namespace list")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .action(async function (options: AnyOptions) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "datastore",
-      "namespaces",
-    ]);
-    cliCtx.logger.debug("Executing datastore namespaces command");
+export const datastoreNamespacesCommand = withRemoteOptions(
+  new Command()
+    .description("List all namespaces in the datastore")
+    .example("List namespaces", "swamp datastore namespace list")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    ),
+).action(async function (options: AnyOptions) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "datastore",
+    "namespaces",
+  ]);
+  cliCtx.logger.debug("Executing datastore namespaces command");
 
-    const repoDir = resolveRepoDir(options.repoDir);
-    const { datastoreConfig } = await resolveDatastoreForRepo(repoDir);
-    const dsBasePath = datastoreBasePath(datastoreConfig);
-
-    let listProvider: DatastoreProvider | undefined;
-    if (isCustomDatastoreConfig(datastoreConfig)) {
-      await datastoreTypeRegistry.ensureLoaded();
-      await datastoreTypeRegistry.ensureTypeLoaded(datastoreConfig.type);
-      const typeInfo = datastoreTypeRegistry.get(datastoreConfig.type);
-      listProvider = typeInfo?.createProvider?.(datastoreConfig.config);
-    }
-
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = {
-      getCurrentNamespace: () => datastoreConfig.namespace,
-      listNamespaces: async () => {
-        if (listProvider?.listNamespaces) {
-          const slugs = await listProvider.listNamespaces(
-            (datastoreConfig as CustomDatastoreConfig).datastorePath,
-          );
-          return slugs.map((ns) => ({
-            namespace: ns,
-            repoId: "",
-            registeredAt: "",
-          }));
-        }
-        return await listNamespaceManifests(dsBasePath);
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
+    );
+    const response = await requestServerResponse<
+      DatastoreNamespaceListResponse
+    >(
+      { server, token },
+      {
+        type: "datastore.namespace.list",
+        payload: {},
       },
-    };
-
+    );
     const renderer = createNamespaceListRenderer(
       cliCtx.outputMode,
       cliCtx.verbosity,
     );
-    await consumeStream(
-      datastoreNamespaceList(ctx, deps),
-      renderer.handlers(),
-    );
-  });
+    renderer.handlers().completed({
+      kind: "completed",
+      data: response.data as unknown as NamespaceListData,
+    });
+    return;
+  }
+
+  const repoDir = resolveRepoDir(options.repoDir);
+  const { datastoreConfig } = await resolveDatastoreForRepo(repoDir);
+  const dsBasePath = datastoreBasePath(datastoreConfig);
+
+  let listProvider: DatastoreProvider | undefined;
+  if (isCustomDatastoreConfig(datastoreConfig)) {
+    await datastoreTypeRegistry.ensureLoaded();
+    await datastoreTypeRegistry.ensureTypeLoaded(datastoreConfig.type);
+    const typeInfo = datastoreTypeRegistry.get(datastoreConfig.type);
+    listProvider = typeInfo?.createProvider?.(datastoreConfig.config);
+  }
+
+  const ctx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = {
+    getCurrentNamespace: () => datastoreConfig.namespace,
+    listNamespaces: async () => {
+      if (listProvider?.listNamespaces) {
+        const slugs = await listProvider.listNamespaces(
+          (datastoreConfig as CustomDatastoreConfig).datastorePath,
+        );
+        return slugs.map((ns) => ({
+          namespace: ns,
+          repoId: "",
+          registeredAt: "",
+        }));
+      }
+      return await listNamespaceManifests(dsBasePath);
+    },
+  };
+
+  const renderer = createNamespaceListRenderer(
+    cliCtx.outputMode,
+    cliCtx.verbosity,
+  );
+  await consumeStream(
+    datastoreNamespaceList(ctx, deps),
+    renderer.handlers(),
+  );
+});

--- a/src/cli/commands/model_edit.ts
+++ b/src/cli/commands/model_edit.ts
@@ -23,6 +23,7 @@ import {
   createLibSwampContext,
   createModelEditDeps,
   modelEdit,
+  type ModelEditData,
   modelSearch,
   type ModelSearchDeps,
 } from "../../libswamp/mod.ts";
@@ -36,24 +37,55 @@ import {
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { readStdin } from "../../infrastructure/io/stdin_reader.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { ModelEditResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const modelEditCommand = new Command()
-  .name("edit")
-  .description("Edit a model definition file")
-  .example("Edit a model", "swamp model edit my-server")
-  .example("Interactive search", "swamp model edit")
-  .arguments("[model_id_or_name:model_name]")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
+export const modelEditCommand = withRemoteOptions(
+  new Command()
+    .name("edit")
+    .description("Edit a model definition file")
+    .example("Edit a model", "swamp model edit my-server")
+    .example("Interactive search", "swamp model edit")
+    .arguments("[model_id_or_name:model_name]")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    ),
+).action(
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
-  .action(async function (options: AnyOptions, modelIdOrName?: string) {
+  async function (options: AnyOptions, modelIdOrName?: string) {
     const cliCtx = createContext(options as GlobalOptions, ["model", "edit"]);
     cliCtx.logger.debug`Editing model: ${modelIdOrName ?? "(interactive)"}`;
+
+    const server = resolveServeUrl(options.server as string | undefined);
+    if (server) {
+      const token = await resolveServerToken(
+        server,
+        options.token as string | undefined,
+      );
+      const content = await readStdin();
+      const response = await requestServerResponse<ModelEditResponse>(
+        { server, token },
+        {
+          type: "model.edit",
+          payload: { modelIdOrName, content },
+        },
+      );
+      const renderer = createModelEditRenderer(cliCtx.outputMode);
+      renderer.handlers().completed({
+        kind: "completed",
+        data: response.data as unknown as ModelEditData,
+      });
+      return;
+    }
 
     const { repoContext, repoDir } = await requireInitializedRepoUnlocked({
       repoDir: resolveRepoDir(options.repoDir),
@@ -103,4 +135,5 @@ export const modelEditCommand = new Command()
     );
 
     cliCtx.logger.debug("Model edit command completed");
-  });
+  },
+);

--- a/src/cli/commands/run_gc.ts
+++ b/src/cli/commands/run_gc.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_WORKFLOW_RUN_RETENTION_DAYS,
   parseDuration,
   runGc,
+  type RunGcData,
   runGcPreview,
 } from "../../libswamp/mod.ts";
 import {
@@ -42,88 +43,121 @@ import {
   requireInitializedRepoReadOnly,
 } from "../repo_context.ts";
 import { promptConfirmation } from "../prompt_helpers.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { RunGcResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const runGcCommand = new Command()
-  .name("gc")
-  .description(
-    "Garbage-collect old workflow runs and model method outputs. Running and suspended runs are never deleted regardless of age.",
-  )
-  .example("Preview what would be collected", "swamp run gc --dry-run")
-  .example("Run GC with default 30-day retention", "swamp run gc --force")
-  .example("Delete runs older than 7 days", "swamp run gc --older-than 7d")
-  .example(
-    "Run non-interactively in JSON mode (no prompt, structured output)",
-    "swamp run gc --json --older-than 14d",
-  )
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .option("--dry-run", "Show what would be deleted without deleting")
-  .option("-y, --yes", "Skip confirmation prompt")
-  .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
-  .option(
-    "--older-than <duration:string>",
-    `Retention period. Units: m=minutes, h=hours, d=days, w=weeks, mo=months, y=years (e.g. 7d, 2w, 1mo). Default: ${DEFAULT_WORKFLOW_RUN_RETENTION_DAYS}d`,
-  )
-  .action(async function (options: AnyOptions) {
-    const cliCtx = createContext(options as GlobalOptions, ["run", "gc"]);
+export const runGcCommand = withRemoteOptions(
+  new Command()
+    .name("gc")
+    .description(
+      "Garbage-collect old workflow runs and model method outputs. Running and suspended runs are never deleted regardless of age.",
+    )
+    .example("Preview what would be collected", "swamp run gc --dry-run")
+    .example("Run GC with default 30-day retention", "swamp run gc --force")
+    .example("Delete runs older than 7 days", "swamp run gc --older-than 7d")
+    .example(
+      "Run non-interactively in JSON mode (no prompt, structured output)",
+      "swamp run gc --json --older-than 14d",
+    )
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option("--dry-run", "Show what would be deleted without deleting")
+    .option("-y, --yes", "Skip confirmation prompt")
+    .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
+    .option(
+      "--older-than <duration:string>",
+      `Retention period. Units: m=minutes, h=hours, d=days, w=weeks, mo=months, y=years (e.g. 7d, 2w, 1mo). Default: ${DEFAULT_WORKFLOW_RUN_RETENTION_DAYS}d`,
+    ),
+).action(async function (options: AnyOptions) {
+  const cliCtx = createContext(options as GlobalOptions, ["run", "gc"]);
 
-    const repoOpts = {
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: cliCtx.outputMode,
-    };
-    const { repoDir, repoContext, datastoreResolver } = options.dryRun
-      ? await requireInitializedRepoReadOnly(repoOpts)
-      : await requireInitializedRepo(repoOpts);
+  let retentionDays = DEFAULT_WORKFLOW_RUN_RETENTION_DAYS;
+  if (options.olderThan) {
+    const ms = parseDuration(options.olderThan);
+    retentionDays = ms / (24 * 60 * 60 * 1000);
+  }
 
-    let retentionDays = DEFAULT_WORKFLOW_RUN_RETENTION_DAYS;
-    if (options.olderThan) {
-      const ms = parseDuration(options.olderThan);
-      retentionDays = ms / (24 * 60 * 60 * 1000);
-    }
-
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createRunGcDeps(
-      repoDir,
-      datastoreResolver,
-      repoContext.markDirty,
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
     );
-
-    const gcInput = {
-      dryRun: !!options.dryRun,
-      workflowRunRetentionDays: retentionDays,
-      outputRetentionDays: retentionDays,
-    };
-
-    if (
-      cliCtx.outputMode === "log" && !options.yes && !options.force &&
-      !options.dryRun
-    ) {
-      const preview = await runGcPreview(ctx, deps, gcInput);
-      if (
-        preview.workflowRunsToDelete === 0 && preview.outputsToDelete === 0
-      ) {
-        cliCtx.logger.info("Nothing to clean up.");
-        return;
-      }
-
-      renderRunGcPreview(preview, cliCtx.outputMode);
-      const confirmed = await promptConfirmation(
-        "Proceed with run garbage collection?",
-      );
-      if (!confirmed) {
-        renderRunGcCancelled(cliCtx.outputMode);
-        return;
-      }
-    }
-
+    const response = await requestServerResponse<RunGcResponse>(
+      { server, token },
+      {
+        type: "run.gc",
+        payload: {
+          dryRun: !!options.dryRun,
+          workflowRunRetentionDays: retentionDays,
+          outputRetentionDays: retentionDays,
+        },
+      },
+    );
     const renderer = createRunGcRenderer(cliCtx.outputMode);
-    await consumeStream(
-      runGc(ctx, deps, gcInput),
-      renderer.handlers(),
+    renderer.handlers().completed({
+      kind: "completed",
+      data: response.data as unknown as RunGcData,
+    });
+    return;
+  }
+
+  const repoOpts = {
+    repoDir: resolveRepoDir(options.repoDir),
+    outputMode: cliCtx.outputMode,
+  };
+  const { repoDir, repoContext, datastoreResolver } = options.dryRun
+    ? await requireInitializedRepoReadOnly(repoOpts)
+    : await requireInitializedRepo(repoOpts);
+
+  const ctx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = createRunGcDeps(
+    repoDir,
+    datastoreResolver,
+    repoContext.markDirty,
+  );
+
+  const gcInput = {
+    dryRun: !!options.dryRun,
+    workflowRunRetentionDays: retentionDays,
+    outputRetentionDays: retentionDays,
+  };
+
+  if (
+    cliCtx.outputMode === "log" && !options.yes && !options.force &&
+    !options.dryRun
+  ) {
+    const preview = await runGcPreview(ctx, deps, gcInput);
+    if (
+      preview.workflowRunsToDelete === 0 && preview.outputsToDelete === 0
+    ) {
+      cliCtx.logger.info("Nothing to clean up.");
+      return;
+    }
+
+    renderRunGcPreview(preview, cliCtx.outputMode);
+    const confirmed = await promptConfirmation(
+      "Proceed with run garbage collection?",
     );
-  });
+    if (!confirmed) {
+      renderRunGcCancelled(cliCtx.outputMode);
+      return;
+    }
+  }
+
+  const renderer = createRunGcRenderer(cliCtx.outputMode);
+  await consumeStream(
+    runGc(ctx, deps, gcInput),
+    renderer.handlers(),
+  );
+});

--- a/src/cli/commands/type_describe.ts
+++ b/src/cli/commands/type_describe.ts
@@ -23,11 +23,19 @@ import {
   createLibSwampContext,
   createTypeDescribeDeps,
   typeDescribe,
+  type TypeDescribeData,
 } from "../../libswamp/mod.ts";
 import { createTypeDescribeRenderer } from "../../presentation/renderers/type_describe.ts";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { ModelTypeDescribeResponse } from "../../serve/protocol.ts";
 
 // Re-export from libswamp for backward compatibility with existing importers
 export {
@@ -39,26 +47,50 @@ export {
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const typeDescribeCommand = new Command()
-  .description("Describe a model type with schema details")
-  .example("Describe a model type", "swamp type describe aws-ec2")
-  .example(
-    "Compact digest for agents",
-    "swamp type describe aws-ec2 --compact --json",
-  )
-  .alias("get")
-  .option(
-    "--compact",
-    "Output a compact digest (method names, descriptions, argument types, output spec names)",
-  )
-  .arguments("<type:model_type>")
+export const typeDescribeCommand = withRemoteOptions(
+  new Command()
+    .description("Describe a model type with schema details")
+    .example("Describe a model type", "swamp type describe aws-ec2")
+    .example(
+      "Compact digest for agents",
+      "swamp type describe aws-ec2 --compact --json",
+    )
+    .alias("get")
+    .option(
+      "--compact",
+      "Output a compact digest (method names, descriptions, argument types, output spec names)",
+    )
+    .arguments("<type:model_type>"),
+).action(
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
-  .action(async function (options: AnyOptions, typeArg: string) {
+  async function (options: AnyOptions, typeArg: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "type",
       "describe",
     ]);
     cliCtx.logger.debug`Describing type: ${typeArg}`;
+
+    const server = resolveServeUrl(options.server as string | undefined);
+    if (server) {
+      const token = await resolveServerToken(
+        server,
+        options.token as string | undefined,
+      );
+      const response = await requestServerResponse<ModelTypeDescribeResponse>(
+        { server, token },
+        { type: "model.type.describe", payload: { typeArg } },
+      );
+      const compact = options.compact as boolean | undefined;
+      const renderer = createTypeDescribeRenderer(
+        cliCtx.outputMode,
+        compact ?? false,
+      );
+      renderer.handlers().completed({
+        kind: "completed",
+        data: response.data as unknown as TypeDescribeData,
+      });
+      return;
+    }
 
     const modelType = ModelType.create(typeArg);
 
@@ -75,4 +107,5 @@ export const typeDescribeCommand = new Command()
     );
 
     cliCtx.logger.debug("Type describe command completed");
-  });
+  },
+);

--- a/src/cli/commands/type_search.ts
+++ b/src/cli/commands/type_search.ts
@@ -25,6 +25,7 @@ import {
   typeDescribe,
   type TypeDescribeData,
   typeSearch,
+  type TypeSearchData,
   type TypeSearchDeps,
   type TypeSearchItem,
 } from "../../libswamp/mod.ts";
@@ -37,6 +38,13 @@ import {
 } from "../context.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { ModelTypeSearchResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -80,6 +88,24 @@ export async function typeSearchAction(
   const libCtx = createLibSwampContext();
   ctx.logger.debug`Searching types with query: ${query ?? "(none)"}`;
 
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
+    );
+    const response = await requestServerResponse<ModelTypeSearchResponse>(
+      { server, token },
+      { type: "model.type.search", payload: { query } },
+    );
+    const renderer = createTypeSearchRenderer(effectiveMode);
+    renderer.handlers().completed({
+      kind: "completed",
+      data: response.data as unknown as TypeSearchData,
+    });
+    return;
+  }
+
   await modelRegistry.ensureLoaded();
   const deps: TypeSearchDeps = {
     getRegisteredTypes: () => modelRegistry.publicTypes(),
@@ -117,14 +143,15 @@ export async function typeSearchAction(
   ctx.logger.debug("Type search command completed");
 }
 
-export const typeSearchCommand = new Command()
-  .name("search")
-  .description("Search for model types")
-  .example("Browse all types", "swamp type search")
-  .example("Search by keyword", "swamp type search aws")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR; not required for type search)",
-  )
-  .arguments("[query:string]")
-  .action(typeSearchAction);
+export const typeSearchCommand = withRemoteOptions(
+  new Command()
+    .name("search")
+    .description("Search for model types")
+    .example("Browse all types", "swamp type search")
+    .example("Search by keyword", "swamp type search aws")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR; not required for type search)",
+    )
+    .arguments("[query:string]"),
+).action(typeSearchAction);

--- a/src/cli/commands/vault_audit_trail.ts
+++ b/src/cli/commands/vault_audit_trail.ts
@@ -23,6 +23,7 @@ import {
   createLibSwampContext,
   createVaultAuditTrailDeps,
   vaultAuditTrail,
+  type VaultAuditTrailData,
 } from "../../libswamp/mod.ts";
 import { createVaultAuditTrailRenderer } from "../../presentation/renderers/vault_audit_trail.ts";
 import {
@@ -32,74 +33,111 @@ import {
 } from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { VaultAuditTrailResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const vaultAuditTrailCommand = new Command()
-  .name("audit-trail")
-  .description("View the secret-read audit trail for vaults.")
-  .example(
-    "Show recent reads",
-    "swamp vault audit-trail",
-  )
-  .example(
-    "Filter by vault",
-    "swamp vault audit-trail --vault my-vault",
-  )
-  .example(
-    "Filter by key and time range",
-    "swamp vault audit-trail --vault my-vault --key API_KEY --since 2026-07-01",
-  )
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .option("--vault <name:string>", "Filter by vault name")
-  .option("--key <key:string>", "Filter by secret key")
-  .option(
-    "--since <date:string>",
-    "Start date, e.g. 2026-07-01 or 2026-07-01T00:00:00Z [default: 7 days ago]",
-  )
-  .option(
-    "--until <date:string>",
-    "End date, e.g. 2026-07-01 or 2026-07-01T00:00:00Z [default: now]",
-  )
-  .option(
-    "--limit <count:integer>",
-    "Maximum number of entries to return [default: 100]",
-  )
-  .action(async function (options: AnyOptions) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "vault",
-      "audit-trail",
-    ]);
+export const vaultAuditTrailCommand = withRemoteOptions(
+  new Command()
+    .name("audit-trail")
+    .description("View the secret-read audit trail for vaults.")
+    .example(
+      "Show recent reads",
+      "swamp vault audit-trail",
+    )
+    .example(
+      "Filter by vault",
+      "swamp vault audit-trail --vault my-vault",
+    )
+    .example(
+      "Filter by key and time range",
+      "swamp vault audit-trail --vault my-vault --key API_KEY --since 2026-07-01",
+    )
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option("--vault <name:string>", "Filter by vault name")
+    .option("--key <key:string>", "Filter by secret key")
+    .option(
+      "--since <date:string>",
+      "Start date, e.g. 2026-07-01 or 2026-07-01T00:00:00Z [default: 7 days ago]",
+    )
+    .option(
+      "--until <date:string>",
+      "End date, e.g. 2026-07-01 or 2026-07-01T00:00:00Z [default: now]",
+    )
+    .option(
+      "--limit <count:integer>",
+      "Maximum number of entries to return [default: 100]",
+    ),
+).action(async function (options: AnyOptions) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "vault",
+    "audit-trail",
+  ]);
 
-    const { repoDir } = await requireInitializedRepoUnlocked({
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: cliCtx.outputMode,
-    });
-
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
     const since = options.since ? parseDate(options.since) : undefined;
     const until = options.until ? parseDate(options.until) : undefined;
-
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createVaultAuditTrailDeps(repoDir);
-    const renderer = createVaultAuditTrailRenderer(cliCtx.outputMode);
-
-    await consumeStream(
-      vaultAuditTrail(ctx, deps, {
-        vaultName: options.vault,
-        secretKey: options.key,
-        since,
-        until,
-        limit: options.limit,
-      }),
-      renderer.handlers(),
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
     );
+    const response = await requestServerResponse<VaultAuditTrailResponse>(
+      { server, token },
+      {
+        type: "vault.audit-trail",
+        payload: {
+          vaultName: options.vault as string | undefined,
+          secretKey: options.key as string | undefined,
+          since: since?.toISOString(),
+          until: until?.toISOString(),
+          limit: options.limit as number | undefined,
+        },
+      },
+    );
+    const renderer = createVaultAuditTrailRenderer(cliCtx.outputMode);
+    renderer.handlers().completed({
+      kind: "completed",
+      data: response.data as unknown as VaultAuditTrailData,
+    });
+    return;
+  }
 
-    cliCtx.logger.debug("Vault audit-trail command completed");
+  const { repoDir } = await requireInitializedRepoUnlocked({
+    repoDir: resolveRepoDir(options.repoDir),
+    outputMode: cliCtx.outputMode,
   });
+
+  const since = options.since ? parseDate(options.since) : undefined;
+  const until = options.until ? parseDate(options.until) : undefined;
+
+  const ctx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = createVaultAuditTrailDeps(repoDir);
+  const renderer = createVaultAuditTrailRenderer(cliCtx.outputMode);
+
+  await consumeStream(
+    vaultAuditTrail(ctx, deps, {
+      vaultName: options.vault,
+      secretKey: options.key,
+      since,
+      until,
+      limit: options.limit,
+    }),
+    renderer.handlers(),
+  );
+
+  cliCtx.logger.debug("Vault audit-trail command completed");
+});
 
 function parseDate(value: string): Date {
   const date = new Date(value);

--- a/src/cli/commands/vault_create.ts
+++ b/src/cli/commands/vault_create.ts
@@ -23,6 +23,7 @@ import {
   createLibSwampContext,
   createVaultCreateDeps,
   vaultCreate,
+  type VaultCreateData,
 } from "../../libswamp/mod.ts";
 import { createVaultCreateRenderer } from "../../presentation/renderers/vault_create.ts";
 import {
@@ -35,6 +36,13 @@ import { UserError } from "../../domain/errors.ts";
 import { requireAuthenticated, requireScope } from "../auth_context.ts";
 import { RENAMED_VAULT_TYPES } from "../../domain/vaults/vault_types.ts";
 import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { VaultCreateResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -57,60 +65,48 @@ async function promptVaultName(): Promise<string> {
   return decoder.decode(buf.subarray(0, n)).trim();
 }
 
-export const vaultCreateCommand = new Command()
-  .name("create")
-  .description("Create a new vault configuration")
-  .example(
-    "Create a local vault",
-    "swamp vault create local_encryption my-vault",
-  )
-  .example(
-    "With provider config",
-    `swamp vault create aws-secrets-manager my-vault --config '{"region":"us-east-1"}'`,
-  )
-  .arguments("<type:string> [name:string]")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .option(
-    "--config <json:string>",
-    "Provider configuration as JSON",
-  )
-  .option(
-    "--audit-reads",
-    "Enable read access audit trail for this vault (can also be set later with vault edit)",
-  )
-  .action(
-    async function (
-      options: AnyOptions,
-      vaultType: string,
-      vaultNameArg?: string,
-    ) {
-      const cliCtx = createContext(options as GlobalOptions, [
-        "vault",
-        "create",
-      ]);
-      const { repoDir } = await requireInitializedRepoUnlocked({
-        repoDir: resolveRepoDir(options.repoDir),
-        outputMode: cliCtx.outputMode,
-      });
+export const vaultCreateCommand = withRemoteOptions(
+  new Command()
+    .name("create")
+    .description("Create a new vault configuration")
+    .example(
+      "Create a local vault",
+      "swamp vault create local_encryption my-vault",
+    )
+    .example(
+      "With provider config",
+      `swamp vault create aws-secrets-manager my-vault --config '{"region":"us-east-1"}'`,
+    )
+    .arguments("<type:string> [name:string]")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option(
+      "--config <json:string>",
+      "Provider configuration as JSON",
+    )
+    .option(
+      "--audit-reads",
+      "Enable read access audit trail for this vault (can also be set later with vault edit)",
+    ),
+).action(
+  async function (
+    options: AnyOptions,
+    vaultType: string,
+    vaultNameArg?: string,
+  ) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "vault",
+      "create",
+    ]);
 
-      // Get vault name - prompt if not provided (stays in CLI)
-      let vaultName = vaultNameArg;
-      if (!vaultName) {
-        if (cliCtx.outputMode === "json") {
-          throw new UserError(
-            "Vault name is required in non-interactive mode. Usage: swamp vault create <type> <name>",
-          );
-        }
-        vaultName = await promptVaultName();
-        if (!vaultName) {
-          throw new UserError("Vault name is required.");
-        }
-      }
-
-      // Parse --config JSON (stays in CLI as input parsing)
+    const server = resolveServeUrl(options.server as string | undefined);
+    if (server) {
+      const token = await resolveServerToken(
+        server,
+        options.token as string | undefined,
+      );
       let config: Record<string, unknown> | undefined;
       if (options.config) {
         try {
@@ -121,39 +117,89 @@ export const vaultCreateCommand = new Command()
           );
         }
       }
-
-      // Validate type before the auth gate so typos produce "unknown type"
-      // instead of a paywall. Renamed types get a helpful redirect message.
-      if (vaultType.toLowerCase() !== "local_encryption") {
-        const renamed = RENAMED_VAULT_TYPES[vaultType.toLowerCase()];
-        if (
-          !renamed && !vaultType.startsWith("@") &&
-          !vaultTypeRegistry.has(vaultType)
-        ) {
-          const availableTypes = vaultTypeRegistry.getAll()
-            .map((t) => t.type).join(", ");
-          throw new UserError(
-            `Unknown vault type: ${vaultType}. Available types: ${availableTypes}. Use 'swamp vault type search' to see available types.`,
-          );
-        }
-        requireAuthenticated("Non-local vaults are a team feature", "vault:*");
-        requireScope("vault:*");
-      }
-
-      const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = await createVaultCreateDeps(repoDir);
-      const renderer = createVaultCreateRenderer(cliCtx.outputMode);
-      await consumeStream(
-        vaultCreate(ctx, deps, {
-          vaultType,
-          name: vaultName,
-          config,
-          repoDir,
-          auditReads: options.auditReads,
-        }),
-        renderer.handlers(),
+      const response = await requestServerResponse<VaultCreateResponse>(
+        { server, token },
+        {
+          type: "vault.create",
+          payload: {
+            vaultType,
+            name: vaultNameArg,
+            config,
+            auditReads: options.auditReads,
+          },
+        },
       );
+      const renderer = createVaultCreateRenderer(cliCtx.outputMode);
+      renderer.handlers().completed({
+        kind: "completed",
+        data: response.data as unknown as VaultCreateData,
+      });
+      return;
+    }
 
-      cliCtx.logger.debug("Vault create command completed");
-    },
-  );
+    const { repoDir } = await requireInitializedRepoUnlocked({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    });
+
+    // Get vault name - prompt if not provided (stays in CLI)
+    let vaultName = vaultNameArg;
+    if (!vaultName) {
+      if (cliCtx.outputMode === "json") {
+        throw new UserError(
+          "Vault name is required in non-interactive mode. Usage: swamp vault create <type> <name>",
+        );
+      }
+      vaultName = await promptVaultName();
+      if (!vaultName) {
+        throw new UserError("Vault name is required.");
+      }
+    }
+
+    // Parse --config JSON (stays in CLI as input parsing)
+    let config: Record<string, unknown> | undefined;
+    if (options.config) {
+      try {
+        config = JSON.parse(options.config) as Record<string, unknown>;
+      } catch {
+        throw new UserError(
+          `Invalid JSON in --config: ${options.config}`,
+        );
+      }
+    }
+
+    // Validate type before the auth gate so typos produce "unknown type"
+    // instead of a paywall. Renamed types get a helpful redirect message.
+    if (vaultType.toLowerCase() !== "local_encryption") {
+      const renamed = RENAMED_VAULT_TYPES[vaultType.toLowerCase()];
+      if (
+        !renamed && !vaultType.startsWith("@") &&
+        !vaultTypeRegistry.has(vaultType)
+      ) {
+        const availableTypes = vaultTypeRegistry.getAll()
+          .map((t) => t.type).join(", ");
+        throw new UserError(
+          `Unknown vault type: ${vaultType}. Available types: ${availableTypes}. Use 'swamp vault type search' to see available types.`,
+        );
+      }
+      requireAuthenticated("Non-local vaults are a team feature", "vault:*");
+      requireScope("vault:*");
+    }
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = await createVaultCreateDeps(repoDir);
+    const renderer = createVaultCreateRenderer(cliCtx.outputMode);
+    await consumeStream(
+      vaultCreate(ctx, deps, {
+        vaultType,
+        name: vaultName,
+        config,
+        repoDir,
+        auditReads: options.auditReads,
+      }),
+      renderer.handlers(),
+    );
+
+    cliCtx.logger.debug("Vault create command completed");
+  },
+);

--- a/src/cli/commands/vault_edit.ts
+++ b/src/cli/commands/vault_edit.ts
@@ -23,6 +23,7 @@ import {
   createLibSwampContext,
   createVaultEditDeps,
   vaultEdit,
+  type VaultEditData,
   vaultSearch,
   type VaultSearchDeps,
 } from "../../libswamp/mod.ts";
@@ -35,69 +36,109 @@ import {
 } from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { VaultEditResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const vaultEditCommand = new Command()
-  .name("edit")
-  .description("Edit a vault configuration file")
-  .example("Edit a vault", "swamp vault edit my-vault")
-  .example("Interactive search", "swamp vault edit")
-  .arguments("[vault_name_or_id:string]")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .option("-t, --type <type:string>", "Vault type (optional, narrows search)")
-  .action(async function (options: AnyOptions, vaultNameOrId?: string) {
-    const cliCtx = createContext(options as GlobalOptions, ["vault", "edit"]);
-    cliCtx.logger.debug`Editing vault: ${vaultNameOrId ?? "(interactive)"}`;
+export const vaultEditCommand = withRemoteOptions(
+  new Command()
+    .name("edit")
+    .description("Edit a vault configuration file")
+    .example("Edit a vault", "swamp vault edit my-vault")
+    .example("Interactive search", "swamp vault edit")
+    .arguments("[vault_name_or_id:string]")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option(
+      "-t, --type <type:string>",
+      "Vault type (optional, narrows search)",
+    ),
+).action(async function (options: AnyOptions, vaultNameOrId?: string) {
+  const cliCtx = createContext(options as GlobalOptions, ["vault", "edit"]);
+  cliCtx.logger.debug`Editing vault: ${vaultNameOrId ?? "(interactive)"}`;
 
-    const { repoContext, repoDir } = await requireInitializedRepoUnlocked({
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: cliCtx.outputMode,
-    });
-    const vaultType = options.type as string | undefined;
-    const libCtx = createLibSwampContext({ logger: cliCtx.logger });
-
-    // Interactive search mode when no argument provided
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
     if (!vaultNameOrId) {
-      if (cliCtx.outputMode === "json") {
-        throw new UserError(
-          "Vault name or ID is required in non-interactive mode",
-        );
-      }
-
-      const searchDeps: VaultSearchDeps = {
-        findAllVaults: () => repoContext.vaultConfigRepo.findAll(),
-      };
-
-      const searchRenderer = createVaultSearchRenderer(cliCtx.outputMode);
-      await consumeStream(
-        vaultSearch(libCtx, searchDeps, { query: undefined }),
-        searchRenderer.handlers(),
+      throw new UserError(
+        "Vault name or ID is required with --server (interactive search is not supported remotely)",
       );
-
-      const selected = searchRenderer.selectedItem();
-      if (!selected) {
-        cliCtx.logger.debug`Search cancelled`;
-        return;
-      }
-
-      cliCtx.logger.debug`Selected vault: ${selected.name} (${selected.id})`;
-      vaultNameOrId = selected.name;
     }
-    const deps = createVaultEditDeps(repoDir);
-
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
+    );
+    const response = await requestServerResponse<VaultEditResponse>(
+      { server, token },
+      {
+        type: "vault.edit",
+        payload: {
+          vaultNameOrId,
+          vaultType: options.type as string | undefined,
+        },
+      },
+    );
     const renderer = createVaultEditRenderer(cliCtx.outputMode);
+    renderer.handlers().completed({
+      kind: "completed",
+      data: response.data as unknown as VaultEditData,
+    });
+    return;
+  }
+
+  const { repoContext, repoDir } = await requireInitializedRepoUnlocked({
+    repoDir: resolveRepoDir(options.repoDir),
+    outputMode: cliCtx.outputMode,
+  });
+  const vaultType = options.type as string | undefined;
+  const libCtx = createLibSwampContext({ logger: cliCtx.logger });
+
+  // Interactive search mode when no argument provided
+  if (!vaultNameOrId) {
+    if (cliCtx.outputMode === "json") {
+      throw new UserError(
+        "Vault name or ID is required in non-interactive mode",
+      );
+    }
+
+    const searchDeps: VaultSearchDeps = {
+      findAllVaults: () => repoContext.vaultConfigRepo.findAll(),
+    };
+
+    const searchRenderer = createVaultSearchRenderer(cliCtx.outputMode);
     await consumeStream(
-      vaultEdit(libCtx, deps, {
-        vaultNameOrId,
-        vaultType,
-      }),
-      renderer.handlers(),
+      vaultSearch(libCtx, searchDeps, { query: undefined }),
+      searchRenderer.handlers(),
     );
 
-    cliCtx.logger.debug("Vault edit command completed");
-  });
+    const selected = searchRenderer.selectedItem();
+    if (!selected) {
+      cliCtx.logger.debug`Search cancelled`;
+      return;
+    }
+
+    cliCtx.logger.debug`Selected vault: ${selected.name} (${selected.id})`;
+    vaultNameOrId = selected.name;
+  }
+  const deps = createVaultEditDeps(repoDir);
+
+  const renderer = createVaultEditRenderer(cliCtx.outputMode);
+  await consumeStream(
+    vaultEdit(libCtx, deps, {
+      vaultNameOrId,
+      vaultType,
+    }),
+    renderer.handlers(),
+  );
+
+  cliCtx.logger.debug("Vault edit command completed");
+});

--- a/src/cli/commands/vault_read_secret.ts
+++ b/src/cli/commands/vault_read_secret.ts
@@ -23,6 +23,7 @@ import {
   createLibSwampContext,
   createVaultReadSecretDeps,
   vaultReadSecret,
+  type VaultReadSecretData,
 } from "../../libswamp/mod.ts";
 import { createVaultReadSecretRenderer } from "../../presentation/renderers/vault_read_secret.ts";
 import {
@@ -35,74 +36,109 @@ import {
   requireInitializedRepoUnlocked,
 } from "../repo_context.ts";
 import { promptConfirmation } from "../prompt_helpers.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { VaultReadSecretResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const vaultReadSecretCommand = new Command()
-  .name("read-secret")
-  .description(
-    `Read a secret value from a vault.
+export const vaultReadSecretCommand = withRemoteOptions(
+  new Command()
+    .name("read-secret")
+    .description(
+      `Read a secret value from a vault.
 
 In interactive (log) mode, prompts for confirmation before revealing the secret
 unless --force is set. In --json mode, outputs the value directly.`,
-  )
-  .example("Read a secret", "swamp vault read-secret my-vault API_KEY --force")
-  .example(
-    "Read a secret (JSON output)",
-    "swamp vault read-secret my-vault API_KEY --json",
-  )
-  .arguments("<vault_name:string> <key:string>")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .option("-y, --yes", "Skip confirmation prompt")
-  .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
-  .action(async function (
-    options: AnyOptions,
-    vaultName: string,
-    key: string,
-  ) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "vault",
-      "read-secret",
-    ]);
-    cliCtx.logger.debug`Reading secret from vault: ${vaultName}`;
+    )
+    .example(
+      "Read a secret",
+      "swamp vault read-secret my-vault API_KEY --force",
+    )
+    .example(
+      "Read a secret (JSON output)",
+      "swamp vault read-secret my-vault API_KEY --json",
+    )
+    .arguments("<vault_name:string> <key:string>")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option("-y, --yes", "Skip confirmation prompt")
+    .option("-f, --force", "Skip confirmation prompt (alias for --yes)"),
+).action(async function (
+  options: AnyOptions,
+  vaultName: string,
+  key: string,
+) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "vault",
+    "read-secret",
+  ]);
+  cliCtx.logger.debug`Reading secret from vault: ${vaultName}`;
 
-    const { repoDir, repoContext, datastoreConfig, syncService } =
-      await requireInitializedRepoUnlocked({
-        repoDir: resolveRepoDir(options.repoDir),
-        outputMode: cliCtx.outputMode,
-      });
-    const { flush } = await acquireVaultSync(
-      datastoreConfig,
-      syncService,
-      repoDir,
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
+    );
+    const response = await requestServerResponse<VaultReadSecretResponse>(
+      { server, token },
+      {
+        type: "vault.read-secret",
+        payload: {
+          vaultName,
+          secretKey: key,
+        },
+      },
+    );
+    const renderer = createVaultReadSecretRenderer(cliCtx.outputMode);
+    renderer.handlers().completed({
+      kind: "completed",
+      data: response.data as unknown as VaultReadSecretData,
+    });
+    return;
+  }
+
+  const { repoDir, repoContext, datastoreConfig, syncService } =
+    await requireInitializedRepoUnlocked({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    });
+  const { flush } = await acquireVaultSync(
+    datastoreConfig,
+    syncService,
+    repoDir,
+  );
+
+  try {
+    if (cliCtx.outputMode === "log" && !options.yes && !options.force) {
+      const confirmed = await promptConfirmation(
+        `This will reveal the secret '${key}' from vault '${vaultName}'. Continue?`,
+      );
+      if (!confirmed) {
+        cliCtx.logger.info`Cancelled.`;
+        return;
+      }
+    }
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = createVaultReadSecretDeps(repoDir, repoContext.eventBus);
+
+    const renderer = createVaultReadSecretRenderer(cliCtx.outputMode);
+    await consumeStream(
+      vaultReadSecret(ctx, deps, { vaultName, secretKey: key }),
+      renderer.handlers(),
     );
 
-    try {
-      if (cliCtx.outputMode === "log" && !options.yes && !options.force) {
-        const confirmed = await promptConfirmation(
-          `This will reveal the secret '${key}' from vault '${vaultName}'. Continue?`,
-        );
-        if (!confirmed) {
-          cliCtx.logger.info`Cancelled.`;
-          return;
-        }
-      }
-
-      const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = createVaultReadSecretDeps(repoDir, repoContext.eventBus);
-
-      const renderer = createVaultReadSecretRenderer(cliCtx.outputMode);
-      await consumeStream(
-        vaultReadSecret(ctx, deps, { vaultName, secretKey: key }),
-        renderer.handlers(),
-      );
-
-      cliCtx.logger.debug("Vault read-secret command completed");
-    } finally {
-      await flush();
-    }
-  });
+    cliCtx.logger.debug("Vault read-secret command completed");
+  } finally {
+    await flush();
+  }
+});

--- a/src/cli/commands/vault_type_search.ts
+++ b/src/cli/commands/vault_type_search.ts
@@ -22,6 +22,7 @@ import {
   consumeStream,
   createLibSwampContext,
   vaultTypeSearch,
+  type VaultTypeSearchData,
   type VaultTypeSearchDeps,
 } from "../../libswamp/mod.ts";
 import { createVaultTypeSearchRenderer } from "../../presentation/renderers/vault_type_search.tsx";
@@ -32,6 +33,13 @@ import {
 } from "../context.ts";
 import { getVaultTypes } from "../../domain/vaults/vault_types.ts";
 import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { VaultTypeSearchResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -47,6 +55,27 @@ export async function vaultTypeSearchAction(
   const effectiveMode = interactiveOutputMode(ctx);
   const libCtx = createLibSwampContext();
   ctx.logger.debug`Searching vault types with query: ${query ?? "(none)"}`;
+
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
+    );
+    const response = await requestServerResponse<VaultTypeSearchResponse>(
+      { server, token },
+      {
+        type: "vault.type.search",
+        payload: { query },
+      },
+    );
+    const renderer = createVaultTypeSearchRenderer(effectiveMode);
+    renderer.handlers().completed({
+      kind: "completed",
+      data: response.data as unknown as VaultTypeSearchData,
+    });
+    return;
+  }
 
   await vaultTypeRegistry.ensureLoaded();
 
@@ -72,10 +101,11 @@ export async function vaultTypeSearchAction(
   ctx.logger.debug("Vault type search command completed");
 }
 
-export const vaultTypeSearchCommand = new Command()
-  .name("search")
-  .description("Search for vault types")
-  .example("Browse vault types", "swamp vault type-search")
-  .example("Search by keyword", "swamp vault type-search aws")
-  .arguments("[query:string]")
-  .action(vaultTypeSearchAction);
+export const vaultTypeSearchCommand = withRemoteOptions(
+  new Command()
+    .name("search")
+    .description("Search for vault types")
+    .example("Browse vault types", "swamp vault type-search")
+    .example("Search by keyword", "swamp vault type-search aws")
+    .arguments("[query:string]"),
+).action(vaultTypeSearchAction);

--- a/src/cli/commands/worker_token_create.ts
+++ b/src/cli/commands/worker_token_create.ts
@@ -41,154 +41,187 @@ import {
   type WorkerTokenCreateEvent,
 } from "../../libswamp/mod.ts";
 import { renderWorkerTokenCreate } from "../../presentation/output/worker_output.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { WorkerTokenCreateResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const workerTokenCreateCommand = new Command()
-  .name("create")
-  .description(
-    "Mint a named worker enrollment token; the plaintext is shown once",
-  )
-  .example(
-    "Mint a 24-hour token",
-    "swamp worker token create ci-runner-3 --duration 24h",
-  )
-  .example(
-    "Choose the vault that stores the plaintext",
-    "swamp worker token create ci-runner-3 --duration 7d --vault prod-vault",
-  )
-  .example(
-    "Mint a fleet token for 3 machines",
-    "swamp worker token create ci-fleet --duration 24h --max-enrollments 3",
-  )
-  .arguments("<name:string>")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .option(
-    "--duration <duration:string>",
-    "Token lifetime (e.g. 30m, 1h, 24h, 7d) — a hard deadline: the enrolled worker is disconnected when it elapses",
-    { required: true },
-  )
-  .option(
-    "--vault <vault:string>",
-    "Vault that stores the token plaintext (defaults to the sole configured vault)",
-  )
-  .option(
-    "--max-enrollments <n:string>",
-    'Maximum machines this token can enroll (positive integer or "unlimited"). Default: 1',
-  )
-  .action(async function (options: AnyOptions, name: string) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "worker",
-      "token",
-      "create",
-    ]);
+export const workerTokenCreateCommand = withRemoteOptions(
+  new Command()
+    .name("create")
+    .description(
+      "Mint a named worker enrollment token; the plaintext is shown once",
+    )
+    .example(
+      "Mint a 24-hour token",
+      "swamp worker token create ci-runner-3 --duration 24h",
+    )
+    .example(
+      "Choose the vault that stores the plaintext",
+      "swamp worker token create ci-runner-3 --duration 7d --vault prod-vault",
+    )
+    .example(
+      "Mint a fleet token for 3 machines",
+      "swamp worker token create ci-fleet --duration 24h --max-enrollments 3",
+    )
+    .arguments("<name:string>")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option(
+      "--duration <duration:string>",
+      "Token lifetime (e.g. 30m, 1h, 24h, 7d) — a hard deadline: the enrolled worker is disconnected when it elapses",
+      { required: true },
+    )
+    .option(
+      "--vault <vault:string>",
+      "Vault that stores the token plaintext (defaults to the sole configured vault)",
+    )
+    .option(
+      "--max-enrollments <n:string>",
+      'Maximum machines this token can enroll (positive integer or "unlimited"). Default: 1',
+    ),
+).action(async function (options: AnyOptions, name: string) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "worker",
+    "token",
+    "create",
+  ]);
 
-    const durationMs = parseDuration(options.duration as string);
-    if (durationMs <= 0) {
-      throw new UserError(
-        `Invalid --duration value "${options.duration}": must be positive`,
-      );
-    }
+  const durationMs = parseDuration(options.duration as string);
+  if (durationMs <= 0) {
+    throw new UserError(
+      `Invalid --duration value "${options.duration}": must be positive`,
+    );
+  }
 
-    let maxEnrollments: MaxEnrollments = 1;
-    if (options.maxEnrollments !== undefined) {
-      const raw = options.maxEnrollments as string;
-      if (raw === "unlimited") {
-        maxEnrollments = "unlimited";
-      } else {
-        const parsed = Number(raw);
-        if (!Number.isInteger(parsed) || parsed <= 0) {
-          throw new UserError(
-            `Invalid --max-enrollments value "${raw}": must be a positive integer or "unlimited"`,
-          );
-        }
-        maxEnrollments = parsed;
+  let maxEnrollments: MaxEnrollments = 1;
+  if (options.maxEnrollments !== undefined) {
+    const raw = options.maxEnrollments as string;
+    if (raw === "unlimited") {
+      maxEnrollments = "unlimited";
+    } else {
+      const parsed = Number(raw);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new UserError(
+          `Invalid --max-enrollments value "${raw}": must be a positive integer or "unlimited"`,
+        );
       }
+      maxEnrollments = parsed;
     }
+  }
 
-    const { repoDir, repoContext, datastoreConfig, syncService } =
-      await requireInitializedRepoUnlocked({
-        repoDir: resolveRepoDir(options.repoDir),
-        outputMode: cliCtx.outputMode,
-      });
-
-    cliCtx.logger.debug`Minting enrollment token ${name}`;
-
-    const libCtx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = await createWorkerTokenCreateDeps(
-      libCtx,
-      repoDir,
-      repoContext,
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
     );
-
-    // Per-model lock: only relevant when a definition with this name already
-    // exists (a re-mint attempt) — mirrors `swamp model method run`.
-    const preResult = await findDefinitionByIdOrName(
-      repoContext.definitionRepo,
-      name,
-    );
-    let flushModelLocks: (() => Promise<void>) | null = null;
-    if (preResult) {
-      const lockResult = await acquireModelLocks(
-        datastoreConfig,
-        [
-          {
-            modelType: preResult.type.normalized,
-            modelId: preResult.definition.id,
-          },
-        ],
-        repoDir,
-        syncService,
-        repoContext.catalogStore,
-      );
-      if (lockResult.synced) repoContext.catalogStore.invalidate();
-      flushModelLocks = lockResult.flush;
-    }
-
-    try {
-      let data: WorkerTokenCreateData | undefined;
-      await consumeStream(
-        workerTokenCreate(libCtx, deps, {
+    const response = await requestServerResponse<WorkerTokenCreateResponse>(
+      { server, token },
+      {
+        type: "worker.token.create",
+        payload: {
           name,
           durationMs,
           vaultName: options.vault as string | undefined,
           maxEnrollments,
-        }),
-        withDefaults<WorkerTokenCreateEvent>({
-          completed: (event) => {
-            data = event.data;
-          },
-          error: (event) => {
-            throw new UserError(event.error.message);
-          },
-        }),
+        },
+      },
+    );
+    renderWorkerTokenCreate(
+      response.data as unknown as WorkerTokenCreateData,
+      cliCtx.outputMode,
+    );
+    return;
+  }
+
+  const { repoDir, repoContext, datastoreConfig, syncService } =
+    await requireInitializedRepoUnlocked({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    });
+
+  cliCtx.logger.debug`Minting enrollment token ${name}`;
+
+  const libCtx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = await createWorkerTokenCreateDeps(
+    libCtx,
+    repoDir,
+    repoContext,
+  );
+
+  // Per-model lock: only relevant when a definition with this name already
+  // exists (a re-mint attempt) — mirrors `swamp model method run`.
+  const preResult = await findDefinitionByIdOrName(
+    repoContext.definitionRepo,
+    name,
+  );
+  let flushModelLocks: (() => Promise<void>) | null = null;
+  if (preResult) {
+    const lockResult = await acquireModelLocks(
+      datastoreConfig,
+      [
+        {
+          modelType: preResult.type.normalized,
+          modelId: preResult.definition.id,
+        },
+      ],
+      repoDir,
+      syncService,
+      repoContext.catalogStore,
+    );
+    if (lockResult.synced) repoContext.catalogStore.invalidate();
+    flushModelLocks = lockResult.flush;
+  }
+
+  try {
+    let data: WorkerTokenCreateData | undefined;
+    await consumeStream(
+      workerTokenCreate(libCtx, deps, {
+        name,
+        durationMs,
+        vaultName: options.vault as string | undefined,
+        maxEnrollments,
+      }),
+      withDefaults<WorkerTokenCreateEvent>({
+        completed: (event) => {
+          data = event.data;
+        },
+        error: (event) => {
+          throw new UserError(event.error.message);
+        },
+      }),
+    );
+    if (data === undefined) {
+      throw new UserError(
+        `Minting token '${name}' ended without completing`,
       );
-      if (data === undefined) {
-        throw new UserError(
-          `Minting token '${name}' ended without completing`,
+    }
+    renderWorkerTokenCreate(data, cliCtx.outputMode);
+  } finally {
+    if (flushModelLocks) {
+      try {
+        await flushModelLocks();
+      } catch (releaseError) {
+        cliCtx.logger.warn(
+          "Failed to release locks during cleanup: {error}",
+          {
+            error: releaseError instanceof Error
+              ? releaseError.message
+              : String(releaseError),
+          },
         );
       }
-      renderWorkerTokenCreate(data, cliCtx.outputMode);
-    } finally {
-      if (flushModelLocks) {
-        try {
-          await flushModelLocks();
-        } catch (releaseError) {
-          cliCtx.logger.warn(
-            "Failed to release locks during cleanup: {error}",
-            {
-              error: releaseError instanceof Error
-                ? releaseError.message
-                : String(releaseError),
-            },
-          );
-        }
-      }
     }
+  }
 
-    cliCtx.logger.debug("Worker token create command completed");
-  });
+  cliCtx.logger.debug("Worker token create command completed");
+});

--- a/src/cli/commands/worker_token_list.ts
+++ b/src/cli/commands/worker_token_list.ts
@@ -31,49 +31,78 @@ import {
   createWorkerListDeps,
   withDefaults,
   workerTokenList,
+  type WorkerTokenListData,
   type WorkerTokenListEvent,
 } from "../../libswamp/mod.ts";
 import { renderWorkerTokenList } from "../../presentation/output/worker_output.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { WorkerTokenListResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const workerTokenListCommand = new Command()
-  .name("list")
-  .description(
-    "List worker enrollment tokens: state, expiry, and bound instance",
-  )
-  .example("List all tokens", "swamp worker token list")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .action(async function (options: AnyOptions) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "worker",
-      "token",
-      "list",
-    ]);
+export const workerTokenListCommand = withRemoteOptions(
+  new Command()
+    .name("list")
+    .description(
+      "List worker enrollment tokens: state, expiry, and bound instance",
+    )
+    .example("List all tokens", "swamp worker token list")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    ),
+).action(async function (options: AnyOptions) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "worker",
+    "token",
+    "list",
+  ]);
 
-    const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: cliCtx.outputMode,
-    });
-
-    const libCtx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createWorkerListDeps(repoContext.dataQueryService);
-
-    await consumeStream(
-      workerTokenList(libCtx, deps),
-      withDefaults<WorkerTokenListEvent>({
-        completed: (event) => {
-          renderWorkerTokenList(event.data, cliCtx.outputMode);
-        },
-        error: (event) => {
-          throw new UserError(event.error.message);
-        },
-      }),
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
     );
+    const response = await requestServerResponse<WorkerTokenListResponse>(
+      { server, token },
+      {
+        type: "worker.token.list",
+        payload: {},
+      },
+    );
+    renderWorkerTokenList(
+      response.data as unknown as WorkerTokenListData,
+      cliCtx.outputMode,
+    );
+    return;
+  }
 
-    cliCtx.logger.debug("Worker token list command completed");
+  const { repoContext } = await requireInitializedRepoReadOnly({
+    repoDir: resolveRepoDir(options.repoDir),
+    outputMode: cliCtx.outputMode,
   });
+
+  const libCtx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = createWorkerListDeps(repoContext.dataQueryService);
+
+  await consumeStream(
+    workerTokenList(libCtx, deps),
+    withDefaults<WorkerTokenListEvent>({
+      completed: (event) => {
+        renderWorkerTokenList(event.data, cliCtx.outputMode);
+      },
+      error: (event) => {
+        throw new UserError(event.error.message);
+      },
+    }),
+  );
+
+  cliCtx.logger.debug("Worker token list command completed");
+});

--- a/src/cli/commands/worker_token_revoke.ts
+++ b/src/cli/commands/worker_token_revoke.ts
@@ -39,100 +39,128 @@ import {
   type WorkerTokenRevokeEvent,
 } from "../../libswamp/mod.ts";
 import { renderWorkerTokenRevoke } from "../../presentation/output/worker_output.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { WorkerTokenRevokeResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const workerTokenRevokeCommand = new Command()
-  .name("revoke")
-  .description("Invalidate a worker enrollment token before it expires")
-  .example("Revoke a token", "swamp worker token revoke ci-runner-3")
-  .arguments("<name:string>")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .action(async function (options: AnyOptions, name: string) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "worker",
-      "token",
-      "revoke",
-    ]);
+export const workerTokenRevokeCommand = withRemoteOptions(
+  new Command()
+    .name("revoke")
+    .description("Invalidate a worker enrollment token before it expires")
+    .example("Revoke a token", "swamp worker token revoke ci-runner-3")
+    .arguments("<name:string>")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    ),
+).action(async function (options: AnyOptions, name: string) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "worker",
+    "token",
+    "revoke",
+  ]);
 
-    const { repoDir, repoContext, datastoreConfig, syncService } =
-      await requireInitializedRepoUnlocked({
-        repoDir: resolveRepoDir(options.repoDir),
-        outputMode: cliCtx.outputMode,
-      });
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
+    );
+    const response = await requestServerResponse<WorkerTokenRevokeResponse>(
+      { server, token },
+      {
+        type: "worker.token.revoke",
+        payload: { name },
+      },
+    );
+    renderWorkerTokenRevoke(
+      response.data as unknown as WorkerTokenRevokeData,
+      cliCtx.outputMode,
+    );
+    return;
+  }
 
-    cliCtx.logger.debug`Revoking enrollment token ${name}`;
+  const { repoDir, repoContext, datastoreConfig, syncService } =
+    await requireInitializedRepoUnlocked({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    });
 
-    const libCtx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = await createWorkerTokenRevokeDeps(
-      libCtx,
+  cliCtx.logger.debug`Revoking enrollment token ${name}`;
+
+  const libCtx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = await createWorkerTokenRevokeDeps(
+    libCtx,
+    repoDir,
+    repoContext,
+  );
+
+  // Per-model lock around the state transition — mirrors
+  // `swamp model method run`.
+  const preResult = await findDefinitionByIdOrName(
+    repoContext.definitionRepo,
+    name,
+  );
+  let flushModelLocks: (() => Promise<void>) | null = null;
+  if (preResult) {
+    const lockResult = await acquireModelLocks(
+      datastoreConfig,
+      [
+        {
+          modelType: preResult.type.normalized,
+          modelId: preResult.definition.id,
+        },
+      ],
       repoDir,
-      repoContext,
+      syncService,
+      repoContext.catalogStore,
     );
+    if (lockResult.synced) repoContext.catalogStore.invalidate();
+    flushModelLocks = lockResult.flush;
+  }
 
-    // Per-model lock around the state transition — mirrors
-    // `swamp model method run`.
-    const preResult = await findDefinitionByIdOrName(
-      repoContext.definitionRepo,
-      name,
+  try {
+    let data: WorkerTokenRevokeData | undefined;
+    await consumeStream(
+      workerTokenRevoke(libCtx, deps, { name }),
+      withDefaults<WorkerTokenRevokeEvent>({
+        completed: (event) => {
+          data = event.data;
+        },
+        error: (event) => {
+          throw new UserError(event.error.message);
+        },
+      }),
     );
-    let flushModelLocks: (() => Promise<void>) | null = null;
-    if (preResult) {
-      const lockResult = await acquireModelLocks(
-        datastoreConfig,
-        [
-          {
-            modelType: preResult.type.normalized,
-            modelId: preResult.definition.id,
-          },
-        ],
-        repoDir,
-        syncService,
-        repoContext.catalogStore,
+    if (data === undefined) {
+      throw new UserError(
+        `Revoking token '${name}' ended without completing`,
       );
-      if (lockResult.synced) repoContext.catalogStore.invalidate();
-      flushModelLocks = lockResult.flush;
     }
-
-    try {
-      let data: WorkerTokenRevokeData | undefined;
-      await consumeStream(
-        workerTokenRevoke(libCtx, deps, { name }),
-        withDefaults<WorkerTokenRevokeEvent>({
-          completed: (event) => {
-            data = event.data;
+    renderWorkerTokenRevoke(data, cliCtx.outputMode);
+  } finally {
+    if (flushModelLocks) {
+      try {
+        await flushModelLocks();
+      } catch (releaseError) {
+        cliCtx.logger.warn(
+          "Failed to release locks during cleanup: {error}",
+          {
+            error: releaseError instanceof Error
+              ? releaseError.message
+              : String(releaseError),
           },
-          error: (event) => {
-            throw new UserError(event.error.message);
-          },
-        }),
-      );
-      if (data === undefined) {
-        throw new UserError(
-          `Revoking token '${name}' ended without completing`,
         );
       }
-      renderWorkerTokenRevoke(data, cliCtx.outputMode);
-    } finally {
-      if (flushModelLocks) {
-        try {
-          await flushModelLocks();
-        } catch (releaseError) {
-          cliCtx.logger.warn(
-            "Failed to release locks during cleanup: {error}",
-            {
-              error: releaseError instanceof Error
-                ? releaseError.message
-                : String(releaseError),
-            },
-          );
-        }
-      }
     }
+  }
 
-    cliCtx.logger.debug("Worker token revoke command completed");
-  });
+  cliCtx.logger.debug("Worker token revoke command completed");
+});

--- a/src/cli/commands/workflow_create.ts
+++ b/src/cli/commands/workflow_create.ts
@@ -23,6 +23,7 @@ import {
   createLibSwampContext,
   createWorkflowCreateDeps,
   workflowCreate,
+  type WorkflowCreateData,
 } from "../../libswamp/mod.ts";
 import { createWorkflowCreateRenderer } from "../../presentation/renderers/workflow_create.ts";
 import {
@@ -31,37 +32,63 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { WorkflowCreateResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const workflowCreateCommand = new Command()
-  .description("Create a new workflow")
-  .example("Create a workflow", "swamp workflow create deploy-pipeline")
-  .arguments("<name:string>")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .action(async function (options: AnyOptions, name: string) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "workflow",
-      "create",
-    ]);
-    cliCtx.logger.debug`Creating workflow: name=${name}`;
+export const workflowCreateCommand = withRemoteOptions(
+  new Command()
+    .description("Create a new workflow")
+    .example("Create a workflow", "swamp workflow create deploy-pipeline")
+    .arguments("<name:string>")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    ),
+).action(async function (options: AnyOptions, name: string) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "workflow",
+    "create",
+  ]);
+  cliCtx.logger.debug`Creating workflow: name=${name}`;
 
-    const { repoDir } = await requireInitializedRepoUnlocked({
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: cliCtx.outputMode,
-    });
-
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createWorkflowCreateDeps(repoDir);
-    const renderer = createWorkflowCreateRenderer(cliCtx.outputMode);
-    await consumeStream(
-      workflowCreate(ctx, deps, { name }),
-      renderer.handlers(),
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
     );
+    const response = await requestServerResponse<WorkflowCreateResponse>(
+      { server, token },
+      { type: "workflow.create", payload: { name } },
+    );
+    const renderer = createWorkflowCreateRenderer(cliCtx.outputMode);
+    renderer.handlers().completed({
+      kind: "completed",
+      data: response.data as unknown as WorkflowCreateData,
+    });
+    return;
+  }
 
-    cliCtx.logger.debug("Workflow create command completed");
+  const { repoDir } = await requireInitializedRepoUnlocked({
+    repoDir: resolveRepoDir(options.repoDir),
+    outputMode: cliCtx.outputMode,
   });
+
+  const ctx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = createWorkflowCreateDeps(repoDir);
+  const renderer = createWorkflowCreateRenderer(cliCtx.outputMode);
+  await consumeStream(
+    workflowCreate(ctx, deps, { name }),
+    renderer.handlers(),
+  );
+
+  cliCtx.logger.debug("Workflow create command completed");
+});

--- a/src/cli/commands/workflow_delete.ts
+++ b/src/cli/commands/workflow_delete.ts
@@ -23,6 +23,7 @@ import {
   createLibSwampContext,
   createWorkflowDeleteDeps,
   workflowDelete,
+  type WorkflowDeleteData,
   workflowDeletePreview,
 } from "../../libswamp/mod.ts";
 import {
@@ -37,29 +38,59 @@ import {
 import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { promptConfirmation } from "../prompt_helpers.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { WorkflowDeleteResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const workflowDeleteCommand = new Command()
-  .name("delete")
-  .description("Delete a workflow and its run history")
-  .example("Delete a workflow", "swamp workflow delete deploy-pipeline")
-  .example("Force delete", "swamp workflow delete deploy-pipeline --force")
-  .arguments("<workflow_id_or_name:workflow_name>")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .option("-y, --yes", "Skip confirmation prompt")
-  .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
+export const workflowDeleteCommand = withRemoteOptions(
+  new Command()
+    .name("delete")
+    .description("Delete a workflow and its run history")
+    .example("Delete a workflow", "swamp workflow delete deploy-pipeline")
+    .example("Force delete", "swamp workflow delete deploy-pipeline --force")
+    .arguments("<workflow_id_or_name:workflow_name>")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option("-y, --yes", "Skip confirmation prompt")
+    .option("-f, --force", "Skip confirmation prompt (alias for --yes)"),
+).action(
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
-  .action(async function (options: AnyOptions, workflowIdOrName: string) {
+  async function (options: AnyOptions, workflowIdOrName: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "workflow",
       "delete",
     ]);
     cliCtx.logger.debug`Deleting workflow: ${workflowIdOrName}`;
+
+    const server = resolveServeUrl(options.server as string | undefined);
+    if (server) {
+      const token = await resolveServerToken(
+        server,
+        options.token as string | undefined,
+      );
+      const response = await requestServerResponse<WorkflowDeleteResponse>(
+        { server, token },
+        {
+          type: "workflow.delete",
+          payload: { workflowIdOrName },
+        },
+      );
+      const renderer = createWorkflowDeleteRenderer(cliCtx.outputMode);
+      renderer.handlers().completed({
+        kind: "completed",
+        data: response.data as unknown as WorkflowDeleteData,
+      });
+      return;
+    }
 
     const { repoDir, datastoreResolver } = await requireInitializedRepo({
       repoDir: resolveRepoDir(options.repoDir),
@@ -106,4 +137,5 @@ export const workflowDeleteCommand = new Command()
     );
 
     cliCtx.logger.debug("Workflow delete command completed");
-  });
+  },
+);

--- a/src/cli/commands/workflow_edit.ts
+++ b/src/cli/commands/workflow_edit.ts
@@ -23,6 +23,7 @@ import {
   createLibSwampContext,
   createWorkflowEditDeps,
   workflowEdit,
+  type WorkflowEditData,
   workflowSearch,
   type WorkflowSearchDeps,
 } from "../../libswamp/mod.ts";
@@ -36,28 +37,59 @@ import {
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { readStdin } from "../../infrastructure/io/stdin_reader.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { WorkflowEditResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const workflowEditCommand = new Command()
-  .name("edit")
-  .description("Edit a workflow file")
-  .example("Edit a workflow", "swamp workflow edit deploy-pipeline")
-  .example("Interactive search", "swamp workflow edit")
-  .arguments("[workflow_id_or_name:workflow_name]")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
+export const workflowEditCommand = withRemoteOptions(
+  new Command()
+    .name("edit")
+    .description("Edit a workflow file")
+    .example("Edit a workflow", "swamp workflow edit deploy-pipeline")
+    .example("Interactive search", "swamp workflow edit")
+    .arguments("[workflow_id_or_name:workflow_name]")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    ),
+).action(
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
-  .action(async function (options: AnyOptions, workflowIdOrName?: string) {
+  async function (options: AnyOptions, workflowIdOrName?: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "workflow",
       "edit",
     ]);
     cliCtx.logger
       .debug`Editing workflow: ${workflowIdOrName ?? "(interactive)"}`;
+
+    const server = resolveServeUrl(options.server as string | undefined);
+    if (server) {
+      const token = await resolveServerToken(
+        server,
+        options.token as string | undefined,
+      );
+      const content = await readStdin();
+      const response = await requestServerResponse<WorkflowEditResponse>(
+        { server, token },
+        {
+          type: "workflow.edit",
+          payload: { workflowIdOrName, content },
+        },
+      );
+      const renderer = createWorkflowEditRenderer(cliCtx.outputMode);
+      renderer.handlers().completed({
+        kind: "completed",
+        data: response.data as unknown as WorkflowEditData,
+      });
+      return;
+    }
 
     const { repoContext, repoDir } = await requireInitializedRepoUnlocked({
       repoDir: resolveRepoDir(options.repoDir),
@@ -108,4 +140,5 @@ export const workflowEditCommand = new Command()
     );
 
     cliCtx.logger.debug("Workflow edit command completed");
-  });
+  },
+);

--- a/src/cli/commands/workflow_evaluate.ts
+++ b/src/cli/commands/workflow_evaluate.ts
@@ -33,6 +33,8 @@ import {
   createLibSwampContext,
   createWorkflowEvaluateDeps,
   workflowEvaluate,
+  type WorkflowEvaluateAllData,
+  type WorkflowEvaluateItemData,
 } from "../../libswamp/mod.ts";
 import { createWorkflowEvaluateRenderer } from "../../presentation/renderers/workflow_evaluate.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
@@ -42,179 +44,209 @@ import { mergeInputArgs, parseInputs } from "../input_parser.ts";
 import { InputValidationService } from "../../domain/inputs/mod.ts";
 import { UserError } from "../../domain/errors.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { WorkflowEvaluateResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const workflowEvaluateCommand = new Command()
-  .name("evaluate")
-  .description("Evaluate expressions in workflow definitions")
-  .example("Evaluate a workflow", "swamp workflow evaluate deploy-pipeline")
-  .example("Evaluate all workflows", "swamp workflow evaluate --all")
-  .example(
-    "With inputs",
-    "swamp workflow evaluate deploy-pipeline --input env=prod",
-  )
-  .arguments("[workflow_id_or_name:string]")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .option("--all", "Evaluate all workflow definitions")
-  .option("--input <value:string>", "Input values (key=value or JSON)", {
-    collect: true,
-  })
-  .option("--arg <value:string>", "Alias for --input", {
-    collect: true,
-    hidden: true,
-  })
-  .option("--input-file <file:string>", "Input values from YAML file")
-  .action(
-    async function (options: AnyOptions, workflowIdOrName?: string) {
-      const cliCtx = createContext(options as GlobalOptions, [
-        "workflow",
-        "evaluate",
-      ]);
+export const workflowEvaluateCommand = withRemoteOptions(
+  new Command()
+    .name("evaluate")
+    .description("Evaluate expressions in workflow definitions")
+    .example("Evaluate a workflow", "swamp workflow evaluate deploy-pipeline")
+    .example("Evaluate all workflows", "swamp workflow evaluate --all")
+    .example(
+      "With inputs",
+      "swamp workflow evaluate deploy-pipeline --input env=prod",
+    )
+    .arguments("[workflow_id_or_name:string]")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option("--all", "Evaluate all workflow definitions")
+    .option("--input <value:string>", "Input values (key=value or JSON)", {
+      collect: true,
+    })
+    .option("--arg <value:string>", "Alias for --input", {
+      collect: true,
+      hidden: true,
+    })
+    .option("--input-file <file:string>", "Input values from YAML file"),
+).action(
+  async function (options: AnyOptions, workflowIdOrName?: string) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "workflow",
+      "evaluate",
+    ]);
 
-      const { inputs } = await parseInputs({
-        input: mergeInputArgs(options),
-        inputFile: options.inputFile as string | undefined,
-      });
+    const { inputs } = await parseInputs({
+      input: mergeInputArgs(options),
+      inputFile: options.inputFile as string | undefined,
+    });
 
-      // If --all flag or no argument, evaluate all workflows (global lock)
-      if (options.all || !workflowIdOrName) {
-        const { repoDir, repoContext, datastoreResolver } =
-          await requireInitializedRepo({
-            repoDir: resolveRepoDir(options.repoDir),
-            outputMode: cliCtx.outputMode,
-          });
-
-        const ctx = createLibSwampContext({ logger: cliCtx.logger });
-        const deps = createWorkflowEvaluateDeps(
-          repoDir,
-          repoContext.workflowRepo,
-          datastoreResolver,
-        );
-        const renderer = createWorkflowEvaluateRenderer(cliCtx.outputMode);
-
-        await consumeStream(
-          workflowEvaluate(ctx, deps, { inputs }),
-          renderer.handlers(),
-        );
-        return;
-      }
-
-      // Single workflow evaluation — use per-model lock
-      const unlocked = await requireInitializedRepoUnlocked({
-        repoDir: resolveRepoDir(options.repoDir),
-        outputMode: cliCtx.outputMode,
-      });
-      const workflowRepo = unlocked.repoContext.workflowRepo;
-
-      // Look up the workflow for input validation and lock resolution
-      const workflow = await workflowRepo.findByName(workflowIdOrName) ??
-        await workflowRepo.findById(createWorkflowId(workflowIdOrName));
-
-      if (!workflow) {
-        throw new UserError(`Workflow not found: ${workflowIdOrName}`);
-      }
-
-      // Validate inputs against workflow schema if provided
-      if (workflow.inputs && Object.keys(inputs).length > 0) {
-        const validationService = new InputValidationService();
-        const inputsWithDefaults = validationService.applyDefaults(
-          inputs,
-          workflow.inputs,
-        );
-        const validationResult = validationService.validate(
-          inputsWithDefaults,
-          workflow.inputs,
-        );
-        if (!validationResult.valid) {
-          const errorMessages = validationResult.errors
-            .map((e) => `  ${e.message}`)
-            .join("\n");
-          throw new UserError(`Input validation failed:\n${errorMessages}`);
-        }
-        // Use inputs with defaults applied
-        Object.assign(inputs, inputsWithDefaults);
-      }
-
-      // Extract model references for per-model locking
-      const modelRefs = await extractModelReferencesFromWorkflow(
-        workflow,
-        workflowRepo,
+    const server = resolveServeUrl(options.server as string | undefined);
+    if (server) {
+      const token = await resolveServerToken(
+        server,
+        options.token as string | undefined,
       );
+      const response = await requestServerResponse<WorkflowEvaluateResponse>(
+        { server, token },
+        {
+          type: "workflow.evaluate",
+          payload: { workflowIdOrName, inputs },
+        },
+      );
+      const renderer = createWorkflowEvaluateRenderer(cliCtx.outputMode);
+      renderer.handlers().completed({
+        kind: "completed",
+        data: response.data as unknown as
+          | WorkflowEvaluateItemData
+          | WorkflowEvaluateAllData,
+      });
+      return;
+    }
 
-      let flushModelLocks: (() => Promise<void>) | null = null;
-      let repoDir: string;
-      let datastoreResolver = unlocked.datastoreResolver;
-
-      if (modelRefs !== null && modelRefs.length > 0) {
-        // Resolve model references to { modelType, modelId }
-        const definitionRepo = unlocked.repoContext.definitionRepo;
-        const resolvedModels: Array<{ modelType: string; modelId: string }> =
-          [];
-
-        for (const ref of modelRefs) {
-          const lookupResult = await findDefinitionByIdOrName(
-            definitionRepo,
-            ref,
-          );
-          if (lookupResult) {
-            resolvedModels.push({
-              modelType: lookupResult.type.normalized,
-              modelId: lookupResult.definition.id,
-            });
-          }
-        }
-
-        if (resolvedModels.length > 0) {
-          const lockResult = await acquireModelLocks(
-            unlocked.datastoreConfig,
-            resolvedModels,
-            unlocked.repoDir,
-            unlocked.syncService,
-            unlocked.repoContext.catalogStore,
-          );
-          if (lockResult.synced) {
-            unlocked.repoContext.catalogStore.invalidate();
-          }
-          flushModelLocks = lockResult.flush;
-        }
-
-        repoDir = unlocked.repoDir;
-      } else if (modelRefs === null) {
-        // Dynamic references — fall back to global lock
-        const logger = getSwampLogger(["workflow", "evaluate"]);
-        logger
-          .info`Workflow contains dynamic model references — using global lock`;
-        const globalResult = await requireInitializedRepo({
+    // If --all flag or no argument, evaluate all workflows (global lock)
+    if (options.all || !workflowIdOrName) {
+      const { repoDir, repoContext, datastoreResolver } =
+        await requireInitializedRepo({
           repoDir: resolveRepoDir(options.repoDir),
           outputMode: cliCtx.outputMode,
         });
-        repoDir = globalResult.repoDir;
-        datastoreResolver = globalResult.datastoreResolver;
-      } else {
-        // No model references
-        repoDir = unlocked.repoDir;
-      }
 
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
       const deps = createWorkflowEvaluateDeps(
         repoDir,
-        workflowRepo,
+        repoContext.workflowRepo,
         datastoreResolver,
       );
       const renderer = createWorkflowEvaluateRenderer(cliCtx.outputMode);
 
-      try {
-        await consumeStream(
-          workflowEvaluate(ctx, deps, { workflowIdOrName, inputs }),
-          renderer.handlers(),
-        );
-      } finally {
-        if (flushModelLocks) await flushModelLocks();
+      await consumeStream(
+        workflowEvaluate(ctx, deps, { inputs }),
+        renderer.handlers(),
+      );
+      return;
+    }
+
+    // Single workflow evaluation — use per-model lock
+    const unlocked = await requireInitializedRepoUnlocked({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    });
+    const workflowRepo = unlocked.repoContext.workflowRepo;
+
+    // Look up the workflow for input validation and lock resolution
+    const workflow = await workflowRepo.findByName(workflowIdOrName) ??
+      await workflowRepo.findById(createWorkflowId(workflowIdOrName));
+
+    if (!workflow) {
+      throw new UserError(`Workflow not found: ${workflowIdOrName}`);
+    }
+
+    // Validate inputs against workflow schema if provided
+    if (workflow.inputs && Object.keys(inputs).length > 0) {
+      const validationService = new InputValidationService();
+      const inputsWithDefaults = validationService.applyDefaults(
+        inputs,
+        workflow.inputs,
+      );
+      const validationResult = validationService.validate(
+        inputsWithDefaults,
+        workflow.inputs,
+      );
+      if (!validationResult.valid) {
+        const errorMessages = validationResult.errors
+          .map((e) => `  ${e.message}`)
+          .join("\n");
+        throw new UserError(`Input validation failed:\n${errorMessages}`);
       }
-    },
-  );
+      // Use inputs with defaults applied
+      Object.assign(inputs, inputsWithDefaults);
+    }
+
+    // Extract model references for per-model locking
+    const modelRefs = await extractModelReferencesFromWorkflow(
+      workflow,
+      workflowRepo,
+    );
+
+    let flushModelLocks: (() => Promise<void>) | null = null;
+    let repoDir: string;
+    let datastoreResolver = unlocked.datastoreResolver;
+
+    if (modelRefs !== null && modelRefs.length > 0) {
+      // Resolve model references to { modelType, modelId }
+      const definitionRepo = unlocked.repoContext.definitionRepo;
+      const resolvedModels: Array<{ modelType: string; modelId: string }> = [];
+
+      for (const ref of modelRefs) {
+        const lookupResult = await findDefinitionByIdOrName(
+          definitionRepo,
+          ref,
+        );
+        if (lookupResult) {
+          resolvedModels.push({
+            modelType: lookupResult.type.normalized,
+            modelId: lookupResult.definition.id,
+          });
+        }
+      }
+
+      if (resolvedModels.length > 0) {
+        const lockResult = await acquireModelLocks(
+          unlocked.datastoreConfig,
+          resolvedModels,
+          unlocked.repoDir,
+          unlocked.syncService,
+          unlocked.repoContext.catalogStore,
+        );
+        if (lockResult.synced) {
+          unlocked.repoContext.catalogStore.invalidate();
+        }
+        flushModelLocks = lockResult.flush;
+      }
+
+      repoDir = unlocked.repoDir;
+    } else if (modelRefs === null) {
+      // Dynamic references — fall back to global lock
+      const logger = getSwampLogger(["workflow", "evaluate"]);
+      logger
+        .info`Workflow contains dynamic model references — using global lock`;
+      const globalResult = await requireInitializedRepo({
+        repoDir: resolveRepoDir(options.repoDir),
+        outputMode: cliCtx.outputMode,
+      });
+      repoDir = globalResult.repoDir;
+      datastoreResolver = globalResult.datastoreResolver;
+    } else {
+      // No model references
+      repoDir = unlocked.repoDir;
+    }
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = createWorkflowEvaluateDeps(
+      repoDir,
+      workflowRepo,
+      datastoreResolver,
+    );
+    const renderer = createWorkflowEvaluateRenderer(cliCtx.outputMode);
+
+    try {
+      await consumeStream(
+        workflowEvaluate(ctx, deps, { workflowIdOrName, inputs }),
+        renderer.handlers(),
+      );
+    } finally {
+      if (flushModelLocks) await flushModelLocks();
+    }
+  },
+);

--- a/src/cli/commands/workflow_validate.ts
+++ b/src/cli/commands/workflow_validate.ts
@@ -30,53 +30,87 @@ import {
   createWorkflowValidateDeps,
   workflowsDirFor,
   workflowValidate,
+  type WorkflowValidateAllData,
+  type WorkflowValidateData,
 } from "../../libswamp/mod.ts";
 import { createWorkflowValidateRenderer } from "../../presentation/renderers/workflow_validate.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { WorkflowValidateResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const workflowValidateCommand = new Command()
-  .name("validate")
-  .description("Validate a workflow against its schema")
-  .example("Validate a workflow", "swamp workflow validate deploy-pipeline")
-  .example("Validate all workflows", "swamp workflow validate")
-  .arguments("[workflow_id_or_name:string]")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .action(async function (options: AnyOptions, workflowIdOrName?: string) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "workflow",
-      "validate",
-    ]);
-    const { repoContext, repoDir } = await requireInitializedRepoReadOnly({
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: cliCtx.outputMode,
-    });
+export const workflowValidateCommand = withRemoteOptions(
+  new Command()
+    .name("validate")
+    .description("Validate a workflow against its schema")
+    .example("Validate a workflow", "swamp workflow validate deploy-pipeline")
+    .example("Validate all workflows", "swamp workflow validate")
+    .arguments("[workflow_id_or_name:string]")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    ),
+).action(async function (options: AnyOptions, workflowIdOrName?: string) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "workflow",
+    "validate",
+  ]);
 
-    // Hot-load pulled/local extensions so step-input validation can resolve
-    // their model types. Without this, pulled extension types are skipped as
-    // "not resolved" and the step silently passes (parity with `type describe`
-    // and `model validate`, which both call ensureLoaded before resolving).
-    await modelRegistry.ensureLoaded();
-
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createWorkflowValidateDeps(
-      repoContext.workflowRepo,
-      repoContext.definitionRepo,
-      workflowsDirFor(repoDir),
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
     );
-
+    const response = await requestServerResponse<WorkflowValidateResponse>(
+      { server, token },
+      {
+        type: "workflow.validate",
+        payload: { workflowIdOrName },
+      },
+    );
     const renderer = createWorkflowValidateRenderer(cliCtx.outputMode);
-    await consumeStream(
-      workflowValidate(ctx, deps, { workflowIdOrName }),
-      renderer.handlers(),
-    );
+    renderer.handlers().completed({
+      kind: "completed",
+      data: response.data as unknown as
+        | WorkflowValidateData
+        | WorkflowValidateAllData,
+    });
+    return;
+  }
 
-    if (!renderer.passed()) {
-      Deno.exit(1);
-    }
+  const { repoContext, repoDir } = await requireInitializedRepoReadOnly({
+    repoDir: resolveRepoDir(options.repoDir),
+    outputMode: cliCtx.outputMode,
   });
+
+  // Hot-load pulled/local extensions so step-input validation can resolve
+  // their model types. Without this, pulled extension types are skipped as
+  // "not resolved" and the step silently passes (parity with `type describe`
+  // and `model validate`, which both call ensureLoaded before resolving).
+  await modelRegistry.ensureLoaded();
+
+  const ctx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = createWorkflowValidateDeps(
+    repoContext.workflowRepo,
+    repoContext.definitionRepo,
+    workflowsDirFor(repoDir),
+  );
+
+  const renderer = createWorkflowValidateRenderer(cliCtx.outputMode);
+  await consumeStream(
+    workflowValidate(ctx, deps, { workflowIdOrName }),
+    renderer.handlers(),
+  );
+
+  if (!renderer.passed()) {
+    Deno.exit(1);
+  }
+});

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -32,17 +32,21 @@ import {
 } from "../cli/commands/version.ts";
 import {
   handleDataDelete,
+  handleDataGc,
   handleDataGet,
   handleDataList,
+  handleDataPrune,
   handleDataQuery,
   handleDataRename,
   handleDataSearch,
   handleDataVersions,
+  handleRunGc,
   handleSummarise,
 } from "./handlers/data_handlers.ts";
 import {
   handleModelCreate,
   handleModelDelete,
+  handleModelEdit,
   handleModelEvaluate,
   handleModelGet,
   handleModelMethodDescribe,
@@ -55,11 +59,17 @@ import {
   handleModelOutputLogs,
   handleModelOutputSearch,
   handleModelSearch,
+  handleModelTypeDescribe,
+  handleModelTypeSearch,
   handleModelValidate,
 } from "./handlers/model_handlers.ts";
 import {
   handleWorkflowApprovals,
   handleWorkflowApprove,
+  handleWorkflowCreate,
+  handleWorkflowDelete,
+  handleWorkflowEdit,
+  handleWorkflowEvaluate,
   handleWorkflowGet,
   handleWorkflowHistoryGet,
   handleWorkflowHistoryLogs,
@@ -70,16 +80,22 @@ import {
   handleWorkflowRunSearch,
   handleWorkflowSchema,
   handleWorkflowSearch,
+  handleWorkflowValidate,
 } from "./handlers/workflow_handlers.ts";
 import {
   handleVaultAnnotate,
+  handleVaultAuditTrail,
+  handleVaultCreate,
   handleVaultDelete,
   handleVaultDescribe,
+  handleVaultEdit,
   handleVaultGet,
   handleVaultInspect,
   handleVaultListKeys,
   handleVaultPut,
+  handleVaultReadSecret,
   handleVaultSearch,
+  handleVaultTypeSearch,
 } from "./handlers/vault_handlers.ts";
 import {
   handleAccessCanI,
@@ -87,6 +103,9 @@ import {
   handleAccessGrantList,
   handleAccessGroupList,
   handleAccessReload,
+  handleAccessTokenList,
+  handleAccessTokenRevoke,
+  handleAccessTokenRotate,
 } from "./handlers/access_handlers.ts";
 import {
   handleReportDescribe,
@@ -96,6 +115,7 @@ import {
 } from "./handlers/report_handlers.ts";
 import {
   handleAuditTimeline,
+  handleDatastoreNamespaceList,
   handleDatastoreSetupExtension,
   handleDatastoreStatus,
   handleDoctorDatastores,
@@ -117,6 +137,9 @@ import {
   handleVaultMigrate,
   handleWorkerList,
   handleWorkerQueueList,
+  handleWorkerTokenCreate,
+  handleWorkerTokenList,
+  handleWorkerTokenRevoke,
   handleWorkerVerify,
 } from "./handlers/admin_handlers.ts";
 import {
@@ -871,6 +894,209 @@ const RunAttachRequestSchema = z.object({
   }),
 });
 
+const AccessTokenListRequestSchema = z.object({
+  type: z.literal("access.token.list"),
+  id: z.string().min(1).max(256),
+  payload: z.object({}).optional(),
+});
+
+const AccessTokenRevokeRequestSchema = z.object({
+  type: z.literal("access.token.revoke"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    name: z.string().min(1),
+  }),
+});
+
+const AccessTokenRotateRequestSchema = z.object({
+  type: z.literal("access.token.rotate"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    name: z.string().min(1),
+    durationMs: z.number().positive().optional(),
+    vaultName: z.string().optional(),
+  }),
+});
+
+const ModelEditRequestSchema = z.object({
+  type: z.literal("model.edit"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    modelIdOrName: z.string().min(1),
+    content: z.string().optional(),
+  }),
+});
+
+const ModelTypeDescribeRequestSchema = z.object({
+  type: z.literal("model.type.describe"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    typeArg: z.string().min(1),
+  }),
+});
+
+const ModelTypeSearchRequestSchema = z.object({
+  type: z.literal("model.type.search"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    query: z.string().optional(),
+  }).optional(),
+});
+
+const WorkflowCreateRequestSchema = z.object({
+  type: z.literal("workflow.create"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    name: z.string().min(1),
+  }),
+});
+
+const WorkflowDeleteRequestSchema = z.object({
+  type: z.literal("workflow.delete"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    workflowIdOrName: z.string().min(1),
+  }),
+});
+
+const WorkflowEditRequestSchema = z.object({
+  type: z.literal("workflow.edit"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    workflowIdOrName: z.string().min(1),
+    content: z.string().optional(),
+  }),
+});
+
+const WorkflowValidateRequestSchema = z.object({
+  type: z.literal("workflow.validate"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    workflowIdOrName: z.string().optional(),
+  }).optional(),
+});
+
+const WorkflowEvaluateRequestSchema = z.object({
+  type: z.literal("workflow.evaluate"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    workflowIdOrName: z.string().optional(),
+    inputs: z.record(z.string(), z.unknown()).optional(),
+  }).optional(),
+});
+
+const VaultCreateRequestSchema = z.object({
+  type: z.literal("vault.create"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    vaultType: z.string().min(1),
+    name: z.string().min(1),
+    config: z.record(z.string(), z.unknown()).optional(),
+    auditReads: z.boolean().optional(),
+  }),
+});
+
+const VaultEditRequestSchema = z.object({
+  type: z.literal("vault.edit"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    vaultNameOrId: z.string().min(1),
+    vaultType: z.string().optional(),
+  }),
+});
+
+const VaultAuditTrailRequestSchema = z.object({
+  type: z.literal("vault.audit-trail"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    vaultName: z.string().optional(),
+    secretKey: z.string().optional(),
+    since: z.string().optional(),
+    until: z.string().optional(),
+    limit: z.number().int().positive().optional(),
+  }).optional(),
+});
+
+const VaultReadSecretRequestSchema = z.object({
+  type: z.literal("vault.read-secret"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    vaultName: z.string().min(1),
+    secretKey: z.string().min(1),
+  }),
+});
+
+const VaultTypeSearchRequestSchema = z.object({
+  type: z.literal("vault.type.search"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    query: z.string().optional(),
+  }).optional(),
+});
+
+const WorkerTokenCreateRequestSchema = z.object({
+  type: z.literal("worker.token.create"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    name: z.string().min(1),
+    durationMs: z.number().positive(),
+    vaultName: z.string().optional(),
+    maxEnrollments: z.union([
+      z.number().int().positive(),
+      z.literal("unlimited"),
+    ])
+      .optional(),
+  }),
+});
+
+const WorkerTokenListRequestSchema = z.object({
+  type: z.literal("worker.token.list"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    showAll: z.boolean().optional(),
+  }).optional(),
+});
+
+const WorkerTokenRevokeRequestSchema = z.object({
+  type: z.literal("worker.token.revoke"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    name: z.string().min(1),
+  }),
+});
+
+const DataGcRequestSchema = z.object({
+  type: z.literal("data.gc"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    dryRun: z.boolean().optional(),
+  }).optional(),
+});
+
+const DataPruneRequestSchema = z.object({
+  type: z.literal("data.prune"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    dryRun: z.boolean().optional(),
+  }).optional(),
+});
+
+const RunGcRequestSchema = z.object({
+  type: z.literal("run.gc"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    dryRun: z.boolean().optional(),
+    workflowRunRetentionDays: z.number().positive().optional(),
+    outputRetentionDays: z.number().positive().optional(),
+  }).optional(),
+});
+
+const DatastoreNamespaceListRequestSchema = z.object({
+  type: z.literal("datastore.namespace.list"),
+  id: z.string().min(1).max(256),
+  payload: z.object({}).optional(),
+});
+
 const ServerVersionRequestSchema = z.object({
   type: z.literal("server.version"),
   id: z.string().min(1).max(256),
@@ -954,6 +1180,29 @@ const ServerRequestSchema = z.discriminatedUnion("type", [
   RunDoctorRequestSchema,
   RunAttachRequestSchema,
   CancelRequestSchema,
+  AccessTokenListRequestSchema,
+  AccessTokenRevokeRequestSchema,
+  AccessTokenRotateRequestSchema,
+  ModelEditRequestSchema,
+  ModelTypeDescribeRequestSchema,
+  ModelTypeSearchRequestSchema,
+  WorkflowCreateRequestSchema,
+  WorkflowDeleteRequestSchema,
+  WorkflowEditRequestSchema,
+  WorkflowValidateRequestSchema,
+  WorkflowEvaluateRequestSchema,
+  VaultCreateRequestSchema,
+  VaultEditRequestSchema,
+  VaultAuditTrailRequestSchema,
+  VaultReadSecretRequestSchema,
+  VaultTypeSearchRequestSchema,
+  WorkerTokenCreateRequestSchema,
+  WorkerTokenListRequestSchema,
+  WorkerTokenRevokeRequestSchema,
+  DataGcRequestSchema,
+  DataPruneRequestSchema,
+  RunGcRequestSchema,
+  DatastoreNamespaceListRequestSchema,
 ]);
 
 /**
@@ -1832,6 +2081,233 @@ export function handleMessage(
         ctx,
         request.id,
         request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "access.token.list":
+      task = handleAccessTokenList(
+        socket,
+        ctx,
+        request.id,
+        controller,
+        principal,
+      );
+      break;
+    case "access.token.revoke":
+      task = handleAccessTokenRevoke(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "access.token.rotate":
+      task = handleAccessTokenRotate(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "model.edit":
+      task = handleModelEdit(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "model.type.describe":
+      task = handleModelTypeDescribe(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "model.type.search":
+      task = handleModelTypeSearch(
+        socket,
+        ctx,
+        request.id,
+        controller,
+        principal,
+        request.payload,
+      );
+      break;
+    case "workflow.create":
+      task = handleWorkflowCreate(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "workflow.delete":
+      task = handleWorkflowDelete(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "workflow.edit":
+      task = handleWorkflowEdit(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "workflow.validate":
+      task = handleWorkflowValidate(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "workflow.evaluate":
+      task = handleWorkflowEvaluate(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "vault.create":
+      task = handleVaultCreate(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "vault.edit":
+      task = handleVaultEdit(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "vault.audit-trail":
+      task = handleVaultAuditTrail(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "vault.read-secret":
+      task = handleVaultReadSecret(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "vault.type.search":
+      task = handleVaultTypeSearch(
+        socket,
+        ctx,
+        request.id,
+        controller,
+        principal,
+        request.payload,
+      );
+      break;
+    case "worker.token.create":
+      task = handleWorkerTokenCreate(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "worker.token.list":
+      task = handleWorkerTokenList(
+        socket,
+        ctx,
+        request.id,
+        controller,
+        principal,
+      );
+      break;
+    case "worker.token.revoke":
+      task = handleWorkerTokenRevoke(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "data.gc":
+      task = handleDataGc(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "data.prune":
+      task = handleDataPrune(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "run.gc":
+      task = handleRunGc(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "datastore.namespace.list":
+      task = handleDatastoreNamespaceList(
+        socket,
+        ctx,
+        request.id,
         controller,
         principal,
       );

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -2612,3 +2612,715 @@ Deno.test("validateServerRequest: workflow.resume accepts request without trace 
   const result = validateServerRequest(input);
   assertEquals(typeof result, "object");
 });
+
+// ── validateServerRequest: new command types (issue #1531) ─────────────
+
+Deno.test("validateServerRequest accepts access.token.list", () => {
+  assertEquals(
+    typeof validateServerRequest({ type: "access.token.list", id: "r1" }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts access.token.revoke", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "access.token.revoke",
+      id: "r1",
+      payload: { name: "my-token" },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest rejects access.token.revoke without name", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "access.token.revoke",
+      id: "r1",
+      payload: {},
+    }),
+    "string",
+  );
+});
+
+Deno.test("validateServerRequest accepts access.token.rotate", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "access.token.rotate",
+      id: "r1",
+      payload: { name: "my-token", durationMs: 3600000 },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts access.token.rotate without optional fields", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "access.token.rotate",
+      id: "r1",
+      payload: { name: "my-token" },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts model.edit", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "model.edit",
+      id: "r1",
+      payload: { modelIdOrName: "test-model", content: "name: test" },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest rejects model.edit without modelIdOrName", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "model.edit",
+      id: "r1",
+      payload: {},
+    }),
+    "string",
+  );
+});
+
+Deno.test("validateServerRequest accepts model.type.describe", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "model.type.describe",
+      id: "r1",
+      payload: { typeArg: "command/shell" },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest rejects model.type.describe without typeArg", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "model.type.describe",
+      id: "r1",
+      payload: {},
+    }),
+    "string",
+  );
+});
+
+Deno.test("validateServerRequest accepts model.type.search", () => {
+  assertEquals(
+    typeof validateServerRequest({ type: "model.type.search", id: "r1" }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts model.type.search with query", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "model.type.search",
+      id: "r1",
+      payload: { query: "shell" },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts workflow.create", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "workflow.create",
+      id: "r1",
+      payload: { name: "deploy" },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest rejects workflow.create without name", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "workflow.create",
+      id: "r1",
+      payload: {},
+    }),
+    "string",
+  );
+});
+
+Deno.test("validateServerRequest accepts workflow.delete", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "workflow.delete",
+      id: "r1",
+      payload: { workflowIdOrName: "deploy" },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts workflow.edit", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "workflow.edit",
+      id: "r1",
+      payload: { workflowIdOrName: "deploy", content: "jobs: {}" },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts workflow.validate", () => {
+  assertEquals(
+    typeof validateServerRequest({ type: "workflow.validate", id: "r1" }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts workflow.validate with workflowIdOrName", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "workflow.validate",
+      id: "r1",
+      payload: { workflowIdOrName: "deploy" },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts workflow.evaluate", () => {
+  assertEquals(
+    typeof validateServerRequest({ type: "workflow.evaluate", id: "r1" }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts workflow.evaluate with inputs", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "workflow.evaluate",
+      id: "r1",
+      payload: { workflowIdOrName: "deploy", inputs: { env: "prod" } },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts vault.create", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "vault.create",
+      id: "r1",
+      payload: { vaultType: "local_encryption", name: "my-vault" },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest rejects vault.create without name", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "vault.create",
+      id: "r1",
+      payload: { vaultType: "local_encryption" },
+    }),
+    "string",
+  );
+});
+
+Deno.test("validateServerRequest accepts vault.edit", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "vault.edit",
+      id: "r1",
+      payload: { vaultNameOrId: "my-vault" },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts vault.audit-trail", () => {
+  assertEquals(
+    typeof validateServerRequest({ type: "vault.audit-trail", id: "r1" }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts vault.audit-trail with filters", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "vault.audit-trail",
+      id: "r1",
+      payload: { vaultName: "v1", secretKey: "k1", limit: 50 },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts vault.read-secret", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "vault.read-secret",
+      id: "r1",
+      payload: { vaultName: "my-vault", secretKey: "API_KEY" },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest rejects vault.read-secret without secretKey", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "vault.read-secret",
+      id: "r1",
+      payload: { vaultName: "my-vault" },
+    }),
+    "string",
+  );
+});
+
+Deno.test("validateServerRequest accepts vault.type.search", () => {
+  assertEquals(
+    typeof validateServerRequest({ type: "vault.type.search", id: "r1" }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts worker.token.create", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "worker.token.create",
+      id: "r1",
+      payload: { name: "wt-1", durationMs: 3600000 },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts worker.token.create with unlimited enrollments", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "worker.token.create",
+      id: "r1",
+      payload: {
+        name: "wt-1",
+        durationMs: 3600000,
+        maxEnrollments: "unlimited",
+      },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest rejects worker.token.create without durationMs", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "worker.token.create",
+      id: "r1",
+      payload: { name: "wt-1" },
+    }),
+    "string",
+  );
+});
+
+Deno.test("validateServerRequest accepts worker.token.list", () => {
+  assertEquals(
+    typeof validateServerRequest({ type: "worker.token.list", id: "r1" }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts worker.token.revoke", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "worker.token.revoke",
+      id: "r1",
+      payload: { name: "wt-1" },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts data.gc", () => {
+  assertEquals(
+    typeof validateServerRequest({ type: "data.gc", id: "r1" }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts data.gc with dryRun", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "data.gc",
+      id: "r1",
+      payload: { dryRun: true },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts data.prune", () => {
+  assertEquals(
+    typeof validateServerRequest({ type: "data.prune", id: "r1" }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts run.gc", () => {
+  assertEquals(
+    typeof validateServerRequest({ type: "run.gc", id: "r1" }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts run.gc with retention options", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "run.gc",
+      id: "r1",
+      payload: {
+        dryRun: true,
+        workflowRunRetentionDays: 30,
+        outputRetentionDays: 14,
+      },
+    }),
+    "object",
+  );
+});
+
+Deno.test("validateServerRequest accepts datastore.namespace.list", () => {
+  assertEquals(
+    typeof validateServerRequest({
+      type: "datastore.namespace.list",
+      id: "r1",
+    }),
+    "object",
+  );
+});
+
+// ── Authorization: new command types (issue #1531) ───────────────────────
+
+Deno.test("authorizeOrReject: access.token.list requires admin on access:*", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({ type: "access.token.list", id: "at-1" })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "admin",
+  );
+});
+
+Deno.test("authorizeOrReject: access.token.revoke requires admin on access:*", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "access.token.revoke",
+      id: "at-2",
+      payload: { name: "tok" },
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+});
+
+Deno.test("authorizeOrReject: worker.token.create requires admin on access:*", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "worker.token.create",
+      id: "wt-1",
+      payload: { name: "wt", durationMs: 3600000 },
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "admin",
+  );
+});
+
+Deno.test("authorizeOrReject: model.edit requires write on model:<name>", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "model.edit",
+      id: "me-1",
+      payload: { modelIdOrName: "test-model" },
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "write",
+  );
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "model:test-model",
+  );
+});
+
+Deno.test("authorizeOrReject: workflow.create requires write on workflow:<name>", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "workflow.create",
+      id: "wc-1",
+      payload: { name: "deploy" },
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "write",
+  );
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "workflow:deploy",
+  );
+});
+
+Deno.test("authorizeOrReject: vault.read-secret requires read on data:<vault>", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "vault.read-secret",
+      id: "vrs-1",
+      payload: { vaultName: "prod-vault", secretKey: "API_KEY" },
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "read",
+  );
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "data:prod-vault",
+  );
+});
+
+Deno.test("authorizeOrReject: data.gc requires write on data:*", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({ type: "data.gc", id: "dgc-1" })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "write",
+  );
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "data:*",
+  );
+});
+
+Deno.test("authorizeOrReject: model.type.search requires read on model:*", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({ type: "model.type.search", id: "mts-1" })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "read",
+  );
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "model:*",
+  );
+});
+
+Deno.test("authorizeOrReject: admin on access:* allows all new command types", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const adminGrant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    actions: ["admin"],
+    resource: { kind: "access", pattern: "*" },
+  });
+  const ctx = makeCtx(modeTokenConfig, [adminGrant]);
+
+  const newTypes = [
+    { type: "access.token.list", id: "admin-atl" },
+    {
+      type: "access.token.revoke",
+      id: "admin-atr",
+      payload: { name: "tok" },
+    },
+    {
+      type: "access.token.rotate",
+      id: "admin-atro",
+      payload: { name: "tok" },
+    },
+    {
+      type: "model.edit",
+      id: "admin-me",
+      payload: { modelIdOrName: "m" },
+    },
+    {
+      type: "model.type.describe",
+      id: "admin-mtd",
+      payload: { typeArg: "command/shell" },
+    },
+    { type: "model.type.search", id: "admin-mts" },
+    { type: "workflow.create", id: "admin-wc", payload: { name: "wf" } },
+    {
+      type: "workflow.delete",
+      id: "admin-wd",
+      payload: { workflowIdOrName: "wf" },
+    },
+    {
+      type: "workflow.edit",
+      id: "admin-we",
+      payload: { workflowIdOrName: "wf" },
+    },
+    { type: "workflow.validate", id: "admin-wv" },
+    { type: "workflow.evaluate", id: "admin-wev" },
+    {
+      type: "vault.create",
+      id: "admin-vc",
+      payload: { vaultType: "local_encryption", name: "v" },
+    },
+    {
+      type: "vault.edit",
+      id: "admin-ve",
+      payload: { vaultNameOrId: "v" },
+    },
+    { type: "vault.audit-trail", id: "admin-vat" },
+    {
+      type: "vault.read-secret",
+      id: "admin-vrs",
+      payload: { vaultName: "v", secretKey: "k" },
+    },
+    { type: "vault.type.search", id: "admin-vts" },
+    {
+      type: "worker.token.create",
+      id: "admin-wtc",
+      payload: { name: "wt", durationMs: 3600000 },
+    },
+    { type: "worker.token.list", id: "admin-wtl" },
+    {
+      type: "worker.token.revoke",
+      id: "admin-wtr",
+      payload: { name: "wt" },
+    },
+    { type: "data.gc", id: "admin-dgc" },
+    { type: "data.prune", id: "admin-dp" },
+    { type: "run.gc", id: "admin-rgc" },
+    { type: "datastore.namespace.list", id: "admin-dnl" },
+  ];
+
+  for (const msg of newTypes) {
+    handleMessage(
+      mock as unknown as WebSocket,
+      ctx,
+      active,
+      makeEvent(JSON.stringify(msg)),
+      testPrincipal,
+    );
+  }
+
+  const unauthorizedErrors = mock.sent
+    .map((s) => JSON.parse(s))
+    .filter((m) =>
+      m.type === "error" &&
+      (m.error as Record<string, unknown>).code === "unauthorized"
+    );
+  assertEquals(
+    unauthorizedErrors.length,
+    0,
+    "admin superuser should not be denied any new command type",
+  );
+});

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -28,6 +28,8 @@ import type {
   AccessGrantListPayload,
   AccessGroupListPayload,
   AccessReloadFileResult,
+  AccessTokenRevokePayload,
+  AccessTokenRotatePayload,
 } from "../protocol.ts";
 import {
   collectErrors,
@@ -69,6 +71,17 @@ import {
   sendError,
 } from "./shared.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import {
+  consumeStream,
+  createLibSwampContext,
+  createServerTokenListDeps,
+  createServerTokenRevokeDeps,
+  createServerTokenRotateDeps,
+  serverTokenList,
+  serverTokenRevoke,
+  serverTokenRotate,
+  withDefaults,
+} from "../../libswamp/mod.ts";
 
 export async function handleAccessGrantList(
   socket: WebSocket,
@@ -540,5 +553,165 @@ export async function handleAccessReload(
     logger.error`Access policy reload failed (requested by ${who}): ${error}`;
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "access_reload_failed", message);
+  }
+}
+
+export async function handleAccessTokenList(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "admin", {
+      kind: "access",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createServerTokenListDeps(
+      ctx.repoContext.dataQueryService,
+    );
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      serverTokenList(libCtx, deps),
+      withDefaults({
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      }),
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "access.token.list",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "access_token_list_failed", message);
+  }
+}
+
+export async function handleAccessTokenRevoke(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: AccessTokenRevokePayload,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "admin", {
+      kind: "access",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = await createServerTokenRevokeDeps(
+      libCtx,
+      ctx.repoDir,
+      ctx.repoContext,
+    );
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      serverTokenRevoke(libCtx, deps, { name: payload.name }),
+      withDefaults({
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      }),
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "access.token.revoke",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "access_token_revoke_failed", message);
+  }
+}
+
+export async function handleAccessTokenRotate(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: AccessTokenRotatePayload,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "admin", {
+      kind: "access",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = await createServerTokenRotateDeps(
+      libCtx,
+      ctx.repoDir,
+      ctx.repoContext,
+    );
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      serverTokenRotate(libCtx, deps, {
+        name: payload.name,
+        durationMs: payload.durationMs,
+        vaultName: payload.vaultName,
+      }),
+      withDefaults({
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      }),
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "access.token.rotate",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "access_token_rotate_failed", message);
   }
 }

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -45,6 +45,9 @@ import {
   createVaultMigrateDeps,
   createWorkerListDeps,
   createWorkerQueueListDeps,
+  createWorkerTokenCreateDeps,
+  createWorkerTokenRevokeDeps,
+  datastoreNamespaceList,
   datastoreSetupExtension,
   datastoreStatus,
   doctorDatastores,
@@ -73,16 +76,28 @@ import {
   validateExtensionName,
   vaultMigrate,
   vaultMigratePreview,
+  withDefaults,
   workerList,
   workerQueueList,
+  workerTokenCreate,
+  workerTokenList,
+  workerTokenRevoke,
 } from "../../libswamp/mod.ts";
 import {
+  type CustomDatastoreConfig,
   isCustomDatastoreConfig,
 } from "../../domain/datastore/datastore_config.ts";
+import type { DatastoreProvider } from "../../domain/datastore/datastore_provider.ts";
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
 import { FilesystemDatastoreVerifier } from "../../infrastructure/persistence/filesystem_datastore_verifier.ts";
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
-import { resolveDatastoreConfig } from "../../cli/resolve_datastore.ts";
+import {
+  datastoreBasePath,
+  resolveDatastoreConfig,
+} from "../../cli/resolve_datastore.ts";
+import {
+  listNamespaceManifests,
+} from "../../infrastructure/persistence/namespace_manifest.ts";
 import { createExtensionInstallDeps } from "../../cli/create_extension_install_deps.ts";
 import { loadIdentity } from "../../cli/load_identity.ts";
 import { resolveModelsDir } from "../../cli/resolve_models_dir.ts";
@@ -97,6 +112,8 @@ import type {
   VaultMigratePayload,
   WorkerListPayload,
   WorkerProbeResult,
+  WorkerTokenCreatePayload,
+  WorkerTokenRevokePayload,
   WorkerVerifyPayload,
 } from "../protocol.ts";
 import { dispatchFleetProbe } from "../fleet_probe_dispatch.ts";
@@ -1742,5 +1759,239 @@ export async function handleServeReload(
     logger.error`Extension reload failed (requested by ${who}): ${error}`;
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "serve_reload_failed", message);
+  }
+}
+
+export async function handleWorkerTokenCreate(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: WorkerTokenCreatePayload,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "admin", {
+      kind: "access",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = await createWorkerTokenCreateDeps(
+      libCtx,
+      ctx.repoDir,
+      ctx.repoContext,
+    );
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      workerTokenCreate(libCtx, deps, {
+        name: payload.name,
+        durationMs: payload.durationMs,
+        vaultName: payload.vaultName,
+        maxEnrollments: payload.maxEnrollments,
+      }),
+      withDefaults({
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      }),
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "worker.token.create",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "worker_token_create_failed", message);
+  }
+}
+
+export async function handleWorkerTokenList(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "admin", {
+      kind: "access",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createWorkerListDeps(
+      ctx.repoContext.dataQueryService,
+    );
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      workerTokenList(libCtx, deps),
+      withDefaults({
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      }),
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "worker.token.list",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "worker_token_list_failed", message);
+  }
+}
+
+export async function handleWorkerTokenRevoke(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: WorkerTokenRevokePayload,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "admin", {
+      kind: "access",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = await createWorkerTokenRevokeDeps(
+      libCtx,
+      ctx.repoDir,
+      ctx.repoContext,
+    );
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      workerTokenRevoke(libCtx, deps, { name: payload.name }),
+      withDefaults({
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      }),
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "worker.token.revoke",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "worker_token_revoke_failed", message);
+  }
+}
+
+export async function handleDatastoreNamespaceList(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "read", {
+      kind: "data",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const dsBasePath = datastoreBasePath(ctx.datastoreConfig);
+
+    let listProvider: DatastoreProvider | undefined;
+    if (isCustomDatastoreConfig(ctx.datastoreConfig)) {
+      await datastoreTypeRegistry.ensureLoaded();
+      await datastoreTypeRegistry.ensureTypeLoaded(ctx.datastoreConfig.type);
+      const typeInfo = datastoreTypeRegistry.get(ctx.datastoreConfig.type);
+      listProvider = typeInfo?.createProvider?.(ctx.datastoreConfig.config);
+    }
+
+    const deps = {
+      getCurrentNamespace: () => ctx.datastoreConfig.namespace,
+      listNamespaces: async () => {
+        if (listProvider?.listNamespaces) {
+          const slugs = await listProvider.listNamespaces(
+            (ctx.datastoreConfig as CustomDatastoreConfig).datastorePath,
+          );
+          return slugs.map((ns: string) => ({
+            namespace: ns,
+            repoId: "",
+            registeredAt: "",
+          }));
+        }
+        return await listNamespaceManifests(dsBasePath);
+      },
+    };
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      datastoreNamespaceList(libCtx, deps),
+      {
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "datastore.namespace.list",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "datastore_namespace_list_failed", message);
   }
 }

--- a/src/serve/handlers/data_handlers.ts
+++ b/src/serve/handlers/data_handlers.ts
@@ -24,32 +24,42 @@
 import {
   consumeStream,
   createDataDeleteDeps,
+  createDataGcDeps,
   createDataGetDeps,
   createDataListDeps,
+  createDataPruneDeps,
   createDataRenameDeps,
   createDataVersionsDeps,
   createLibSwampContext,
+  createRunGcDeps,
   createSummariseDeps,
   dataDelete,
+  dataGc,
   dataGet,
   dataList,
+  dataPrune,
   dataQuery,
   type DataQueryDeps,
   dataRename,
   dataSearch,
   type DataSearchDeps,
   dataVersions,
+  DEFAULT_WORKFLOW_RUN_RETENTION_DAYS,
   parseDuration,
+  runGc,
   summarise,
 } from "../../libswamp/mod.ts";
 import type {
   DataDeletePayload,
+  DataGcPayload,
   DataGetPayload,
   DataListPayload,
+  DataPrunePayload,
   DataQueryPayload,
   DataRenamePayload,
   DataSearchPayload,
   DataVersionsPayload,
+  RunGcPayload,
   SummarisePayload,
 } from "../protocol.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
@@ -595,5 +605,174 @@ export async function handleSummarise(
   } catch (error) {
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "summarise_failed", message);
+  }
+}
+
+export async function handleDataGc(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: DataGcPayload | undefined,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "write", {
+      kind: "data",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createDataGcDeps(
+      ctx.repoDir,
+      ctx.datastoreResolver,
+      ctx.repoContext.markDirty,
+    );
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      dataGc(libCtx, deps, { dryRun: payload?.dryRun ?? false }),
+      {
+        collecting: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "data.gc",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "data_gc_failed", message);
+  }
+}
+
+export async function handleDataPrune(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: DataPrunePayload | undefined,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "write", {
+      kind: "data",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createDataPruneDeps(
+      ctx.repoDir,
+      ctx.datastoreResolver,
+      ctx.repoContext.unifiedDataRepo,
+    );
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      dataPrune(libCtx, deps, { dryRun: payload?.dryRun ?? false }),
+      {
+        collecting: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "data.prune",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "data_prune_failed", message);
+  }
+}
+
+export async function handleRunGc(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: RunGcPayload | undefined,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "write", {
+      kind: "data",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createRunGcDeps(
+      ctx.repoDir,
+      ctx.datastoreResolver,
+      ctx.repoContext.markDirty,
+    );
+
+    const retentionDays = payload?.workflowRunRetentionDays ??
+      DEFAULT_WORKFLOW_RUN_RETENTION_DAYS;
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      runGc(libCtx, deps, {
+        dryRun: payload?.dryRun ?? false,
+        workflowRunRetentionDays: retentionDays,
+        outputRetentionDays: payload?.outputRetentionDays ?? retentionDays,
+      }),
+      {
+        collecting: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "run.gc",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "run_gc_failed", message);
   }
 }

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -26,6 +26,7 @@ import {
   createLibSwampContext,
   createModelCreateDeps,
   createModelDeleteDeps,
+  createModelEditDeps,
   createModelEvaluateDeps,
   createModelGetDeps,
   createModelMethodDescribeDeps,
@@ -34,9 +35,11 @@ import {
   createModelOutputGetDeps,
   createModelOutputLogsDeps,
   createModelValidateDeps,
+  createTypeDescribeDeps,
   modelCreate,
   modelDelete,
   modelDeletePreview,
+  modelEdit,
   modelEvaluate,
   modelGet,
   modelMethodDescribe,
@@ -50,12 +53,16 @@ import {
   modelSearch,
   type ModelSearchDeps,
   modelValidate,
+  typeDescribe,
+  typeSearch,
+  type TypeSearchDeps,
 } from "../../libswamp/mod.ts";
 import { createModelMethodRunDeps } from "../deps.ts";
 import { serializeEvent } from "../serializer.ts";
 import type {
   ModelCreatePayload,
   ModelDeletePayload,
+  ModelEditPayload,
   ModelEvaluatePayload,
   ModelGetPayload,
   ModelMethodDescribePayload,
@@ -68,6 +75,8 @@ import type {
   ModelOutputLogsPayload,
   ModelOutputSearchPayload,
   ModelSearchPayload,
+  ModelTypeDescribePayload,
+  ModelTypeSearchPayload,
   ModelValidatePayload,
 } from "../protocol.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
@@ -1354,5 +1363,162 @@ export async function handleModelEvaluate(
   } catch (error) {
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "model_evaluate_failed", message);
+  }
+}
+
+export async function handleModelEdit(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: ModelEditPayload,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "write", {
+      kind: "model",
+      name: payload.modelIdOrName,
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createModelEditDeps(ctx.repoDir);
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      modelEdit(libCtx, deps, {
+        modelIdOrName: payload.modelIdOrName,
+        stdinContent: payload.content,
+      }),
+      {
+        resolving: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "model.edit",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "model_edit_failed", message);
+  }
+}
+
+export async function handleModelTypeDescribe(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: ModelTypeDescribePayload,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "read", {
+      kind: "model",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createTypeDescribeDeps();
+    const modelType = ModelType.create(payload.typeArg);
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      typeDescribe(libCtx, deps, modelType),
+      {
+        resolving: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "model.type.describe",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "model_type_describe_failed", message);
+  }
+}
+
+export async function handleModelTypeSearch(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  controller: AbortController,
+  principal: Principal | null,
+  payload?: ModelTypeSearchPayload,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "read", {
+      kind: "model",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    await modelRegistry.ensureLoaded();
+    const deps: TypeSearchDeps = {
+      getRegisteredTypes: () => modelRegistry.publicTypes(),
+    };
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      typeSearch(libCtx, deps, { query: payload?.query }),
+      {
+        resolving: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "model.type.search",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "model_type_search_failed", message);
   }
 }

--- a/src/serve/handlers/vault_handlers.ts
+++ b/src/serve/handlers/vault_handlers.ts
@@ -25,36 +25,53 @@ import {
   consumeStream,
   createLibSwampContext,
   createVaultAnnotateDeps,
+  createVaultAuditTrailDeps,
+  createVaultCreateDeps,
   createVaultDeleteDeps,
   createVaultDescribeDeps,
+  createVaultEditDeps,
   createVaultGetDeps,
   createVaultInspectDeps,
   createVaultListKeysDeps,
   createVaultPutDeps,
+  createVaultReadSecretDeps,
   vaultAnnotate,
+  vaultAuditTrail,
+  vaultCreate,
   vaultDelete,
   vaultDeletePreview,
   vaultDescribe,
+  vaultEdit,
   vaultGet,
   vaultInspect,
   vaultListKeys,
   vaultPut,
   vaultPutPreview,
+  vaultReadSecret,
   vaultSearch,
   type VaultSearchDeps,
+  vaultTypeSearch,
+  type VaultTypeSearchDeps,
 } from "../../libswamp/mod.ts";
 import type {
   VaultAnnotatePayload,
+  VaultAuditTrailPayload,
+  VaultCreatePayload,
   VaultDeletePayload,
   VaultDescribePayload,
+  VaultEditPayload,
   VaultGetPayload,
   VaultInspectPayload,
   VaultListKeysPayload,
   VaultPutPayload,
+  VaultReadSecretPayload,
   VaultSearchPayload,
+  VaultTypeSearchPayload,
 } from "../protocol.ts";
 import { acquireVaultSync } from "../../cli/repo_context.ts";
 import type { Principal } from "../../domain/access/principal.ts";
+import { getVaultTypes } from "../../domain/vaults/vault_types.ts";
+import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
 import {
   authorizeOrReject,
   type ConnectionContext,
@@ -677,5 +694,281 @@ export async function handleVaultAnnotate(
   } catch (error) {
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "vault_annotate_failed", message);
+  }
+}
+
+export async function handleVaultCreate(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: VaultCreatePayload,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "write", {
+      kind: "data",
+      name: payload.name,
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = await createVaultCreateDeps(ctx.repoDir);
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      vaultCreate(libCtx, deps, {
+        vaultType: payload.vaultType,
+        name: payload.name,
+        config: payload.config,
+        repoDir: ctx.repoDir,
+        auditReads: payload.auditReads,
+      }),
+      {
+        creating: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "vault.create",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "vault_create_failed", message);
+  }
+}
+
+export async function handleVaultEdit(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: VaultEditPayload,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "write", {
+      kind: "data",
+      name: payload.vaultNameOrId,
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createVaultEditDeps(ctx.repoDir);
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      vaultEdit(libCtx, deps, {
+        vaultNameOrId: payload.vaultNameOrId,
+        vaultType: payload.vaultType,
+      }),
+      {
+        resolving: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "vault.edit",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "vault_edit_failed", message);
+  }
+}
+
+export async function handleVaultAuditTrail(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: VaultAuditTrailPayload | undefined,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "read", {
+      kind: "data",
+      name: payload?.vaultName ?? "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createVaultAuditTrailDeps(ctx.repoDir);
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      vaultAuditTrail(libCtx, deps, {
+        vaultName: payload?.vaultName,
+        secretKey: payload?.secretKey,
+        since: payload?.since ? new Date(payload.since) : undefined,
+        until: payload?.until ? new Date(payload.until) : undefined,
+        limit: payload?.limit,
+      }),
+      {
+        resolving: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "vault.audit-trail",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "vault_audit_trail_failed", message);
+  }
+}
+
+export async function handleVaultReadSecret(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: VaultReadSecretPayload,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (rejectReservedVault(socket, requestId, payload.vaultName)) return;
+
+  if (
+    !authorizeOrReject(socket, requestId, principal, "read", {
+      kind: "data",
+      name: payload.vaultName,
+      fields: { key: payload.secretKey },
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createVaultReadSecretDeps(
+      ctx.repoDir,
+      ctx.repoContext.eventBus,
+    );
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      vaultReadSecret(libCtx, deps, {
+        vaultName: payload.vaultName,
+        secretKey: payload.secretKey,
+      }),
+      {
+        resolving: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "vault.read-secret",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "vault_read_secret_failed", message);
+  }
+}
+
+export async function handleVaultTypeSearch(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  controller: AbortController,
+  principal: Principal | null,
+  payload?: VaultTypeSearchPayload,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "read", {
+      kind: "data",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    await vaultTypeRegistry.ensureLoaded();
+    const deps: VaultTypeSearchDeps = {
+      getVaultTypes: () => getVaultTypes(),
+    };
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      vaultTypeSearch(libCtx, deps, { query: payload?.query }),
+      {
+        resolving: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "vault.type.search",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "vault_type_search_failed", message);
   }
 }

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -26,14 +26,23 @@ import {
   createLibSwampContext,
   createWorkflowApprovalsDeps,
   createWorkflowApproveDeps,
+  createWorkflowCreateDeps,
+  createWorkflowDeleteDeps,
+  createWorkflowEditDeps,
+  createWorkflowEvaluateDeps,
   createWorkflowGetDeps,
   createWorkflowHistoryGetDeps,
   createWorkflowHistoryLogsDeps,
   createWorkflowRejectDeps,
+  createWorkflowValidateDeps,
   mapWorkflowExecutionEvent,
   workflowApprovals,
   type WorkflowApprovalsEvent,
   workflowApprove,
+  workflowCreate,
+  workflowDelete,
+  workflowEdit,
+  workflowEvaluate,
   workflowGet,
   workflowHistoryGet,
   workflowHistoryLogs,
@@ -44,13 +53,19 @@ import {
   workflowRunSearch,
   type WorkflowRunSearchDeps,
   workflowSchema,
+  workflowsDirFor,
   workflowSearch,
   type WorkflowSearchDeps,
+  workflowValidate,
 } from "../../libswamp/mod.ts";
 import { createWorkflowRunDeps, executeWorkflowWithLocks } from "../deps.ts";
 import { serializeEvent } from "../serializer.ts";
 import type {
   WorkflowApprovePayload,
+  WorkflowCreatePayload,
+  WorkflowDeletePayload,
+  WorkflowEditPayload,
+  WorkflowEvaluatePayload,
   WorkflowGetPayload,
   WorkflowHistoryGetPayload,
   WorkflowHistoryLogsPayload,
@@ -61,6 +76,7 @@ import type {
   WorkflowRunSearchPayload,
   WorkflowSchemaPayload,
   WorkflowSearchPayload,
+  WorkflowValidatePayload,
 } from "../protocol.ts";
 import { acquireModelLocks } from "../../cli/repo_context.ts";
 import {
@@ -1215,4 +1231,275 @@ export async function handleWorkflowResume(
   }
 
   await subscribeUntilDetach(buffer, socket, requestId, controller);
+}
+
+export async function handleWorkflowCreate(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: WorkflowCreatePayload,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "write", {
+      kind: "workflow",
+      name: payload.name,
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createWorkflowCreateDeps(ctx.repoDir);
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      workflowCreate(libCtx, deps, { name: payload.name }),
+      {
+        creating: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "workflow.create",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "workflow_create_failed", message);
+  }
+}
+
+export async function handleWorkflowDelete(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: WorkflowDeletePayload,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "write", {
+      kind: "workflow",
+      name: payload.workflowIdOrName,
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createWorkflowDeleteDeps(ctx.repoDir, ctx.datastoreResolver);
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      workflowDelete(libCtx, deps, {
+        workflowIdOrName: payload.workflowIdOrName,
+      }),
+      {
+        deleting: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "workflow.delete",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "workflow_delete_failed", message);
+  }
+}
+
+export async function handleWorkflowEdit(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: WorkflowEditPayload,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "write", {
+      kind: "workflow",
+      name: payload.workflowIdOrName,
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createWorkflowEditDeps(
+      ctx.repoDir,
+      ctx.repoContext.workflowRepo,
+    );
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      workflowEdit(libCtx, deps, {
+        workflowIdOrName: payload.workflowIdOrName,
+        stdinContent: payload.content,
+      }),
+      {
+        resolving: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "workflow.edit",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "workflow_edit_failed", message);
+  }
+}
+
+export async function handleWorkflowValidate(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: WorkflowValidatePayload | undefined,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "read", {
+      kind: "workflow",
+      name: payload?.workflowIdOrName ?? "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createWorkflowValidateDeps(
+      ctx.repoContext.workflowRepo,
+      ctx.repoContext.definitionRepo,
+      workflowsDirFor(ctx.repoDir),
+    );
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      workflowValidate(libCtx, deps, {
+        workflowIdOrName: payload?.workflowIdOrName,
+      }),
+      {
+        resolving: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "workflow.validate",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "workflow_validate_failed", message);
+  }
+}
+
+export async function handleWorkflowEvaluate(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: WorkflowEvaluatePayload | undefined,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "read", {
+      kind: "workflow",
+      name: payload?.workflowIdOrName ?? "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createWorkflowEvaluateDeps(
+      ctx.repoDir,
+      ctx.repoContext.workflowRepo,
+      ctx.datastoreResolver,
+    );
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      workflowEvaluate(libCtx, deps, {
+        workflowIdOrName: payload?.workflowIdOrName,
+        inputs: payload?.inputs ?? {},
+      }),
+      {
+        evaluating: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "workflow.evaluate",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "workflow_evaluate_failed", message);
+  }
 }

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -438,6 +438,127 @@ export interface VaultMigratePayload {
   targetConfig?: Record<string, unknown>;
 }
 
+// ── Access token operations ──────────────────────────────────────────
+
+export type AccessTokenListPayload = Record<string, never>;
+
+export interface AccessTokenRevokePayload {
+  name: string;
+}
+
+export interface AccessTokenRotatePayload {
+  name: string;
+  durationMs?: number;
+  vaultName?: string;
+}
+
+// ── Model edit / type operations ────────────────────────────────────
+
+export interface ModelEditPayload {
+  modelIdOrName: string;
+  content?: string;
+}
+
+export interface ModelTypeDescribePayload {
+  typeArg: string;
+}
+
+export interface ModelTypeSearchPayload {
+  query?: string;
+}
+
+// ── Workflow CRUD operations ────────────────────────────────────────
+
+export interface WorkflowCreatePayload {
+  name: string;
+}
+
+export interface WorkflowDeletePayload {
+  workflowIdOrName: string;
+}
+
+export interface WorkflowEditPayload {
+  workflowIdOrName: string;
+  content?: string;
+}
+
+export interface WorkflowValidatePayload {
+  workflowIdOrName?: string;
+}
+
+export interface WorkflowEvaluatePayload {
+  workflowIdOrName?: string;
+  inputs?: Record<string, unknown>;
+}
+
+// ── Vault CRUD / audit operations ───────────────────────────────────
+
+export interface VaultCreatePayload {
+  vaultType: string;
+  name: string;
+  config?: Record<string, unknown>;
+  auditReads?: boolean;
+}
+
+export interface VaultEditPayload {
+  vaultNameOrId: string;
+  vaultType?: string;
+}
+
+export interface VaultAuditTrailPayload {
+  vaultName?: string;
+  secretKey?: string;
+  since?: string;
+  until?: string;
+  limit?: number;
+}
+
+export interface VaultReadSecretPayload {
+  vaultName: string;
+  secretKey: string;
+}
+
+export interface VaultTypeSearchPayload {
+  query?: string;
+}
+
+// ── Worker token operations ─────────────────────────────────────────
+
+export interface WorkerTokenCreatePayload {
+  name: string;
+  durationMs: number;
+  vaultName?: string;
+  maxEnrollments?: number | "unlimited";
+}
+
+export interface WorkerTokenListPayload {
+  showAll?: boolean;
+}
+
+export interface WorkerTokenRevokePayload {
+  name: string;
+}
+
+// ── Data / run housekeeping ─────────────────────────────────────────
+
+export interface DataGcPayload {
+  dryRun?: boolean;
+}
+
+export interface DataPrunePayload {
+  dryRun?: boolean;
+}
+
+export interface RunGcPayload {
+  dryRun?: boolean;
+  workflowRunRetentionDays?: number;
+  outputRetentionDays?: number;
+}
+
+// ── Datastore namespace ─────────────────────────────────────────────
+
+export type DatastoreNamespaceListPayload = Record<string, never>;
+
 // ── Doctor operations ────────────────────────────────────────────────
 
 export type DoctorVaultsPayload = Record<string, never>;
@@ -633,7 +754,82 @@ export type ServerRequest =
     payload?: RunDoctorPayload;
   }
   | { type: "run.attach"; id: string; payload: RunAttachPayload }
-  | { type: "cancel"; id: string };
+  | { type: "cancel"; id: string }
+  | {
+    type: "access.token.list";
+    id: string;
+    payload?: AccessTokenListPayload;
+  }
+  | {
+    type: "access.token.revoke";
+    id: string;
+    payload: AccessTokenRevokePayload;
+  }
+  | {
+    type: "access.token.rotate";
+    id: string;
+    payload: AccessTokenRotatePayload;
+  }
+  | { type: "model.edit"; id: string; payload: ModelEditPayload }
+  | {
+    type: "model.type.describe";
+    id: string;
+    payload: ModelTypeDescribePayload;
+  }
+  | {
+    type: "model.type.search";
+    id: string;
+    payload?: ModelTypeSearchPayload;
+  }
+  | { type: "workflow.create"; id: string; payload: WorkflowCreatePayload }
+  | { type: "workflow.delete"; id: string; payload: WorkflowDeletePayload }
+  | { type: "workflow.edit"; id: string; payload: WorkflowEditPayload }
+  | {
+    type: "workflow.validate";
+    id: string;
+    payload?: WorkflowValidatePayload;
+  }
+  | {
+    type: "workflow.evaluate";
+    id: string;
+    payload?: WorkflowEvaluatePayload;
+  }
+  | { type: "vault.create"; id: string; payload: VaultCreatePayload }
+  | { type: "vault.edit"; id: string; payload: VaultEditPayload }
+  | {
+    type: "vault.audit-trail";
+    id: string;
+    payload?: VaultAuditTrailPayload;
+  }
+  | { type: "vault.read-secret"; id: string; payload: VaultReadSecretPayload }
+  | {
+    type: "vault.type.search";
+    id: string;
+    payload?: VaultTypeSearchPayload;
+  }
+  | {
+    type: "worker.token.create";
+    id: string;
+    payload: WorkerTokenCreatePayload;
+  }
+  | {
+    type: "worker.token.list";
+    id: string;
+    payload?: WorkerTokenListPayload;
+  }
+  | {
+    type: "worker.token.revoke";
+    id: string;
+    payload: WorkerTokenRevokePayload;
+  }
+  | { type: "data.gc"; id: string; payload?: DataGcPayload }
+  | { type: "data.prune"; id: string; payload?: DataPrunePayload }
+  | { type: "run.gc"; id: string; payload?: RunGcPayload }
+  | {
+    type: "datastore.namespace.list";
+    id: string;
+    payload?: DatastoreNamespaceListPayload;
+  };
 
 // ── Outbound (server → client) ───────────────────────────────────────────
 
@@ -981,6 +1177,98 @@ export interface DoctorExtensionsResponse {
   data: Record<string, unknown>;
 }
 
+export interface AccessTokenListResponse {
+  data: Record<string, unknown>;
+}
+
+export interface AccessTokenRevokeResponse {
+  data: Record<string, unknown>;
+}
+
+export interface AccessTokenRotateResponse {
+  data: Record<string, unknown>;
+}
+
+export interface ModelEditResponse {
+  data: Record<string, unknown>;
+}
+
+export interface ModelTypeDescribeResponse {
+  data: Record<string, unknown>;
+}
+
+export interface ModelTypeSearchResponse {
+  data: Record<string, unknown>;
+}
+
+export interface WorkflowCreateResponse {
+  data: Record<string, unknown>;
+}
+
+export interface WorkflowDeleteResponse {
+  data: Record<string, unknown>;
+}
+
+export interface WorkflowEditResponse {
+  data: Record<string, unknown>;
+}
+
+export interface WorkflowValidateResponse {
+  data: Record<string, unknown>;
+}
+
+export interface WorkflowEvaluateResponse {
+  data: Record<string, unknown>;
+}
+
+export interface VaultCreateResponse {
+  data: Record<string, unknown>;
+}
+
+export interface VaultEditResponse {
+  data: Record<string, unknown>;
+}
+
+export interface VaultAuditTrailResponse {
+  data: Record<string, unknown>;
+}
+
+export interface VaultReadSecretResponse {
+  data: Record<string, unknown>;
+}
+
+export interface VaultTypeSearchResponse {
+  data: Record<string, unknown>;
+}
+
+export interface WorkerTokenCreateResponse {
+  data: Record<string, unknown>;
+}
+
+export interface WorkerTokenListResponse {
+  data: Record<string, unknown>;
+}
+
+export interface WorkerTokenRevokeResponse {
+  data: Record<string, unknown>;
+}
+
+export interface DataGcResponse {
+  data: Record<string, unknown>;
+}
+
+export interface DataPruneResponse {
+  data: Record<string, unknown>;
+}
+
+export interface RunGcResponse {
+  data: Record<string, unknown>;
+}
+
+export interface DatastoreNamespaceListResponse {
+  data: Record<string, unknown>;
+}
+
 export interface RunHistoryPayload {
   active?: boolean;
   all?: boolean;
@@ -1189,4 +1477,83 @@ export type ServerMessage =
     type: "run.interrupted";
     id: string;
     payload: { runId: string; instanceId: string; reason: "instance_dead" };
+  }
+  | {
+    type: "access.token.list";
+    id: string;
+    payload: AccessTokenListResponse;
+  }
+  | {
+    type: "access.token.revoke";
+    id: string;
+    payload: AccessTokenRevokeResponse;
+  }
+  | {
+    type: "access.token.rotate";
+    id: string;
+    payload: AccessTokenRotateResponse;
+  }
+  | { type: "model.edit"; id: string; payload: ModelEditResponse }
+  | {
+    type: "model.type.describe";
+    id: string;
+    payload: ModelTypeDescribeResponse;
+  }
+  | {
+    type: "model.type.search";
+    id: string;
+    payload: ModelTypeSearchResponse;
+  }
+  | { type: "workflow.create"; id: string; payload: WorkflowCreateResponse }
+  | { type: "workflow.delete"; id: string; payload: WorkflowDeleteResponse }
+  | { type: "workflow.edit"; id: string; payload: WorkflowEditResponse }
+  | {
+    type: "workflow.validate";
+    id: string;
+    payload: WorkflowValidateResponse;
+  }
+  | {
+    type: "workflow.evaluate";
+    id: string;
+    payload: WorkflowEvaluateResponse;
+  }
+  | { type: "vault.create"; id: string; payload: VaultCreateResponse }
+  | { type: "vault.edit"; id: string; payload: VaultEditResponse }
+  | {
+    type: "vault.audit-trail";
+    id: string;
+    payload: VaultAuditTrailResponse;
+  }
+  | {
+    type: "vault.read-secret";
+    id: string;
+    payload: VaultReadSecretResponse;
+  }
+  | {
+    type: "vault.type.search";
+    id: string;
+    payload: VaultTypeSearchResponse;
+  }
+  | {
+    type: "worker.token.create";
+    id: string;
+    payload: WorkerTokenCreateResponse;
+  }
+  | {
+    type: "worker.token.list";
+    id: string;
+    payload: WorkerTokenListResponse;
+  }
+  | {
+    type: "worker.token.revoke";
+    id: string;
+    payload: WorkerTokenRevokeResponse;
+  }
+  | { type: "data.gc"; id: string; payload: DataGcResponse }
+  | { type: "data.prune"; id: string; payload: DataPruneResponse }
+  | { type: "run.gc"; id: string; payload: RunGcResponse }
+  | {
+    type: "datastore.namespace.list";
+    id: string;
+    payload: DatastoreNamespaceListResponse;
   };


### PR DESCRIPTION
## Summary

Closes #1531

- Adds server-side WebSocket protocol handlers and client-side `--server` wiring for **23 CLI commands** that were previously local-only
- Each command gets: protocol payload/response types, Zod validation schema, dispatch case, server handler with authorization gate, and `withRemoteOptions()` CLI wiring
- All 23 commands verified end-to-end against a running `swamp serve` instance in both `--json` and `--log` output modes

### Commands added

| Domain | Commands |
|--------|----------|
| Access token | `list`, `revoke`, `rotate` (admin auth) |
| Model | `edit` (write), `type describe`, `type search` (read) |
| Workflow | `create`, `delete`, `edit` (write), `validate`, `evaluate` (read) |
| Vault | `create`, `edit` (write), `audit-trail`, `read-secret`, `type search` (read) |
| Worker token | `create`, `list`, `revoke` (admin auth) |
| Data housekeeping | `gc`, `prune` (write) |
| Run | `gc` (write) |
| Datastore | `namespace list` (read) |

### Deferred

- `model cancel` — requires fundamentally different server-side approach (local impl kills PIDs; server needs run-cancel protocol)
- Global `--server` option — separate follow-up to replace per-command `withRemoteOptions()` wrapping

## Test Plan

- 47 new tests in `connection_test.ts` covering schema validation for all 24 message types and authorization gates (admin, write, read resource checks, superuser bypass)
- All 23 commands tested end-to-end against a live `swamp serve --auth-mode token` instance
- Verified both `--json` and `--log` output modes render correctly via proper renderers
- `model edit` and `workflow edit` verified with valid YAML piped through stdin
- `vault read-secret` verified with full put→read cycle
- Worker token create/list/revoke verified with real token data
- Full test suite: 9941 passed, 0 failed (1 pre-existing flaky timing test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)