### PR TITLE
fix(serve): harden HA concurrency controls, token transport, and boot resilience

### DIFF
--- a/.claude/skills/swamp/references/workflow/references/expressions-and-foreach.md
+++ b/.claude/skills/swamp/references/workflow/references/expressions-and-foreach.md
@@ -358,9 +358,10 @@ A hard reference to a missing field surfaces an error and the run does not
 start. The rest of the workflow reads extracted values as normal inputs
 (`${{ inputs.identifier }}`).
 
-**Security:** `webhook.headers` values are not redacted. Avoid forwarding
-sensitive headers into model attributes — they would be stored in `.swamp/data/`
-and visible in `swamp data get` output.
+**Security:** Sensitive `webhook.headers` values (authentication, proxy
+credentials, and headers ending in `-token` or `-secret`) are redacted before
+the payload is exposed to workflow expressions. Redacted headers are omitted
+entirely, so a workflow referencing one will fail on the missing field.
 
 ## Data Artifact Tracking
 

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -203,9 +203,11 @@ trigger:
 
 swamp's CEL has no `??` operator — guard optional payload fields with the
 `has()` macro and a ternary: `has(x.y) ? x.y : fallback`. A hard reference to a
-missing field surfaces an error and the run does not start. Header values are
-not redacted (the same caveat as `env`). See `design/workflow.md` for the full
-walkthrough.
+missing field surfaces an error and the run does not start. Sensitive headers
+(authentication, proxy credentials, and headers ending in `-token` or `-secret`)
+are redacted before the payload is exposed to workflow expressions — redacted
+headers are omitted entirely, so a workflow referencing one will fail on the
+missing field. See `design/workflow.md` for the full walkthrough.
 
 **Run-scoped resource keys** — use `run.id` to prevent collisions when the
 same workflow runs concurrently:

--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -124,10 +124,9 @@ swamp worker connect wss://orch:9090 \
   --label tier=ci
 ```
 
-The CLI appends the server token as a `?token=` query parameter to the
-WebSocket URL before connecting, using the same `appendTokenToUrl` helper as
-`--server` commands. This avoids leaking the token in `SWAMP_ORCHESTRATOR_URL`
-environment dumps or process listings.
+The CLI sends the server token via the `Authorization: Bearer` header on the
+WebSocket upgrade request. This avoids leaking the token in URL query
+parameters, which would appear in reverse proxy and load balancer access logs.
 
 ### A symmetric control protocol, two handler registries
 
@@ -196,14 +195,16 @@ provided, so `export SWAMP_SERVE_URL=wss://demo.swamp-club.ai` avoids
 repeating the URL on every invocation. The explicit flag takes precedence when
 both are set.
 
-When `--auth-mode token` is active, the server validates a `?token=name.secret`
-query parameter at WebSocket upgrade time via the `swamp/server-token` model's
-`redeem` method (timing-safe, vault-backed). Unauthenticated connections receive
-HTTP 401. The client resolves the token from (in precedence order) the
-`--token` flag, the `SWAMP_SERVER_TOKEN` + `SWAMP_SERVER_URL` env vars, or
-stored credentials in `~/.config/swamp/servers.json` (managed by
-`swamp auth server-login`). Token management is through
-`swamp access token mint/list/revoke`.
+When `--auth-mode token` is active, the server validates the token presented at
+WebSocket upgrade time via the `swamp/server-token` model's `redeem` method
+(timing-safe, vault-backed). The server accepts the token via `Authorization:
+Bearer`, the `Sec-WebSocket-Protocol` subprotocol, or a `?token=` query
+parameter (in that priority order). The CLI sends it via the `Authorization`
+header. Unauthenticated connections receive HTTP 401. The client resolves the
+token from (in precedence order) the `--token` flag, the `SWAMP_SERVER_TOKEN` +
+`SWAMP_SERVER_URL` env vars, or stored credentials in
+`~/.config/swamp/servers.json` (managed by `swamp auth server-login`). Token
+management is through `swamp access token mint/list/revoke`.
 
 When `--auth-mode oauth` is active, users authenticate via the OAuth device
 grant flow (RFC 8628) against swamp-club. The server acts as an OAuth client
@@ -230,7 +231,7 @@ The flow:
 
 After the device flow, OAuth-minted tokens are indistinguishable from
 manually-minted tokens. The WebSocket upgrade, cancel endpoint, and all
-handler authorization use the same `?token=<name>.<secret>` +
+handler authorization use the same `<name>.<secret>` token +
 `authenticateServerToken` path for both modes. The only difference is
 collectives: the `authorizeOrReject` function reads collectives from the
 token record (via a per-connection WeakMap set at upgrade time), enabling
@@ -254,11 +255,12 @@ v1 is swamp-club-specific: the OAuth client endpoint paths
 The `--oauth-provider` flag accepts a custom URL but only swamp-club is
 tested.
 
-The token travels as a `?token=` query parameter on the WebSocket upgrade URL.
-This avoids the browser WebSocket limitation (no custom headers), but the
-plaintext will appear in any reverse proxy or load balancer access logs that
-capture the full request URL. Use TLS (`wss://`) for non-loopback deployments
-and configure access-log redaction on any intermediary that fronts the server.
+The CLI sends the token via the `Authorization: Bearer` header on the WebSocket
+upgrade request. The server also accepts the `Sec-WebSocket-Protocol`
+subprotocol and `?token=` query parameter (for backward compatibility with older
+clients), but the header transport is preferred because it keeps credentials out
+of URL paths that reverse proxies and CDNs log. Use TLS (`wss://`) for
+non-loopback deployments.
 
 ### Extra headers for reverse proxies and tunnels
 

--- a/integration/serve_run_test.ts
+++ b/integration/serve_run_test.ts
@@ -279,6 +279,7 @@ async function withDetachedServeRepo(
         oauthProvider: "https://swamp-club.com",
         groupsField: "collectives",
         restrictedModelTypes: [],
+        restrictedCommands: [],
       },
       activeRunRegistry: registry,
       cancelRegistry: new RunCancelRegistry(),

--- a/integration/serve_run_test.ts
+++ b/integration/serve_run_test.ts
@@ -42,6 +42,8 @@ import { requireInitializedRepoUnlocked } from "../src/cli/repo_context.ts";
 import { handleConnection } from "../src/serve/connection.ts";
 import { DefaultDatastorePathResolver } from "../src/infrastructure/persistence/default_datastore_path_resolver.ts";
 import { runWorkflowOverServer } from "../src/cli/remote_run.ts";
+import { ActiveRunRegistry } from "../src/serve/active_run_registry.ts";
+import { RunCancelRegistry } from "../src/serve/run_cancel_registry.ts";
 import { createWorkflowRunRenderer } from "../src/presentation/renderers/workflow_run.ts";
 import type { WorkflowRunEvent } from "../src/libswamp/mod.ts";
 
@@ -202,5 +204,182 @@ Deno.test({
       }, UserError);
       assertStringIncludes(error.message, "not found");
     });
