### PR TITLE
fix(vault): let provider handle key existence in vault delete

### DIFF
--- a/src/cli/commands/vault_delete.ts
+++ b/src/cli/commands/vault_delete.ts
@@ -175,22 +175,26 @@ When using --server, the confirmation prompt is not available — use --force to
       );
     } catch (error) {
       if (
-        options.force &&
         error instanceof Error &&
         /not found|can't find|ResourceNotFoundException/i.test(error.message)
       ) {
-        const renderer = createVaultDeleteRenderer(cliCtx.outputMode);
-        renderer.handlers().completed({
-          kind: "completed",
-          data: {
-            vaultName,
-            secretKey: key,
-            vaultType: preview.vaultType,
-            timestamp: new Date().toISOString(),
-            noOp: true,
-          },
-        });
-        return;
+        if (options.force) {
+          const renderer = createVaultDeleteRenderer(cliCtx.outputMode);
+          renderer.handlers().completed({
+            kind: "completed",
+            data: {
+              vaultName,
+              secretKey: key,
+              vaultType: preview.vaultType,
+              timestamp: new Date().toISOString(),
+              noOp: true,
+            },
+          });
+          return;
+        }
+        throw new UserError(
+          `Secret '${key}' not found in vault '${vaultName}'`,
+        );
       }
       throw error;
     }

--- a/src/cli/commands/vault_delete.ts
+++ b/src/cli/commands/vault_delete.ts
@@ -154,8 +154,31 @@ When using --server, the confirmation prompt is not available — use --force to
       );
     }
 
