### PR TITLE
feat(auth): report plan and trial status in swamp auth whoami

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,14 @@ See `design/skills.md` for the full skill testing pipeline.
   `""value""`. Numbers and other primitives render unquoted, so a bare
   `${count}` is correct in all cases.
 
+- The `organizations` array from `GET /api/whoami` is an authorization contract,
+  not a general-purpose payload. `getCollectives()` in
+  `src/infrastructure/http/swamp_club_client.ts` reduces it to slugs, and
+  extension push and pull authorize namespace ownership from that list. Add new
+  server-supplied data as its own optional top-level field joined on `slug` (as
+  `collectiveEntitlements` does) rather than as extra keys on the organization
+  entries, so changes to unrelated concerns can never reach the publish path.
+
 Changes should only touch what's necessary — don't refactor adjacent code that
 isn't part of the task. Keep the blast radius small.
 

--- a/design/libswamp.md
+++ b/design/libswamp.md
@@ -677,7 +677,8 @@ export { merge } from "./stream/merge.ts";
 export { assertCompletes, assertErrors, collect } from "./testing.ts";
 
 // Auth operations
-export { createAuthDeps, type AuthDeps, type AuthWhoamiEvent, whoami, type WhoamiIdentity } from "./auth/whoami.ts";
+export { createAuthDeps, type AuthDeps, type AuthWhoamiEvent, whoami, type WhoamiCollectiveEntitlement, type WhoamiIdentity } from "./auth/whoami.ts";
+export type { WhoamiTrial } from "../infrastructure/http/swamp_club_client.ts";
 
 // Workflow operations
 export { workflowRun, type WorkflowRunDeps, type WorkflowRunEvent, type WorkflowRunInput, ... } from "./workflows/run.ts";

