### PR TITLE
feat(vault): add optional tags parameter to VaultProvider.put()

### DIFF
--- a/packages/testing/mod.ts
+++ b/packages/testing/mod.ts
@@ -89,6 +89,7 @@ export {
   type VaultAnnotationData,
   type VaultAnnotationProvider,
   type VaultProvider,
+  type VaultPutOptions,
 } from "./vault_types.ts";
 
 export {

--- a/packages/testing/vault_conformance.ts
+++ b/packages/testing/vault_conformance.ts
@@ -155,6 +155,17 @@ export interface VaultConformanceOptions {
   keyPrefix?: string;
   /** Delete test keys after the test (default: true). */
   cleanup?: boolean;
+  /**
+   * When true, tests that put() forwards tags to the provider.
+   * Only enable for providers that support provider-native tags.
+   * Requires a getStoredTags callback to verify tag storage.
+   */
+  testTags?: boolean;
+  /**
+   * Callback to retrieve tags stored for a secret key.
+   * Required when testTags is true.
+   */
+  getStoredTags?: (secretKey: string) => Record<string, string> | undefined;
 }
 
 /**
@@ -256,6 +267,45 @@ export async function assertVaultConformance(
       true,
       "get() must reject for a key that was never put()",
     );
+
+    // tag pass-through (opt-in)
+    if (options?.testTags) {
+      assertExists(
+        options.getStoredTags,
+        "getStoredTags callback is required when testTags is true",
+      );
+      const tagKey = `${prefix}tagged-${crypto.randomUUID().slice(0, 8)}`;
+      const testTags = { env: "test", team: "platform" };
+      await provider.put(tagKey, "tagged-value", { tags: testTags });
+      createdKeys.push(tagKey);
+
+      const storedTags = options.getStoredTags(tagKey);
+      assertExists(
+        storedTags,
+        "getStoredTags() must return tags for a key that was put() with tags",
+      );
+      assertEquals(
+        storedTags["env"],
+        "test",
+        "stored tags must include the tags passed to put()",
+      );
+      assertEquals(
+        storedTags["team"],
+        "platform",
+        "stored tags must include the tags passed to put()",
+      );
+
+      // put without tags should not create tags
+      const noTagKey = `${prefix}no-tags-${crypto.randomUUID().slice(0, 8)}`;
+      await provider.put(noTagKey, "untagged-value");
+      createdKeys.push(noTagKey);
+      const noTags = options.getStoredTags(noTagKey);
+      assertEquals(
+        noTags,
+        undefined,
+        "getStoredTags() must return undefined for a key put() without tags",
+      );
+    }
   } finally {
     if (cleanup) {
       // Best-effort cleanup — don't fail the test if cleanup fails.

--- a/packages/testing/vault_conformance_test.ts
+++ b/packages/testing/vault_conformance_test.ts
@@ -122,11 +122,43 @@ Deno.test("assertVaultConformance: passes for conforming in-memory vault", async
   await assertVaultConformance(vault, { cleanup: false });
 });
 
+Deno.test("assertVaultConformance: passes with testTags enabled", async () => {
+  const { vault, getStoredTags } = createVaultTestContext();
+  await assertVaultConformance(vault, {
+    cleanup: false,
+    testTags: true,
+    getStoredTags,
+  });
+});
+
 Deno.test("assertVaultConformance: passes with pre-seeded vault", async () => {
   const { vault } = createVaultTestContext({
     secrets: { "existing-key": "existing-value" },
   });
   await assertVaultConformance(vault, { cleanup: false });
+});
+
+Deno.test("createVaultTestContext: put stores tags and getStoredTags retrieves them", async () => {
+  const { vault, getStoredTags } = createVaultTestContext();
+  await vault.put("my-key", "my-value", {
+    tags: { env: "prod", team: "platform" },
+  });
+  const stored = getStoredTags("my-key");
+  assertEquals(stored, { env: "prod", team: "platform" });
+});
+
+Deno.test("createVaultTestContext: put without tags yields undefined from getStoredTags", async () => {
+  const { vault, getStoredTags } = createVaultTestContext();
+  await vault.put("my-key", "my-value");
+  assertEquals(getStoredTags("my-key"), undefined);
+});
+
+Deno.test("createVaultTestContext: getStoredTags returns copy not reference", async () => {
+  const { vault, getStoredTags } = createVaultTestContext();
+  await vault.put("my-key", "my-value", { tags: { env: "prod" } });
+  const stored = getStoredTags("my-key")!;
+  stored["env"] = "mutated";
+  assertEquals(getStoredTags("my-key")!["env"], "prod");
 });
 
 Deno.test("assertVaultConformance: detects broken get (returns wrong value)", async () => {

--- a/packages/testing/vault_test_context.ts
+++ b/packages/testing/vault_test_context.ts
@@ -21,6 +21,7 @@ import type {
   VaultAnnotation,
   VaultAnnotationProvider,
   VaultProvider,
+  VaultPutOptions,
 } from "./vault_types.ts";
 
 /** A recorded vault operation for inspection. */
@@ -62,6 +63,8 @@ export interface VaultTestContextResult {
   annotationProvider: VaultAnnotationProvider | undefined;
   /** Returns all secrets currently stored in the vault. */
   getStoredSecrets(): Record<string, string>;
+  /** Returns tags stored for a given secret key, or undefined if none. */
+  getStoredTags(secretKey: string): Record<string, string> | undefined;
   /** Returns all vault operations recorded during the test. */
   getOperations(): VaultOperation[];
   /** Returns operations filtered by method name. */
@@ -94,6 +97,7 @@ export function createVaultTestContext(
   const secrets = new Map<string, string>(
     Object.entries(options?.secrets ?? {}),
   );
+  const tags = new Map<string, Record<string, string>>();
   const annotations = new Map<string, VaultAnnotation>();
   const operations: VaultOperation[] = [];
   const name = options?.name ?? "test-vault";
@@ -125,9 +129,16 @@ export function createVaultTestContext(
       return Promise.resolve(secret);
     },
 
-    put(secretKey: string, secretValue: string): Promise<void> {
+    put(
+      secretKey: string,
+      secretValue: string,
+      putOptions?: VaultPutOptions,
+    ): Promise<void> {
       record("put", secretKey, secretValue);
       secrets.set(secretKey, secretValue);
+      if (putOptions?.tags && Object.keys(putOptions.tags).length > 0) {
+        tags.set(secretKey, { ...putOptions.tags });
+      }
       return Promise.resolve();
     },
 
@@ -176,6 +187,10 @@ export function createVaultTestContext(
     vault,
     annotationProvider,
     getStoredSecrets: () => Object.fromEntries(secrets),
+    getStoredTags: (secretKey: string) => {
+      const stored = tags.get(secretKey);
+      return stored ? { ...stored } : undefined;
+    },
     getOperations: () => [...operations],
     getOperationsByMethod: (method) =>
       operations.filter((op) => op.method === method),

--- a/packages/testing/vault_types.ts
+++ b/packages/testing/vault_types.ts
@@ -26,6 +26,14 @@
  */
 
 /**
+ * Options for the VaultProvider.put() method.
+ */
+export interface VaultPutOptions {
+  /** Provider-native tags to attach to the secret at creation time. */
+  tags?: Record<string, string>;
+}
+
+/**
  * Interface for vault providers that securely store and retrieve secrets.
  *
  * Extension authors implement this interface to create custom vault backends.
@@ -34,7 +42,11 @@ export interface VaultProvider {
   /** Retrieves a secret value from the vault. */
   get(secretKey: string): Promise<string>;
   /** Stores a secret value in the vault. */
-  put(secretKey: string, secretValue: string): Promise<void>;
+  put(
+    secretKey: string,
+    secretValue: string,
+    options?: VaultPutOptions,
+  ): Promise<void>;
   /** Lists all secret keys in the vault (names only, not values). */
   list(): Promise<string[]>;
   /** Gets the name/type of this vault provider. */

--- a/src/domain/vaults/control_plane_vault_provider.ts
+++ b/src/domain/vaults/control_plane_vault_provider.ts
@@ -65,7 +65,11 @@ export class ControlPlaneVaultProvider
     return await aesGcmDecrypt(blob, key);
   }
 
-  async put(secretKey: string, secretValue: string): Promise<void> {
+  async put(
+    secretKey: string,
+    secretValue: string,
+    _options?: import("./vault_provider.ts").VaultPutOptions,
+  ): Promise<void> {
     const key = this.#requireKey();
     const blob = await aesGcmEncrypt(secretValue, key);
     const encoded = new TextEncoder().encode(JSON.stringify(blob));

--- a/src/domain/vaults/local_encryption_vault_provider.ts
+++ b/src/domain/vaults/local_encryption_vault_provider.ts
@@ -118,7 +118,11 @@ export class LocalEncryptionVaultProvider
     }
   }
 
-  async put(secretKey: string, secretValue: string): Promise<void> {
+  async put(
+    secretKey: string,
+    secretValue: string,
+    _options?: import("./vault_provider.ts").VaultPutOptions,
+  ): Promise<void> {
     this.validateSecretKey(secretKey);
     await this.ensureVaultDirectory();
 

--- a/src/domain/vaults/mock_vault_provider.ts
+++ b/src/domain/vaults/mock_vault_provider.ts
@@ -51,7 +51,11 @@ export class MockVaultProvider implements VaultProvider, VaultDeleteProvider {
     return Promise.resolve(secret);
   }
 
-  put(secretKey: string, secretValue: string): Promise<void> {
+  put(
+    secretKey: string,
+    secretValue: string,
+    _options?: import("./vault_provider.ts").VaultPutOptions,
+  ): Promise<void> {
     this.secrets.set(secretKey, secretValue);
     return Promise.resolve();
   }

--- a/src/domain/vaults/testing_package_compat_test.ts
+++ b/src/domain/vaults/testing_package_compat_test.ts
@@ -47,11 +47,23 @@ function _checkVaultProviderFields(vault: TestingVaultProvider) {
     "key",
     "value",
   );
+  const _putWithTagsResult: ReturnType<CanonicalVaultProvider["put"]> = vault
+    .put(
+      "key",
+      "value",
+      { tags: { env: "test" } },
+    );
   const _listResult: ReturnType<CanonicalVaultProvider["list"]> = vault.list();
   const _getNameResult: ReturnType<CanonicalVaultProvider["getName"]> = vault
     .getName();
 
-  void [_getResult, _putResult, _listResult, _getNameResult];
+  void [
+    _getResult,
+    _putResult,
+    _putWithTagsResult,
+    _listResult,
+    _getNameResult,
+  ];
 }
 
 // VaultAnnotationProvider: verify the testing type's methods match the canonical type.

--- a/src/domain/vaults/vault_provider.ts
+++ b/src/domain/vaults/vault_provider.ts
@@ -18,6 +18,14 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
+ * Options for the VaultProvider.put() method.
+ */
+export interface VaultPutOptions {
+  /** Provider-native tags to attach to the secret at creation time. */
+  tags?: Record<string, string>;
+}
+
+/**
  * Interface for vault providers that can securely store and retrieve secrets.
  */
 export interface VaultProvider {
@@ -35,9 +43,14 @@ export interface VaultProvider {
    *
    * @param secretKey - The key identifier for the secret
    * @param secretValue - The secret value to store
+   * @param options - Optional settings including provider-native tags
    * @throws Error if the secret cannot be stored
    */
-  put(secretKey: string, secretValue: string): Promise<void>;
+  put(
+    secretKey: string,
+    secretValue: string,
+    options?: VaultPutOptions,
+  ): Promise<void>;
 
   /**
    * Lists all secret keys in the vault.


### PR DESCRIPTION
## Summary

- Adds `VaultPutOptions` interface with optional `tags` field to `VaultProvider.put()` in both the canonical domain type (`src/domain/vaults/vault_provider.ts`) and the `@systeminit/swamp-testing` package (`packages/testing/vault_types.ts`)
- Updates all three internal VaultProvider implementations (Mock, ControlPlane, LocalEncryption) to accept the new optional parameter
- Adds opt-in tag conformance testing to `assertVaultConformance` via `testTags` and `getStoredTags` options
- Updates `createVaultTestContext` in-memory vault to store tags and expose them via `getStoredTags()`
- Updates type compatibility test to verify the new `put()` signature

This aligns the interface with the tag-on-create support already shipped in the vault extensions (`@swamp/aws-sm`, `@swamp/azure-kv`, `@swamp/1password`) from swamp-extensions issue #1534.

Closes #1541

## Test Plan

- `deno check` passes (only pre-existing unrelated error in `reconcile_from_disk_bench.ts`)
- `deno fmt --check` passes
- `deno lint` passes
- All vault conformance tests pass (17 total, 4 new):
  - `assertVaultConformance: passes with testTags enabled`
  - `createVaultTestContext: put stores tags and getStoredTags retrieves them`
  - `createVaultTestContext: put without tags yields undefined from getStoredTags`
  - `createVaultTestContext: getStoredTags returns copy not reference`
- Type compatibility test passes (`testing_package_compat_test.ts`)
- All existing vault domain tests pass (mock, control plane, local encryption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)