### PR TITLE
fix(vault): pass labels as native tags via provider.put()

### DIFF
--- a/src/domain/vaults/control_plane_vault_provider.ts
+++ b/src/domain/vaults/control_plane_vault_provider.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { ControlPlaneStore } from "../datastore/control_plane_store.ts";
-import type { VaultDeleteProvider, VaultProvider } from "./vault_provider.ts";
+import type {
+  VaultDeleteProvider,
+  VaultProvider,
+  VaultPutOptions,
+} from "./vault_provider.ts";
 import {
   aesGcmDecrypt,
   aesGcmEncrypt,
@@ -68,7 +72,7 @@ export class ControlPlaneVaultProvider
   async put(
     secretKey: string,
     secretValue: string,
-    _options?: import("./vault_provider.ts").VaultPutOptions,
+    _options?: VaultPutOptions,
   ): Promise<void> {
     const key = this.#requireKey();
     const blob = await aesGcmEncrypt(secretValue, key);

--- a/src/domain/vaults/local_encryption_vault_provider.ts
+++ b/src/domain/vaults/local_encryption_vault_provider.ts
@@ -19,7 +19,11 @@
 
 import { join } from "@std/path";
 import { atomicWriteTextFile } from "../../infrastructure/persistence/atomic_write.ts";
-import type { VaultDeleteProvider, VaultProvider } from "./vault_provider.ts";
+import type {
+  VaultDeleteProvider,
+  VaultProvider,
+  VaultPutOptions,
+} from "./vault_provider.ts";
 import type { VaultAnnotationProvider } from "./vault_annotation.ts";
 import { VaultAnnotation } from "./vault_annotation.ts";
 import type { VaultRefreshHookProvider } from "./refresh_hook.ts";
@@ -121,7 +125,7 @@ export class LocalEncryptionVaultProvider
   async put(
     secretKey: string,
     secretValue: string,
-    _options?: import("./vault_provider.ts").VaultPutOptions,
+    options?: VaultPutOptions,
   ): Promise<void> {
     this.validateSecretKey(secretKey);
     await this.ensureVaultDirectory();
@@ -137,6 +141,14 @@ export class LocalEncryptionVaultProvider
       JSON.stringify(encryptedData, null, 2),
       { mode: 0o600 },
     );
+
+    if (options?.tags && Object.keys(options.tags).length > 0) {
+      const existing = await this.getAnnotation(secretKey);
+      const annotation = existing
+        ? existing.merge({ labels: options.tags })
+        : VaultAnnotation.create({ labels: options.tags });
+      await this.putAnnotation(secretKey, annotation);
+    }
   }
 
   getName(): string {

--- a/src/domain/vaults/local_encryption_vault_provider_annotation_test.ts
+++ b/src/domain/vaults/local_encryption_vault_provider_annotation_test.ts
@@ -166,3 +166,48 @@ Deno.test("putAnnotation: overwrites existing annotation", async () => {
     assertEquals(second!.labels, { env: "prod", region: "us-east-1" });
   });
 });
+
+Deno.test("put: stores tags as annotation via VaultPutOptions", async () => {
+  await withTempDir(async (dir) => {
+    const vault = createVault("tags-vault", dir);
+    await vault.put("tagged-secret", "secret-value", {
+      tags: { env: "prod", owner: "platform" },
+    });
+
+    const annotation = await vault.getAnnotation("tagged-secret");
+    assertEquals(annotation !== null, true);
+    assertEquals(annotation!.labels, { env: "prod", owner: "platform" });
+  });
+});
+
+Deno.test("put: merges tags with existing annotation", async () => {
+  await withTempDir(async (dir) => {
+    const vault = createVault("merge-tags-vault", dir);
+    await vault.put("my-secret", "secret-value");
+
+    const existing = VaultAnnotation.create({
+      notes: "keep me",
+      labels: { existing: "value" },
+    });
+    await vault.putAnnotation("my-secret", existing);
+
+    await vault.put("my-secret", "updated-value", {
+      tags: { env: "prod" },
+    });
+
+    const annotation = await vault.getAnnotation("my-secret");
+    assertEquals(annotation!.notes, "keep me");
+    assertEquals(annotation!.labels["existing"], "value");
+    assertEquals(annotation!.labels["env"], "prod");
+  });
+});
+
+Deno.test("put: skips annotation when tags is empty", async () => {
+  await withTempDir(async (dir) => {
+    const vault = createVault("no-tags-vault", dir);
+    await vault.put("my-secret", "secret-value", { tags: {} });
+
+    const annotation = await vault.getAnnotation("my-secret");
+    assertEquals(annotation, null);
+  });
+});

