### PR TITLE
feat(extensions): warn on stderr when pulled extensions are significantly outdated

### DIFF
--- a/src/cli/commands/extension_outdated.ts
+++ b/src/cli/commands/extension_outdated.ts
@@ -50,6 +50,9 @@ import {
   withRemoteOptions,
 } from "../remote_run.ts";
 import type { ExtensionOutdatedResponse } from "../../serve/protocol.ts";
+import { extensionCacheKey } from "../../domain/extensions/extension_update_check_cache.ts";
+import { FileExtensionUpdateCheckRepository } from "../../infrastructure/persistence/extension_update_check_repository.ts";
+import { swampPath } from "../../infrastructure/persistence/paths.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -174,6 +177,8 @@ export const extensionOutdatedCommand = withRemoteOptions(
     extensionUpdate(ctx, deps, { checkOnly: true }),
   );
 
+  await populateUpdateCheckCache(repoDir, completed.data.extensions);
+
   const filtered = filterOutdated(completed.data.extensions);
   const hasUpdateAvailable = filtered.some(
     (s) => s.status === "update_available",
@@ -194,3 +199,31 @@ export const extensionOutdatedCommand = withRemoteOptions(
     Deno.exit(1);
   }
 });
+
+async function populateUpdateCheckCache(
+  repoDir: string,
+  statuses: ExtensionUpdateStatus[],
+): Promise<void> {
+  try {
+    const cacheRepo = new FileExtensionUpdateCheckRepository(
+      swampPath(repoDir, ""),
+    );
+    const cache = await cacheRepo.read();
+    const now = new Date().toISOString();
+
+    for (const s of statuses) {
+      if (s.status !== "up_to_date" && s.status !== "update_available") {
+        continue;
+      }
+      const key = extensionCacheKey(s.name, s.channel);
+      cache[key] = {
+        checkedAt: now,
+        latestVersion: s.latestVersion,
+      };
+    }
+
+    await cacheRepo.write(cache);
+  } catch {
+    // Non-fatal — cache population failure should not affect the command
+  }
+}

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -184,6 +184,12 @@ import type {
   ResolvedSourceDirs,
 } from "../domain/repo/swamp_sources.ts";
 import { discoverManifestCrossKindDirs } from "../domain/extensions/manifest_cross_kind_discovery.ts";
+import { readUpstreamExtensions } from "../infrastructure/persistence/upstream_extensions.ts";
+import { FileExtensionUpdateCheckRepository } from "../infrastructure/persistence/extension_update_check_repository.ts";
+import {
+  findStaleExtensions,
+  formatStalenessWarning,
+} from "../domain/extensions/extension_staleness.ts";
 
 // Import models barrel to trigger self-registration
 import "../domain/models/models.ts";
