### PR TITLE
fix(extensions): surface latestBeta/latestRc in search results and fix multi-channel union (swamp-club#1555)

### DIFF
--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -152,7 +152,10 @@ export const extensionSearchCommand = withRemoteOptions(
     }
   }
   if (options.channel) {
-    options.channel = options.channel.filter((ch: string) => ch !== "stable");
+    const hasNonStable = options.channel.some((ch: string) => ch !== "stable");
+    if (!hasNonStable) {
+      options.channel = [];
+    }
   }
 
   // Validate sort option value

--- a/src/cli/commands/extension_search_test.ts
+++ b/src/cli/commands/extension_search_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertStringIncludes, assertThrows } from "@std/assert";
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
 import { UserError } from "../../domain/errors.ts";
 
 Deno.test("extension search: --sort relevance without query throws UserError", () => {
@@ -109,4 +109,44 @@ Deno.test("extension search: invalid sort option throws UserError", () => {
   );
   assertStringIncludes(error.message, "invalid");
   assertStringIncludes(error.message, "Must be one of");
+});
+
+// Channel stable-stripping tests — replicate the logic from the command to
+// test the stripping behavior in isolation.
+
+function applyChannelStripping(channel: string[]): string[] {
+  const hasNonStable = channel.some((ch: string) => ch !== "stable");
+  if (!hasNonStable) {
+    return [];
+  }
+  return channel;
+}
+
+Deno.test("extension search: --channel stable alone is stripped to empty array", () => {
+  assertEquals(applyChannelStripping(["stable"]), []);
+});
+
+Deno.test("extension search: --channel beta is preserved", () => {
+  assertEquals(applyChannelStripping(["beta"]), ["beta"]);
+});
+
+Deno.test("extension search: --channel stable --channel beta keeps both values", () => {
+  assertEquals(
+    applyChannelStripping(["stable", "beta"]),
+    ["stable", "beta"],
+  );
+});
+
+Deno.test("extension search: --channel beta --channel rc keeps both values", () => {
+  assertEquals(
+    applyChannelStripping(["beta", "rc"]),
+    ["beta", "rc"],
+  );
+});
+
+Deno.test("extension search: --channel stable --channel beta --channel rc keeps all values", () => {
+  assertEquals(
+    applyChannelStripping(["stable", "beta", "rc"]),
+    ["stable", "beta", "rc"],
+  );
 });

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -146,6 +146,8 @@ export interface ExtensionSearchEntry {
   labels: string[];
   contentTypes?: string[];
   latestVersion: string | null;
+  latestRc?: string | null;
+  latestBeta?: string | null;
   createdAt: string;
   updatedAt: string;
   deprecatedAt?: string | null;

--- a/src/libswamp/extensions/search.ts
+++ b/src/libswamp/extensions/search.ts
@@ -29,6 +29,8 @@ export interface ExtensionSearchItem {
   repositoryVerified: boolean | null;
   repositoryVerifiedUrl: string | null;
   latestVersion: string | null;
+  latestRc: string | null;
+  latestBeta: string | null;
   platforms: string[];
   labels: string[];
   contentTypes: string[];
@@ -86,6 +88,8 @@ export interface ExtensionSearchDeps {
       repositoryVerified?: boolean | null;
       repositoryVerifiedUrl?: string | null;
       latestVersion: string | null;
+      latestRc?: string | null;
+      latestBeta?: string | null;
       platforms: string[];
       labels: string[];
       contentTypes?: string[];
@@ -136,6 +140,8 @@ export async function* extensionSearch(
             repositoryVerified: ext.repositoryVerified ?? null,
             repositoryVerifiedUrl: ext.repositoryVerifiedUrl ?? null,
             latestVersion: ext.latestVersion,
+            latestRc: ext.latestRc ?? null,
+            latestBeta: ext.latestBeta ?? null,
             platforms: ext.platforms,
             labels: ext.labels,
             contentTypes: ext.contentTypes ?? [],

--- a/src/libswamp/extensions/search_test.ts
+++ b/src/libswamp/extensions/search_test.ts
@@ -148,6 +148,69 @@ Deno.test("extensionSearch: passes query and params through", async () => {
   assertEquals(capturedParams?.page, 2);
 });
 
+Deno.test("extensionSearch: maps latestBeta and latestRc from API response", async () => {
+  const deps = makeDeps({
+    searchExtensions: () =>
+      Promise.resolve({
+        extensions: [
+          {
+            name: "@ns/beta-only",
+            description: "Beta-only extension",
+            latestVersion: null,
+            latestRc: null,
+            latestBeta: "2026.08.01.1",
+            platforms: [],
+            labels: [],
+            contentTypes: [],
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-02T00:00:00Z",
+          },
+          {
+            name: "@ns/rc-and-stable",
+            description: "Has RC and stable",
+            latestVersion: "2026.07.01.1",
+            latestRc: "2026.08.05.1",
+            latestBeta: null,
+            platforms: [],
+            labels: [],
+            contentTypes: [],
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-02T00:00:00Z",
+          },
+        ],
+        meta: { total: 2, page: 1, perPage: 20 },
+      }),
+  });
+
+  const events = await collect<ExtensionSearchEvent>(
+    extensionSearch(createLibSwampContext(), deps, { query: "ns" }),
+  );
+
+  const completed = events[1] as Extract<
+    ExtensionSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results[0].latestVersion, null);
+  assertEquals(completed.data.results[0].latestRc, null);
+  assertEquals(completed.data.results[0].latestBeta, "2026.08.01.1");
+  assertEquals(completed.data.results[1].latestVersion, "2026.07.01.1");
+  assertEquals(completed.data.results[1].latestRc, "2026.08.05.1");
+  assertEquals(completed.data.results[1].latestBeta, null);
+});
+
+Deno.test("extensionSearch: defaults latestBeta and latestRc to null when absent from API", async () => {
+  const events = await collect<ExtensionSearchEvent>(
+    extensionSearch(createLibSwampContext(), makeDeps(), { query: "aws" }),
+  );
+
+  const completed = events[1] as Extract<
+    ExtensionSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results[0].latestRc, null);
+  assertEquals(completed.data.results[0].latestBeta, null);
+});
+
 Deno.test("extensionSearch: empty results", async () => {
   const deps = makeDeps({
     searchExtensions: () =>

--- a/src/presentation/renderers/extension_search.tsx
+++ b/src/presentation/renderers/extension_search.tsx
@@ -128,6 +128,16 @@ export function createExtensionSearchRenderer(
 
 const DESCRIPTION_MAX = 60;
 
+function versionLabel(item: ExtensionSearchItem): string {
+  return item.latestVersion
+    ? `v${item.latestVersion}`
+    : item.latestRc
+    ? `rc: ${item.latestRc}`
+    : item.latestBeta
+    ? `beta: ${item.latestBeta}`
+    : "prerelease";
+}
+
 function renderExtensionResultLine(
   item: ExtensionSearchItem,
 ): React.ReactElement {
@@ -143,7 +153,7 @@ function renderExtensionResultLine(
     <Text>
       {`${item.name} `}
       <Text dimColor>
-        {item.latestVersion ? `v${item.latestVersion}` : "prerelease"}
+        {versionLabel(item)}
       </Text>
       {deprecated && <Text color="yellow">[deprecated]</Text>}
       {truncatedDesc && <Text dimColor>{` ${EM_DASH} ${truncatedDesc}`}</Text>}
@@ -163,7 +173,7 @@ function renderExtensionPreview(
     <Text key="name" wrap="truncate-end">
       <Text color="cyan" bold>{item.name}</Text>{" "}
       <Text dimColor>
-        {item.latestVersion ? `v${item.latestVersion}` : "prerelease"}
+        {versionLabel(item)}
       </Text>
     </Text>,
   ];

--- a/src/presentation/renderers/extension_search.tsx
+++ b/src/presentation/renderers/extension_search.tsx
@@ -268,9 +268,7 @@ function renderExtensionScrollback(
   _detail: ExtensionSearchItem | undefined,
 ): string {
   const lines: string[] = [
-    `${item.name} ${
-      item.latestVersion ? `v${item.latestVersion}` : "prerelease"
-    }`,
+    `${item.name} ${versionLabel(item)}`,
   ];
 
   if (item.description) {


### PR DESCRIPTION
## Summary

Closes swamp-club#1555.

- Surface `latestBeta` and `latestRc` version fields in extension search results — the server already sends them but the client types silently dropped them during mapping
- Fix multi-channel union: `--channel stable --channel beta` now returns the union (54 results) instead of collapsing to one channel (1 result) — caused by the CLI unconditionally stripping "stable" from the channel array
- Update the search renderer to display the best available version (stable > rc > beta > "prerelease"), matching the existing `extension info` pattern

## Verified

| invocation | before | after |
|---|---|---|
| `--channel beta` (version fields) | `latestVersion: null`, no beta field | `latestBeta: "2026.08.01.1"` |
| `--channel stable --channel beta` | 1 result (collapsed) | 54 results (union) |
| `--channel stable` (no-op) | 53 (unchanged behavior) | 53 (unchanged behavior) |

## Test Plan

- [x] `deno check` passes (pre-existing unrelated type error in `deno_runtime.ts`)
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] 10,027 tests pass (1 flaky `extension_rm` failure unrelated to this change — passes on retry)
- [x] Compiled binary and verified both fixes against live registry with `@magistr` collective
- [x] New unit tests for `latestBeta`/`latestRc` mapping (2 tests) and channel stripping behavior (5 tests)