--- a/design/rendering.md
+++ b/design/rendering.md
@@ -275,6 +275,19 @@ class LogAuthWhoamiRenderer implements Renderer<AuthWhoamiEvent> {
         writeOutput(
           `${e.identity.username} (${e.identity.email}) on ${e.identity.serverUrl}`,
         );
+
+        // Richer output when the server sent entitlement...
+        const entitlements = e.identity.collectiveEntitlements;
+        if (entitlements && entitlements.length > 0) {
+          writeOutput(`${bold(cyan("Plan:"))} ${bold(planName)}`);
+          writeOutput(cyan("Collectives:"));
+          writeOutput(collectiveLines(entitlements).join("\n"));
+          return;
+        }
+
+        // ...and the original single line when it didn't. An older or
+        // self-hosted swamp-club sends no entitlement fields, and upgrading
+        // the CLI alone must not change what those users see.
         if (e.identity.collectives && e.identity.collectives.length > 0) {
           writeOutput(`Collectives: ${e.identity.collectives.join(", ")}`);
         }
@@ -286,6 +299,11 @@ class LogAuthWhoamiRenderer implements Renderer<AuthWhoamiEvent> {
   }
 }
 ```
+
+Note the shape of that fallback: the renderer branches on whether the *server*
+supplied a field, not on a CLI-side flag. Optional-everything is what lets one
+CLI talk to several server versions, and the pre-existing output is the
+behaviour to preserve, not a legacy path to tolerate.
 
 ### JSON-mode renderer
 
@@ -306,6 +324,13 @@ class JsonAuthWhoamiRenderer implements Renderer<AuthWhoamiEvent> {
             name: e.identity.name,
             ...(e.identity.collectives
               ? { collectives: e.identity.collectives }
+              : {}),
+            // Entitlement passes through verbatim. Log mode makes display
+            // decisions (it hides a paid collective's trial); JSON mode makes
+            // none — it is what gets pasted into a support report.
+            ...(e.identity.plan ? { plan: e.identity.plan } : {}),
+            ...(e.identity.collectiveEntitlements
+              ? { collectiveEntitlements: e.identity.collectiveEntitlements }
               : {}),
           },
           null,

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -59,12 +59,53 @@ export interface CreateApiKeyResponse {
   key: string;
 }
 
-/** An organization the user belongs to. */
+/**
+ * A collective's trial clock, as the server resolved it.
+ *
+ * Every number here is elapsed-based and computed server-side, so it is
+ * timezone-independent. Render `daysRemaining` as given — recomputing it from
+ * `endsAt` in local time reintroduces the zone bug the server avoided.
+ */
+export interface WhoamiTrial {
+  state: "none" | "active" | "expired";
+  startedAt: string | null;
+  endsAt: string | null;
+  trigger?: string | null;
+  dayNumber?: number;
+  daysRemaining: number;
+}
+
+/**
+ * An organization the user belongs to.
+ *
+ * Membership only — deliberately carries no billing. Extension push and pull
+ * authorize namespace ownership from this list (via {@link getCollectives}),
+ * so entitlement travels in {@link WhoamiResponse.collectiveEntitlements}
+ * instead of as extra keys here. Keeping the two apart means a change to how
+ * plans are reported can never reach the publish path.
+ */
 export interface WhoamiOrganization {
   slug: string;
   name: string;
   role: string;
   personal: boolean;
+}
+
+/**
+ * What one collective entitles the user to, joined to
+ * {@link WhoamiOrganization} on `slug`.
+ *
+ * All fields but `slug` are optional: a self-hosted or older swamp-club sends
+ * no entitlement at all, and whoami must not degrade to an error when it is
+ * missing.
+ */
+export interface WhoamiCollectiveEntitlementResponse {
+  slug: string;
+  plan?: string;
+  planName?: string;
+  /** Owner/admin only — the server omits it for plain members. */
+  subscriptionStatus?: string | null;
+  trial?: WhoamiTrial | null;
 }
 
 /** Response from the /api/whoami endpoint. */
@@ -74,7 +115,11 @@ export interface WhoamiResponse {
   username?: string;
   email?: string;
   name?: string;
+  /** Strongest plan across the user's collectives. Server-derived. */
+  plan?: string;
   organizations?: WhoamiOrganization[];
+  /** Per-collective entitlement. Absent from servers that predate it. */
+  collectiveEntitlements?: WhoamiCollectiveEntitlementResponse[];
   collectiveToken?: boolean;
   collectiveId?: string;
   collectiveSlug?: string;

--- a/src/infrastructure/http/swamp_club_client_test.ts
+++ b/src/infrastructure/http/swamp_club_client_test.ts
@@ -19,7 +19,7 @@
 
 import { assertEquals, assertRejects } from "@std/assert";
 import { assertStringIncludes } from "@std/assert/string-includes";
-import { SwampClubClient } from "./swamp_club_client.ts";
+import { getCollectives, SwampClubClient } from "./swamp_club_client.ts";
 import { UserError } from "../../domain/errors.ts";
 
 /** Start a simple mock HTTP server that returns canned responses. */
@@ -828,4 +828,73 @@ Deno.test("submitIssue: respects caller abort signal", async () => {
   } finally {
     await mock.shutdown();
   }
+});
+
+// --- getCollectives: the extension-push authorization path (issue #1544) ---
+
+Deno.test("getCollectives: returns slugs from organizations", () => {
+  const slugs = getCollectives({
+    authenticated: true,
+    organizations: [
+      { slug: "acme", name: "Acme", role: "owner", personal: false },
+      { slug: "keeb", name: "keeb", role: "owner", personal: true },
+    ],
+  });
+
+  assertEquals(slugs, ["acme", "keeb"]);
+});
+
+Deno.test("getCollectives: entitlement never changes the collective list", () => {
+  // Extension push and pull authorize namespace ownership from this list
+  // (push.ts `fetchCollectives`). Entitlement is reported in its own
+  // `collectiveEntitlements` field precisely so billing can never add, drop,
+  // or reorder a collective the publish path depends on.
+  const organizations = [
+    { slug: "acme", name: "Acme", role: "owner", personal: false },
+    { slug: "keeb", name: "keeb", role: "owner", personal: true },
+  ];
+
+  const withoutEntitlement = getCollectives({
+    authenticated: true,
+    organizations,
+  });
+  const withEntitlement = getCollectives({
+    authenticated: true,
+    organizations,
+    plan: "team",
+    collectiveEntitlements: [
+      {
+        slug: "acme",
+        plan: "team",
+        planName: "Team",
+        subscriptionStatus: "active",
+        trial: null,
+      },
+      { slug: "keeb", plan: "free", planName: "Free", trial: null },
+    ],
+  });
+
+  assertEquals(withEntitlement, withoutEntitlement);
+  assertEquals(withEntitlement, ["acme", "keeb"]);
+});
+
+Deno.test("getCollectives: a collective missing entitlement is still listed", () => {
+  // The two arrays are joined on slug, not zipped. A collective absent from
+  // `collectiveEntitlements` must still authorize a push.
+  const slugs = getCollectives({
+    authenticated: true,
+    organizations: [
+      { slug: "acme", name: "Acme", role: "owner", personal: false },
+      { slug: "orphan", name: "Orphan", role: "member", personal: false },
+    ],
+    collectiveEntitlements: [
+      { slug: "acme", plan: "team", planName: "Team", trial: null },
+    ],
+  });
+
+  assertEquals(slugs, ["acme", "orphan"]);
+});
+
+Deno.test("getCollectives: undefined when the server sends no organizations", () => {
+  assertEquals(getCollectives({ authenticated: true }), undefined);
 });

--- a/src/libswamp/auth/whoami.ts
+++ b/src/libswamp/auth/whoami.ts
@@ -21,7 +21,10 @@ import {
   apiKeyFingerprint,
   type AuthCredentials,
 } from "../../domain/auth/auth_credentials.ts";
-import type { WhoamiResponse } from "../../infrastructure/http/swamp_club_client.ts";
+import type {
+  WhoamiResponse,
+  WhoamiTrial,
+} from "../../infrastructure/http/swamp_club_client.ts";
 import {
   getCollectives,
   SwampClubClient,
@@ -39,6 +42,24 @@ import {
   type SwampError,
 } from "../errors.ts";
 
+/**
+ * What one collective entitles the operative to, as the server reported it.
+ *
+ * Carried alongside — never instead of — {@link WhoamiIdentity.collectives}.
+ * That field is a slug list persisted to auth.json and read by three other
+ * call sites; widening it would rewrite every existing user's credentials file
+ * and turn a cache into a second, staler source of truth for a question the
+ * server owns.
+ */
+export interface WhoamiCollectiveEntitlement {
+  slug: string;
+  plan?: string;
+  planName?: string;
+  /** Owner/admin only — absent when the server withheld it. */
+  subscriptionStatus?: string | null;
+  trial?: WhoamiTrial | null;
+}
+
 export interface WhoamiIdentity {
   serverUrl: string;
   id: string;
@@ -46,6 +67,14 @@ export interface WhoamiIdentity {
   email: string;
   name: string;
   collectives?: string[];
+  /** Strongest plan across the operative's collectives. Server-derived. */
+  plan?: string;
+  /**
+   * Per-collective entitlement. Absent when the server sends none — an older
+   * or self-hosted swamp-club — which is what keeps whoami working against
+   * every server version.
+   */
+  collectiveEntitlements?: WhoamiCollectiveEntitlement[];
   collectiveToken?: boolean;
   collectiveSlug?: string;
   scopes?: string[];
@@ -108,6 +137,35 @@ export function createAuthDeps(options: CreateAuthDepsOptions = {}): AuthDeps {
   };
 }
 
+/**
+ * Per-collective entitlement from a whoami response, or undefined when the
+ * server sent none.
+ *
+ * Reads the dedicated `collectiveEntitlements` field, never `organizations` —
+ * that array is membership, and extension push authorizes against it. Returns
+ * undefined rather than an empty array so the renderers can tell "this server
+ * does not report entitlement" apart from "entitlement says everything is
+ * free", and fall back to the older output shape only in the first case.
+ */
+function toEntitlements(
+  response: WhoamiResponse,
+): WhoamiCollectiveEntitlement[] | undefined {
+  const entitlements = response.collectiveEntitlements;
+  if (!entitlements || entitlements.length === 0) return undefined;
+
+  return entitlements.map((entitlement) => ({
+    slug: entitlement.slug,
+    ...(entitlement.plan !== undefined ? { plan: entitlement.plan } : {}),
+    ...(entitlement.planName !== undefined
+      ? { planName: entitlement.planName }
+      : {}),
+    ...(entitlement.subscriptionStatus !== undefined
+      ? { subscriptionStatus: entitlement.subscriptionStatus }
+      : {}),
+    ...(entitlement.trial !== undefined ? { trial: entitlement.trial } : {}),
+  }));
+}
+
 /** Verifies the current authenticated identity via the swamp-club API. */
 export async function* whoami(
   ctx: LibSwampContext,
@@ -137,6 +195,7 @@ export async function* whoami(
     }
 
     const collectives = getCollectives(response);
+    const entitlements = toEntitlements(response);
 
     if (!response.collectiveToken) {
       // Refresh cached collectives in auth.json so they stay current.
@@ -156,6 +215,8 @@ export async function* whoami(
         email: response.email ?? "",
         name: response.name ?? "",
         ...(collectives ? { collectives } : {}),
+        ...(response.plan ? { plan: response.plan } : {}),
+        ...(entitlements ? { collectiveEntitlements: entitlements } : {}),
         ...(response.collectiveToken
           ? {
             collectiveToken: true,

--- a/src/libswamp/auth/whoami_response.fixture.json
+++ b/src/libswamp/auth/whoami_response.fixture.json
@@ -1,0 +1,47 @@
+{
+  "authenticated": true,
+  "id": "user-1",
+  "username": "keeb",
+  "email": "test@example.com",
+  "name": "Test",
+  "organizations": [
+    {
+      "slug": "acme",
+      "name": "Acme",
+      "role": "owner",
+      "personal": false
+    },
+    {
+      "slug": "keeb",
+      "name": "keeb",
+      "role": "owner",
+      "personal": true
+    }
+  ],
+  "plan": "team",
+  "collectiveEntitlements": [
+    {
+      "slug": "acme",
+      "plan": "team",
+      "planName": "Team",
+      "subscriptionStatus": "active",
+      "trial": null
+    },
+    {
+      "slug": "keeb",
+      "plan": "free",
+      "planName": "Free",
+      "subscriptionStatus": null,
+      "trial": {
+        "state": "active",
+        "startedAt": "2026-07-20T00:00:00.000Z",
+        "endsAt": "2026-08-19T00:00:00.000Z",
+        "trigger": "collective_created",
+        "dayNumber": 18,
+        "daysRemaining": 13,
+        "totalDays": 30,
+        "extended": false
+      }
+    }
+  ]
+}

--- a/src/libswamp/auth/whoami_test.ts
+++ b/src/libswamp/auth/whoami_test.ts
@@ -365,3 +365,111 @@ Deno.test("createAuthDeps: saveCredentials writes file when SWAMP_API_KEY is not
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
+
+// --- entitlement mapping (issue #1544) ---
+
+/** The exact JSON a current swamp-club returns for an owner. Kept in step with
+ * `tests/fixtures/whoami-owner-response.json` in the swamp-club repo, which a
+ * server test asserts against — so a field rename there breaks a test here. */
+const ownerFixture: WhoamiResponse = JSON.parse(
+  await Deno.readTextFile(
+    new URL("./whoami_response.fixture.json", import.meta.url),
+  ),
+);
+
+Deno.test("whoami maps server entitlement onto the identity", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps({
+    credentials: testCredentials,
+    whoamiResponse: ownerFixture,
+  });
+
+  const events = await collect<AuthWhoamiEvent>(whoami(ctx, deps));
+  const completed = events.at(-1) as Extract<
+    AuthWhoamiEvent,
+    { kind: "completed" }
+  >;
+
+  assertEquals(completed.identity.plan, "team");
+  assertEquals(completed.identity.collectiveEntitlements?.length, 2);
+
+  const [acme, keeb] = completed.identity.collectiveEntitlements!;
+  assertEquals(acme.slug, "acme");
+  assertEquals(acme.plan, "team");
+  assertEquals(acme.planName, "Team");
+  assertEquals(acme.subscriptionStatus, "active");
+  assertEquals(acme.trial, null);
+
+  assertEquals(keeb.plan, "free");
+  assertEquals(keeb.trial?.state, "active");
+  assertEquals(keeb.trial?.daysRemaining, 13);
+});
+
+Deno.test("whoami leaves entitlement absent when the server sends none", async () => {
+  // An older or self-hosted swamp-club. The renderers key off this to fall
+  // back to the pre-entitlement output.
+  const ctx = createLibSwampContext();
+  const deps = makeDeps({
+    credentials: testCredentials,
+    whoamiResponse: testWhoamiResponse,
+  });
+
+  const events = await collect<AuthWhoamiEvent>(whoami(ctx, deps));
+  const completed = events.at(-1) as Extract<
+    AuthWhoamiEvent,
+    { kind: "completed" }
+  >;
+
+  assertEquals(completed.identity.plan, undefined);
+  assertEquals(completed.identity.collectiveEntitlements, undefined);
+  assertEquals(completed.identity.collectives, ["si"]);
+});
+
+Deno.test("whoami omits subscriptionStatus the server withheld from a member", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps({
+    credentials: testCredentials,
+    whoamiResponse: {
+      ...ownerFixture,
+      organizations: [
+        { slug: "acme", name: "Acme", role: "member", personal: false },
+      ],
+      collectiveEntitlements: [
+        { slug: "acme", plan: "team", planName: "Team", trial: null },
+      ],
+    },
+  });
+
+  const events = await collect<AuthWhoamiEvent>(whoami(ctx, deps));
+  const completed = events.at(-1) as Extract<
+    AuthWhoamiEvent,
+    { kind: "completed" }
+  >;
+
+  const entitlement = completed.identity.collectiveEntitlements![0];
+  assertEquals("subscriptionStatus" in entitlement, false);
+  assertEquals(entitlement.plan, "team");
+});
+
+Deno.test("whoami caches only slugs, never entitlement", async () => {
+  // AuthCredentials.collectives is a persisted on-disk cache. A plan written
+  // there would go stale and become a second, wrong source of truth for a
+  // question the server owns.
+  const ctx = createLibSwampContext();
+  let saved: AuthCredentials | null = null;
+  const deps: AuthDeps = {
+    loadCredentials: () => Promise.resolve(testCredentials),
+    saveCredentials: (credentials) => {
+      saved = credentials;
+      return Promise.resolve();
+    },
+    fetchWhoami: () => Promise.resolve(ownerFixture),
+    serverUrlOverride: undefined,
+  };
+
+  await collect<AuthWhoamiEvent>(whoami(ctx, deps));
+
+  assertEquals(saved!.collectives, ["acme", "keeb"]);
+  assertEquals("plan" in saved!, false);
+  assertEquals("collectiveEntitlements" in saved!, false);
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -63,8 +63,10 @@ export {
   type AuthWhoamiEvent,
   createAuthDeps,
   whoami,
+  type WhoamiCollectiveEntitlement,
   type WhoamiIdentity,
 } from "./auth/whoami.ts";
+export type { WhoamiTrial } from "../infrastructure/http/swamp_club_client.ts";
 
 // Workflow operations
 export {

--- a/src/presentation/renderers/auth_whoami.ts
+++ b/src/presentation/renderers/auth_whoami.ts
@@ -17,11 +17,74 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { AuthWhoamiEvent, EventHandlers } from "../../libswamp/mod.ts";
+import type {
+  AuthWhoamiEvent,
+  EventHandlers,
+  WhoamiCollectiveEntitlement,
+  WhoamiIdentity,
+} from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
+import { bold, cyan, dim } from "@std/fmt/colors";
+
+/**
+ * The entitlement note for one collective: its billing status when paid, its
+ * trial when not.
+ *
+ * A paying collective is never told it is on a free trial — the same rule the
+ * web surface applies to its trial banner. It lives here rather than on the
+ * server because whoami is also a billing-triage endpoint: the server reports
+ * the trial whatever the plan, and `--json` keeps it, so nothing is lost by
+ * declining to show it.
+ */
+function entitlementNote(
+  entitlement: WhoamiCollectiveEntitlement,
+): string | undefined {
+  const paid = entitlement.plan !== undefined && entitlement.plan !== "free";
+  if (paid) return entitlement.subscriptionStatus ?? undefined;
+
+  const trial = entitlement.trial;
+  if (!trial || trial.state === "none") return undefined;
+  if (trial.state === "expired") return "trial expired";
+
+  const days = trial.daysRemaining;
+  const unit = days === 1 ? "day" : "days";
+  // Render the server's day count as given — it is elapsed-based and so
+  // timezone-independent. Recomputing from endsAt locally would reintroduce
+  // exactly the zone bug the server avoided. The date is only a hint.
+  const ends = trial.endsAt ? ` (ends ${trial.endsAt.slice(0, 10)})` : "";
+  return `trial: ${days} ${unit} left${ends}`;
+}
+
+/** Display name for the top-level roll-up, borrowed from a matching collective. */
+function rollUpPlanName(identity: WhoamiIdentity): string | undefined {
+  if (!identity.plan) return undefined;
+  const match = identity.collectiveEntitlements?.find(
+    (c) => c.plan === identity.plan && c.planName,
+  );
+  return match?.planName ?? identity.plan;
+}
+
+/** The aligned per-collective block. */
+function collectiveLines(
+  entitlements: WhoamiCollectiveEntitlement[],
+): string[] {
+  const slugWidth = Math.max(...entitlements.map((c) => c.slug.length));
+  const planWidth = Math.max(
+    ...entitlements.map((c) => (c.planName ?? c.plan ?? "").length),
+  );
+
+  return entitlements.map((c) => {
+    const plan = c.planName ?? c.plan ?? "";
+    const note = entitlementNote(c);
+    const row = `  ${bold(c.slug.padEnd(slugWidth))}  ${
+      plan.padEnd(planWidth)
+    }`;
+    return note ? `${row}  ${dim(note)}` : row.trimEnd();
+  });
+}
 
 class LogAuthWhoamiRenderer implements Renderer<AuthWhoamiEvent> {
   handlers(): EventHandlers<AuthWhoamiEvent> {
@@ -41,6 +104,21 @@ class LogAuthWhoamiRenderer implements Renderer<AuthWhoamiEvent> {
             `${e.identity.username} (${e.identity.email}) on ${e.identity.serverUrl}`,
           );
         }
+
+        const entitlements = e.identity.collectiveEntitlements;
+        if (entitlements && entitlements.length > 0) {
+          const planName = rollUpPlanName(e.identity);
+          if (planName) {
+            writeOutput(`${bold(cyan("Plan:"))} ${bold(planName)}`);
+          }
+          writeOutput(cyan("Collectives:"));
+          writeOutput(collectiveLines(entitlements).join("\n"));
+          return;
+        }
+
+        // No entitlement from this server — an older or self-hosted
+        // swamp-club. Fall back to the exact output shipped before this
+        // existed, so upgrading the CLI alone changes nothing.
         if (e.identity.collectives && e.identity.collectives.length > 0) {
           writeOutput(`Collectives: ${e.identity.collectives.join(", ")}`);
         }
@@ -76,6 +154,13 @@ class JsonAuthWhoamiRenderer implements Renderer<AuthWhoamiEvent> {
               }),
             ...(e.identity.collectives
               ? { collectives: e.identity.collectives }
+              : {}),
+            // Passed through verbatim, trial included regardless of plan —
+            // log mode hides a paid collective's trial, but --json is what
+            // gets pasted into a billing-triage report and must stay complete.
+            ...(e.identity.plan ? { plan: e.identity.plan } : {}),
+            ...(e.identity.collectiveEntitlements
+              ? { collectiveEntitlements: e.identity.collectiveEntitlements }
               : {}),
           },
           null,

--- a/src/presentation/renderers/auth_whoami_test.ts
+++ b/src/presentation/renderers/auth_whoami_test.ts
@@ -17,13 +17,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+import { stripAnsiCode } from "@std/fmt/colors";
 import {
   type AuthWhoamiEvent,
   consumeStream,
+  type WhoamiCollectiveEntitlement,
   type WhoamiIdentity,
 } from "../../libswamp/mod.ts";
 import { createAuthWhoamiRenderer } from "./auth_whoami.ts";
+import type { OutputMode } from "../output/output.ts";
 import { UserError } from "../../domain/errors.ts";
 
 function makeIdentity(
@@ -235,4 +238,191 @@ Deno.test("createAuthWhoamiRenderer - factory returns correct type per mode", ()
   const jsonRenderer = createAuthWhoamiRenderer("json");
   assertEquals(typeof logRenderer.handlers, "function");
   assertEquals(typeof jsonRenderer.handlers, "function");
+});
+
+// --- entitlement rendering (issue #1544) ---
+
+function makeEntitledIdentity(
+  entitlements: WhoamiCollectiveEntitlement[],
+  plan?: string,
+): WhoamiIdentity {
+  return {
+    ...makeIdentity({ collectives: entitlements.map((c) => c.slug) }),
+    ...(plan ? { plan } : {}),
+    collectiveEntitlements: entitlements,
+  };
+}
+
+function captureLog(identity: WhoamiIdentity, mode: OutputMode): string {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+  try {
+    const renderer = createAuthWhoamiRenderer(mode);
+    renderer.handlers().completed({ kind: "completed", identity });
+  } finally {
+    console.log = originalLog;
+  }
+  return stripAnsiCode(logs.join("\n"));
+}
+
+Deno.test("LogAuthWhoamiRenderer - no entitlement renders the pre-entitlement output", () => {
+  // The compatibility guarantee: upgrading the CLI alone, against an older or
+  // self-hosted swamp-club, must not change a byte of this.
+  const output = captureLog(
+    makeIdentity({ collectives: ["org-a", "org-b"] }),
+    "log",
+  );
+
+  assertEquals(
+    output,
+    "alice (alice@example.com) on https://club.example.com\n" +
+      "Collectives: org-a, org-b",
+  );
+});
+
+Deno.test("LogAuthWhoamiRenderer - shows the plan roll-up and per-collective block", () => {
+  const output = captureLog(
+    makeEntitledIdentity([
+      {
+        slug: "acme",
+        plan: "team",
+        planName: "Team",
+        subscriptionStatus: "active",
+        trial: null,
+      },
+      {
+        slug: "keeb",
+        plan: "free",
+        planName: "Free",
+        trial: {
+          state: "active",
+          startedAt: "2026-07-20T00:00:00.000Z",
+          endsAt: "2026-08-19T00:00:00.000Z",
+          daysRemaining: 13,
+        },
+      },
+    ], "team"),
+    "log",
+  );
+
+  assertStringIncludes(output, "Plan: Team");
+  assertStringIncludes(output, "Collectives:");
+  assertStringIncludes(output, "acme  Team  active");
+  assertStringIncludes(
+    output,
+    "keeb  Free  trial: 13 days left (ends 2026-08-19)",
+  );
+});
+
+Deno.test("LogAuthWhoamiRenderer - a paying collective is never shown a trial", () => {
+  // Same rule the web surface applies to its trial banner. The data is still
+  // in --json; only the display suppresses it.
+  const output = captureLog(
+    makeEntitledIdentity([
+      {
+        slug: "acme",
+        plan: "team",
+        planName: "Team",
+        subscriptionStatus: "active",
+        trial: {
+          state: "active",
+          startedAt: "2026-07-20T00:00:00.000Z",
+          endsAt: "2026-08-19T00:00:00.000Z",
+          daysRemaining: 13,
+        },
+      },
+    ], "team"),
+    "log",
+  );
+
+  assertEquals(output.includes("trial"), false);
+  assertStringIncludes(output, "active");
+});
+
+Deno.test("LogAuthWhoamiRenderer - an expired trial says so", () => {
+  const output = captureLog(
+    makeEntitledIdentity([
+      {
+        slug: "keeb",
+        plan: "free",
+        planName: "Free",
+        trial: {
+          state: "expired",
+          startedAt: "2026-05-01T00:00:00.000Z",
+          endsAt: "2026-05-31T00:00:00.000Z",
+          daysRemaining: 0,
+        },
+      },
+    ], "free"),
+    "log",
+  );
+
+  assertStringIncludes(output, "trial expired");
+});
+
+Deno.test("LogAuthWhoamiRenderer - one day left is singular", () => {
+  const output = captureLog(
+    makeEntitledIdentity([
+      {
+        slug: "keeb",
+        plan: "free",
+        planName: "Free",
+        trial: {
+          state: "active",
+          startedAt: "2026-07-08T00:00:00.000Z",
+          endsAt: "2026-08-07T00:00:00.000Z",
+          daysRemaining: 1,
+        },
+      },
+    ], "free"),
+    "log",
+  );
+
+  assertStringIncludes(output, "trial: 1 day left");
+});
+
+Deno.test("LogAuthWhoamiRenderer - a member's withheld status renders no note", () => {
+  const output = captureLog(
+    makeEntitledIdentity([
+      { slug: "acme", plan: "team", planName: "Team", trial: null },
+    ], "team"),
+    "log",
+  );
+
+  assertStringIncludes(output, "acme");
+  assertStringIncludes(output, "Team");
+  assertEquals(output.includes("active"), false);
+});
+
+Deno.test("JsonAuthWhoamiRenderer - passes plan and entitlement through verbatim", () => {
+  const trial = {
+    state: "active" as const,
+    startedAt: "2026-07-20T00:00:00.000Z",
+    endsAt: "2026-08-19T00:00:00.000Z",
+    daysRemaining: 13,
+  };
+  const output = captureLog(
+    makeEntitledIdentity([
+      { slug: "acme", plan: "team", planName: "Team", trial },
+    ], "team"),
+    "json",
+  );
+  const parsed = JSON.parse(output);
+
+  assertEquals(parsed.plan, "team");
+  assertEquals(parsed.collectiveEntitlements.length, 1);
+  assertEquals(parsed.collectiveEntitlements[0].planName, "Team");
+  // Retained even though log mode would hide it for a paid collective —
+  // --json is what gets pasted into a billing-triage report.
+  assertEquals(parsed.collectiveEntitlements[0].trial, trial);
+});
+
+Deno.test("JsonAuthWhoamiRenderer - omits entitlement keys when the server sent none", () => {
+  const output = captureLog(makeIdentity({ collectives: ["org-a"] }), "json");
+  const parsed = JSON.parse(output);
+
+  assertEquals("plan" in parsed, false);
+  assertEquals("collectiveEntitlements" in parsed, false);
+  assertEquals(parsed.collectives, ["org-a"]);
 });


### PR DESCRIPTION
## Summary

`swamp auth whoami` told you *who* you were but not *what you're entitled to*. Answering "am I on a paid plan?", "am I in a trial?", or "which collective needs upgrading?" meant opening the web UI.

whoami now surfaces per-collective entitlement:

```
keeb (nick@swamp-club.com) on https://swamp-club.com
Plan: Team
Collectives:
  acme  Team  active
  keeb  Free  trial: 13 days left (ends 2026-08-19)