@@ -461,6 +467,7 @@ export async function configureExtensionLoaders(
   await checkForMissingPulledExtensions(repoDir, marker, deferredWarnings);
   await checkForSupersededSkills(repoDir, marker, deferredWarnings);
   await checkForLocalBundledSkills(repoDir, marker, deferredWarnings);
+  await checkForStaleExtensions(repoDir, marker, lockfilePath, quiet);
 }
 
 /**
@@ -1016,6 +1023,49 @@ async function checkForLocalBundledSkills(
     const updatedMarker = {
       ...marker,
       lastSkillMigrationWarning: new Date().toISOString(),
+    };
+    await markerRepo.write(repoPath, updatedMarker);
+  } catch {
+    // Non-fatal — don't block startup
+  }
+}
+
+const STALENESS_WARNING_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+async function checkForStaleExtensions(
+  repoDir: string,
+  marker: RepoMarkerData | null,
+  lockfilePath: string,
+  quiet: boolean,
+): Promise<void> {
+  try {
+    if (quiet || !marker) return;
+
+    if (marker.lastStalenessWarning) {
+      const lastWarning = new Date(marker.lastStalenessWarning).getTime();
+      if (Date.now() - lastWarning < STALENESS_WARNING_INTERVAL_MS) {
+        return;
+      }
+    }
+
+    const lockfile = await readUpstreamExtensions(lockfilePath);
+    if (Object.keys(lockfile).length === 0) return;
+
+    const swampDir = swampPath(repoDir, "");
+    const cacheRepo = new FileExtensionUpdateCheckRepository(swampDir);
+    const cache = await cacheRepo.read();
+    if (Object.keys(cache).length === 0) return;
+
+    const stale = findStaleExtensions(lockfile, cache);
+    if (stale.length === 0) return;
+
+    console.error(`swamp-warning: ${formatStalenessWarning(stale)}`);
+
+    const repoPath = RepoPath.create(repoDir);
+    const markerRepo = new RepoMarkerRepository();
+    const updatedMarker: RepoMarkerData = {
+      ...marker,
+      lastStalenessWarning: new Date().toISOString(),
     };
     await markerRepo.write(repoPath, updatedMarker);
   } catch {

--- a/src/domain/extensions/extension_staleness.ts
+++ b/src/domain/extensions/extension_staleness.ts
@@ -1,0 +1,79 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { CalVer } from "../models/calver.ts";
+import { extensionCacheKey } from "./extension_update_check_cache.ts";
+import type { ExtensionUpdateCheckMap } from "./extension_update_check_cache.ts";
+
+export interface InstalledExtensionEntry {
+  readonly version: string;
+  readonly channel?: string;
+}
+
+export interface StaleExtension {
+  readonly name: string;
+  readonly installedVersion: string;
+  readonly latestVersion: string;
+  readonly daysBehind: number;
+}
+
+const DEFAULT_STALENESS_THRESHOLD_DAYS = 14;
+
+export function findStaleExtensions(
+  lockfile: Record<string, InstalledExtensionEntry>,
+  cache: ExtensionUpdateCheckMap,
+  thresholdDays: number = DEFAULT_STALENESS_THRESHOLD_DAYS,
+): StaleExtension[] {
+  const stale: StaleExtension[] = [];
+
+  for (const [name, entry] of Object.entries(lockfile)) {
+    const key = extensionCacheKey(name, entry.channel);
+    const cached = cache[key];
+    if (!cached) continue;
+
+    if (
+      !CalVer.isValid(entry.version) || !CalVer.isValid(cached.latestVersion)
+    ) {
+      continue;
+    }
+
+    const installed = CalVer.create(entry.version);
+    const latest = CalVer.create(cached.latestVersion);
+    const daysBehind = CalVer.daysBehind(installed, latest);
+
+    if (daysBehind >= thresholdDays) {
+      stale.push({
+        name,
+        installedVersion: entry.version,
+        latestVersion: cached.latestVersion,
+        daysBehind,
+      });
+    }
+  }
+
+  stale.sort((a, b) => b.daysBehind - a.daysBehind);
+  return stale;
+}
+
+export function formatStalenessWarning(stale: StaleExtension[]): string {
+  const details = stale.map((s) =>
+    `${s.name} (${s.daysBehind}d behind, ${s.installedVersion} → ${s.latestVersion})`
+  ).join(", ");
+  return `${stale.length} pulled extension(s) are outdated: ${details}. Run 'swamp extension pull' to update.`;
+}

--- a/src/domain/extensions/extension_staleness_test.ts
+++ b/src/domain/extensions/extension_staleness_test.ts
@@ -1,0 +1,227 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  findStaleExtensions,
+  formatStalenessWarning,
+  type InstalledExtensionEntry,
+} from "./extension_staleness.ts";
+import type { ExtensionUpdateCheckMap } from "./extension_update_check_cache.ts";
+
+Deno.test("findStaleExtensions: returns empty when cache is empty", () => {
+  const lockfile: Record<string, InstalledExtensionEntry> = {
+    "@swamp/s3-datastore": {
+      version: "2026.05.26.1",
+    },
+  };
+  const cache: ExtensionUpdateCheckMap = {};
+
+  assertEquals(findStaleExtensions(lockfile, cache), []);
+});
+
+Deno.test("findStaleExtensions: returns empty when extension is up to date", () => {
+  const lockfile: Record<string, InstalledExtensionEntry> = {
+    "@swamp/s3-datastore": {
+      version: "2026.07.25.1",
+    },
+  };
+  const cache: ExtensionUpdateCheckMap = {
+    "@swamp/s3-datastore": {
+      checkedAt: "2026-07-26T00:00:00Z",
+      latestVersion: "2026.07.25.1",
+    },
+  };
+
+  assertEquals(findStaleExtensions(lockfile, cache), []);
+});
+
+Deno.test("findStaleExtensions: returns empty when below threshold", () => {
+  const lockfile: Record<string, InstalledExtensionEntry> = {
+    "@swamp/s3-datastore": {
+      version: "2026.07.10.1",
+    },
+  };
+  const cache: ExtensionUpdateCheckMap = {
+    "@swamp/s3-datastore": {
+      checkedAt: "2026-07-20T00:00:00Z",
+      latestVersion: "2026.07.20.1",
+    },
+  };
+
+  assertEquals(findStaleExtensions(lockfile, cache), []);
+});
+
+Deno.test("findStaleExtensions: detects stale extension at threshold boundary", () => {
+  const lockfile: Record<string, InstalledExtensionEntry> = {
+    "@swamp/s3-datastore": {
+      version: "2026.06.12.1",
+    },
+  };
+  const cache: ExtensionUpdateCheckMap = {
+    "@swamp/s3-datastore": {
+      checkedAt: "2026-06-26T00:00:00Z",
+      latestVersion: "2026.06.26.1",
+    },
+  };
+
+  const result = findStaleExtensions(lockfile, cache);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "@swamp/s3-datastore");
+  assertEquals(result[0].daysBehind, 14);
+});
+
+Deno.test("findStaleExtensions: detects multiple stale extensions sorted by daysBehind desc", () => {
+  const lockfile: Record<string, InstalledExtensionEntry> = {
+    "@swamp/s3-datastore": {
+      version: "2026.05.26.1",
+    },
+    "@swamp/vault-aws": {
+      version: "2026.03.01.1",
+    },
+  };
+  const cache: ExtensionUpdateCheckMap = {
+    "@swamp/s3-datastore": {
+      checkedAt: "2026-07-27T00:00:00Z",
+      latestVersion: "2026.07.25.1",
+    },
+    "@swamp/vault-aws": {
+      checkedAt: "2026-07-27T00:00:00Z",
+      latestVersion: "2026.07.20.1",
+    },
+  };
+
+  const result = findStaleExtensions(lockfile, cache);
+  assertEquals(result.length, 2);
+  assertEquals(result[0].name, "@swamp/vault-aws");
+  assertEquals(result[0].daysBehind, 141);
+  assertEquals(result[1].name, "@swamp/s3-datastore");
+  assertEquals(result[1].daysBehind, 60);
+});
+
+Deno.test("findStaleExtensions: skips extensions with invalid CalVer in lockfile", () => {
+  const lockfile: Record<string, InstalledExtensionEntry> = {
+    "@swamp/broken": {
+      version: "not-a-calver",
+    },
+  };
+  const cache: ExtensionUpdateCheckMap = {
+    "@swamp/broken": {
+      checkedAt: "2026-07-27T00:00:00Z",
+      latestVersion: "2026.07.25.1",
+    },
+  };
+
+  assertEquals(findStaleExtensions(lockfile, cache), []);
+});
+
+Deno.test("findStaleExtensions: skips extensions with invalid CalVer in cache", () => {
+  const lockfile: Record<string, InstalledExtensionEntry> = {
+    "@swamp/s3-datastore": {
+      version: "2026.05.26.1",
+    },
+  };
+  const cache: ExtensionUpdateCheckMap = {
+    "@swamp/s3-datastore": {
+      checkedAt: "2026-07-27T00:00:00Z",
+      latestVersion: "invalid",
+    },
+  };
+
+  assertEquals(findStaleExtensions(lockfile, cache), []);
+});
+
+Deno.test("findStaleExtensions: uses channel-aware cache key", () => {
+  const lockfile: Record<string, InstalledExtensionEntry> = {
+    "@swamp/s3-datastore": {
+      version: "2026.05.26.1",
+
+      channel: "beta",
+    },
+  };
+  const cache: ExtensionUpdateCheckMap = {
+    "@swamp/s3-datastore:beta": {
+      checkedAt: "2026-07-27T00:00:00Z",
+      latestVersion: "2026.07.25.1",
+    },
+  };
+
+  const result = findStaleExtensions(lockfile, cache);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].daysBehind, 60);
+});
+
+Deno.test("findStaleExtensions: respects custom threshold", () => {
+  const lockfile: Record<string, InstalledExtensionEntry> = {
+    "@swamp/s3-datastore": {
+      version: "2026.06.01.1",
+    },
+  };
+  const cache: ExtensionUpdateCheckMap = {
+    "@swamp/s3-datastore": {
+      checkedAt: "2026-06-20T00:00:00Z",
+      latestVersion: "2026.06.16.1",
+    },
+  };
+
+  assertEquals(findStaleExtensions(lockfile, cache, 30), []);
+  const defaultResult = findStaleExtensions(lockfile, cache);
+  assertEquals(
+    defaultResult.length,
+    1,
+    "default 14-day threshold should catch 15-day gap",
+  );
+  const result = findStaleExtensions(lockfile, cache, 7);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].daysBehind, 15);
+});
+
+Deno.test("formatStalenessWarning: formats single extension", () => {
+  const result = formatStalenessWarning([{
+    name: "@swamp/s3-datastore",
+    installedVersion: "2026.05.26.1",
+    latestVersion: "2026.07.25.1",
+    daysBehind: 60,
+  }]);
+  assertEquals(
+    result,
+    "1 pulled extension(s) are outdated: @swamp/s3-datastore (60d behind, 2026.05.26.1 → 2026.07.25.1). Run 'swamp extension pull' to update.",
+  );
+});
+
+Deno.test("formatStalenessWarning: formats multiple extensions", () => {
+  const result = formatStalenessWarning([
+    {
+      name: "@swamp/vault-aws",
+      installedVersion: "2026.03.01.1",
+      latestVersion: "2026.07.20.1",
+      daysBehind: 141,
+    },
+    {
+      name: "@swamp/s3-datastore",
+      installedVersion: "2026.05.26.1",
+      latestVersion: "2026.07.25.1",
+      daysBehind: 60,
+    },
+  ]);
+  assertEquals(
+    result,
+    "2 pulled extension(s) are outdated: @swamp/vault-aws (141d behind, 2026.03.01.1 → 2026.07.20.1), @swamp/s3-datastore (60d behind, 2026.05.26.1 → 2026.07.25.1). Run 'swamp extension pull' to update.",
+  );
+});

--- a/src/domain/models/calver.ts
+++ b/src/domain/models/calver.ts
@@ -137,6 +137,30 @@ export class CalVer {
   }
 
   /**
+   * Returns the number of calendar days between two CalVer dates.
+   *
+   * Ignores the MICRO segment — only the YYYY.MM.DD prefix matters.
+   * Returns 0 when `installed` is the same date or newer than `latest`.
+   */
+  static daysBehind(installed: CalVer, latest: CalVer): number {
+    const iParts = installed.value.split(".");
+    const lParts = latest.value.split(".");
+    const iMs = Date.UTC(
+      Number(iParts[0]),
+      Number(iParts[1]) - 1,
+      Number(iParts[2]),
+    );
+    const lMs = Date.UTC(
+      Number(lParts[0]),
+      Number(lParts[1]) - 1,
+      Number(lParts[2]),
+    );
+    const diffMs = lMs - iMs;
+    if (diffMs <= 0) return 0;
+    return Math.floor(diffMs / (24 * 60 * 60 * 1000));
+  }
+
+  /**
    * Value equality.
    */
   equals(other: CalVer): boolean {

--- a/src/domain/models/calver_test.ts
+++ b/src/domain/models/calver_test.ts
@@ -201,6 +201,50 @@ Deno.test("CalVer.withEpochMicro produces a valid CalVer", () => {
   assertEquals(CalVer.isValid(result.value), true);
 });
 
+// --- daysBehind ---
+
+Deno.test("CalVer.daysBehind: returns 0 for identical versions", () => {
+  const a = CalVer.create("2026.05.26.1");
+  const b = CalVer.create("2026.05.26.1");
+  assertEquals(CalVer.daysBehind(a, b), 0);
+});
+
+Deno.test("CalVer.daysBehind: returns 0 when installed is newer", () => {
+  const installed = CalVer.create("2026.07.25.1");
+  const latest = CalVer.create("2026.05.26.1");
+  assertEquals(CalVer.daysBehind(installed, latest), 0);
+});
+
+Deno.test("CalVer.daysBehind: computes days across months", () => {
+  const installed = CalVer.create("2026.05.26.1");
+  const latest = CalVer.create("2026.07.25.1");
+  assertEquals(CalVer.daysBehind(installed, latest), 60);
+});
+
+Deno.test("CalVer.daysBehind: computes days across years", () => {
+  const installed = CalVer.create("2025.12.01.1");
+  const latest = CalVer.create("2026.01.31.1");
+  assertEquals(CalVer.daysBehind(installed, latest), 61);
+});
+
+Deno.test("CalVer.daysBehind: ignores micro segment", () => {
+  const a = CalVer.create("2026.05.26.1");
+  const b = CalVer.create("2026.05.26.99");
+  assertEquals(CalVer.daysBehind(a, b), 0);
+});
+
+Deno.test("CalVer.daysBehind: single day difference", () => {
+  const installed = CalVer.create("2026.06.01.1");
+  const latest = CalVer.create("2026.06.02.1");
+  assertEquals(CalVer.daysBehind(installed, latest), 1);
+});
+
+Deno.test("CalVer.daysBehind: handles leap year boundary", () => {
+  const installed = CalVer.create("2024.02.28.1");
+  const latest = CalVer.create("2024.03.01.1");
+  assertEquals(CalVer.daysBehind(installed, latest), 2); // Feb 29 is a leap day
+});
+
 // --- toString ---
 
 Deno.test("CalVer.toString returns the raw string", () => {

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -62,6 +62,7 @@ export interface RepoMarkerData {
   trustMemberCollectives?: boolean;
   lastSkillMigrationWarning?: string;
   skillMigrationDismissed?: boolean;
+  lastStalenessWarning?: string;
   autoGc?: boolean;
   defaultVault?: string;
 }


### PR DESCRIPTION
## Summary

- Emit a single aggregated `swamp-warning:` line on stderr during CLI startup when pulled extensions are 14+ calendar days behind the cached registry latest
- Warning is rate-limited to once per 24 hours via `lastStalenessWarning` in the repo marker — no noise on subsequent commands
- Cache-gated: only warns when `extension-update-checks.json` already has data — zero network calls added to the hot path
- `swamp extension outdated` now populates the update check cache as a side effect, seeding future staleness warnings

Example output:
```
swamp-warning: 1 pulled extension(s) are outdated: @swamp/aws/s3 (20d behind, 2026.07.18.3 → 2026.08.07.1). Run 'swamp extension pull' to update.
```

Closes swamp-club/lab#1436

## Test Plan

- Unit tests for `CalVer.daysBehind()` covering same version, future version, cross-month, cross-year, leap year boundaries
- Unit tests for `findStaleExtensions()` covering empty cache, up-to-date, below threshold, threshold boundary, multiple extensions, invalid CalVer, channel-aware keys, custom threshold
- Unit tests for `formatStalenessWarning()` formatting
- Manual E2E verification: created scratch repo, pulled `@swamp/aws/s3@2026.07.18.3`, ran `extension outdated` to seed cache, confirmed `swamp-warning:` fires on `model list`, confirmed second invocation is silent (rate limit)
- Full test suite: 10,038 passed, 1 failed (pre-existing `serve_ready_test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
