### PR TITLE
fix(datastore): scope migration destination to namespace in setup extension (swamp-club#1559)

### DIFF
--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -456,11 +456,12 @@ export async function* datastoreSetupExtension(
 
         const sourceDir = `${input.repoDir}/.swamp`;
 
-        // Migrate local .swamp/ data to cache path
-        const config = { type: "filesystem" as const, path: cachePath };
+        // Migrate local .swamp/ data to cache path (namespace-scoped when set)
+        const migrationDest = ns ? join(cachePath, ns) : cachePath;
+        const config = { type: "filesystem" as const, path: migrationDest };
         const result = await deps.migrateData(
           sourceDir,
-          cachePath,
+          migrationDest,
           config,
         );
         errors.push(...result.errors);

--- a/src/libswamp/datastores/setup_test.ts
+++ b/src/libswamp/datastores/setup_test.ts
@@ -943,6 +943,55 @@ Deno.test("datastoreSetupExtension: omits namespace when not configured", async 
   assertEquals(pull?.options?.namespace, undefined);
 });
 
+Deno.test("datastoreSetupExtension: migrates to namespace-scoped cache path when namespace is set", async () => {
+  let capturedDestPath: string | undefined;
+  const deps = makeDeps({
+    migrateData: (_sourceDir: string, destPath: string) => {
+      capturedDestPath = destPath;
+      return Promise.resolve({
+        filesCopied: 5,
+        bytesCopied: 1024,
+        directoriesMigrated: ["data", "outputs"],
+        errors: [],
+      });
+    },
+  });
+  const input = makeExtensionInput({
+    type: SETUP_NS_TYPE,
+    namespace: "infra",
+  });
+
+  await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  assertEquals(capturedDestPath, join("/tmp/repo", ".cache", "infra"));
+});
+
+Deno.test("datastoreSetupExtension: migrates to bare cache path when no namespace is set", async () => {
+  let capturedDestPath: string | undefined;
+  const deps = makeDeps({
+    migrateData: (_sourceDir: string, destPath: string) => {
+      capturedDestPath = destPath;
+      return Promise.resolve({
+        filesCopied: 5,
+        bytesCopied: 1024,
+        directoriesMigrated: ["data", "outputs"],
+        errors: [],
+      });
+    },
+  });
+  const input = makeExtensionInput({
+    type: SETUP_NS_TYPE,
+  });
+
+  await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  assertEquals(capturedDestPath, join("/tmp/repo", ".cache"));
+});
+
 Deno.test("datastoreSetupExtension: threads namespace on skip-migration pull-only path", async () => {
   setupSyncSpyCalls.length = 0;
   const deps = makeDeps();

--- a/src/libswamp/datastores/setup_test.ts
+++ b/src/libswamp/datastores/setup_test.ts
@@ -41,6 +41,7 @@ import {
   SyncTimeoutError,
 } from "../../domain/datastore/datastore_sync_service.ts";
 import { readNamespaceManifest } from "../../infrastructure/persistence/namespace_manifest.ts";
+import { assertPathEquals } from "../../infrastructure/persistence/path_test_helpers.ts";
 
 function makeDeps(
   overrides: Partial<DatastoreSetupDeps> = {},
@@ -965,7 +966,7 @@ Deno.test("datastoreSetupExtension: migrates to namespace-scoped cache path when
     datastoreSetupExtension(createLibSwampContext(), deps, input),
   );
 
-  assertEquals(capturedDestPath, join("/tmp/repo", ".cache", "infra"));
+  assertPathEquals(capturedDestPath, join("/tmp/repo", ".cache", "infra"));
 });
 
 Deno.test("datastoreSetupExtension: migrates to bare cache path when no namespace is set", async () => {
@@ -989,7 +990,7 @@ Deno.test("datastoreSetupExtension: migrates to bare cache path when no namespac
     datastoreSetupExtension(createLibSwampContext(), deps, input),
   );
 
-  assertEquals(capturedDestPath, join("/tmp/repo", ".cache"));
+  assertPathEquals(capturedDestPath, join("/tmp/repo", ".cache"));
 });
 
 Deno.test("datastoreSetupExtension: threads namespace on skip-migration pull-only path", async () => {


### PR DESCRIPTION
## Summary

- `datastoreSetupExtension()` was migrating `.swamp/` files to the bare cache root (`cachePath`), ignoring the bound namespace. When a namespace is set, migrated files landed at `{cachePath}/outputs/` instead of `{cachePath}/{namespace}/outputs/`, stranding them outside the namespace directory that the subsequent push walks.
- The migration destination now uses `join(cachePath, ns)` when a namespace is configured, so files land where the namespace-scoped push expects them.

## Test Plan

- Added unit test asserting `migrateData` receives the namespace-scoped destination path (`join(cachePath, namespace)`) when namespace is set
- Added unit test asserting `migrateData` receives the bare cache path when no namespace is configured
- All 43 existing setup tests continue to pass

Closes swamp-club/swamp-club#1559