```

This is the CLI half. **It is inert until the swamp-club side ships** — every field is optional, so against today's server nothing changes.

## The one thing worth reviewing carefully

Entitlement arrives in a **dedicated `collectiveEntitlements` field**, joined to `organizations` on slug — deliberately *not* as extra keys on the organizations entries.

That array is what extension push and pull authorize namespace ownership against: `getCollectives()` (`swamp_club_client.ts`) feeds `fetchCollectives` in `push.ts`, and `lib/auth.ts` in swamp-club records that a collective missing from this list means publishing is rejected. Keeping billing out of it means a future change to how plans are reported can never reach the publish path.

`getCollectives()` had **no tests at all** despite three call sites depending on it. It now has four, pinning that entitlement never changes the collective list and that the two arrays join on slug rather than being zipped.

## Two other placement decisions

- **Entitlement is never written to auth.json.** `AuthCredentials.collectives` stays a slug list. A cached plan would go stale and become a second, wrong answer to a question the server owns.
- **A paying collective is not shown a trial — but only in log mode.** The server reports the trial whatever the plan and `--json` passes it through, because "paste your `swamp auth whoami --json`" should be enough to triage a billing report.

## Test Plan

- `deno run test` — 9965 passed. One unrelated failure in `integration/serve_ready_test.ts`, which **passes in isolation** (flaky under parallelism; touches nothing here).
- `deno lint`, `deno fmt --check`, `deno run compile` — clean.
- New coverage: 4 `getCollectives()` regression tests, 4 libswamp mapping tests, 6 renderer tests.
- The load-bearing case is asserted by exact string equality: against a server sending no entitlement, log output is **byte-identical** to before.
- Response fixture is shared with a swamp-club server test, so a field rename there breaks a unit test here.

## Notes

- `deno check` fails on `src/libswamp/extensions/reconcile_from_disk_bench.ts` (TS2741, `getDenoEnv`). Pre-existing on main, untouched by this PR — wants its own issue.
- Docs: `design/rendering.md`'s worked `auth whoami` example reproduced both renderers verbatim and would have gone stale; updated along with the `design/libswamp.md` export list.
- Follow-up filed as #1545 (use this data to explain private-extension push refusals) and swamp-uat#338 (end-to-end coverage).

Refs #1544

🤖 Generated with [Claude Code](https://claude.com/claude-code)