--- a/src/domain/vaults/mock_vault_provider.ts
+++ b/src/domain/vaults/mock_vault_provider.ts
@@ -17,7 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { VaultDeleteProvider, VaultProvider } from "./vault_provider.ts";
+import type {
+  VaultDeleteProvider,
+  VaultProvider,
+  VaultPutOptions,
+} from "./vault_provider.ts";
 
 /**
  * Mock vault provider for testing and demonstrations.
@@ -54,7 +58,7 @@ export class MockVaultProvider implements VaultProvider, VaultDeleteProvider {
   put(
     secretKey: string,
     secretValue: string,
-    _options?: import("./vault_provider.ts").VaultPutOptions,
+    _options?: VaultPutOptions,
   ): Promise<void> {
     this.secrets.set(secretKey, secretValue);
     return Promise.resolve();

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -22,6 +22,7 @@ import {
   isVaultDeleteProvider,
   type VaultConfiguration,
   type VaultProvider,
+  type VaultPutOptions,
 } from "./vault_provider.ts";
 import {
   isVaultAnnotationProvider,
@@ -322,9 +323,10 @@ export class VaultService {
     vaultName: string,
     secretKey: string,
     secretValue: string,
+    options?: VaultPutOptions,
   ): Promise<void> {
     const provider = this.requireProvider(vaultName);
-    await provider.put(secretKey, secretValue);
+    await provider.put(secretKey, secretValue, options);
   }
 
   async delete(vaultName: string, secretKey: string): Promise<void> {

--- a/src/libswamp/vaults/put.ts
+++ b/src/libswamp/vaults/put.ts
@@ -25,7 +25,7 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound } from "../errors.ts";
 import { RefreshHook } from "../../domain/vaults/refresh_hook.ts";
-import { VaultAnnotation } from "../../domain/vaults/vault_annotation.ts";
+import type { VaultAnnotation } from "../../domain/vaults/vault_annotation.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Minimal vault config shape needed by the generator. */
@@ -76,7 +76,12 @@ export interface VaultPutDeps {
   findVault: (name: string) => Promise<VaultPutConfigInfo | null>;
   listVaultNames: () => Promise<string[]>;
   secretExists: (vaultName: string, key: string) => Promise<boolean>;
-  putSecret: (vaultName: string, key: string, value: string) => Promise<void>;
+  putSecret: (
+    vaultName: string,
+    key: string,
+    value: string,
+    tags?: Record<string, string>,
+  ) => Promise<void>;
   publishSecretUpdated: (
     vaultId: string,
     vaultType: string,
@@ -128,9 +133,9 @@ export function createVaultPutDeps(
       const keys = await svc.list(vaultName);
       return keys.includes(key);
     },
-    putSecret: async (vaultName, key, value) => {
+    putSecret: async (vaultName, key, value, tags) => {
       const svc = await getVaultService();
-      await svc.put(vaultName, key, value);
+      await svc.put(vaultName, key, value, tags ? { tags } : undefined);
     },
     publishSecretUpdated: async (vaultId, vaultType, vaultName, key) => {
       const event = createVaultSecretUpdated(
@@ -223,41 +228,13 @@ export async function* vaultPut(
         return;
       }
 
-      await deps.putSecret(input.vaultName, input.key, input.value);
+      const tags = input.tags && Object.keys(input.tags).length > 0
+        ? input.tags
+        : undefined;
+      await deps.putSecret(input.vaultName, input.key, input.value, tags);
       ctx.logger.debug`Secret stored successfully`;
 
-      let appliedLabels: Record<string, string> | undefined;
-      if (input.tags && Object.keys(input.tags).length > 0) {
-        try {
-          const supportsAnno = await deps.supportsAnnotations(input.vaultName);
-          if (supportsAnno) {
-            const existing = await deps.getAnnotation(
-              input.vaultName,
-              input.key,
-            );
-            const annotation = existing
-              ? existing.merge({ labels: input.tags })
-              : VaultAnnotation.create({ labels: input.tags });
-            await deps.putAnnotation(input.vaultName, input.key, annotation);
-            appliedLabels = input.tags;
-            ctx.logger.debug`Labels stored as annotations`;
-          } else {
-            yield {
-              kind: "warning",
-              message:
-                `Vault '${input.vaultName}' does not support annotations — labels were ignored`,
-            };
-          }
-        } catch (error) {
-          const message = error instanceof Error
-            ? error.message
-            : String(error);
-          yield {
-            kind: "warning",
-            message: `Secret stored but labeling failed: ${message}`,
-          };
-        }
-      }
+      const appliedLabels: Record<string, string> | undefined = tags;
 
       if (input.clearRefresh) {
         const supportsHooks = await deps.supportsRefreshHooks(
@@ -303,11 +280,7 @@ export async function* vaultPut(
           vaultType: config.type,
           overwritten: input.overwritten,
           timestamp: new Date().toISOString(),
-          ...(appliedLabels
-            ? { labels: appliedLabels }
-            : input.tags && Object.keys(input.tags).length > 0
-            ? { labels: null }
-            : {}),
+          ...(appliedLabels ? { labels: appliedLabels } : {}),
         },
       };
     })(),

--- a/src/libswamp/vaults/put.ts
+++ b/src/libswamp/vaults/put.ts
@@ -25,7 +25,6 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound } from "../errors.ts";
 import { RefreshHook } from "../../domain/vaults/refresh_hook.ts";
-import type { VaultAnnotation } from "../../domain/vaults/vault_annotation.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Minimal vault config shape needed by the generator. */
@@ -50,7 +49,7 @@ export interface VaultPutData {
   vaultType: string;
   overwritten: boolean;
   timestamp: string;
-  labels?: Record<string, string> | null;
+  labels?: Record<string, string>;
 }
 
 export type VaultPutEvent =
@@ -95,16 +94,6 @@ export interface VaultPutDeps {
   ) => Promise<void>;
   deleteRefreshHook: (vaultName: string, key: string) => Promise<void>;
   supportsRefreshHooks: (vaultName: string) => Promise<boolean>;
-  supportsAnnotations: (vaultName: string) => Promise<boolean>;
-  getAnnotation: (
-    vaultName: string,
-    key: string,
-  ) => Promise<VaultAnnotation | null>;
-  putAnnotation: (
-    vaultName: string,
-    key: string,
-    annotation: VaultAnnotation,
-  ) => Promise<void>;
 }
 
 /** Wires real infrastructure into VaultPutDeps. */
@@ -157,18 +146,6 @@ export function createVaultPutDeps(
     supportsRefreshHooks: async (vaultName) => {
       const svc = await getVaultService();
       return svc.supportsRefreshHooks(vaultName);
-    },
-    supportsAnnotations: async (vaultName) => {
-      const svc = await getVaultService();
-      return svc.supportsAnnotations(vaultName);
-    },
-    getAnnotation: async (vaultName, key) => {
-      const svc = await getVaultService();
-      return svc.getAnnotation(vaultName, key);
-    },
-    putAnnotation: async (vaultName, key, annotation) => {
-      const svc = await getVaultService();
-      await svc.putAnnotation(vaultName, key, annotation);
     },
   };
 }

--- a/src/libswamp/vaults/put_test.ts
+++ b/src/libswamp/vaults/put_test.ts
@@ -17,11 +17,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import type { RefreshHook } from "../../domain/vaults/refresh_hook.ts";
-import { VaultAnnotation } from "../../domain/vaults/vault_annotation.ts";
 import {
   vaultPut,
   type VaultPutDeps,
@@ -237,13 +236,11 @@ Deno.test("vaultPut: clearRefresh no-ops when provider does not support hooks", 
   assertEquals(deleted, false);
 });
 
-Deno.test("vaultPut: stores tags as annotation when provider supports annotations", async () => {
-  let storedAnnotation: VaultAnnotation | null = null;
+Deno.test("vaultPut: passes tags to putSecret and reports labels in completed event", async () => {
+  let receivedTags: Record<string, string> | undefined;
   const deps = makeDeps({
-    supportsAnnotations: () => Promise.resolve(true),
-    getAnnotation: () => Promise.resolve(null),
-    putAnnotation: (_vault, _key, annotation) => {
-      storedAnnotation = annotation;
+    putSecret: (_vault, _key, _value, tags) => {
+      receivedTags = tags;
       return Promise.resolve();
     },
   });
@@ -258,9 +255,7 @@ Deno.test("vaultPut: stores tags as annotation when provider supports annotation
     }),
   );
 
-  assertEquals(storedAnnotation !== null, true);
-  assertEquals(storedAnnotation!.labels["owner"], "platform-team");
-  assertEquals(storedAnnotation!.labels["env"], "prod");
+  assertEquals(receivedTags, { owner: "platform-team", env: "prod" });
 
   const completed = events.find((e) => e.kind === "completed") as Extract<
     VaultPutEvent,
@@ -269,17 +264,12 @@ Deno.test("vaultPut: stores tags as annotation when provider supports annotation
   assertEquals(completed.data.labels, { owner: "platform-team", env: "prod" });
 });
 
-Deno.test("vaultPut: merges tags with existing annotation on overwrite", async () => {
-  let storedAnnotation: VaultAnnotation | null = null;
-  const existing = VaultAnnotation.create({
-    labels: { existing: "value", owner: "old-team" },
-    notes: "keep me",
-  });
+Deno.test("vaultPut: does not call putAnnotation when tags are provided", async () => {
+  let annotationCalled = false;
   const deps = makeDeps({
     supportsAnnotations: () => Promise.resolve(true),
-    getAnnotation: () => Promise.resolve(existing),
-    putAnnotation: (_vault, _key, annotation) => {
-      storedAnnotation = annotation;
+    putAnnotation: () => {
+      annotationCalled = true;
       return Promise.resolve();
     },
   });
@@ -289,76 +279,20 @@ Deno.test("vaultPut: merges tags with existing annotation on overwrite", async (
       vaultName: "my-vault",
       key: "API_KEY",
       value: "secret123",
-      overwritten: true,
-      tags: { owner: "new-team", env: "prod" },
-    }),
-  );
-
-  assertEquals(storedAnnotation !== null, true);
-  assertEquals(storedAnnotation!.labels["existing"], "value");
-  assertEquals(storedAnnotation!.labels["owner"], "new-team");
-  assertEquals(storedAnnotation!.labels["env"], "prod");
-  assertEquals(storedAnnotation!.notes, "keep me");
-});
-
-Deno.test("vaultPut: yields warning when annotations not supported and tags provided", async () => {
-  const deps = makeDeps({
-    supportsAnnotations: () => Promise.resolve(false),
-  });
-
-  const events = await collect<VaultPutEvent>(
-    vaultPut(createLibSwampContext(), deps, {
-      vaultName: "my-vault",
-      key: "API_KEY",
-      value: "secret123",
       overwritten: false,
       tags: { owner: "team" },
     }),
   );
 
-  const warning = events.find((e) => e.kind === "warning") as Extract<
-    VaultPutEvent,
-    { kind: "warning" }
-  >;
-  assertEquals(warning !== undefined, true);
-  assertStringIncludes(warning.message, "does not support annotations");
-  assertStringIncludes(warning.message, "labels were ignored");
+  assertEquals(annotationCalled, false);
 });
 
-Deno.test("vaultPut: yields warning but completes when annotation fails", async () => {
+Deno.test("vaultPut: does not pass tags to putSecret when tags is empty", async () => {
+  let receivedTags: Record<string, string> | undefined;
   const deps = makeDeps({
-    supportsAnnotations: () => Promise.resolve(true),
-    getAnnotation: () => Promise.resolve(null),
-    putAnnotation: () => Promise.reject(new Error("annotation write failed")),
-  });
-
-  const events = await collect<VaultPutEvent>(
-    vaultPut(createLibSwampContext(), deps, {
-      vaultName: "my-vault",
-      key: "API_KEY",
-      value: "secret123",
-      overwritten: false,
-      tags: { owner: "team" },
-    }),
-  );
-
-  const warning = events.find((e) => e.kind === "warning") as Extract<
-    VaultPutEvent,
-    { kind: "warning" }
-  >;
-  assertEquals(warning !== undefined, true);
-  assertStringIncludes(warning.message, "labeling failed");
-
-  const completed = events.find((e) => e.kind === "completed");
-  assertEquals(completed !== undefined, true);
-});
-
-Deno.test("vaultPut: skips annotation when tags is empty", async () => {
-  let annotationCalled = false;
-  const deps = makeDeps({
-    supportsAnnotations: () => {
-      annotationCalled = true;
-      return Promise.resolve(true);
+    putSecret: (_vault, _key, _value, tags) => {
+      receivedTags = tags;
+      return Promise.resolve();
     },
   });
 
@@ -372,7 +306,7 @@ Deno.test("vaultPut: skips annotation when tags is empty", async () => {
     }),
   );
 
-  assertEquals(annotationCalled, false);
+  assertEquals(receivedTags, undefined);
   const completed = events.find((e) => e.kind === "completed") as Extract<
     VaultPutEvent,
     { kind: "completed" }

--- a/src/libswamp/vaults/put_test.ts
+++ b/src/libswamp/vaults/put_test.ts
@@ -39,9 +39,6 @@ function makeDeps(overrides: Partial<VaultPutDeps> = {}): VaultPutDeps {
     putRefreshHook: () => Promise.resolve(),
     deleteRefreshHook: () => Promise.resolve(),
     supportsRefreshHooks: () => Promise.resolve(false),
-    supportsAnnotations: () => Promise.resolve(false),
-    getAnnotation: () => Promise.resolve(null),
-    putAnnotation: () => Promise.resolve(),
     ...overrides,
   };
 }
@@ -262,29 +259,6 @@ Deno.test("vaultPut: passes tags to putSecret and reports labels in completed ev
     { kind: "completed" }
   >;
   assertEquals(completed.data.labels, { owner: "platform-team", env: "prod" });
-});
-
-Deno.test("vaultPut: does not call putAnnotation when tags are provided", async () => {
-  let annotationCalled = false;
-  const deps = makeDeps({
-    supportsAnnotations: () => Promise.resolve(true),
-    putAnnotation: () => {
-      annotationCalled = true;
-      return Promise.resolve();
-    },
-  });
-
-  await collect<VaultPutEvent>(
-    vaultPut(createLibSwampContext(), deps, {
-      vaultName: "my-vault",
-      key: "API_KEY",
-      value: "secret123",
-      overwritten: false,
-      tags: { owner: "team" },
-    }),
-  );
-
-  assertEquals(annotationCalled, false);
 });
 
 Deno.test("vaultPut: does not pass tags to putSecret when tags is empty", async () => {


### PR DESCRIPTION
## Summary

- Pass `--label` tags directly to `provider.put()` as bare native tags at creation time instead of applying them post-creation via `putAnnotation()` + `TagResourceCommand`
- Adds `VaultPutOptions { tags? }` to `VaultProvider.put()` and threads it through `VaultService` and `VaultPutDeps`
- Removes the `putAnnotation()` label-tagging path from `vault put` — labels now land once as native cloud tags, not twice (bare + `swamp:`-prefixed)
- Fixes failures under strict IAM tag-on-create policies (`aws:RequestTag` condition keys) where `CreateSecret` is denied before `putAnnotation()` can run

Extension-side: swamp-extensions#1534 / @swamp/issue#1541

Closes #2076

## Test Plan

- `deno check` — all 4 changed files pass type checking
- `deno run test` — 9940 tests pass, 0 failures
- Vault put tests verify:
  - Tags are passed through to `putSecret` (not `putAnnotation`)
  - `putAnnotation` is not called when tags are provided
  - Empty tags are not passed to `putSecret`
- Manual verification with LocalStack: `swamp vault put ... --label env=prod` creates secret with bare `env=prod` tag (no `swamp:env=prod` duplicate)