-    if (!preview.secretExists) {
-      if (options.force) {
+    if (cliCtx.outputMode === "log" && !options.yes && !options.force) {
+      const confirmed = await promptConfirmation(
+        `Delete secret '${key}' from vault '${vaultName}'?`,
+      );
+      if (!confirmed) {
+        renderVaultDeleteCancelled(cliCtx.outputMode);
+        return;
+      }
+    }
+
+    try {
+      const renderer = createVaultDeleteRenderer(cliCtx.outputMode);
+      await consumeStream(
+        vaultDelete(ctx, deps, {
+          vaultName,
+          key,
+        }),
+        renderer.handlers(),
+      );
+    } catch (error) {
+      if (
+        options.force &&
+        error instanceof Error &&
+        /not found|can't find|ResourceNotFoundException/i.test(error.message)
+      ) {
         const renderer = createVaultDeleteRenderer(cliCtx.outputMode);
         renderer.handlers().completed({
           kind: "completed",
@@ -169,29 +192,8 @@ When using --server, the confirmation prompt is not available — use --force to
         });
         return;
       }
-      throw new UserError(
-        `Secret '${key}' not found in vault '${vaultName}'`,
-      );
+      throw error;
     }
-
-    if (cliCtx.outputMode === "log" && !options.yes && !options.force) {
-      const confirmed = await promptConfirmation(
-        `Delete secret '${key}' from vault '${vaultName}'?`,
-      );
-      if (!confirmed) {
-        renderVaultDeleteCancelled(cliCtx.outputMode);
-        return;
-      }
-    }
-
-    const renderer = createVaultDeleteRenderer(cliCtx.outputMode);
-    await consumeStream(
-      vaultDelete(ctx, deps, {
-        vaultName,
-        key,
-      }),
-      renderer.handlers(),
-    );
 
     cliCtx.logger.debug("Vault delete command completed");
   } finally {

--- a/src/libswamp/vaults/delete.ts
+++ b/src/libswamp/vaults/delete.ts
@@ -37,7 +37,6 @@ export interface VaultDeletePreview {
   vaultName: string;
   vaultType: string;
   secretKey: string;
-  secretExists: boolean;
   supportsDelete: boolean;
 }
 
@@ -62,7 +61,6 @@ export interface VaultDeleteInput {
 export interface VaultDeleteDeps {
   findVault: (name: string) => Promise<VaultDeleteConfigInfo | null>;
   listVaultNames: () => Promise<string[]>;
-  secretExists: (vaultName: string, key: string) => Promise<boolean>;
   supportsDelete: (vaultName: string) => Promise<boolean>;
   deleteSecret: (vaultName: string, key: string) => Promise<void>;
   publishSecretDeleted: (
@@ -92,11 +90,6 @@ export function createVaultDeleteDeps(
     listVaultNames: async () => {
       const all = await vaultConfigRepo.findAll();
       return all.map((v) => v.name);
-    },
-    secretExists: async (vaultName, key) => {
-      const svc = await getVaultService();
-      const keys = await svc.list(vaultName);
-      return keys.includes(key);
     },
     supportsDelete: async (vaultName) => {
       const svc = await getVaultService();
@@ -141,14 +134,12 @@ export async function vaultDeletePreview(
   }
 
   const supports = await deps.supportsDelete(vaultName);
-  const exists = supports ? await deps.secretExists(vaultName, key) : false;
-  ctx.logger.debug`Secret exists: ${exists}, supports delete: ${supports}`;
+  ctx.logger.debug`Supports delete: ${supports}`;
 
   return {
     vaultName: config.name,
     vaultType: config.type,
     secretKey: key,
-    secretExists: exists,
     supportsDelete: supports,
   };
 }

--- a/src/libswamp/vaults/delete_test.ts
+++ b/src/libswamp/vaults/delete_test.ts
@@ -32,7 +32,6 @@ function makeDeps(overrides: Partial<VaultDeleteDeps> = {}): VaultDeleteDeps {
     findVault: () =>
       Promise.resolve({ id: "v1", name: "my-vault", type: "local_encryption" }),
     listVaultNames: () => Promise.resolve(["my-vault"]),
-    secretExists: () => Promise.resolve(true),
     supportsDelete: () => Promise.resolve(true),
     deleteSecret: () => Promise.resolve(),
     publishSecretDeleted: () => Promise.resolve(),
@@ -40,7 +39,7 @@ function makeDeps(overrides: Partial<VaultDeleteDeps> = {}): VaultDeleteDeps {
   };
 }
 
-Deno.test("vaultDeletePreview: returns preview with secret existence check", async () => {
+Deno.test("vaultDeletePreview: returns preview for existing vault", async () => {
   const deps = makeDeps();
 
   const preview = await vaultDeletePreview(
@@ -53,7 +52,6 @@ Deno.test("vaultDeletePreview: returns preview with secret existence check", asy
   assertEquals(preview.vaultName, "my-vault");
   assertEquals(preview.vaultType, "local_encryption");
   assertEquals(preview.secretKey, "API_KEY");
-  assertEquals(preview.secretExists, true);
   assertEquals(preview.supportsDelete, true);
 });
 
@@ -89,22 +87,6 @@ Deno.test("vaultDeletePreview: reports unsupported when provider lacks delete", 
   );
 
   assertEquals(preview.supportsDelete, false);
-  assertEquals(preview.secretExists, false);
-});
-
-Deno.test("vaultDeletePreview: reports non-existent secret", async () => {
-  const deps = makeDeps({
-    secretExists: () => Promise.resolve(false),
-  });
-
-  const preview = await vaultDeletePreview(
-    createLibSwampContext(),
-    deps,
-    "my-vault",
-    "MISSING_KEY",
-  );
-
-  assertEquals(preview.secretExists, false);
 });
 
 Deno.test("vaultDelete: yields completed after deleting secret", async () => {
@@ -175,4 +157,30 @@ Deno.test("vaultDelete: publishes VaultSecretDeleted event", async () => {
 
   assertEquals(publishedKey, "SECRET");
   assertEquals(publishedVaultName, "my-vault");
+});
+
+Deno.test("vaultDelete: succeeds when provider normalizes key names", async () => {
+  let deletedKey = "";
+  const deps = makeDeps({
+    deleteSecret: (_vault, key) => {
+      deletedKey = key;
+      return Promise.resolve();
+    },
+  });
+
+  const events = await collect<VaultDeleteEvent>(
+    vaultDelete(createLibSwampContext(), deps, {
+      vaultName: "my-vault",
+      key: "client_id",
+    }),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0].kind, "deleting");
+  const completed = events[1] as Extract<
+    VaultDeleteEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.secretKey, "client_id");
+  assertEquals(deletedKey, "client_id");
 });

--- a/src/serve/handlers/vault_handlers.ts
+++ b/src/serve/handlers/vault_handlers.ts
@@ -306,6 +306,7 @@ export async function handleVaultDelete(
     return;
   }
 
+  let vaultType = "";
   try {
     const libCtx = createLibSwampContext();
     const deps = createVaultDeleteDeps(ctx.repoDir, ctx.repoContext.eventBus);
@@ -317,6 +318,8 @@ export async function handleVaultDelete(
       payload.key,
     );
 
+    vaultType = preview.vaultType;
+
     if (!preview.supportsDelete) {
       sendError(
         socket,
@@ -324,33 +327,6 @@ export async function handleVaultDelete(
         "unsupported",
         `Vault '${payload.vaultName}' (type: ${preview.vaultType}) does not support deleting secrets`,
       );
-      return;
-    }
-
-    if (!preview.secretExists && !payload.force) {
-      sendError(
-        socket,
-        requestId,
-        "not_found",
-        `Secret '${payload.key}' not found in vault '${payload.vaultName}'`,
-      );
-      return;
-    }
-
-    if (!preview.secretExists && payload.force) {
-      send(socket, {
-        type: "vault.delete",
-        id: requestId,
-        payload: {
-          data: {
-            vaultName: payload.vaultName,
-            secretKey: payload.key,
-            vaultType: preview.vaultType,
-            noOp: true,
-            timestamp: new Date().toISOString(),
-          },
-        },
-      });
       return;
     }
 
@@ -389,6 +365,24 @@ export async function handleVaultDelete(
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {
       sendError(socket, requestId, "cancelled", "Operation was cancelled");
+    } else if (
+      payload.force &&
+      error instanceof Error &&
+      /not found|can't find|ResourceNotFoundException/i.test(error.message)
+    ) {
+      send(socket, {
+        type: "vault.delete",
+        id: requestId,
+        payload: {
+          data: {
+            vaultName: payload.vaultName,
+            secretKey: payload.key,
+            vaultType,
+            noOp: true,
+            timestamp: new Date().toISOString(),
+          },
+        },
+      });
     } else {
       const message = sanitizeErrorForClient(error);
       sendError(socket, requestId, "vault_delete_failed", message);

--- a/src/serve/handlers/vault_handlers.ts
+++ b/src/serve/handlers/vault_handlers.ts
@@ -366,23 +366,31 @@ export async function handleVaultDelete(
     if (error instanceof DOMException && error.name === "AbortError") {
       sendError(socket, requestId, "cancelled", "Operation was cancelled");
     } else if (
-      payload.force &&
       error instanceof Error &&
       /not found|can't find|ResourceNotFoundException/i.test(error.message)
     ) {
-      send(socket, {
-        type: "vault.delete",
-        id: requestId,
-        payload: {
-          data: {
-            vaultName: payload.vaultName,
-            secretKey: payload.key,
-            vaultType,
-            noOp: true,
-            timestamp: new Date().toISOString(),
+      if (payload.force) {
+        send(socket, {
+          type: "vault.delete",
+          id: requestId,
+          payload: {
+            data: {
+              vaultName: payload.vaultName,
+              secretKey: payload.key,
+              vaultType,
+              noOp: true,
+              timestamp: new Date().toISOString(),
+            },
           },
-        },
-      });
+        });
+      } else {
+        sendError(
+          socket,
+          requestId,
+          "not_found",
+          `Secret '${payload.key}' not found in vault '${payload.vaultName}'`,
+        );
+      }
     } else {
       const message = sanitizeErrorForClient(error);
       sendError(socket, requestId, "vault_delete_failed", message);


### PR DESCRIPTION
## Summary

- Remove the `secretExists` pre-check from vault delete — providers already handle not-found in their `delete()` methods, and the pre-check compared raw user input against provider-normalized `list()` output, which fails for providers that transform key names (e.g. Azure KV converts `_` to `-`)
- For `--force`, catch not-found errors from the provider and treat as no-op
- Update serve handler with the same fix

Closes swamp-club#1543

## Test plan

- [x] Unit tests pass (`deno run test src/libswamp/vaults/delete_test.ts`)
- [x] Added regression test: provider whose `delete()` succeeds with unnormalized key names
- [x] Full test suite passes (9967 tests)
- [x] E2E verified against MiniStack (AWS SM emulator): put, list, delete, `--force` with non-existent key
- [x] `deno check` passes (1 pre-existing error in unrelated file)
- [x] `deno lint` and `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)