+  },
+});
+
+// ── Detached run path (with ActiveRunRegistry) ──────────────────────────
+
+async function withDetachedServeRepo(
+  registryOpts: { maxConcurrent?: number; maxPerPrincipal?: number },
+  fn: (args: {
+    repoDir: string;
+    url: string;
+    registry: ActiveRunRegistry;
+  }) => Promise<void>,
+): Promise<void> {
+  const repoDir = await Deno.makeTempDir({ prefix: "swamp-serve-detach-" });
+  let shutdown: (() => Promise<void>) | null = null;
+  const registry = new ActiveRunRegistry(registryOpts);
+  try {
+    await consumeStream(
+      repoInit(
+        createLibSwampContext({}),
+        createRepoInitDeps("20260101.120000.0"),
+        { path: repoDir, force: false, version: "20260101.120000.0" },
+      ),
+      withDefaults({
+        error: (event) => {
+          throw new Error(String(event.error?.message ?? "repo init failed"));
+        },
+      }),
+    );
+
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "detach-demo",
+      jobs: [
+        Job.create({
+          name: "main",
+          steps: [
+            Step.create({
+              name: "echo",
+              task: StepTask.directExecution(
+                "command/shell",
+                "detach-shell",
+                "execute",
+                { run: "echo detach-ok" },
+              ),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const {
+      repoDir: resolvedRepoDir,
+      repoContext,
+      datastoreConfig,
+      syncService,
+    } = await requireInitializedRepoUnlocked({ repoDir, outputMode: "log" });
+    const connectionCtx = {
+      repoDir: resolvedRepoDir,
+      repoContext,
+      datastoreConfig,
+      datastoreResolver: new DefaultDatastorePathResolver(
+        resolvedRepoDir,
+        datastoreConfig,
+      ),
+      syncService,
+      authConfig: {
+        mode: "none" as const,
+        admins: [],
+        allowedCollectives: [],
+        allowedUsers: [],
+        oauthProvider: "https://swamp-club.com",
+        groupsField: "collectives",
+        restrictedModelTypes: [],
+      },
+      activeRunRegistry: registry,
+      cancelRegistry: new RunCancelRegistry(),
+    };
+
+    const server = Deno.serve(
+      { port: 0, hostname: "127.0.0.1", onListen: () => {} },
+      (req) => {
+        const upgrade = req.headers.get("upgrade") ?? "";
+        if (upgrade.toLowerCase() === "websocket") {
+          const { socket, response } = Deno.upgradeWebSocket(req);
+          handleConnection(socket, connectionCtx, null);
+          return response;
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    );
+    shutdown = () => server.shutdown();
+    await fn({
+      repoDir,
+      url: `ws://127.0.0.1:${server.addr.port}`,
+      registry,
+    });
+  } finally {
+    await shutdown?.();
+    await Deno.remove(repoDir, { recursive: true }).catch(() => {});
+  }
+}
+
+Deno.test({
+  name:
+    "serve detached: workflow runs through the detached path, events stream, completion settles",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withDetachedServeRepo({}, async ({ url, registry }) => {
+      const kinds: string[] = [];
+      for await (
+        const event of runWorkflowOverServer({
+          server: url,
+          payload: { workflowIdOrName: "detach-demo" },
+        })
+      ) {
+        kinds.push(event.kind);
+      }
+
+      assertEquals(kinds.includes("started"), true);
+      assertEquals(kinds.at(-1), "completed");
+
+      await registry.drainAll(5_000);
+      assertEquals(registry.size, 0);
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "serve detached: rejected registration returns error, no run in registry",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withDetachedServeRepo(
+      { maxConcurrent: 1 },
+      async ({ url, registry }) => {
+        // Start run 1 without consuming all events (let it detach),
+        // then try run 2 while the slot is full.
+        const iterable = runWorkflowOverServer({
+          server: url,
+          payload: { workflowIdOrName: "detach-demo" },
+        });
+        const iter = iterable[Symbol.asyncIterator]();
+
+        // Read first event (started) — run is now registered
+        const first = await iter.next();
+        assertEquals(first.done, false);
+        assertEquals(registry.size, 1);
+
+        // Try a second run while slot is full
+        const error = await assertRejects(async () => {
+          for await (
+            const _ of runWorkflowOverServer({
+              server: url,
+              payload: { workflowIdOrName: "detach-demo" },
+            })
+          ) { /* consume */ }
+        }, UserError);
+
+        // Verify rejection message contains no numeric limit
+        assertEquals(error.message.includes("100"), false);
+        assertEquals(error.message.includes("limit:"), false);
+        assertStringIncludes(error.message, "Too many concurrent runs");
+
+        // Drain the first run
+        let done = false;
+        while (!done) {
+          const r = await iter.next();
+          done = r.done ?? false;
+        }
+        await registry.drainAll(5_000);
+        assertEquals(registry.size, 0);
+      },
+    );
   },
 });

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -149,7 +149,10 @@ import {
   replayPendingRuns,
   sweepStaleRecords,
 } from "../../serve/boot_reconciliation.ts";
-import { InstanceHeartbeatService } from "../../serve/instance_heartbeat.ts";
+import {
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+  InstanceHeartbeatService,
+} from "../../serve/instance_heartbeat.ts";
 import { FileSystemControlPlaneStore } from "../../infrastructure/persistence/fs_control_plane_store.ts";
 import type { ControlPlaneStore } from "../../domain/datastore/control_plane_store.ts";
 import { installUnhandledRejectionGuard } from "../../serve/unhandled_rejection_guard.ts";
@@ -930,6 +933,22 @@ export const serveCommand = new Command()
       "Only effective with a control-plane-capable datastore (env: SWAMP_RECONCILIATION_INTERVAL)",
   )
   .option(
+    "--max-concurrent-runs <count:integer>",
+    "Maximum number of concurrent detached runs across all principals. Default: 100. " +
+      "(env: SWAMP_MAX_CONCURRENT_RUNS)",
+  )
+  .option(
+    "--max-runs-per-principal <count:integer>",
+    "Maximum number of concurrent detached runs per authenticated principal. " +
+      "Unset by default (no per-principal limit). (env: SWAMP_MAX_RUNS_PER_PRINCIPAL)",
+  )
+  .option(
+    "--max-run-duration <duration:string>",
+    "Maximum wall-clock time a detached run may execute before being aborted. " +
+      "Accepts seconds (3600), explicit units (1h, 30m). Unset by default (no limit). " +
+      "(env: SWAMP_MAX_RUN_DURATION)",
+  )
+  .option(
     "--hot-reload",
     "Enable SIGHUP-based hot-reload for pulled extension bundles. " +
       "Writes a PID file to .swamp/serve.pid; use 'swamp serve reload' to trigger a reload",
@@ -1033,6 +1052,39 @@ export const serveCommand = new Command()
     const reconciliationIntervalMs = reconciliationIntervalRaw !== undefined
       ? parseTimeout(reconciliationIntervalRaw, "--reconciliation-interval")
       : undefined;
+
+    const maxConcurrentRuns = merged.maxConcurrentRuns;
+    if (
+      maxConcurrentRuns !== undefined &&
+      (!Number.isInteger(maxConcurrentRuns) || maxConcurrentRuns < 1)
+    ) {
+      throw new UserError(
+        `--max-concurrent-runs must be a positive integer, got ${maxConcurrentRuns}`,
+      );
+    }
+    const maxRunsPerPrincipal = merged.maxRunsPerPrincipal;
+    if (
+      maxRunsPerPrincipal !== undefined &&
+      (!Number.isInteger(maxRunsPerPrincipal) || maxRunsPerPrincipal < 1)
+    ) {
+      throw new UserError(
+        `--max-runs-per-principal must be a positive integer, got ${maxRunsPerPrincipal}`,
+      );
+    }
+    const maxRunDurationRaw = merged.maxRunDuration !== undefined
+      ? String(merged.maxRunDuration)
+      : undefined;
+    const maxRunDurationMs = maxRunDurationRaw !== undefined
+      ? parseTimeout(maxRunDurationRaw, "--max-run-duration")
+      : undefined;
+    const MAX_SETTIMEOUT_MS = 2_147_483_647;
+    if (
+      maxRunDurationMs !== undefined && maxRunDurationMs > MAX_SETTIMEOUT_MS
+    ) {
+      throw new UserError(
+        `--max-run-duration (${maxRunDurationRaw}) exceeds the maximum safe timer duration (~24.8 days)`,
+      );
+    }
 
     const authConfig = buildServeAuthConfig({
       authMode: merged.authMode,
@@ -1321,15 +1373,19 @@ export const serveCommand = new Command()
       }
     }
 
-    if (
-      hasRemoteControlPlane &&
-      staleTtlMs !== undefined && heartbeatIntervalMs !== undefined &&
-      staleTtlMs < heartbeatIntervalMs * 2
-    ) {
-      throw new UserError(
-        `--stale-ttl (${staleTtlRaw}) must be at least 2x --heartbeat-interval (${heartbeatIntervalRaw}), ` +
-          "otherwise live instances will appear stale",
-      );
+    if (hasRemoteControlPlane) {
+      const effectiveStaleTtl = staleTtlMs ?? DEFAULT_STALE_TTL_MS;
+      const effectiveHeartbeat = heartbeatIntervalMs ??
+        DEFAULT_HEARTBEAT_INTERVAL_MS;
+      if (effectiveStaleTtl < effectiveHeartbeat * 2) {
+        const staleTtlLabel = staleTtlRaw ?? `${DEFAULT_STALE_TTL_MS}ms`;
+        const heartbeatLabel = heartbeatIntervalRaw ??
+          `${DEFAULT_HEARTBEAT_INTERVAL_MS}ms`;
+        throw new UserError(
+          `--stale-ttl (${staleTtlLabel}) must be at least 2x --heartbeat-interval (${heartbeatLabel}), ` +
+            "otherwise live instances will appear stale",
+        );
+      }
     }
 
     if (hasRemoteControlPlane) {
@@ -1357,6 +1413,7 @@ export const serveCommand = new Command()
       // namespaced path — root keys are no longer addressable — so we
       // use a sentinel to skip re-migration on subsequent boots.
       const rootRecords = new Map<string, Uint8Array>();
+      const rootReadErrors: Array<{ prefix: string; error: Error }> = [];
       if (serveNamespace) {
         const rootStore = syncService.controlPlaneStore!();
         for (
@@ -1376,14 +1433,10 @@ export const serveCommand = new Command()
               if (data) rootRecords.set(key, new Uint8Array(data));
             }
           } catch (err) {
-            logger.warn(
-              "Failed to read root control-plane records under {prefix}: {error}",
-              {
-                prefix,
-                error: err instanceof Error ? err.message : String(err),
-              },
-            );
-            throw err;
+            rootReadErrors.push({
+              prefix,
+              error: err instanceof Error ? err : new Error(String(err)),
+            });
           }
         }
       }
@@ -1395,7 +1448,28 @@ export const serveCommand = new Command()
         namespace: serveNamespace,
       });
 
-      if (serveNamespace && rootRecords.size > 0) {
+      if (serveNamespace && rootReadErrors.length > 0) {
+        const namespacedStore = syncService.controlPlaneStore!();
+        const sentinel = await namespacedStore.get(MIGRATION_SENTINEL);
+        if (sentinel) {
+          for (const { prefix, error } of rootReadErrors) {
+            logger.debug(
+              "Root read failed for {prefix} (migration already complete): {error}",
+              { prefix, error: error.message },
+            );
+          }
+        } else {
+          throw new Error(
+            `Cannot complete namespace migration: root control-plane read failed for ` +
+              `${rootReadErrors.map((e) => e.prefix).join(", ")}: ` +
+              rootReadErrors[0].error.message,
+          );
+        }
+      }
+
+      if (
+        serveNamespace && rootRecords.size > 0 && rootReadErrors.length === 0
+      ) {
         const namespacedStore = syncService.controlPlaneStore!();
         const sentinel = await namespacedStore.get(MIGRATION_SENTINEL);
         if (!sentinel) {
@@ -1850,7 +1924,11 @@ export const serveCommand = new Command()
 
     const cancelRegistry = new RunCancelRegistry();
     const detachRuns = merged.detachRuns;
-    const activeRunRegistry = new ActiveRunRegistry();
+    const activeRunRegistry = new ActiveRunRegistry({
+      maxConcurrent: maxConcurrentRuns,
+      maxPerPrincipal: maxRunsPerPrincipal,
+      maxRunDurationMs,
+    });
 
     if (detachRuns) {
       logger.warn(
@@ -2620,7 +2698,14 @@ export const serveCommand = new Command()
               clearRateLimit(cancelRemoteAddr);
 
               const cancelPrincipal = parsePrincipal(authResult.principalId);
-              if (policySnapshotLoader) {
+              if (!policySnapshotLoader) {
+                return Response.json({
+                  status: "error",
+                  message:
+                    "Authorization enforcement is enabled but no policy snapshot is available",
+                }, { status: 403 });
+              }
+              {
                 const service = policySnapshotLoader.decisionService;
                 const decision = service.decide(
                   {
@@ -2685,6 +2770,9 @@ export const serveCommand = new Command()
               }, { status: 400 });
             }
             let count = cancelRegistry.cancelAll(typeFilter);
+            if (activeRunRegistry) {
+              count += activeRunRegistry.cancelAll(typeFilter);
+            }
             if (
               (!typeFilter || typeFilter === "workflow-run") &&
               scheduledExecution

--- a/src/cli/commands/worker_connect.ts
+++ b/src/cli/commands/worker_connect.ts
@@ -34,7 +34,6 @@ import { VERSION } from "./version.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 import { parseTimeout } from "../duration_parser.ts";
 import { resolveExtraHeaders } from "../../domain/auth/extra_headers.ts";
-import { appendTokenToUrl } from "../remote_run.ts";
 
 // Import models barrel so built-in models resolve from the worker's own
 // registry when a `builtin:` bundle fingerprint is dispatched.
@@ -230,10 +229,14 @@ export const workerConnectCommand = new Command()
     });
 
     try {
-      const extraHeaders = resolveExtraHeaders();
-      const authenticatedUrl = appendTokenToUrl(url, serverToken);
+      const extraHeaders: Record<string, string> = {
+        ...resolveExtraHeaders(),
+      };
+      if (serverToken) {
+        extraHeaders["Authorization"] = `Bearer ${serverToken}`;
+      }
       const result = await runWorker({
-        url: authenticatedUrl,
+        url,
         token,
         labels,
         swampVersion: VERSION,

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -26,10 +26,10 @@
  * drains until the server confirms.
  *
  * Authentication: when `--auth-mode token` is active on the server, the
- * client appends `?token=<name>.<secret>` to the WebSocket URL. The token
- * comes from (in precedence order): the `--token` flag, the
- * `SWAMP_SERVER_TOKEN` env var, or the `~/.config/swamp/servers.json` file
- * via `ServerCredentialRepository`.
+ * client sends the token via the `Authorization: Bearer` header on the
+ * WebSocket upgrade request. The token comes from (in precedence order):
+ * the `--token` flag, the `SWAMP_SERVER_TOKEN` env var, or the
+ * `~/.config/swamp/servers.json` file via `ServerCredentialRepository`.
  */
 
 import type { Command } from "@cliffy/command";
@@ -80,18 +80,6 @@ export interface ServerRunOptions {
   headers?: Record<string, string>;
   /** Test seam: WebSocket factory. */
   createSocket?: (url: string, headers?: Record<string, string>) => WebSocket;
-}
-
-/**
- * Appends a `?token=` query parameter to a WebSocket URL for server token
- * authentication. Returns the original URL unmodified when no token is
- * provided.
- */
-export function appendTokenToUrl(url: string, token?: string): string {
-  if (!token) return url;
-  const parsed = new URL(url);
-  parsed.searchParams.set("token", token);
-  return parsed.href;
 }
 
 /**
@@ -193,10 +181,16 @@ export function requestServerResponse<T>(
   request: { type: string; id?: string; payload?: unknown },
 ): Promise<T> {
   const baseUrl = normalizeServerUrl(options.server);
-  const url = appendTokenToUrl(baseUrl, options.token);
-  const headers = options.headers ?? resolveExtraHeaders();
+  const extraHeaders = options.headers ?? resolveExtraHeaders();
+  const headers: Record<string, string> = { ...extraHeaders };
+  if (options.token) {
+    headers["Authorization"] = `Bearer ${options.token}`;
+  }
   const requestId = request.id ?? crypto.randomUUID();
-  const socket = (options.createSocket ?? defaultCreateSocket)(url, headers);
+  const socket = (options.createSocket ?? defaultCreateSocket)(
+    baseUrl,
+    headers,
+  );
   const timeoutMs = options.timeoutMs ?? REQUEST_RESPONSE_TIMEOUT_MS;
 
   const raw = new Promise<T>((resolve, reject) => {
@@ -426,10 +420,16 @@ async function* singleConnectionStream(
   StreamOutcome
 > {
   const baseUrl = normalizeServerUrl(options.server);
-  const url = appendTokenToUrl(baseUrl, options.token);
-  const headers = options.headers ?? resolveExtraHeaders();
+  const extraHeaders = options.headers ?? resolveExtraHeaders();
+  const headers: Record<string, string> = { ...extraHeaders };
+  if (options.token) {
+    headers["Authorization"] = `Bearer ${options.token}`;
+  }
   const requestId = crypto.randomUUID();
-  const socket = (options.createSocket ?? defaultCreateSocket)(url, headers);
+  const socket = (options.createSocket ?? defaultCreateSocket)(
+    baseUrl,
+    headers,
+  );
 
   const queue: ServerMessage[] = [];
   let wake: (() => void) | null = null;

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -25,7 +25,6 @@ import {
 } from "@std/assert";
 import { UserError } from "../domain/errors.ts";
 import {
-  appendTokenToUrl,
   normalizeServerUrl,
   probeServerHealth,
   requestServerResponse,
@@ -395,30 +394,6 @@ Deno.test({
       await server.shutdown();
     }
   },
-});
-
-// ── appendTokenToUrl tests ──────────────────────────────────────────────
-
-Deno.test("appendTokenToUrl: appends token as query param", () => {
-  const result = appendTokenToUrl(
-    "ws://localhost:9090/",
-    "adam-token.secret123",
-  );
-  assertEquals(result, "ws://localhost:9090/?token=adam-token.secret123");
-});
-
-Deno.test("appendTokenToUrl: returns unchanged URL when no token", () => {
-  const url = "ws://localhost:9090/";
-  assertEquals(appendTokenToUrl(url), url);
-  assertEquals(appendTokenToUrl(url, undefined), url);
-});
-
-Deno.test("appendTokenToUrl: preserves existing path", () => {
-  const result = appendTokenToUrl(
-    "wss://swamp.acme.internal:9090/api",
-    "tok.sec",
-  );
-  assertEquals(result, "wss://swamp.acme.internal:9090/api?token=tok.sec");
 });
 
 // ── resolveServerToken tests ────────────────────────────────────────────
@@ -996,6 +971,165 @@ Deno.test({
         ) {}
       }, UserError);
       assertStringIncludes(error.message, "closed before the run completed");
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+// ── Token transport tests ─────────────────────────────────────────────
+
+Deno.test({
+  name:
+    "requestServerResponse: sends token via Authorization header, not query param",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    let capturedUrl: string | undefined;
+    let capturedAuthHeader: string | null | undefined;
+    const server = Deno.serve(
+      { port: 0, hostname: "127.0.0.1", onListen: () => {} },
+      (req) => {
+        capturedUrl = req.url;
+        capturedAuthHeader = req.headers.get("authorization");
+        const { socket, response } = Deno.upgradeWebSocket(req);
+        socket.onmessage = (event) => {
+          const parsed = JSON.parse(event.data as string);
+          socket.send(JSON.stringify({
+            type: parsed.type,
+            id: parsed.id,
+            payload: { ok: true },
+          }));
+        };
+        return response;
+      },
+    );
+    try {
+      const url = `ws://127.0.0.1:${server.addr.port}`;
+      await requestServerResponse<{ ok: boolean }>(
+        { server: url, token: "mytoken.secret" },
+        { type: "test" },
+      );
+      assertEquals(capturedAuthHeader, "Bearer mytoken.secret");
+      const parsedUrl = new URL(capturedUrl!);
+      assertEquals(parsedUrl.searchParams.has("token"), false);
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name: "requestServerResponse: extra headers passed alongside Authorization",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    let capturedAuthHeader: string | null | undefined;
+    let capturedCustomHeader: string | null | undefined;
+    const server = Deno.serve(
+      { port: 0, hostname: "127.0.0.1", onListen: () => {} },
+      (req) => {
+        capturedAuthHeader = req.headers.get("authorization");
+        capturedCustomHeader = req.headers.get("x-custom");
+        const { socket, response } = Deno.upgradeWebSocket(req);
+        socket.onmessage = (event) => {
+          const parsed = JSON.parse(event.data as string);
+          socket.send(JSON.stringify({
+            type: parsed.type,
+            id: parsed.id,
+            payload: { ok: true },
+          }));
+        };
+        return response;
+      },
+    );
+    try {
+      const url = `ws://127.0.0.1:${server.addr.port}`;
+      await requestServerResponse<{ ok: boolean }>(
+        {
+          server: url,
+          token: "tok.sec",
+          headers: { "X-Custom": "proxy-value" },
+        },
+        { type: "test" },
+      );
+      assertEquals(capturedAuthHeader, "Bearer tok.sec");
+      assertEquals(capturedCustomHeader, "proxy-value");
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "remote run: reconnect sends Authorization header, not query param token",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const capturedHeaders: (string | null)[] = [];
+    const capturedUrls: string[] = [];
+    let connectionCount = 0;
+    const server = Deno.serve(
+      { port: 0, hostname: "127.0.0.1", onListen: () => {} },
+      (req) => {
+        capturedHeaders.push(req.headers.get("authorization"));
+        capturedUrls.push(req.url);
+        connectionCount++;
+        const { socket, response } = Deno.upgradeWebSocket(req);
+        socket.onmessage = (event) => {
+          const parsed = JSON.parse(event.data as string);
+          if (parsed.type === "workflow.run") {
+            socket.send(JSON.stringify({
+              type: "event",
+              id: parsed.id,
+              event: {
+                kind: "started",
+                runId: "run-abc",
+                workflowName: "wf",
+                seq: 1,
+              },
+            }));
+            setTimeout(() => socket.close(), 20);
+          } else if (parsed.type === "run.attach") {
+            socket.send(JSON.stringify({
+              type: "run.attached",
+              id: parsed.id,
+              payload: {
+                runId: "run-abc",
+                kind: "workflow-run",
+                startedAt: "2026-08-01T00:00:00Z",
+              },
+            }));
+            socket.send(JSON.stringify({
+              type: "event",
+              id: parsed.id,
+              event: { kind: "completed", status: "succeeded", seq: 2 },
+            }));
+            socket.send(JSON.stringify({ type: "done", id: parsed.id }));
+          }
+        };
+        return response;
+      },
+    );
+    try {
+      const url = `ws://127.0.0.1:${server.addr.port}`;
+      for await (
+        const _ of runWorkflowOverServer({
+          server: url,
+          token: "tok.reconnect-secret",
+          payload: { workflowIdOrName: "wf" },
+        })
+      ) { /* consume */ }
+      assertEquals(connectionCount >= 2, true);
+      for (let i = 0; i < capturedHeaders.length; i++) {
+        assertEquals(
+          capturedHeaders[i],
+          "Bearer tok.reconnect-secret",
+        );
+        const parsed = new URL(capturedUrls[i]);
+        assertEquals(parsed.searchParams.has("token"), false);
+      }
     } finally {
       await server.shutdown();
     }

--- a/src/domain/models/active_run.ts
+++ b/src/domain/models/active_run.ts
@@ -194,6 +194,8 @@ export class ActiveRun {
 
   isStale(ttlMs: number): boolean {
     if (this._status !== "running") return false;
-    return Date.now() - this._heartbeatAt.getTime() > ttlMs;
+    const heartbeatTime = this._heartbeatAt.getTime();
+    if (isNaN(heartbeatTime)) return true;
+    return Date.now() - heartbeatTime > ttlMs;
   }
 }

--- a/src/domain/models/active_run_test.ts
+++ b/src/domain/models/active_run_test.ts
@@ -263,3 +263,20 @@ Deno.test("ActiveRun.fromData: initiatedBy absent defaults to null", () => {
 
   assertEquals(run.initiatedBy, null);
 });
+
+Deno.test("ActiveRun.isStale: returns true for invalid heartbeatAt (NaN)", () => {
+  const run = ActiveRun.fromData({
+    id: "test-id",
+    runKind: "model_method",
+    modelType: "@test/model",
+    methodName: "start",
+    workflowName: null,
+    pid: 1234,
+    hostname: "test-host",
+    startedAt: new Date().toISOString(),
+    heartbeatAt: "not-a-date",
+    status: "running",
+  });
+
+  assertEquals(run.isStale(90_000), true);
+});

--- a/src/serve/active_run_registry.ts
+++ b/src/serve/active_run_registry.ts
@@ -18,8 +18,27 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { RunEventBuffer } from "./run_event_buffer.ts";
+import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+
+const logger = getSwampLogger(["serve", "active-run-registry"]);
+
+const ANONYMOUS_PRINCIPAL = "@anonymous";
 
 export type RunKind = "workflow-run" | "workflow-resume" | "method-run";
+
+export type RegistryErrorCode =
+  | "already_registered"
+  | "global_cap"
+  | "principal_cap";
+
+export class RegistryCapacityError extends Error {
+  readonly code: RegistryErrorCode;
+  constructor(code: RegistryErrorCode, message: string) {
+    super(message);
+    this.name = "RegistryCapacityError";
+    this.code = code;
+  }
+}
 
 export interface ActiveRun {
   readonly runId: string;
@@ -29,30 +48,76 @@ export interface ActiveRun {
   readonly controller: AbortController;
   readonly startedAt: Date;
   readonly completion: Promise<void>;
+  readonly principalId: string | null;
+}
+
+export interface ActiveRunRegistryOptions {
+  maxConcurrent?: number;
+  maxPerPrincipal?: number;
+  maxRunDurationMs?: number;
 }
 
 export class ActiveRunRegistry {
   readonly #runs = new Map<string, ActiveRun>();
   readonly #maxConcurrent: number;
+  readonly #maxPerPrincipal: number | undefined;
+  readonly #maxRunDurationMs: number | undefined;
+  readonly #timers = new Map<string, ReturnType<typeof setTimeout>>();
 
-  constructor(options?: { maxConcurrent?: number }) {
-    this.#maxConcurrent = options?.maxConcurrent ?? 100;
+  constructor(options?: ActiveRunRegistryOptions) {
+    this.#maxConcurrent = Math.max(1, options?.maxConcurrent ?? 100);
+    this.#maxPerPrincipal = options?.maxPerPrincipal !== undefined
+      ? Math.max(1, options.maxPerPrincipal)
+      : undefined;
+    this.#maxRunDurationMs = options?.maxRunDurationMs;
   }
 
   register(run: ActiveRun): void {
     if (this.#runs.has(run.runId)) {
-      throw new Error(`Run ${run.runId} is already registered`);
+      throw new RegistryCapacityError(
+        "already_registered",
+        `Run ${run.runId} is already registered`,
+      );
     }
     if (this.#runs.size >= this.#maxConcurrent) {
-      throw new Error(
+      throw new RegistryCapacityError(
+        "global_cap",
         `Too many concurrent runs (limit: ${this.#maxConcurrent}); wait for active runs to complete`,
       );
     }
+    if (this.#maxPerPrincipal !== undefined) {
+      const effectivePrincipal = run.principalId ?? ANONYMOUS_PRINCIPAL;
+      const count = this.#countForPrincipal(effectivePrincipal);
+      if (count >= this.#maxPerPrincipal) {
+        throw new RegistryCapacityError(
+          "principal_cap",
+          `Too many concurrent runs for principal ${effectivePrincipal} (limit: ${this.#maxPerPrincipal}); wait for active runs to complete`,
+        );
+      }
+    }
     this.#runs.set(run.runId, run);
+
+    if (this.#maxRunDurationMs !== undefined) {
+      const timer = setTimeout(() => {
+        this.#timers.delete(run.runId);
+        logger.warn(
+          "Run {runId} exceeded max duration ({durationMs}ms), aborting",
+          { runId: run.runId, durationMs: this.#maxRunDurationMs! },
+        );
+        run.controller.abort(new Error("max run duration exceeded"));
+      }, this.#maxRunDurationMs);
+      Deno.unrefTimer(timer);
+      this.#timers.set(run.runId, timer);
+    }
   }
 
   deregister(runId: string): void {
     this.#runs.delete(runId);
+    const timer = this.#timers.get(runId);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      this.#timers.delete(runId);
+    }
   }
 
   rekey(oldId: string, newId: string): boolean {
@@ -61,6 +126,11 @@ export class ActiveRunRegistry {
     if (this.#runs.has(newId)) return false;
     this.#runs.delete(oldId);
     this.#runs.set(newId, { ...run, runId: newId });
+    const timer = this.#timers.get(oldId);
+    if (timer !== undefined) {
+      this.#timers.delete(oldId);
+      this.#timers.set(newId, timer);
+    }
     return true;
   }
 
@@ -73,6 +143,16 @@ export class ActiveRunRegistry {
     if (!run) return false;
     run.controller.abort(new Error("cancelled by user"));
     return true;
+  }
+
+  cancelAll(typeFilter?: string): number {
+    let count = 0;
+    for (const run of this.#runs.values()) {
+      if (typeFilter && !matchesTypeFilter(run.kind, typeFilter)) continue;
+      run.controller.abort(new Error("cancelled by user"));
+      count++;
+    }
+    return count;
   }
 
   list(): ReadonlyArray<ActiveRun> {
@@ -99,4 +179,19 @@ export class ActiveRunRegistry {
       new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
     ]);
   }
+
+  #countForPrincipal(effectivePrincipalId: string): number {
+    let count = 0;
+    for (const run of this.#runs.values()) {
+      const p = run.principalId ?? ANONYMOUS_PRINCIPAL;
+      if (p === effectivePrincipalId) count++;
+    }
+    return count;
+  }
+}
+
+function matchesTypeFilter(kind: RunKind, filter: string): boolean {
+  if (kind === filter) return true;
+  if (filter === "workflow-run" && kind === "workflow-resume") return true;
+  return false;
 }

--- a/src/serve/active_run_registry_test.ts
+++ b/src/serve/active_run_registry_test.ts
@@ -18,7 +18,12 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertThrows } from "@std/assert";
-import { type ActiveRun, ActiveRunRegistry } from "./active_run_registry.ts";
+import {
+  type ActiveRun,
+  ActiveRunRegistry,
+  RegistryCapacityError,
+  type RunKind,
+} from "./active_run_registry.ts";
 import { RunEventBuffer } from "./run_event_buffer.ts";
 
 function deferred(): {
@@ -34,16 +39,21 @@ function deferred(): {
 
 function makeRun(
   runId: string,
-  completion?: Promise<void>,
+  opts?: {
+    completion?: Promise<void>;
+    principalId?: string | null;
+    kind?: RunKind;
+  },
 ): ActiveRun {
   return {
     runId,
-    kind: "workflow-run",
+    kind: opts?.kind ?? "workflow-run",
     resourceName: "test-workflow",
     buffer: new RunEventBuffer(100),
     controller: new AbortController(),
     startedAt: new Date(),
-    completion: completion ?? Promise.resolve(),
+    completion: opts?.completion ?? Promise.resolve(),
+    principalId: opts?.principalId ?? null,
   };
 }
 
@@ -120,8 +130,8 @@ Deno.test("ActiveRunRegistry: drainAll resolves when all completions resolve", a
   const reg = new ActiveRunRegistry();
   const d1 = deferred();
   const d2 = deferred();
-  reg.register(makeRun("r1", d1.promise));
-  reg.register(makeRun("r2", d2.promise));
+  reg.register(makeRun("r1", { completion: d1.promise }));
+  reg.register(makeRun("r2", { completion: d2.promise }));
 
   let drained = false;
   const drainPromise = reg.drainAll(5_000).then(() => {
@@ -140,7 +150,7 @@ Deno.test("ActiveRunRegistry: drainAll resolves when all completions resolve", a
 Deno.test("ActiveRunRegistry: drainAll resolves on timeout even if runs are stuck", async () => {
   const reg = new ActiveRunRegistry();
   const neverResolves = new Promise<void>(() => {});
-  reg.register(makeRun("stuck", neverResolves));
+  reg.register(makeRun("stuck", { completion: neverResolves }));
 
   const start = Date.now();
   await reg.drainAll(100);
@@ -218,4 +228,561 @@ Deno.test("ActiveRunRegistry: allows registration after deregister frees a slot"
   reg.deregister("r1");
   reg.register(makeRun("r2"));
   assertEquals(reg.size, 1);
+});
+
+// ── Per-principal accounting ────────────────────────────────────────────
+
+Deno.test("ActiveRunRegistry: per-principal limit rejects when one principal fills their quota", () => {
+  const reg = new ActiveRunRegistry({ maxPerPrincipal: 2 });
+  reg.register(makeRun("r1", { principalId: "user:alice" }));
+  reg.register(makeRun("r2", { principalId: "user:alice" }));
+
+  assertThrows(
+    () => reg.register(makeRun("r3", { principalId: "user:alice" })),
+    Error,
+    "Too many concurrent runs for principal user:alice",
+  );
+});
+
+Deno.test("ActiveRunRegistry: per-principal limit allows different principals", () => {
+  const reg = new ActiveRunRegistry({ maxPerPrincipal: 1 });
+  reg.register(makeRun("r1", { principalId: "user:alice" }));
+  reg.register(makeRun("r2", { principalId: "user:bob" }));
+
+  assertEquals(reg.size, 2);
+});
+
+Deno.test("ActiveRunRegistry: per-principal limit applies to null principal as @anonymous", () => {
+  const reg = new ActiveRunRegistry({ maxPerPrincipal: 1 });
+  reg.register(makeRun("r1", { principalId: null }));
+
+  assertThrows(
+    () => reg.register(makeRun("r2", { principalId: null })),
+    Error,
+    "Too many concurrent runs for principal @anonymous",
+  );
+});
+
+Deno.test("ActiveRunRegistry: per-principal slot released on deregister", () => {
+  const reg = new ActiveRunRegistry({ maxPerPrincipal: 1 });
+  reg.register(makeRun("r1", { principalId: "user:alice" }));
+
+  assertThrows(
+    () => reg.register(makeRun("r2", { principalId: "user:alice" })),
+    Error,
+  );
+
+  reg.deregister("r1");
+  reg.register(makeRun("r2", { principalId: "user:alice" }));
+  assertEquals(reg.size, 1);
+});
+
+Deno.test("ActiveRunRegistry: global cap still enforced alongside per-principal", () => {
+  const reg = new ActiveRunRegistry({
+    maxConcurrent: 2,
+    maxPerPrincipal: 5,
+  });
+  reg.register(makeRun("r1", { principalId: "user:alice" }));
+  reg.register(makeRun("r2", { principalId: "user:bob" }));
+
+  assertThrows(
+    () => reg.register(makeRun("r3", { principalId: "user:charlie" })),
+    Error,
+    "Too many concurrent runs (limit: 2)",
+  );
+});
+
+// ── Typed error classification ──────────────────────────────────────────
+
+Deno.test("ActiveRunRegistry: duplicate registration throws already_registered", () => {
+  const reg = new ActiveRunRegistry();
+  reg.register(makeRun("r1"));
+
+  try {
+    reg.register(makeRun("r1"));
+    throw new Error("should have thrown");
+  } catch (err) {
+    assertEquals(err instanceof RegistryCapacityError, true);
+    assertEquals((err as RegistryCapacityError).code, "already_registered");
+  }
+});
+
+Deno.test("ActiveRunRegistry: global cap throws global_cap", () => {
+  const reg = new ActiveRunRegistry({ maxConcurrent: 1 });
+  reg.register(makeRun("r1"));
+
+  try {
+    reg.register(makeRun("r2"));
+    throw new Error("should have thrown");
+  } catch (err) {
+    assertEquals(err instanceof RegistryCapacityError, true);
+    assertEquals((err as RegistryCapacityError).code, "global_cap");
+  }
+});
+
+Deno.test("ActiveRunRegistry: per-principal cap throws principal_cap", () => {
+  const reg = new ActiveRunRegistry({ maxPerPrincipal: 1 });
+  reg.register(makeRun("r1", { principalId: "user:alice" }));
+
+  try {
+    reg.register(makeRun("r2", { principalId: "user:alice" }));
+    throw new Error("should have thrown");
+  } catch (err) {
+    assertEquals(err instanceof RegistryCapacityError, true);
+    assertEquals((err as RegistryCapacityError).code, "principal_cap");
+  }
+});
+
+// ── cancelAll ───────────────────────────────────────────────────────────
+
+Deno.test("ActiveRunRegistry: cancelAll aborts all runs", () => {
+  const reg = new ActiveRunRegistry();
+  const r1 = makeRun("r1", { kind: "workflow-run" });
+  const r2 = makeRun("r2", { kind: "method-run" });
+  reg.register(r1);
+  reg.register(r2);
+
+  const count = reg.cancelAll();
+  assertEquals(count, 2);
+  assertEquals(r1.controller.signal.aborted, true);
+  assertEquals(r2.controller.signal.aborted, true);
+});
+
+Deno.test("ActiveRunRegistry: cancelAll with type filter", () => {
+  const reg = new ActiveRunRegistry();
+  const r1 = makeRun("r1", { kind: "workflow-run" });
+  const r2 = makeRun("r2", { kind: "method-run" });
+  reg.register(r1);
+  reg.register(r2);
+
+  const count = reg.cancelAll("method-run");
+  assertEquals(count, 1);
+  assertEquals(r1.controller.signal.aborted, false);
+  assertEquals(r2.controller.signal.aborted, true);
+});
+
+Deno.test("ActiveRunRegistry: cancelAll workflow-run filter includes workflow-resume", () => {
+  const reg = new ActiveRunRegistry();
+  const r1 = makeRun("r1", { kind: "workflow-run" });
+  const r2 = makeRun("r2", { kind: "workflow-resume" });
+  const r3 = makeRun("r3", { kind: "method-run" });
+  reg.register(r1);
+  reg.register(r2);
+  reg.register(r3);
+
+  const count = reg.cancelAll("workflow-run");
+  assertEquals(count, 2);
+  assertEquals(r1.controller.signal.aborted, true);
+  assertEquals(r2.controller.signal.aborted, true);
+  assertEquals(r3.controller.signal.aborted, false);
+});
+
+Deno.test("ActiveRunRegistry: cancelAll returns zero for empty registry", () => {
+  const reg = new ActiveRunRegistry();
+  assertEquals(reg.cancelAll(), 0);
+});
+
+// ── Max run duration ────────────────────────────────────────────────────
+
+Deno.test("ActiveRunRegistry: max duration aborts run after timeout", async () => {
+  const reg = new ActiveRunRegistry({ maxRunDurationMs: 100 });
+  const d = deferred();
+  const run = makeRun("r1", { completion: d.promise });
+  reg.register(run);
+
+  await new Promise<void>((resolve) => setTimeout(resolve, 200));
+
+  assertEquals(run.controller.signal.aborted, true);
+  d.resolve();
+  reg.deregister("r1");
+});
+
+Deno.test("ActiveRunRegistry: max duration timer cleared on deregister", async () => {
+  const reg = new ActiveRunRegistry({ maxRunDurationMs: 100 });
+  const d = deferred();
+  const run = makeRun("r1", { completion: d.promise });
+  reg.register(run);
+  reg.deregister("r1");
+
+  await new Promise<void>((resolve) => setTimeout(resolve, 200));
+
+  assertEquals(run.controller.signal.aborted, false);
+  d.resolve();
+});
+
+Deno.test("ActiveRunRegistry: max duration timer rekeyed with run", async () => {
+  const reg = new ActiveRunRegistry({ maxRunDurationMs: 200 });
+  const d = deferred();
+  const run = makeRun("r1", { completion: d.promise });
+  reg.register(run);
+  reg.rekey("r1", "r2");
+
+  await new Promise<void>((resolve) => setTimeout(resolve, 300));
+
+  assertEquals(run.controller.signal.aborted, true);
+  d.resolve();
+  reg.deregister("r2");
+});
+
+// ── Deferred completion pattern ─────────────────────────────────────────
+
+Deno.test("ActiveRunRegistry: completion settles and drainAll returns even when cleanup throws", async () => {
+  const reg = new ActiveRunRegistry();
+
+  let resolveCompletion!: () => void;
+  const completion = new Promise<void>((r) => {
+    resolveCompletion = r;
+  });
+
+  const run: ActiveRun = {
+    runId: "r1",
+    kind: "workflow-resume",
+    resourceName: "wf",
+    buffer: new RunEventBuffer(100),
+    controller: new AbortController(),
+    startedAt: new Date(),
+    completion,
+    principalId: null,
+  };
+  reg.register(run);
+
+  const throwingDispose = () => {
+    throw new Error("simulated dispose failure");
+  };
+
+  (async () => {
+    try {
+      await Promise.reject(new Error("simulated work failure"));
+    } finally {
+      try {
+        throwingDispose();
+      } catch { /* swallow like the handler does */ }
+      reg.deregister("r1");
+      resolveCompletion();
+    }
+  })().catch(() => {});
+
+  const start = Date.now();
+  await reg.drainAll(5_000);
+  const elapsed = Date.now() - start;
+
+  assertEquals(reg.size, 0);
+  assertEquals(elapsed < 1000, true);
+});
+
+Deno.test("ActiveRunRegistry: drainAll blocks when completion never settles", async () => {
+  const reg = new ActiveRunRegistry();
+  const neverSettles = new Promise<void>(() => {});
+  reg.register(makeRun("stuck", { completion: neverSettles }));
+
+  const start = Date.now();
+  await reg.drainAll(100);
+  const elapsed = Date.now() - start;
+
+  assertEquals(elapsed >= 90, true);
+  assertEquals(elapsed < 500, true);
+});
+
+// ── Handler-pattern integration tests ───────────────────────────────────
+// These simulate the exact deferred-promise pattern used in the three
+// handler sites to prove the properties at the wiring level.
+
+Deno.test("handler pattern: rejected registration never starts work", () => {
+  const reg = new ActiveRunRegistry({ maxConcurrent: 1 });
+  reg.register(makeRun("r1"));
+
+  let resolveCompletion!: () => void;
+  const completion = new Promise<void>((r) => {
+    resolveCompletion = r;
+  });
+
+  let workStarted = false;
+  try {
+    reg.register({
+      runId: "r2",
+      kind: "method-run",
+      resourceName: "m",
+      buffer: new RunEventBuffer(100),
+      controller: new AbortController(),
+      startedAt: new Date(),
+      completion,
+      principalId: "user:alice",
+    });
+  } catch (err) {
+    assertEquals(err instanceof RegistryCapacityError, true);
+    resolveCompletion();
+    // Work IIFE would start here in the handler — but we returned early
+    assertEquals(workStarted, false);
+    return;
+  }
+
+  // If we get here, registration should have failed
+  workStarted = true;
+  resolveCompletion();
+  throw new Error("registration should have been rejected");
+});
+
+Deno.test("handler pattern: successful registration produces events through buffer", async () => {
+  const reg = new ActiveRunRegistry();
+  const buffer = new RunEventBuffer(100);
+
+  let resolveCompletion!: () => void;
+  const completion = new Promise<void>((r) => {
+    resolveCompletion = r;
+  });
+
+  const controller = new AbortController();
+  reg.register({
+    runId: "r1",
+    kind: "workflow-run",
+    resourceName: "wf",
+    buffer,
+    controller,
+    startedAt: new Date(),
+    completion,
+    principalId: "user:alice",
+  });
+
+  // Simulate work IIFE
+  (async () => {
+    try {
+      await Promise.resolve();
+      buffer.push({ kind: "started", runId: "r1" });
+      buffer.push({ kind: "completed", status: "succeeded" });
+      buffer.finish({ kind: "done" });
+    } finally {
+      reg.deregister("r1");
+      resolveCompletion();
+    }
+  })().catch(() => {});
+
+  // Simulate subscribeUntilDetach — read events via callback subscriber
+  const events: Array<Record<string, unknown>> = [];
+  const { promise: subscribeDone, resolve: subscribeDoneResolve } = deferred();
+  buffer.subscribe({
+    onEvent: (_seq, event) => {
+      events.push(event);
+    },
+    onTerminal: (terminal) => {
+      events.push(terminal);
+    },
+    onDetach: () => {
+      subscribeDoneResolve();
+    },
+  });
+
+  await subscribeDone;
+  assertEquals(events.length, 3);
+  assertEquals(events[0].kind, "started");
+  assertEquals(events[1].kind, "completed");
+  assertEquals(events[2].kind, "done");
+
+  await reg.drainAll(1_000);
+  assertEquals(reg.size, 0);
+});
+
+Deno.test("handler pattern: completion settles on every exit path", async () => {
+  const reg = new ActiveRunRegistry();
+
+  const failWith = (msg: string) => {
+    throw new Error(msg);
+  };
+
+  // Path 1: normal completion
+  {
+    let resolve!: () => void;
+    const completion = new Promise<void>((r) => {
+      resolve = r;
+    });
+    reg.register({
+      ...makeRun("p1"),
+      completion,
+    });
+    (async () => {
+      try {
+        await Promise.resolve();
+      } finally {
+        reg.deregister("p1");
+        resolve();
+      }
+    })().catch(() => {});
+  }
+
+  // Path 2: work throws
+  {
+    let resolve!: () => void;
+    const completion = new Promise<void>((r) => {
+      resolve = r;
+    });
+    reg.register({
+      ...makeRun("p2"),
+      completion,
+    });
+    (async () => {
+      try {
+        await Promise.reject(new Error("work failed"));
+      } finally {
+        reg.deregister("p2");
+        resolve();
+      }
+    })().catch(() => {});
+  }
+
+  // Path 3: cleanup throws before deregister
+  {
+    let resolve!: () => void;
+    const completion = new Promise<void>((r) => {
+      resolve = r;
+    });
+    reg.register({
+      ...makeRun("p3"),
+      completion,
+    });
+    (async () => {
+      try {
+        await Promise.reject(new Error("work failed"));
+      } finally {
+        try {
+          failWith("dispose failed");
+        } catch { /* swallow */ }
+        reg.deregister("p3");
+        try {
+          failWith("deleteActiveRun failed");
+        } catch { /* swallow */ }
+        resolve();
+      }
+    })().catch(() => {});
+  }
+
+  // Path 4: abort signal
+  {
+    let resolve!: () => void;
+    const completion = new Promise<void>((r) => {
+      resolve = r;
+    });
+    const controller = new AbortController();
+    reg.register({
+      ...makeRun("p4"),
+      controller,
+      completion,
+    });
+    controller.abort(new Error("cancelled"));
+    (async () => {
+      try {
+        await Promise.resolve();
+        if (controller.signal.aborted) throw controller.signal.reason;
+      } finally {
+        reg.deregister("p4");
+        resolve();
+      }
+    })().catch(() => {});
+  }
+
+  // All four should settle immediately
+  const start = Date.now();
+  await reg.drainAll(5_000);
+  const elapsed = Date.now() - start;
+
+  assertEquals(reg.size, 0);
+  assertEquals(elapsed < 500, true);
+});
+
+Deno.test("handler pattern: concurrent duplicate resume — winner survives", () => {
+  const reg = new ActiveRunRegistry();
+  const buffer1 = new RunEventBuffer(100);
+  const buffer2 = new RunEventBuffer(100);
+  const controller1 = new AbortController();
+  const controller2 = new AbortController();
+
+  let resolve1!: () => void;
+  const completion1 = new Promise<void>((r) => {
+    resolve1 = r;
+  });
+  let resolve2!: () => void;
+  const completion2 = new Promise<void>((r) => {
+    resolve2 = r;
+  });
+
+  // First resume registers successfully
+  reg.register({
+    runId: "resume-123",
+    kind: "workflow-resume",
+    resourceName: "wf",
+    buffer: buffer1,
+    controller: controller1,
+    startedAt: new Date(),
+    completion: completion1,
+    principalId: "user:alice",
+  });
+
+  // Second resume with same ID fails
+  try {
+    reg.register({
+      runId: "resume-123",
+      kind: "workflow-resume",
+      resourceName: "wf",
+      buffer: buffer2,
+      controller: controller2,
+      startedAt: new Date(),
+      completion: completion2,
+      principalId: "user:bob",
+    });
+    throw new Error("should have thrown");
+  } catch (err) {
+    assertEquals(err instanceof RegistryCapacityError, true);
+    assertEquals((err as RegistryCapacityError).code, "already_registered");
+    resolve2();
+  }
+
+  // Winner is still intact, running, and cancellable
+  const winner = reg.get("resume-123");
+  assertEquals(winner !== undefined, true);
+  assertEquals(winner!.controller.signal.aborted, false);
+  assertEquals(winner!.principalId, "user:alice");
+  assertEquals(reg.cancel("resume-123"), true);
+  assertEquals(controller1.signal.aborted, true);
+
+  // Loser's controller is untouched
+  assertEquals(controller2.signal.aborted, false);
+
+  reg.deregister("resume-123");
+  resolve1();
+  assertEquals(reg.size, 0);
+});
+
+// ── Error message disclosure tests ──────────────────────────────────────
+
+Deno.test("RegistryCapacityError: global_cap message contains numeric limit (server-only)", () => {
+  const reg = new ActiveRunRegistry({ maxConcurrent: 42 });
+  for (let i = 0; i < 42; i++) {
+    reg.register(makeRun(`r${i}`));
+  }
+
+  try {
+    reg.register(makeRun("overflow"));
+    throw new Error("should have thrown");
+  } catch (err) {
+    const e = err as RegistryCapacityError;
+    assertEquals(e.code, "global_cap");
+    // The message has the limit (for server logs) — handlers must NOT forward it
+    assertEquals(e.message.includes("42"), true);
+  }
+});
+
+Deno.test("RegistryCapacityError: principal_cap message contains principal and limit (server-only)", () => {
+  const reg = new ActiveRunRegistry({ maxPerPrincipal: 3 });
+  for (let i = 0; i < 3; i++) {
+    reg.register(makeRun(`r${i}`, { principalId: "user:alice" }));
+  }
+
+  try {
+    reg.register(makeRun("overflow", { principalId: "user:alice" }));
+    throw new Error("should have thrown");
+  } catch (err) {
+    const e = err as RegistryCapacityError;
+    assertEquals(e.code, "principal_cap");
+    // The message has the principal and limit — handlers must NOT forward it
+    assertEquals(e.message.includes("user:alice"), true);
+    assertEquals(e.message.includes("3"), true);
+  }
 });

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -93,6 +93,7 @@ import {
   principalToString,
 } from "../../domain/access/principal.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
+import { RegistryCapacityError } from "../active_run_registry.ts";
 import { RunEventBuffer } from "../run_event_buffer.ts";
 import { deleteActiveRun, writeActiveRun } from "../active_run_tracker.ts";
 import {
@@ -337,10 +338,42 @@ export async function handleModelMethodRun(
   const buffer = new RunEventBuffer(DEFAULT_BUFFER_CAPACITY);
   const runController = new AbortController();
   const runId: string = crypto.randomUUID();
+  const startedAt = new Date();
 
   buffer.push({ kind: "run.accepted", runId });
 
-  const completion = (async () => {
+  let resolveCompletion!: () => void;
+  const completion = new Promise<void>((r) => {
+    resolveCompletion = r;
+  });
+
+  try {
+    registry.register({
+      runId,
+      kind: "method-run",
+      resourceName: payload.modelIdOrName,
+      buffer,
+      controller: runController,
+      startedAt,
+      completion,
+      principalId: principal ? principalToString(principal) : null,
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    logger.warn("Detached method run rejected: {error}", { error: detail });
+    resolveCompletion();
+    if (err instanceof RegistryCapacityError) {
+      const clientMsg = err.code === "already_registered"
+        ? "A run with this ID is already in progress"
+        : "Too many concurrent runs; wait for active runs to complete";
+      sendError(socket, requestId, err.code, clientMsg);
+    } else {
+      sendError(socket, requestId, "internal_error", "Run registration failed");
+    }
+    return;
+  }
+
+  (async () => {
     let flushLocks: (() => Promise<void>) | null = null;
     try {
       if (preResult) {
@@ -441,33 +474,24 @@ export async function handleModelMethodRun(
         }
       }
       registry.deregister(runId);
-      if (ctx.controlPlaneStore && ctx.instanceId) {
-        deleteActiveRun(ctx.controlPlaneStore, ctx.instanceId, runId);
+      try {
+        if (ctx.controlPlaneStore && ctx.instanceId) {
+          deleteActiveRun(ctx.controlPlaneStore, ctx.instanceId, runId);
+        }
+      } catch (cleanupErr) {
+        logger.warn("Failed to delete active run record: {error}", {
+          error: cleanupErr instanceof Error
+            ? cleanupErr.message
+            : String(cleanupErr),
+        });
       }
+      resolveCompletion();
     }
-  })();
-
-  const startedAt = new Date();
-  try {
-    registry.register({
-      runId,
-      kind: "method-run",
-      resourceName: payload.modelIdOrName,
-      buffer,
-      controller: runController,
-      startedAt,
-      completion,
+  })().catch((err) => {
+    logger.warn("Unhandled error in detached method run: {error}", {
+      error: err instanceof Error ? err.message : String(err),
     });
-  } catch {
-    runController.abort();
-    sendError(
-      socket,
-      requestId,
-      "too_many_requests",
-      `Too many concurrent runs; wait for active runs to complete`,
-    );
-    return;
-  }
+  });
 
   if (ctx.controlPlaneStore && ctx.instanceId) {
     writeActiveRun(ctx.controlPlaneStore, ctx.instanceId, runId, {

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -104,6 +104,7 @@ import {
   runWithParentTrace,
 } from "../../infrastructure/tracing/mod.ts";
 import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
+import { RegistryCapacityError } from "../active_run_registry.ts";
 import { RunEventBuffer } from "../run_event_buffer.ts";
 import {
   deleteActiveRun,
@@ -118,7 +119,9 @@ import {
   sendError,
   subscribeUntilDetach,
 } from "./shared.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 
+const logger = getSwampLogger(["serve", "connection"]);
 const DEFAULT_BUFFER_CAPACITY = 10_000;
 
 export async function handleWorkflowRun(
@@ -208,7 +211,38 @@ export async function handleWorkflowRun(
   let runId: string = crypto.randomUUID();
   const startedAt = new Date();
 
-  const completion = (async () => {
+  let resolveCompletion!: () => void;
+  const completion = new Promise<void>((r) => {
+    resolveCompletion = r;
+  });
+
+  try {
+    registry.register({
+      runId,
+      kind: "workflow-run",
+      resourceName: payload.workflowIdOrName,
+      buffer,
+      controller: runController,
+      startedAt,
+      completion,
+      principalId: principal ? principalToString(principal) : null,
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    logger.warn("Detached workflow run rejected: {error}", { error: detail });
+    resolveCompletion();
+    if (err instanceof RegistryCapacityError) {
+      const clientMsg = err.code === "already_registered"
+        ? "A run with this ID is already in progress"
+        : "Too many concurrent runs; wait for active runs to complete";
+      sendError(socket, requestId, err.code, clientMsg);
+    } else {
+      sendError(socket, requestId, "internal_error", "Run registration failed");
+    }
+    return;
+  }
+
+  (async () => {
     try {
       await executeWorkflowWithLocks(
         ctx.repoDir,
@@ -282,32 +316,24 @@ export async function handleWorkflowRun(
       }
     } finally {
       registry.deregister(runId);
-      if (ctx.controlPlaneStore && ctx.instanceId) {
-        deleteActiveRun(ctx.controlPlaneStore, ctx.instanceId, runId);
+      try {
+        if (ctx.controlPlaneStore && ctx.instanceId) {
+          deleteActiveRun(ctx.controlPlaneStore, ctx.instanceId, runId);
+        }
+      } catch (cleanupErr) {
+        logger.warn("Failed to delete active run record: {error}", {
+          error: cleanupErr instanceof Error
+            ? cleanupErr.message
+            : String(cleanupErr),
+        });
       }
+      resolveCompletion();
     }
-  })();
-
-  try {
-    registry.register({
-      runId,
-      kind: "workflow-run",
-      resourceName: payload.workflowIdOrName,
-      buffer,
-      controller: runController,
-      startedAt,
-      completion,
+  })().catch((err) => {
+    logger.warn("Unhandled error in detached workflow run: {error}", {
+      error: err instanceof Error ? err.message : String(err),
     });
-  } catch {
-    runController.abort();
-    sendError(
-      socket,
-      requestId,
-      "too_many_requests",
-      `Too many concurrent runs; wait for active runs to complete`,
-    );
-    return;
-  }
+  });
 
   if (ctx.controlPlaneStore && ctx.instanceId) {
     writeActiveRun(ctx.controlPlaneStore, ctx.instanceId, runId, {
@@ -1101,8 +1127,42 @@ export async function handleWorkflowResume(
   const buffer = new RunEventBuffer(DEFAULT_BUFFER_CAPACITY);
   const runController = new AbortController();
   const runId: string = resolvedRun.id;
+  const startedAt = new Date();
 
-  const completion = (async () => {
+  let resolveCompletion!: () => void;
+  const completion = new Promise<void>((r) => {
+    resolveCompletion = r;
+  });
+
+  try {
+    registry.register({
+      runId,
+      kind: "workflow-resume",
+      resourceName: payload.workflowIdOrName,
+      buffer,
+      controller: runController,
+      startedAt,
+      completion,
+      principalId: principal ? principalToString(principal) : null,
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    logger.warn("Detached workflow resume rejected: {error}", {
+      error: detail,
+    });
+    resolveCompletion();
+    if (err instanceof RegistryCapacityError) {
+      const clientMsg = err.code === "already_registered"
+        ? "A run with this ID is already in progress"
+        : "Too many concurrent runs; wait for active runs to complete";
+      sendError(socket, requestId, err.code, clientMsg);
+    } else {
+      sendError(socket, requestId, "internal_error", "Run registration failed");
+    }
+    return;
+  }
+
+  (async () => {
     const stepLockHook: StepLockHook = async (modelType, modelId) => {
       const lockResult = await acquireModelLocks(
         ctx.datastoreConfig,
@@ -1192,35 +1252,34 @@ export async function handleWorkflowResume(
         });
       }
     } finally {
-      ephemeral?.dispose();
-      registry.deregister(runId);
-      if (ctx.controlPlaneStore && ctx.instanceId) {
-        deleteActiveRun(ctx.controlPlaneStore, ctx.instanceId, runId);
+      try {
+        ephemeral?.dispose();
+      } catch (disposeErr) {
+        logger.warn("Failed to dispose ephemeral store: {error}", {
+          error: disposeErr instanceof Error
+            ? disposeErr.message
+            : String(disposeErr),
+        });
       }
+      registry.deregister(runId);
+      try {
+        if (ctx.controlPlaneStore && ctx.instanceId) {
+          deleteActiveRun(ctx.controlPlaneStore, ctx.instanceId, runId);
+        }
+      } catch (cleanupErr) {
+        logger.warn("Failed to delete active run record: {error}", {
+          error: cleanupErr instanceof Error
+            ? cleanupErr.message
+            : String(cleanupErr),
+        });
+      }
+      resolveCompletion();
     }
-  })();
-
-  const startedAt = new Date();
-  try {
-    registry.register({
-      runId,
-      kind: "workflow-resume",
-      resourceName: payload.workflowIdOrName,
-      buffer,
-      controller: runController,
-      startedAt,
-      completion,
+  })().catch((err) => {
+    logger.warn("Unhandled error in detached workflow resume: {error}", {
+      error: err instanceof Error ? err.message : String(err),
     });
-  } catch {
-    runController.abort();
-    sendError(
-      socket,
-      requestId,
-      "too_many_requests",
-      `Too many concurrent runs; wait for active runs to complete`,
-    );
-    return;
-  }
+  });
 
   if (ctx.controlPlaneStore && ctx.instanceId) {
     writeActiveRun(ctx.controlPlaneStore, ctx.instanceId, runId, {

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -41,6 +41,9 @@ export const SERVE_ENV_MAP: Readonly<Record<string, string>> = {
   staleTtl: "SWAMP_STALE_TTL",
   reconciliationInterval: "SWAMP_RECONCILIATION_INTERVAL",
   groupRefreshInterval: "SWAMP_GROUP_REFRESH_INTERVAL",
+  maxConcurrentRuns: "SWAMP_MAX_CONCURRENT_RUNS",
+  maxRunsPerPrincipal: "SWAMP_MAX_RUNS_PER_PRINCIPAL",
+  maxRunDuration: "SWAMP_MAX_RUN_DURATION",
 };
 
 // ── Webhook Config Types ──────────────────────────────────────────────
@@ -89,6 +92,9 @@ export interface ServeConfigFile {
   "heartbeat-interval"?: string;
   "stale-ttl"?: string;
   "reconciliation-interval"?: string;
+  "max-concurrent-runs"?: number;
+  "max-runs-per-principal"?: number;
+  "max-run-duration"?: string;
 }
 
 // ── Known Keys ────────────────────────────────────────────────────────
@@ -112,6 +118,9 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
   "heartbeat-interval",
   "stale-ttl",
   "reconciliation-interval",
+  "max-concurrent-runs",
+  "max-runs-per-principal",
+  "max-run-duration",
 ]);
 
 const KNOWN_AUTH_KEYS = new Set([
@@ -509,6 +518,9 @@ export interface MergedServeOptions {
   staleTtl?: string;
   reconciliationInterval?: string;
   hotReload: boolean;
+  maxConcurrentRuns?: number;
+  maxRunsPerPrincipal?: number;
+  maxRunDuration?: string;
 }
 
 export function mergeServeOptions(
@@ -557,6 +569,31 @@ export function mergeServeOptions(
     }
 
     return defaultValue;
+  }
+
+  function resolveOptionalNumber(
+    flagName: string,
+    cliValue: number | undefined,
+    configValue: number | undefined,
+  ): number | undefined {
+    if (explicitFlags.has(flagName)) {
+      return cliValue;
+    }
+
+    const envVarName = SERVE_ENV_MAP[kebabToCamel(flagName)];
+    if (envVarName) {
+      const envValue = envLookup(envVarName);
+      if (envValue !== undefined && envValue.trim() !== "") {
+        const n = Number(envValue);
+        if (!isNaN(n)) return n;
+      }
+    }
+
+    if (configValue !== undefined) {
+      return configValue;
+    }
+
+    return undefined;
   }
 
   function resolveBoolean(
@@ -773,6 +810,25 @@ export function mergeServeOptions(
     false,
   );
 
+  const maxConcurrentRuns = resolveOptionalNumber(
+    "max-concurrent-runs",
+    cliOptions.maxConcurrentRuns as number | undefined,
+    config?.["max-concurrent-runs"],
+  );
+
+  const maxRunsPerPrincipal = resolveOptionalNumber(
+    "max-runs-per-principal",
+    cliOptions.maxRunsPerPrincipal as number | undefined,
+    config?.["max-runs-per-principal"],
+  );
+
+  const maxRunDuration = resolveString(
+    "max-run-duration",
+    cliOptions.maxRunDuration as string | undefined,
+    config?.["max-run-duration"],
+    undefined,
+  );
+
   // Webhooks: CLI --webhook flags replace config file webhooks entirely
   let webhook: string[] | undefined;
   let webhookEndpoints: WebhookEndpoint[] | undefined;
@@ -813,5 +869,8 @@ export function mergeServeOptions(
     staleTtl,
     reconciliationInterval,
     hotReload,
+    maxConcurrentRuns,
+    maxRunsPerPrincipal,
+    maxRunDuration,
   };
 }

--- a/src/serve/serve_config_test.ts
+++ b/src/serve/serve_config_test.ts
@@ -633,3 +633,125 @@ Deno.test("loadServeConfig: non-string grants-file produces error", () => {
     );
   });
 });
+
+// ── mergeServeOptions: new concurrency/duration fields ────────────────
+
+Deno.test("mergeServeOptions: max-concurrent-runs from CLI flag", () => {
+  const cliOptions = { maxConcurrentRuns: 50 };
+  const explicitFlags = new Set(["max-concurrent-runs"]);
+  const merged = mergeServeOptions(
+    null,
+    cliOptions,
+    explicitFlags,
+    () => undefined,
+  );
+  assertEquals(merged.maxConcurrentRuns, 50);
+});
+
+Deno.test("mergeServeOptions: max-concurrent-runs from env var", () => {
+  const merged = mergeServeOptions(
+    null,
+    {},
+    new Set<string>(),
+    (name) => name === "SWAMP_MAX_CONCURRENT_RUNS" ? "25" : undefined,
+  );
+  assertEquals(merged.maxConcurrentRuns, 25);
+});
+
+Deno.test("mergeServeOptions: max-concurrent-runs from config file", () => {
+  const config: ServeConfigFile = { "max-concurrent-runs": 75 };
+  const merged = mergeServeOptions(
+    config,
+    {},
+    new Set<string>(),
+    () => undefined,
+  );
+  assertEquals(merged.maxConcurrentRuns, 75);
+});
+
+Deno.test("mergeServeOptions: max-concurrent-runs defaults to undefined", () => {
+  const merged = mergeServeOptions(
+    null,
+    {},
+    new Set<string>(),
+    () => undefined,
+  );
+  assertEquals(merged.maxConcurrentRuns, undefined);
+});
+
+Deno.test("mergeServeOptions: max-runs-per-principal from CLI flag", () => {
+  const cliOptions = { maxRunsPerPrincipal: 5 };
+  const explicitFlags = new Set(["max-runs-per-principal"]);
+  const merged = mergeServeOptions(
+    null,
+    cliOptions,
+    explicitFlags,
+    () => undefined,
+  );
+  assertEquals(merged.maxRunsPerPrincipal, 5);
+});
+
+Deno.test("mergeServeOptions: max-run-duration from CLI flag", () => {
+  const cliOptions = { maxRunDuration: "1h" };
+  const explicitFlags = new Set(["max-run-duration"]);
+  const merged = mergeServeOptions(
+    null,
+    cliOptions,
+    explicitFlags,
+    () => undefined,
+  );
+  assertEquals(merged.maxRunDuration, "1h");
+});
+
+Deno.test("mergeServeOptions: max-run-duration from config file", () => {
+  const config: ServeConfigFile = { "max-run-duration": "30m" };
+  const merged = mergeServeOptions(
+    config,
+    {},
+    new Set<string>(),
+    () => undefined,
+  );
+  assertEquals(merged.maxRunDuration, "30m");
+});
+
+Deno.test("mergeServeOptions: non-numeric env var for max-concurrent-runs is ignored", () => {
+  const merged = mergeServeOptions(
+    null,
+    {},
+    new Set<string>(),
+    (name) => name === "SWAMP_MAX_CONCURRENT_RUNS" ? "abc" : undefined,
+  );
+  assertEquals(merged.maxConcurrentRuns, undefined);
+});
+
+Deno.test("mergeServeOptions: CLI flag zero for max-concurrent-runs passes through", () => {
+  const cliOptions = { maxConcurrentRuns: 0 };
+  const explicitFlags = new Set(["max-concurrent-runs"]);
+  const merged = mergeServeOptions(
+    null,
+    cliOptions,
+    explicitFlags,
+    () => undefined,
+  );
+  assertEquals(merged.maxConcurrentRuns, 0);
+});
+
+Deno.test("mergeServeOptions: empty env var for max-concurrent-runs is ignored", () => {
+  const merged = mergeServeOptions(
+    null,
+    {},
+    new Set<string>(),
+    (name) => name === "SWAMP_MAX_CONCURRENT_RUNS" ? "" : undefined,
+  );
+  assertEquals(merged.maxConcurrentRuns, undefined);
+});
+
+Deno.test("mergeServeOptions: whitespace-only env var for max-concurrent-runs is ignored", () => {
+  const merged = mergeServeOptions(
+    null,
+    {},
+    new Set<string>(),
+    (name) => name === "SWAMP_MAX_CONCURRENT_RUNS" ? "   " : undefined,
+  );
+  assertEquals(merged.maxConcurrentRuns, undefined);
+});


### PR DESCRIPTION
## Summary

Security hardening for the swamp serve HA system, covering medium-severity items
from a security review plus incidental fixes discovered during implementation.

### Concurrency controls (new)

- **Per-principal run accounting**: `--max-runs-per-principal` limits how many
  concurrent detached runs a single authenticated principal can hold. Unauthenticated
  clients (auth-mode none) are bucketed as `@anonymous` so the limit still applies.
- **Global cap**: `--max-concurrent-runs` (default 100) with proper validation
  (rejects ≤0, non-integer, NaN from bad config/env values, empty/whitespace env vars).
- **Max run duration**: `--max-run-duration` aborts runs that exceed the configured
  wall-clock time. Timer is unref'd so it doesn't block shutdown. Values exceeding
  the 32-bit setTimeout limit (~24.8 days) are rejected at startup.
- **Typed error classification**: `RegistryCapacityError` with `.code` field
  (`already_registered`, `global_cap`, `principal_cap`) replaces string-based
  classification. Client-facing error messages are fixed strings that never expose
  numeric limits or principal identifiers — detail stays in server-side logs only.

### Register-before-work restructure

All three detached-run handler sites (workflow run, workflow resume, model method
run) now call `register()` before starting the async work IIFE. Previously the
IIFE started immediately and `register()` was called after — a rejected
registration still consumed locks and I/O. The deferred-promise pattern decouples
the completion promise from the IIFE lifetime. `resolveCompletion()` is
unconditionally reached through wrapped cleanup (ephemeral.dispose, deleteActiveRun)
and explicit `.catch()` on each IIFE.

This also fixes a concurrent-resume clobber bug: previously request B's IIFE kept
running after its registration failed, and B's finally block deregistered A's
entry while A was still executing.

### Bulk cancel

- `POST /api/v1/cancel` now includes `activeRunRegistry.cancelAll()` — previously
  bulk cancel missed all detached runs (the default mode).
- `workflow-run` type filter now matches `workflow-resume` runs via `matchesTypeFilter()`.

### Token transport

- Client sends the server token via `Authorization: Bearer` header instead of a
  `?token=` query parameter. The server's query-parameter acceptance is preserved
  for backward compatibility with older clients.
- `appendTokenToUrl` removed (dead code after the transport change).
- `design/remote-execution.md` updated to reflect the new transport.

### Boot resilience

- Namespace migration root-read errors are collected instead of thrown. After
  `hydrateLocalCache` binds the namespace and the sentinel is checked: if the
  sentinel is present (migration complete), errors are logged at debug; if absent
  and errors occurred, a descriptive error is thrown.

### Fail-safe corrections

- Cancel endpoint authorization guard inverted to fail closed when the policy
  snapshot is absent (previously silently skipped authorization).
- `ActiveRun.isStale` returns `true` for NaN heartbeat timestamps, matching
  `InstanceHeartbeatService.isStale` behavior.
- Stale-TTL validation uses effective defaults after merge, so
  `--heartbeat-interval 5m` alone is rejected against the 90s default stale TTL.

### Documentation

- `design/expressions.md`, `expressions-and-foreach.md`: updated to reflect that
  sensitive webhook headers are now redacted/omitted, not exposed raw.
- `design/remote-execution.md`: query-parameter references replaced with
  Authorization header description; removed obsolete access-log redaction advice.

## Test Plan

- 9979 tests pass (16 new test files/sections, +1538 lines)
- **Registry-level**: typed error codes, per-principal accounting, global cap,
  cancelAll with workflow-resume, max duration timer + unref + rekey, deferred
  completion settlement through all exit paths (normal/error/cleanup-throws/abort)
- **Handler-pattern tests**: rejected registration never starts work, successful
  registration streams events through buffer subscriber, concurrent duplicate
  resume leaves winner intact
- **Integration tests**: detached workflow runs end-to-end through real
  `handleConnection` with `ActiveRunRegistry` on context — events stream,
  completion settles, registry drains to 0. Rejected registration at capacity
  returns generic message with no numeric limit.
- **Token transport**: Authorization header sent on initial connect and reconnect,
  extra proxy headers pass through alongside, no query-param token
- **Config validation**: zero/negative/non-integer rejected, YAML number coerced,
  empty/whitespace/non-numeric env vars ignored, timer overflow rejected
- **Runtime tested**: startup validation (10 cases), per-principal cap, global cap,
  bulk cancel count, cancel in auth-mode none, max-run-duration abort, shutdown
  timing (33s, not 35s+ from stuck promise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)