### PR TITLE
fix(serve): handle cross-device rename during grant migration

### DIFF
--- a/src/domain/access/admin_materializer.ts
+++ b/src/domain/access/admin_materializer.ts
@@ -278,7 +278,25 @@ export async function migrateGrantDefinitions(
     } catch (statError) {
       if (!(statError instanceof Deno.errors.NotFound)) throw statError;
 
-      await Deno.rename(srcPath, dstPath);
+      try {
+        await Deno.rename(srcPath, dstPath);
+      } catch {
+        // Cross-filesystem move (repo and home on different mounts): rename
+        // throws EXDEV, so fall back to copy-then-remove. A NotFound from
+        // either step means a concurrent invocation already migrated the
+        // file — skip it.
+        try {
+          await Deno.copyFile(srcPath, dstPath);
+        } catch (copyError) {
+          if (copyError instanceof Deno.errors.NotFound) continue;
+          throw copyError;
+        }
+        try {
+          await Deno.remove(srcPath);
+        } catch (removeError) {
+          if (!(removeError instanceof Deno.errors.NotFound)) throw removeError;
+        }
+      }
       result.moved++;
       logger.info`Migrated grant definition ${entry.name} to auto-definitions`;
     }

--- a/src/infrastructure/persistence/directory_merge.ts
+++ b/src/infrastructure/persistence/directory_merge.ts
@@ -82,7 +82,23 @@ export async function mergeDirInto(
         // doesn't exist
       }
       if (!dstExists) {
-        await Deno.rename(srcPath, dstPath);
+        try {
+          await Deno.rename(srcPath, dstPath);
+        } catch {
+          try {
+            await Deno.copyFile(srcPath, dstPath);
+          } catch (copyError) {
+            if (copyError instanceof Deno.errors.NotFound) continue;
+            throw copyError;
+          }
+          try {
+            await Deno.remove(srcPath);
+          } catch (removeError) {
+            if (!(removeError instanceof Deno.errors.NotFound)) {
+              throw removeError;
+            }
+          }
+        }
         moved++;
       } else if (entry.isDirectory && !entry.isSymlink) {
         moved += await mergeRecursive(srcPath, dstPath, relPath);


### PR DESCRIPTION
## Summary

- Fix EXDEV (error 18) crash when `swamp serve` starts on Kubernetes with repo and home directory on different volume mounts
- `migrateGrantDefinitions` and `mergeDirInto` now fall back to copy-then-remove when `Deno.rename()` fails across filesystem boundaries
- Matches the existing pattern used in `telemetry_spool_migration.ts`

## Test Plan

- Existing unit tests for `admin_materializer` and `directory_merge` pass (same-filesystem path)
- Full test suite passes (9951 tests)
- Verified on Kubernetes pod where `/repo` and `/home/swamp/.swamp` are separate mounts