### PR TITLE
fix(workflows): add findGlobalByStatus to avoid OOM in serve boot reconciliation

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -2094,7 +2094,8 @@ export const serveCommand = new Command()
     // The tracker is the liveness authority; the YAML entity is the run record.
     // Legacy runs (pre-tracker) fall back to PID liveness checking.
     const reapCutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    const recentRuns = await repoContext.workflowRunRepo.findAllGlobalSince(
+    const recentRuns = await repoContext.workflowRunRepo.findGlobalByStatus(
+      "running",
       reapCutoff,
     );
     await reapOrphanedWorkflowRuns(
@@ -2991,13 +2992,16 @@ export const serveCommand = new Command()
             let allRuns:
               | Awaited<
                 ReturnType<
-                  typeof repoContext.workflowRunRepo.findAllGlobalSince
+                  typeof repoContext.workflowRunRepo.findGlobalByStatus
                 >
               >
               | undefined;
             try {
               allRuns = await repoContext.workflowRunRepo
-                .findAllGlobalSince(earliestCutoff);
+                .findGlobalByStatus(
+                  ["running", "cancelled"],
+                  earliestCutoff,
+                );
             } catch (err) {
               logger.warn(
                 "Failed to load workflow runs for interrupt: {error}",

--- a/src/domain/data/run_lifecycle_service_test.ts
+++ b/src/domain/data/run_lifecycle_service_test.ts
@@ -36,6 +36,7 @@ function createMockWorkflowRunRepo(
     findLatestByWorkflowId: () => Promise.resolve(null),
     findAllGlobal: () => Promise.resolve([]),
     findAllGlobalSince: () => Promise.resolve([]),
+    findGlobalByStatus: () => Promise.resolve([]),
     save: () => Promise.resolve(),
     nextId: () => "mock-id" as ReturnType<WorkflowRunRepository["nextId"]>,
     getPath: () => "",

--- a/src/domain/summary/summary_service_test.ts
+++ b/src/domain/summary/summary_service_test.ts
@@ -152,6 +152,20 @@ function createMockWorkflowRunRepo(
           run.startedAt !== undefined && run.startedAt >= cutoff
         ),
       ),
+    findGlobalByStatus: (status: string | string[], since?: Date) => {
+      const statuses = new Set(Array.isArray(status) ? status : [status]);
+      return Promise.resolve(
+        items.filter(({ run }) => {
+          if (!statuses.has(run.status)) return false;
+          if (since !== undefined) {
+            if (run.startedAt === undefined || run.startedAt < since) {
+              return false;
+            }
+          }
+          return true;
+        }),
+      );
+    },
     findById: () => Promise.resolve(null),
     findAllByWorkflowId: () => Promise.resolve([]),
     findLatestByWorkflowId: () => Promise.resolve(null),

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -173,6 +173,21 @@ class InMemoryWorkflowRunRepository implements WorkflowRunRepository {
     );
   }
 
+  async findGlobalByStatus(
+    status: string | string[],
+    since?: Date,
+  ): Promise<{ run: WorkflowRun; workflowId: WorkflowId }[]> {
+    const statuses = new Set(Array.isArray(status) ? status : [status]);
+    const all = await this.findAllGlobal();
+    return all.filter(({ run }) => {
+      if (!statuses.has(run.status)) return false;
+      if (since !== undefined) {
+        if (run.startedAt === undefined || run.startedAt < since) return false;
+      }
+      return true;
+    });
+  }
+
   save(workflowId: WorkflowId, run: WorkflowRun): Promise<void> {
     const existing = this.runs.get(workflowId) ?? [];
     const idx = existing.findIndex((r) => r.id === run.id);
@@ -3281,6 +3296,13 @@ class TrackingRunRepository implements WorkflowRunRepository {
     cutoff: Date,
   ): Promise<{ run: WorkflowRun; workflowId: WorkflowId }[]> {
     return this.inner.findAllGlobalSince(cutoff);
+  }
+
+  findGlobalByStatus(
+    status: string | string[],
+    since?: Date,
+  ): Promise<{ run: WorkflowRun; workflowId: WorkflowId }[]> {
+    return this.inner.findGlobalByStatus(status, since);
   }
 
   save(workflowId: WorkflowId, run: WorkflowRun): Promise<void> {

--- a/src/domain/workflows/repositories.ts
+++ b/src/domain/workflows/repositories.ts
@@ -101,6 +101,21 @@ export interface WorkflowRunRepository {
   ): Promise<{ run: WorkflowRun; workflowId: WorkflowId }[]>;
 
   /**
+   * Finds all workflow runs across all workflows whose status matches one of
+   * the given values. When `since` is provided, only runs with
+   * `startedAt >= since` are included.
+   *
+   * Implementations use the per-workflow runs index to filter by status
+   * without hydrating full aggregates, then load only matching runs via
+   * `findById`. Falls back to a lightweight summary scan when no index
+   * exists.
+   */
+  findGlobalByStatus(
+    status: string | string[],
+    since?: Date,
+  ): Promise<{ run: WorkflowRun; workflowId: WorkflowId }[]>;
+
+  /**
    * Saves a workflow run.
    */
   save(workflowId: WorkflowId, run: WorkflowRun): Promise<void>;

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -423,6 +423,90 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
     return runs;
   }
 
+  async findGlobalByStatus(
+    status: string | string[],
+    since?: Date,
+  ): Promise<{ run: WorkflowRun; workflowId: WorkflowId }[]> {
+    const statuses = Array.isArray(status) ? status : [status];
+    const statusSet = new Set(statuses);
+    const sinceMs = since?.getTime();
+    const results: { run: WorkflowRun; workflowId: WorkflowId }[] = [];
+
+    try {
+      for await (const entry of Deno.readDir(this.baseDir)) {
+        if (!entry.isDirectory) continue;
+        const workflowId = entry.name as WorkflowId;
+        const matchingIds = await this.findRunIdsByStatusFromIndex(
+          workflowId,
+          statusSet,
+          sinceMs,
+        );
+        for (const runId of matchingIds) {
+          const run = await this.findById(
+            workflowId,
+            runId as WorkflowRunId,
+          );
+          if (run && statusSet.has(run.status)) {
+            if (sinceMs !== undefined) {
+              const startedAtMs = run.startedAt?.getTime();
+              if (startedAtMs === undefined || startedAtMs < sinceMs) continue;
+            }
+            results.push({ run, workflowId });
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return results.sort((a, b) => {
+      const aTime = a.run.startedAt?.getTime() ?? 0;
+      const bTime = b.run.startedAt?.getTime() ?? 0;
+      return bTime - aTime;
+    });
+  }
+
+  private async findRunIdsByStatusFromIndex(
+    workflowId: WorkflowId,
+    statusSet: Set<string>,
+    sinceMs: number | undefined,
+  ): Promise<string[]> {
+    const runsDir = this.getRunsDir(workflowId);
+    const indexDir = this.getLocalIndexDir(workflowId);
+    const index = await this.getValidatedIndex(runsDir, indexDir);
+
+    if (index) {
+      const ids: string[] = [];
+      for (const [id, entry] of Object.entries(index)) {
+        if (!statusSet.has(entry.status)) continue;
+        if (sinceMs !== undefined) {
+          const startedAtMs = entry.startedAt
+            ? new Date(entry.startedAt).getTime()
+            : undefined;
+          if (startedAtMs === undefined || startedAtMs < sinceMs) continue;
+        }
+        ids.push(id);
+      }
+      return ids;
+    }
+
+    // Fallback: lightweight summary scan
+    const summaries = await this.findAllSummariesByWorkflowId(workflowId);
+    return summaries
+      .filter((s) => {
+        if (!statusSet.has(s.status)) return false;
+        if (sinceMs !== undefined) {
+          const startedAtMs = s.startedAt?.getTime();
+          if (startedAtMs === undefined || startedAtMs < sinceMs) return false;
+        }
+        return true;
+      })
+      .map((s) => s.id);
+  }
+
   async save(workflowId: WorkflowId, run: WorkflowRun): Promise<void> {
     const path = this.getPath(workflowId, run.id);
     await this.notifyDirty(path);

--- a/src/infrastructure/persistence/yaml_workflow_run_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository_test.ts
@@ -998,6 +998,144 @@ Deno.test("findLatestByWorkflowId: falls back to summary scan when index missing
   });
 });
 
+Deno.test("findGlobalByStatus: returns only runs matching the target status", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlWorkflowRunRepository(dir);
+    const workflow = createTestWorkflow();
+
+    const running = WorkflowRun.create(workflow);
+    running.start();
+    await repo.save(workflow.id, running);
+
+    const succeeded = WorkflowRun.create(workflow);
+    succeeded.start();
+    const jobRun = succeeded.getJob("job1");
+    jobRun?.start();
+    jobRun?.getStep("step1")?.start();
+    jobRun?.getStep("step1")?.succeed({ result: "ok" });
+    jobRun?.succeed();
+    succeeded.complete();
+    await repo.save(workflow.id, succeeded);
+
+    const found = await repo.findGlobalByStatus("running");
+    assertEquals(found.length, 1);
+    assertEquals(found[0].run.id, running.id);
+    assertEquals(found[0].run.status, "running");
+  });
+});
+
+Deno.test("findGlobalByStatus: accepts array of statuses", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlWorkflowRunRepository(dir);
+    const workflow = createTestWorkflow();
+
+    const running = WorkflowRun.create(workflow);
+    running.start();
+    await repo.save(workflow.id, running);
+
+    const succeeded = WorkflowRun.create(workflow);
+    succeeded.start();
+    const jobRun = succeeded.getJob("job1");
+    jobRun?.start();
+    jobRun?.getStep("step1")?.start();
+    jobRun?.getStep("step1")?.succeed({ result: "ok" });
+    jobRun?.succeed();
+    succeeded.complete();
+    await repo.save(workflow.id, succeeded);
+
+    const found = await repo.findGlobalByStatus(["running", "succeeded"]);
+    assertEquals(found.length, 2);
+    const statuses = new Set(found.map((f) => f.run.status));
+    assert(statuses.has("running"));
+    assert(statuses.has("succeeded"));
+  });
+});
+
+Deno.test("findGlobalByStatus: respects since cutoff", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlWorkflowRunRepository(dir);
+    const workflow = createTestWorkflow();
+
+    const old = WorkflowRun.create(workflow);
+    old.start();
+    await repo.save(workflow.id, old);
+
+    // Patch the YAML so startedAt is 7 days ago, then delete the index
+    // so it rebuilds from the patched YAML on the next read.
+    const oldPath = repo.getPath(workflow.id, old.id);
+    const oldDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const content = await Deno.readTextFile(oldPath);
+    const patched = content.replace(
+      /startedAt: .*/,
+      `startedAt: "${oldDate.toISOString()}"`,
+    );
+    await Deno.writeTextFile(oldPath, patched);
+    const indexPath = getIndexPath(
+      join(dir, ".swamp", "workflow-runs", workflow.id),
+    );
+    await Deno.remove(indexPath);
+
+    const fresh = WorkflowRun.create(workflow);
+    fresh.start();
+    await repo.save(workflow.id, fresh);
+
+    const cutoff = new Date(Date.now() - 60 * 60 * 1000);
+    const found = await repo.findGlobalByStatus("running", cutoff);
+    assertEquals(found.length, 1);
+    assertEquals(found[0].run.id, fresh.id);
+  });
+});
+
+Deno.test("findGlobalByStatus: returns empty when no runs match", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlWorkflowRunRepository(dir);
+    const workflow = createTestWorkflow();
+
+    const succeeded = WorkflowRun.create(workflow);
+    succeeded.start();
+    const jobRun = succeeded.getJob("job1");
+    jobRun?.start();
+    jobRun?.getStep("step1")?.start();
+    jobRun?.getStep("step1")?.succeed({ result: "ok" });
+    jobRun?.succeed();
+    succeeded.complete();
+    await repo.save(workflow.id, succeeded);
+
+    const found = await repo.findGlobalByStatus("running");
+    assertEquals(found.length, 0);
+  });
+});
+
+Deno.test("findGlobalByStatus: works across multiple workflows", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlWorkflowRunRepository(dir);
+    const wf1 = createTestWorkflow();
+    const wf2Id = createWorkflowId(crypto.randomUUID());
+
+    const run1 = WorkflowRun.create(wf1);
+    run1.start();
+    await repo.save(wf1.id, run1);
+
+    const run2 = WorkflowRun.create(wf1);
+    run2.start();
+    await repo.save(wf2Id, run2);
+
+    const found = await repo.findGlobalByStatus("running");
+    assertEquals(found.length, 2);
+    const workflowIds = new Set(found.map((f) => f.workflowId));
+    assert(workflowIds.has(wf1.id));
+    assert(workflowIds.has(wf2Id));
+  });
+});
+
+Deno.test("findGlobalByStatus: returns empty for nonexistent base dir", async () => {
+  const repo = new YamlWorkflowRunRepository(
+    "/tmp/does-not-exist-" + crypto.randomUUID(),
+  );
+  const found = await repo.findGlobalByStatus("running");
+  assertEquals(found.length, 0);
+});
+
 Deno.test("save: index is written to local path, not cache baseDir", async () => {
   await withTempDir(async (dir) => {
     const cacheDir = await Deno.makeTempDir();

--- a/src/libswamp/workflows/run_test.ts
+++ b/src/libswamp/workflows/run_test.ts
@@ -115,6 +115,20 @@ class InMemoryWorkflowRunRepository implements WorkflowRunRepository {
       run.startedAt !== undefined && run.startedAt >= cutoff
     );
   }
+  async findGlobalByStatus(
+    status: string | string[],
+    since?: Date,
+  ): Promise<{ run: WorkflowRun; workflowId: WorkflowId }[]> {
+    const statuses = new Set(Array.isArray(status) ? status : [status]);
+    const all = await this.findAllGlobal();
+    return all.filter(({ run }) => {
+      if (!statuses.has(run.status)) return false;
+      if (since !== undefined) {
+        if (run.startedAt === undefined || run.startedAt < since) return false;
+      }
+      return true;
+    });
+  }
   save(wfId: WorkflowId, run: WorkflowRun): Promise<void> {
     const existing = this.runs.get(wfId) ?? [];
     const idx = existing.findIndex((r) => r.id === run.id);


### PR DESCRIPTION
## Summary

- Add `findGlobalByStatus(status: string | string[], since?: Date)` to `WorkflowRunRepository` interface — uses `.runs-index.json` to identify runs matching the target status, then loads only those as full aggregates via `findById`. Falls back to lightweight summary scan when no index exists.
- Replace `findAllGlobalSince(7 days)` in boot reconciliation with `findGlobalByStatus("running", reapCutoff)` — the reap function only needs running runs anyway.
- Replace `findAllGlobalSince(earliestCutoff)` in graceful shutdown with `findGlobalByStatus(["running", "cancelled"], earliestCutoff)`.
- Turns O(all_recent_runs x full_aggregate_cost) into O(matching_runs x full_aggregate_cost) + O(all_indexed x JSON_read_cost).

## Test Plan

- 6 new unit tests for `findGlobalByStatus` covering: single status, multi-status array, since-cutoff, no matching runs, cross-workflow, and nonexistent base dir
- All 10,026 existing tests pass (1 pre-existing platform-specific failure unrelated to this change)
- Type checking passes across the full codebase

Closes swamp-club#1558