### PR TITLE
fix(access): correct vault retrieval hint in token mint/rotate output

### DIFF
--- a/src/presentation/output/access_token_output.ts
+++ b/src/presentation/output/access_token_output.ts
@@ -91,8 +91,11 @@ export function renderServerTokenCreate(
     "",
     `Retrieve the token with: ${
       bold(
-        `swamp vault get ${data.vaultRef.vaultName} ${data.vaultRef.secretKey}`,
+        `swamp vault read-secret ${data.vaultRef.vaultName} ${data.vaultRef.secretKey} --yes`,
       )
+    }`,
+    `The client token is ${bold("<name>.<secret>")} — prepend the token name: ${
+      bold(`${data.name}.<secret>`)
     }`,
   ];
   writeOutput(lines.join("\n"));
@@ -169,8 +172,11 @@ export function renderServerTokenRotate(
     "",
     `Retrieve the new token with: ${
       bold(
-        `swamp vault get ${data.vaultRef.vaultName} ${data.vaultRef.secretKey}`,
+        `swamp vault read-secret ${data.vaultRef.vaultName} ${data.vaultRef.secretKey} --yes`,
       )
+    }`,
+    `The client token is ${bold("<name>.<secret>")} — prepend the token name: ${
+      bold(`${data.name}.<secret>`)
     }`,
   ];
   writeOutput(lines.join("\n"));

--- a/src/presentation/output/access_token_output_test.ts
+++ b/src/presentation/output/access_token_output_test.ts
@@ -1,0 +1,81 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertStringIncludes } from "@std/assert";
+import { stripAnsiCode } from "@std/fmt/colors";
+import type {
+  ServerTokenCreateData,
+  ServerTokenRotateData,
+} from "../../libswamp/mod.ts";
+import {
+  renderServerTokenCreate,
+  renderServerTokenRotate,
+} from "./access_token_output.ts";
+
+function captureLogs(fn: () => void): string {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+  try {
+    fn();
+  } finally {
+    console.log = originalLog;
+  }
+  return stripAnsiCode(logs.join("\n"));
+}
+
+const createData: ServerTokenCreateData = {
+  name: "swamp-ui",
+  principalId: "user:sntxrr",
+  expiresAt: "2027-08-07T00:00:00Z",
+  vaultRef: { vaultName: "serve-local", secretKey: "server-token-swamp-ui" },
+};
+
+const rotateData: ServerTokenRotateData = {
+  name: "swamp-ui",
+  principalId: "user:sntxrr",
+  expiresAt: "2027-08-07T00:00:00Z",
+  vaultRef: { vaultName: "serve-local", secretKey: "server-token-swamp-ui" },
+};
+
+Deno.test("renderServerTokenCreate: hint uses vault read-secret, not vault get", () => {
+  const output = captureLogs(() => renderServerTokenCreate(createData, "log"));
+  assertStringIncludes(
+    output,
+    "swamp vault read-secret serve-local server-token-swamp-ui --yes",
+  );
+});
+
+Deno.test("renderServerTokenCreate: includes wire-format guidance", () => {
+  const output = captureLogs(() => renderServerTokenCreate(createData, "log"));
+  assertStringIncludes(output, "swamp-ui.<secret>");
+});
+
+Deno.test("renderServerTokenRotate: hint uses vault read-secret, not vault get", () => {
+  const output = captureLogs(() => renderServerTokenRotate(rotateData, "log"));
+  assertStringIncludes(
+    output,
+    "swamp vault read-secret serve-local server-token-swamp-ui --yes",
+  );
+});
+
+Deno.test("renderServerTokenRotate: includes wire-format guidance", () => {
+  const output = captureLogs(() => renderServerTokenRotate(rotateData, "log"));
+  assertStringIncludes(output, "swamp-ui.<secret>");
+});


### PR DESCRIPTION
## Summary

- `swamp access token mint` and `rotate` emitted `swamp vault get <vault> <key>` as the retrieval hint, but `vault get` only takes a vault name — changed to `swamp vault read-secret <vault> <key> --yes`
- Added wire-format guidance: the client token is `<name>.<secret>`, so operators know to prepend the token name
- Added unit tests for both render functions verifying the correct hint command, `--yes` flag, and wire-format guidance

Fixes swamp-club#1549

## Test Plan

- [x] 4 new unit tests in `access_token_output_test.ts` — all pass
- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno fmt` clean