### PR TITLE
feat(serve): add --restricted-commands flag for admin-only commands

### DIFF
--- a/integration/serve_run_test.ts
+++ b/integration/serve_run_test.ts
@@ -115,6 +115,7 @@ async function withServeRepo(
         oauthProvider: "https://swamp-club.com",
         groupsField: "collectives",
         restrictedModelTypes: [],
+        restrictedCommands: [],
       },
     };
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -341,6 +341,12 @@ export function collectServeExtraArgs(options: AnyOptions): string[] {
       options.restrictedModelTypes as string,
     );
   }
+  if (options.restrictedCommands) {
+    args.push(
+      "--restricted-commands",
+      options.restrictedCommands as string,
+    );
+  }
   if (options.groupRefreshInterval) {
     args.push(
       "--group-refresh-interval",
@@ -542,6 +548,10 @@ const daemonEnableCommand = new Command()
   .option(
     "--restricted-model-types <types:string>",
     "Comma-separated model types that require admin authority to create or run (e.g. command/shell). Requires --auth-mode token or oauth",
+  )
+  .option(
+    "--restricted-commands <cmds:string>",
+    "Comma-separated server commands that require admin authority (e.g. datastore.namespace.list,extension.install). Requires --auth-mode token or oauth",
   )
   .option(
     "--group-refresh-interval <duration:string>",
@@ -862,6 +872,10 @@ export const serveCommand = new Command()
     "Comma-separated model types that require admin authority to create or run (e.g. command/shell). Requires --auth-mode token or oauth",
   )
   .option(
+    "--restricted-commands <cmds:string>",
+    "Comma-separated server commands that require admin authority (e.g. datastore.namespace.list,extension.install). Requires --auth-mode token or oauth",
+  )
+  .option(
     "--group-refresh-interval <duration:string>",
     "How often to re-fetch IdP group memberships for active server tokens (env: SWAMP_GROUP_REFRESH_INTERVAL). " +
       "Accepts seconds (14400), explicit units (4h, 30m), or 0 to disable. Default: 4h. Requires --auth-mode oauth.",
@@ -1029,6 +1043,7 @@ export const serveCommand = new Command()
       oauthClientId: merged.oauthClientId,
       groupsField: merged.groupsField,
       restrictedModelTypes: merged.restrictedModelTypes,
+      restrictedCommands: merged.restrictedCommands,
     });
 
     if (authConfig.mode === "none" && authConfig.admins.length > 0) {
@@ -1044,6 +1059,16 @@ export const serveCommand = new Command()
     ) {
       logger.warn(
         "--restricted-model-types is set but --auth-mode is {mode} — type restrictions will have no effect",
+        { mode: authConfig.mode },
+      );
+    }
+
+    if (
+      authConfig.mode === "none" &&
+      authConfig.restrictedCommands.length > 0
+    ) {
+      logger.warn(
+        "--restricted-commands is set but --auth-mode is {mode} — command restrictions will have no effect",
         { mode: authConfig.mode },
       );
     }

--- a/src/domain/access/serve_auth_config.ts
+++ b/src/domain/access/serve_auth_config.ts
@@ -32,6 +32,7 @@ export interface ServeAuthConfig {
   oauthClientId?: string;
   groupsField: string;
   restrictedModelTypes: string[];
+  restrictedCommands: string[];
 }
 
 const VALID_AUTH_MODES: ReadonlySet<string> = new Set([
@@ -51,6 +52,7 @@ export interface ServeAuthConfigInput {
   oauthClientId?: string;
   groupsField?: string;
   restrictedModelTypes?: string;
+  restrictedCommands?: string;
 }
 
 function parseCommaSeparated(value: string | undefined): string[] {
@@ -97,6 +99,7 @@ export function buildServeAuthConfig(
   const restrictedModelTypes = parseCommaSeparated(
     input.restrictedModelTypes,
   ).map((t) => ModelType.create(t).normalized);
+  const restrictedCommands = parseCommaSeparated(input.restrictedCommands);
 
   if (admins.length > 0) {
     validateAdmins(admins, mode);
@@ -150,5 +153,6 @@ export function buildServeAuthConfig(
     oauthClientId,
     groupsField,
     restrictedModelTypes,
+    restrictedCommands,
   };
 }

--- a/src/domain/access/serve_auth_config_test.ts
+++ b/src/domain/access/serve_auth_config_test.ts
@@ -286,6 +286,23 @@ Deno.test("buildServeAuthConfig: restrictedModelTypes defaults to empty", () => 
   assertEquals(config.restrictedModelTypes, []);
 });
 
+Deno.test("buildServeAuthConfig: restrictedCommands defaults to empty", () => {
+  const config = buildServeAuthConfig({});
+  assertEquals(config.restrictedCommands, []);
+});
+
+Deno.test("buildServeAuthConfig: restrictedCommands parses comma-separated list", () => {
+  const config = buildServeAuthConfig({
+    restrictedCommands:
+      "datastore.namespace.list, extension.install, vault.put",
+  });
+  assertEquals(config.restrictedCommands, [
+    "datastore.namespace.list",
+    "extension.install",
+    "vault.put",
+  ]);
+});
+
 Deno.test("buildServeAuthConfig: restrictedModelTypes parses and normalizes types", () => {
   const config = buildServeAuthConfig({
     restrictedModelTypes: "command/shell, AWS::Lambda::Function",

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -145,6 +145,7 @@ import {
 import {
   authorizeOrReject,
   type ConnectionContext,
+  isRestrictedCommand,
   MAX_PREDICATE_LENGTH,
   MAX_QUERY_RESULTS,
   send,
@@ -1344,6 +1345,21 @@ export function handleMessage(
 
   const controller = new AbortController();
   activeRequests.set(request.id, controller);
+
+  if (
+    isRestrictedCommand(request.type, ctx.authConfig.restrictedCommands)
+  ) {
+    if (
+      !authorizeOrReject(socket, request.id, principal, "admin", {
+        kind: "access",
+        name: request.type,
+        fields: {},
+      }, ctx)
+    ) {
+      activeRequests.delete(request.id);
+      return;
+    }
+  }
 
   let task: Promise<void>;
   switch (request.type) {

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -412,6 +412,7 @@ const modeNoneConfig: ServeAuthConfig = {
   oauthProvider: "",
   groupsField: "",
   restrictedModelTypes: [],
+  restrictedCommands: [],
 };
 
 const modeTokenConfig: ServeAuthConfig = {
@@ -422,6 +423,7 @@ const modeTokenConfig: ServeAuthConfig = {
   oauthProvider: "",
   groupsField: "",
   restrictedModelTypes: [],
+  restrictedCommands: [],
 };
 
 const testPrincipal: Principal = { kind: "user", id: "adam" };
@@ -1077,6 +1079,7 @@ const restrictedConfig: ServeAuthConfig = {
   oauthProvider: "",
   groupsField: "",
   restrictedModelTypes: ["command/shell"],
+  restrictedCommands: [],
 };
 
 Deno.test("restrictedModelTypes: non-admin denied run on restricted type", async () => {
@@ -1199,6 +1202,116 @@ Deno.test("restrictedModelTypes: non-restricted type still allowed for non-admin
         methodName: "apply",
         typeArg: "terraform/aws",
         definitionName: "my-terraform",
+      },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  const unauthorizedErrors = mock.sent
+    .map((s) => JSON.parse(s))
+    .filter((m) =>
+      m.type === "error" &&
+      (m.error as Record<string, unknown>).code === "unauthorized"
+    );
+  assertEquals(unauthorizedErrors.length, 0);
+});
+
+// ── restrictedCommands: admin-only enforcement via config ─────────────────
+
+const restrictedCommandConfig: ServeAuthConfig = {
+  mode: "token",
+  admins: [],
+  allowedCollectives: [],
+  allowedUsers: [],
+  oauthProvider: "",
+  groupsField: "",
+  restrictedModelTypes: [],
+  restrictedCommands: ["model.search"],
+};
+
+Deno.test("restrictedCommands: non-admin denied on restricted command", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(restrictedCommandConfig, [lowPrivGrant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "model.search",
+      id: "rc-denied-1",
+      payload: { query: "test" },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  const errorMessage = String(
+    (msg.error as Record<string, unknown>).message,
+  );
+  assertStringIncludes(errorMessage, "admin");
+  assertStringIncludes(errorMessage, "access:");
+  assertStringIncludes(errorMessage, "model.search");
+});
+
+Deno.test("restrictedCommands: admin can use restricted command", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const adminGrant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    actions: ["admin"],
+    resource: { kind: "access", pattern: "*" },
+  });
+  const ctx = makeCtx(restrictedCommandConfig, [adminGrant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "model.search",
+      id: "rc-admin-1",
+      payload: { query: "test" },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  const unauthorizedErrors = mock.sent
+    .map((s) => JSON.parse(s))
+    .filter((m) =>
+      m.type === "error" &&
+      (m.error as Record<string, unknown>).code === "unauthorized"
+    );
+  assertEquals(unauthorizedErrors.length, 0);
+});
+
+Deno.test("restrictedCommands: non-restricted command still allowed for non-admin", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(restrictedCommandConfig, [lowPrivGrant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "model.method.run",
+      id: "rc-allowed-1",
+      payload: {
+        modelIdOrName: "my-model",
+        methodName: "run",
+        typeArg: "terraform/aws",
+        definitionName: "my-model",
       },
     })),
     testPrincipal,

--- a/src/serve/device_auth_handler_test.ts
+++ b/src/serve/device_auth_handler_test.ts
@@ -38,6 +38,7 @@ function makeMockDeps(
       oauthClientId: "test-client-id",
       groupsField: "collectives",
       restrictedModelTypes: [],
+      restrictedCommands: [],
     },
     repoDir: "/tmp/test-repo",
     repoContext: {} as RepositoryContext,

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -155,6 +155,14 @@ export function isAdminOnlyModelType(
   return false;
 }
 
+export function isRestrictedCommand(
+  command: string,
+  restrictedCommands: readonly string[],
+): boolean {
+  if (restrictedCommands.length === 0) return false;
+  return restrictedCommands.includes(command);
+}
+
 const connectionCollectives = new WeakMap<WebSocket, readonly string[]>();
 const connectionGroups = new WeakMap<WebSocket, readonly string[]>();
 const connectionPrincipalId = new WeakMap<WebSocket, string>();

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -68,6 +68,7 @@ export interface ServeConfigFile {
     "oauth-client-id"?: string;
     "groups-field"?: string;
     "restricted-model-types"?: string[];
+    "restricted-commands"?: string[];
     "group-refresh-interval"?: string;
   };
   tls?: {
@@ -122,6 +123,7 @@ const KNOWN_AUTH_KEYS = new Set([
   "oauth-client-id",
   "groups-field",
   "restricted-model-types",
+  "restricted-commands",
   "group-refresh-interval",
 ]);
 
@@ -495,6 +497,7 @@ export interface MergedServeOptions {
   oauthClientId?: string;
   groupsField?: string;
   restrictedModelTypes?: string;
+  restrictedCommands?: string;
   groupRefreshInterval?: string;
   trustProxy: boolean;
   wsIdleTimeout?: string;
@@ -686,6 +689,13 @@ export function mergeServeOptions(
     undefined,
   );
 
+  const restrictedCommands = resolveString(
+    "restricted-commands",
+    cliOptions.restrictedCommands as string | undefined,
+    config?.auth?.["restricted-commands"]?.join(","),
+    undefined,
+  );
+
   const groupRefreshInterval = resolveString(
     "group-refresh-interval",
     cliOptions.groupRefreshInterval as string | undefined,
@@ -791,6 +801,7 @@ export function mergeServeOptions(
     oauthClientId,
     groupsField,
     restrictedModelTypes,
+    restrictedCommands,
     groupRefreshInterval,
     trustProxy,
     wsIdleTimeout,

--- a/src/serve/serve_config_test.ts
+++ b/src/serve/serve_config_test.ts
@@ -443,6 +443,7 @@ Deno.test("mergeServeOptions: auth config arrays converted to comma-separated st
       "allowed-collectives": ["eng", "ops"],
       "allowed-users": ["carol"],
       "restricted-model-types": ["command/shell", "command/exec"],
+      "restricted-commands": ["extension.install", "vault.put"],
     },
   };
   const cliOptions = {};
@@ -460,6 +461,7 @@ Deno.test("mergeServeOptions: auth config arrays converted to comma-separated st
   assertEquals(merged.allowedCollectives, "eng,ops");
   assertEquals(merged.allowedUsers, "carol");
   assertEquals(merged.restrictedModelTypes, "command/shell,command/exec");
+  assertEquals(merged.restrictedCommands, "extension.install,vault.put");
 });
 
 Deno.test("mergeServeOptions: CLI webhooks replace config webhooks", () => {


### PR DESCRIPTION
## Summary

- Adds `--restricted-commands` flag (and `auth.restricted-commands` in `serve.yaml`) that restricts specified server commands to admin-only access
- Follows the same pattern as `--restricted-model-types`: comma-separated list, requires `--auth-mode token` or `oauth`, warns when `auth-mode` is `none`
- Enforcement is centralized before the WebSocket dispatch switch, so all ~90 server commands are covered without per-handler changes
- Non-admin users get a clear error message naming the restricted command (e.g. `"does not have 'admin' on access:datastore.namespace.list"`)

## Test Plan

- [x] Unit tests for `buildServeAuthConfig` parsing (defaults to empty, parses comma-separated list)
- [x] Unit tests for `mergeServeOptions` config file merge (`restricted-commands` array → comma string)
- [x] Connection tests for enforcement (non-admin denied, admin allowed, non-restricted command allowed)
- [x] All existing test fixtures updated with `restrictedCommands: []`
- [x] Compiled binary, started `swamp serve` with `--restricted-commands model.search,extension.install`, minted tokens, and verified over live WebSocket: regular user denied with clear error, admin allowed, non-restricted commands unaffected
- [x] All 9947 tests pass, lint and fmt clean