### PR TITLE
feat(access): resolve user subjects to human-readable names in grant list

### DIFF
--- a/src/cli/commands/access_grant.ts
+++ b/src/cli/commands/access_grant.ts
@@ -353,8 +353,11 @@ const accessGrantListCommand = new Command()
           grants.push(parsed.data);
         }
       }
+      const displayNames = response.subjectDisplayNames as
+        | Record<string, string>
+        | undefined;
       const renderer = createAccessGrantListRenderer(ctx.outputMode);
-      renderer.render(grants);
+      renderer.render(grants, displayNames);
       return;
     }
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1528,6 +1528,7 @@ export const serveCommand = new Command()
     );
 
     let oauthClientSecret = "";
+    const resolvedUserNames: Record<string, string> = {};
     if (authConfig.mode === "oauth") {
       const oauthVaultService = await VaultService.fromRepository(
         resolvedRepoDir,
@@ -1748,6 +1749,12 @@ export const serveCommand = new Command()
           TOKEN_SECRETS_VAULT_NAME,
           resolvedMap,
         );
+        for (const [key, sub] of Object.entries(resolvedMap)) {
+          const username = key.startsWith("allowed:")
+            ? key.slice("allowed:".length)
+            : key;
+          resolvedUserNames[sub] = username;
+        }
       } else if (credentials.resolvedAdmins) {
         for (let i = 0; i < authConfig.admins.length; i++) {
           const admin = authConfig.admins[i];
@@ -1782,6 +1789,12 @@ export const serveCommand = new Command()
                 "Restart serve without --oauth-client-id to re-register",
             );
           }
