### PR TITLE
fix(access): resolve user names in authorization error messages

### DIFF
--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -905,6 +905,61 @@ Deno.test("authorizeOrReject: explicit deny returns denied error frame", () => {
   assertStringIncludes(errorMessage, "explicitly denied");
 });
 
+Deno.test("authorizeOrReject: resolvedUserNames replaces raw ID in error message", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const opaqueId = "699e486007f77116ebf44bd2";
+  const principal: Principal = { kind: "user", id: opaqueId };
+  const ctx = makeCtx(modeTokenConfig, []);
+  ctx.resolvedUserNames = { [opaqueId]: "stack72" };
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "workflow.run",
+      id: "auth-resolve-1",
+      payload: { workflowIdOrName: "@acme/deploy" },
+    })),
+    principal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  const errorMessage = String((msg.error as Record<string, unknown>).message);
+  assertStringIncludes(errorMessage, "user:stack72");
+  assertEquals(errorMessage.includes(opaqueId), false);
+});
+
+Deno.test("authorizeOrReject: falls back to raw ID when resolvedUserNames absent", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const opaqueId = "699e486007f77116ebf44bd2";
+  const principal: Principal = { kind: "user", id: opaqueId };
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "workflow.run",
+      id: "auth-resolve-2",
+      payload: { workflowIdOrName: "@acme/deploy" },
+    })),
+    principal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  const errorMessage = String((msg.error as Record<string, unknown>).message);
+  assertStringIncludes(errorMessage, `user:${opaqueId}`);
+});
+
 // ── Authorization: missing policySnapshotLoader in enforcing mode ─────────
 
 // ── Authorization: denormalized access model typeArgs require admin ──────────

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -284,7 +284,7 @@ export function authorizeOrReject(
     if (adminDecision && adminDecision.effect === "allow") return true;
   }
 
-  const principalStr = principalToString(principal);
+  const principalStr = resolveDisplayPrincipal(principal, ctx);
   if (decision && decision.effect === "deny") {
     sendError(
       socket,
@@ -301,6 +301,16 @@ export function authorizeOrReject(
     );
   }
   return false;
+}
+
+function resolveDisplayPrincipal(
+  principal: Principal,
+  ctx: ConnectionContext,
+): string {
+  if (principal.kind === "user" && ctx.resolvedUserNames?.[principal.id]) {
+    return `user:${ctx.resolvedUserNames[principal.id]}`;
+  }
+  return principalToString(principal);
 }
 
 export function send(socket: WebSocket, message: ServerMessage): void {


### PR DESCRIPTION
## Summary

- Authorization error messages now show `user:stack72` instead of
  `user:699e486007f77116ebf44bd2` by resolving OAuth sub claims via
  the `resolvedUserNames` map already populated at server startup
- Falls back to the raw principal ID when no resolved name is available
  (token-only auth, `--allowed-collectives`-only users)
- Follows the same pattern established in #2096 for the grant list

## Test Plan

- [x] Unit test: resolved name replaces opaque ID in error message
- [x] Unit test: falls back to raw ID when `resolvedUserNames` absent
- [x] All existing `authorizeOrReject` tests pass (190 in connection_test.ts)
- [x] Full test suite: 10,056 passed, 0 failed
- [x] `deno fmt`, `deno lint`, `deno check` all pass