### PR TITLE
feat(model): exclude internal model types from search/list by default

### DIFF
--- a/packages/client/protocol.ts
+++ b/packages/client/protocol.ts
@@ -119,6 +119,7 @@ export interface ModelDeletePayload {
 
 export interface ModelSearchPayload {
   query?: string;
+  includeInternal?: boolean;
 }
 
 export interface ModelMethodDescribePayload {

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -157,5 +157,6 @@ export const modelCommand = new Command()
         "--repo-dir <dir:string>",
         "Repository directory (env: SWAMP_REPO_DIR)",
       )
+      .option("--all", "Include internal model types")
       .action(modelSearchAction),
   );

--- a/src/cli/commands/model_search.ts
+++ b/src/cli/commands/model_search.ts
@@ -29,6 +29,7 @@ import {
   type ModelSearchDeps,
   type ModelSearchItem,
 } from "../../libswamp/mod.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
 import { createModelSearchRenderer } from "../../presentation/renderers/model_search.tsx";
 import {
   createContext,
@@ -113,6 +114,7 @@ export async function modelSearchAction(
 
   const deps: ModelSearchDeps = {
     findAllGlobal: () => repoContext.definitionRepo.findAllGlobal(),
+    isInternalType: (type: string) => modelRegistry.isInternal(type),
   };
 
   const repoDir = resolveRepoDir(options.repoDir);
@@ -120,9 +122,10 @@ export async function modelSearchAction(
     ? await createModelFetchPreview(repoDir)
     : undefined;
 
+  const includeInternal = options.all as boolean | undefined;
   const renderer = createModelSearchRenderer(effectiveMode, fetchPreview);
   await consumeStream(
-    modelSearch(libCtx, deps, { query }),
+    modelSearch(libCtx, deps, { query, includeInternal }),
     renderer.handlers(),
   );
 
@@ -142,9 +145,11 @@ export const modelSearchCommand = withRemoteOptions(
     .description("Search for model definitions")
     .example("Browse all models", "swamp model search")
     .example("Search by keyword", "swamp model search aws")
+    .example("Include internal types", "swamp model search --all")
     .arguments("[query:string]")
     .option(
       "--repo-dir <dir:string>",
       "Repository directory (env: SWAMP_REPO_DIR)",
-    ),
+    )
+    .option("--all", "Include internal model types"),
 ).action(modelSearchAction);

--- a/src/cli/commands/model_search.ts
+++ b/src/cli/commands/model_search.ts
@@ -81,6 +81,7 @@ export async function modelSearchAction(
   query?: string,
 ): Promise<void> {
   const ctx = createContext(options as GlobalOptions, ["model", "search"]);
+  const includeInternal = options.all as boolean | undefined;
 
   const server = resolveServeUrl(options.server as string | undefined);
   if (server) {
@@ -92,7 +93,7 @@ export async function modelSearchAction(
       { server, token },
       {
         type: "model.search",
-        payload: { query },
+        payload: { query, includeInternal },
       },
     );
     const renderer = createModelSearchRenderer(ctx.outputMode);
@@ -121,8 +122,6 @@ export async function modelSearchAction(
   const fetchPreview = effectiveMode === "log"
     ? await createModelFetchPreview(repoDir)
     : undefined;
-
-  const includeInternal = options.all as boolean | undefined;
   const renderer = createModelSearchRenderer(effectiveMode, fetchPreview);
   await consumeStream(
     modelSearch(libCtx, deps, { query, includeInternal }),

--- a/src/cli/commands/model_search_test.ts
+++ b/src/cli/commands/model_search_test.ts
@@ -47,6 +47,22 @@ Deno.test("modelSearchCommand is registered as subcommand of modelCommand", asyn
   assertEquals(searchCmd !== undefined, true);
 });
 
+Deno.test("modelSearchCommand has --all option", async () => {
+  const { modelSearchCommand } = await import("./model_search.ts");
+  const options = modelSearchCommand.getOptions();
+  const allOption = options.find((o) => o.name === "all");
+  assertEquals(allOption !== undefined, true);
+});
+
+Deno.test("model list alias has --all option", async () => {
+  const { modelCommand } = await import("./model_create.ts");
+  const listCmd = modelCommand.getCommand("list", true);
+  assertEquals(listCmd !== undefined, true);
+  const options = listCmd!.getOptions();
+  const allOption = options.find((o) => o.name === "all");
+  assertEquals(allOption !== undefined, true);
+});
+
 // filterModels tests
 Deno.test("filterModels returns all models when query is empty", async () => {
   const { filterModels } = await import(

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -1273,6 +1273,13 @@ export class ModelRegistry {
       : type.normalized;
     this.internalTypes.add(normalized);
   }
+
+  isInternal(type: ModelType | string): boolean {
+    const normalized = typeof type === "string"
+      ? ModelType.create(type).normalized
+      : type.normalized;
+    return this.internalTypes.has(normalized);
+  }
 }
 
 /**

--- a/src/domain/models/model_test.ts
+++ b/src/domain/models/model_test.ts
@@ -444,6 +444,16 @@ Deno.test("ModelRegistry.publicTypes excludes internal models", () => {
   assertEquals(publicTypes[0].normalized, "swamp/echo");
 });
 
+Deno.test("ModelRegistry.isInternal returns true for internal types", () => {
+  const registry = new ModelRegistry();
+  registry.register(createTestModel("swamp/echo"));
+  registry.register(createTestModel("swamp/internal"));
+  registry.markInternal("swamp/internal");
+
+  assertEquals(registry.isInternal("swamp/internal"), true);
+  assertEquals(registry.isInternal("swamp/echo"), false);
+});
+
 Deno.test("ModelDefinition method can execute", async () => {
   const model = createTestModel("swamp/echo");
 

--- a/src/libswamp/models/search.ts
+++ b/src/libswamp/models/search.ts
@@ -53,6 +53,7 @@ export interface ModelSearchDeps {
       type: { normalized: string };
     }>
   >;
+  isInternalType?: (type: string) => boolean;
 }
 
 /**
@@ -60,6 +61,7 @@ export interface ModelSearchDeps {
  */
 export interface ModelSearchInput {
   query?: string;
+  includeInternal?: boolean;
 }
 
 /**
@@ -80,7 +82,10 @@ export async function* modelSearch(
       yield { kind: "resolving" };
 
       const allResults = await deps.findAllGlobal();
-      const results: ModelSearchItem[] = allResults.map(
+      const filtered = input.includeInternal || !deps.isInternalType
+        ? allResults
+        : allResults.filter((r) => !deps.isInternalType!(r.type.normalized));
+      const results: ModelSearchItem[] = filtered.map(
         ({ definition, type }) => ({
           id: definition.id,
           name: definition.name,

--- a/src/libswamp/models/search_test.ts
+++ b/src/libswamp/models/search_test.ts
@@ -26,21 +26,36 @@ import {
   type ModelSearchEvent,
 } from "./search.ts";
 
+const DEFAULT_RESULTS = [
+  {
+    definition: { id: "def-1", name: "my-ec2" },
+    type: { normalized: "aws/ec2-instance" },
+  },
+  {
+    definition: { id: "def-2", name: "my-bucket" },
+    type: { normalized: "aws/s3-bucket" },
+  },
+];
+
+const RESULTS_WITH_INTERNAL = [
+  ...DEFAULT_RESULTS,
+  {
+    definition: { id: "def-3", name: "server-token-1" },
+    type: { normalized: "swamp/server-token" },
+  },
+  {
+    definition: { id: "def-4", name: "grant-1" },
+    type: { normalized: "swamp/grant" },
+  },
+];
+
+const INTERNAL_TYPES = new Set(["swamp/server-token", "swamp/grant"]);
+
 function makeDeps(
   overrides: Partial<ModelSearchDeps> = {},
 ): ModelSearchDeps {
   return {
-    findAllGlobal: () =>
-      Promise.resolve([
-        {
-          definition: { id: "def-1", name: "my-ec2" },
-          type: { normalized: "aws/ec2-instance" },
-        },
-        {
-          definition: { id: "def-2", name: "my-bucket" },
-          type: { normalized: "aws/s3-bucket" },
-        },
-      ]),
+    findAllGlobal: () => Promise.resolve(DEFAULT_RESULTS),
     ...overrides,
   };
 }
@@ -94,4 +109,53 @@ Deno.test("modelSearch: returns empty results when no models exist", async () =>
     { kind: "completed" }
   >;
   assertEquals(completed.data.results.length, 0);
+});
+
+Deno.test("modelSearch: excludes internal types by default", async () => {
+  const deps = makeDeps({
+    findAllGlobal: () => Promise.resolve(RESULTS_WITH_INTERNAL),
+    isInternalType: (type: string) => INTERNAL_TYPES.has(type),
+  });
+  const events = await collect<ModelSearchEvent>(
+    modelSearch(createLibSwampContext(), deps, {}),
+  );
+
+  const completed = events[1] as Extract<
+    ModelSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 2);
+  assertEquals(completed.data.results[0].name, "my-ec2");
+  assertEquals(completed.data.results[1].name, "my-bucket");
+});
+
+Deno.test("modelSearch: includes internal types when includeInternal is true", async () => {
+  const deps = makeDeps({
+    findAllGlobal: () => Promise.resolve(RESULTS_WITH_INTERNAL),
+    isInternalType: (type: string) => INTERNAL_TYPES.has(type),
+  });
+  const events = await collect<ModelSearchEvent>(
+    modelSearch(createLibSwampContext(), deps, { includeInternal: true }),
+  );
+
+  const completed = events[1] as Extract<
+    ModelSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 4);
+});
+
+Deno.test("modelSearch: returns all when isInternalType dep is not provided", async () => {
+  const deps = makeDeps({
+    findAllGlobal: () => Promise.resolve(RESULTS_WITH_INTERNAL),
+  });
+  const events = await collect<ModelSearchEvent>(
+    modelSearch(createLibSwampContext(), deps, {}),
+  );
+
+  const completed = events[1] as Extract<
+    ModelSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 4);
 });

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -524,11 +524,15 @@ export async function handleModelSearch(
     const libCtx = createLibSwampContext();
     const deps: ModelSearchDeps = {
       findAllGlobal: () => ctx.repoContext.definitionRepo.findAllGlobal(),
+      isInternalType: (type: string) => modelRegistry.isInternal(type),
     };
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(
-      modelSearch(libCtx, deps, { query: payload?.query }),
+      modelSearch(libCtx, deps, {
+        query: payload?.query,
+        includeInternal: payload?.includeInternal,
+      }),
       {
         resolving: () => {},
         completed: (e) => {

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -113,6 +113,7 @@ export interface DataListPayload {
 
 export interface ModelSearchPayload {
   query?: string;
+  includeInternal?: boolean;
 }
 
 export interface ModelMethodDescribePayload {


### PR DESCRIPTION
## Summary

- Filter internal swamp serve model types (`swamp/server-token`, `swamp/enrollment-token`, `swamp/worker`, `swamp/step-lease`, `swamp/pending-dispatch`, `swamp/fleet-probe`, `swamp/grant`, `swamp/group`) from `swamp model search` and `swamp model list` output by default
- Add `--all` flag to both commands to include internal types when needed for debugging or administration
- Add `ModelRegistry.isInternal()` method, extending the existing `markInternal()`/`publicTypes()` infrastructure to model definition listing
- Filter at the `modelSearch` generator (application service layer) so both CLI and serve get consistent behavior
- Add `includeInternal` to the serve `model.search` protocol payload for remote clients

## Test Plan

- [x] `ModelRegistry.isInternal()` returns correct values for marked/unmarked types
- [x] `modelSearch` generator excludes internal types by default when `isInternalType` dep is provided
- [x] `modelSearch` generator includes internal types when `includeInternal: true`
- [x] `modelSearch` generator returns all when `isInternalType` dep is not provided (backwards compat)
- [x] `modelSearchCommand` has `--all` option
- [x] Hidden `list` alias has `--all` option
- [x] All 10010 existing tests pass
- [x] `deno check`, `deno lint`, `deno fmt` clean

Closes #1546