+        }
+        for (const [key, sub] of Object.entries(credentials.resolvedAdmins)) {
+          const username = key.startsWith("allowed:")
+            ? key.slice("allowed:".length)
+            : key;
+          resolvedUserNames[sub] = username;
         }
       } else {
         throw new UserError(
@@ -2132,6 +2145,9 @@ export const serveCommand = new Command()
         staleTtlMs,
         grantsFile: externalGrantsFilePath,
         hotReload: merged.hotReload,
+        ...(Object.keys(resolvedUserNames).length > 0
+          ? { resolvedUserNames }
+          : {}),
       };
 
     const ac = new AbortController();

--- a/src/presentation/renderers/access_grant.ts
+++ b/src/presentation/renderers/access_grant.ts
@@ -22,10 +22,16 @@ import type { OutputMode } from "../output/output.ts";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
 
 export interface AccessGrantListRenderer {
-  render(grants: Grant[]): void;
+  render(grants: Grant[], displayNames?: Record<string, string>): void;
 }
 
-function formatSubject(subject: Grant["subject"]): string {
+function formatSubject(
+  subject: Grant["subject"],
+  displayNames?: Record<string, string>,
+): string {
+  if (subject.kind === "user" && displayNames?.[subject.name]) {
+    return `${subject.kind}:${displayNames[subject.name]}`;
+  }
   return `${subject.kind}:${subject.name}`;
 }
 
@@ -34,7 +40,7 @@ function formatResource(resource: Grant["resource"]): string {
 }
 
 class LogAccessGrantListRenderer implements AccessGrantListRenderer {
-  render(grants: Grant[]): void {
+  render(grants: Grant[], displayNames?: Record<string, string>): void {
     if (grants.length === 0) {
       writeOutput("No active grants found.");
       return;
@@ -50,7 +56,7 @@ class LogAccessGrantListRenderer implements AccessGrantListRenderer {
 
     for (const grant of grants) {
       const id = grant.id.padEnd(idDisplay);
-      const subject = formatSubject(grant.subject).padEnd(28);
+      const subject = formatSubject(grant.subject, displayNames).padEnd(28);
       const effect = grant.effect.padEnd(6);
       const actions = grant.actions.join(",").padEnd(20);
       const resource = formatResource(grant.resource).padEnd(28);

--- a/src/presentation/renderers/access_grant_test.ts
+++ b/src/presentation/renderers/access_grant_test.ts
@@ -93,3 +93,88 @@ Deno.test("accessGrantListRenderer json: outputs JSON array", () => {
   const parsed = JSON.parse(output.join(""));
   assertStringIncludes(parsed[0].id, "test-uuid");
 });
+
+Deno.test("accessGrantListRenderer log: resolves user subject with display name", () => {
+  const renderer = createAccessGrantListRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    const grant = makeGrant({
+      subject: { kind: "user", name: "8d540893-434a-4422-8970-6edba6602e9b" },
+    });
+    renderer.render([grant], {
+      "8d540893-434a-4422-8970-6edba6602e9b": "paul",
+    });
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[1], "user:paul");
+});
+
+Deno.test("accessGrantListRenderer log: falls back to raw sub when no display name", () => {
+  const renderer = createAccessGrantListRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    const grant = makeGrant({
+      subject: { kind: "user", name: "unknown-sub-id" },
+    });
+    renderer.render([grant], { "other-sub": "bob" });
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[1], "user:unknown-sub-id");
+});
+
+Deno.test("accessGrantListRenderer log: does not resolve group subjects", () => {
+  const renderer = createAccessGrantListRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    const grant = makeGrant({
+      subject: { kind: "group", name: "platform-eng" },
+    });
+    renderer.render([grant], { "platform-eng": "should-not-appear" });
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[1], "group:platform-eng");
+});
+
+Deno.test("accessGrantListRenderer json: ignores display names", () => {
+  const renderer = createAccessGrantListRenderer("json");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    const grant = makeGrant({
+      subject: { kind: "user", name: "8d540893-434a-4422-8970-6edba6602e9b" },
+    });
+    renderer.render([grant], {
+      "8d540893-434a-4422-8970-6edba6602e9b": "paul",
+    });
+  } finally {
+    console.log = origLog;
+  }
+  const parsed = JSON.parse(output.join(""));
+  assertStringIncludes(
+    parsed[0].subject.name,
+    "8d540893-434a-4422-8970-6edba6602e9b",
+  );
+});
+
+Deno.test("accessGrantListRenderer log: works without display names argument", () => {
+  const renderer = createAccessGrantListRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.render([makeGrant()]);
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[1], "user:adam");
+});

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -144,6 +144,44 @@ export async function handleAccessGrantList(
       );
     }
 
+    const subjectDisplayNames: Record<string, string> = {};
+    const unresolvedSubs = new Set<string>();
+
+    for (const r of results) {
+      if (r.grant.subject.kind !== "user") continue;
+      const sub = r.grant.subject.name;
+      if (ctx.resolvedUserNames?.[sub]) {
+        subjectDisplayNames[sub] = ctx.resolvedUserNames[sub];
+      } else {
+        unresolvedSubs.add(sub);
+      }
+    }
+
+    if (unresolvedSubs.size > 0) {
+      const libCtx = createLibSwampContext();
+      const deps = createServerTokenListDeps(
+        ctx.repoContext.dataQueryService,
+      );
+      await consumeStream(
+        serverTokenList(libCtx, deps),
+        withDefaults({
+          completed: (e) => {
+            for (const token of e.data.tokens) {
+              const tokenSub = token.principalId.startsWith("user:")
+                ? token.principalId.slice(5)
+                : token.principalId;
+              if (
+                unresolvedSubs.has(tokenSub) &&
+                !subjectDisplayNames[tokenSub]
+              ) {
+                subjectDisplayNames[tokenSub] = token.principalEmail;
+              }
+            }
+          },
+        }),
+      );
+    }
+
     send(socket, {
       type: "access.grant.list",
       id: requestId,
@@ -152,6 +190,9 @@ export async function handleAccessGrantList(
           ...r.grant,
           instanceName: r.instanceName,
         })) as unknown as Record<string, unknown>[],
+        ...(Object.keys(subjectDisplayNames).length > 0
+          ? { subjectDisplayNames }
+          : {}),
       },
     });
   } catch (error) {

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -107,6 +107,8 @@ export interface ConnectionContext {
   grantsFile?: string;
   /** Whether --hot-reload is enabled — gates serve.reload over WebSocket. */
   hotReload?: boolean;
+  /** Inverted resolvedAdmins map: OAuth sub → username. Populated at startup in OAuth mode. */
+  resolvedUserNames?: Record<string, string>;
 }
 
 // SECURITY: Authorization must operate on canonical (normalized) model types,

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -848,6 +848,7 @@ export interface SerializedError {
 
 export interface AccessGrantListResponse {
   grants: Record<string, unknown>[];
+  subjectDisplayNames?: Record<string, string>;
 }
 
 export interface AccessGroupListResponse {


### PR DESCRIPTION
## Summary

- `swamp access grant list --server` now shows `user:stack72` instead of `user:699e486007f77116ebf44bd2` by resolving OAuth sub claims to human-readable names
- Primary resolution uses the inverted admin/allowed-user map built at server startup (sub→username)
- Falls back to `principalEmail` from server tokens for users not in the resolved-admins map (e.g. users admitted via `--allowed-collectives`)
- Groups and idp-groups are unchanged — their names are already readable
- JSON output preserves raw subject data (no resolution applied)

## Test Plan

- [x] Unit tests: 5 new tests for renderer display name resolution (user resolved, fallback to raw sub, groups not resolved, JSON ignores display names, works without display names)
- [x] Manual test: token auth mode — verified `user:<uuid>` resolves to `user:<email>` via server token fallback
- [x] Manual test: OAuth auth mode — verified `user:<oauth-sub>` resolves to `user:stack72` via inverted `resolvedAdmins` map
- [x] Manual test: JSON mode preserves raw subject data
- [x] Manual test: group subjects not resolved
- [x] `deno fmt`, `deno lint`, `deno check` all pass
- [x] Full test suite: 10,012 passed, 1 pre-existing flaky failure (serve_ready_test port collision)

Closes #1547