### PR TITLE
fix(skills): replace invalid 'vault get' with 'vault read-secret' in skill docs

### DIFF
--- a/.claude/skills/swamp/references/model/references/troubleshooting.md
+++ b/.claude/skills/swamp/references/model/references/troubleshooting.md
@@ -313,7 +313,7 @@ echo $AWS_REGION
 aws sts get-caller-identity
 
 # Check vault expressions resolve
-swamp vault get <vault-name> <key> --json
+swamp vault read-secret <vault-name> <key> --json
 ```
 
 ## Data and Output Issues

--- a/.claude/skills/swamp/references/vault/references/examples.md
+++ b/.claude/skills/swamp/references/vault/references/examples.md
@@ -269,7 +269,7 @@ config:
 
 ```bash
 # Get secrets from local vault (one at a time for security)
-swamp vault get prod-secrets API_KEY --json
+swamp vault read-secret prod-secrets API_KEY --json
 # Copy the value
 
 # Put into AWS vault


### PR DESCRIPTION
## Summary

- Replaced `swamp vault get <vault> <key>` with `swamp vault read-secret <vault> <key>` in two skill reference files
- `vault get` only shows vault configuration details — `vault read-secret` is the correct command for retrieving secrets by key
- Affected files: `troubleshooting.md` (model skill) and `examples.md` (vault skill)

Closes swamp-club#1550

## Test plan

- [x] Verified `swamp vault --help` confirms `read-secret` is the correct subcommand
- [x] Grepped all skill docs — only these two files used the invalid two-argument form
- [x] Other `vault get` usages are valid single-argument calls (showing vault config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)