### PR TITLE
fix(datastore): make namespace migrate idempotent when nothing to move

### DIFF
--- a/src/libswamp/datastores/namespace_migrate.ts
+++ b/src/libswamp/datastores/namespace_migrate.ts
@@ -271,15 +271,30 @@ export async function* datastoreNamespaceMigrate(
       }
 
       if (directories.length === 0) {
-        const hint = input.reverse
-          ? " If data was pushed to a remote datastore, run 'swamp datastore sync --pull' first to populate the local cache."
-          : "";
         yield {
-          kind: "error",
-          error: validationFailed(
-            `No data directories found to migrate.${hint}`,
-          ),
-          succeededDirectories: [],
+          kind: "preview",
+          data: {
+            namespace,
+            datastorePath,
+            reverse: input.reverse,
+            confirm: input.confirm,
+            directories: [],
+            totalFiles: 0,
+            totalBytes: 0,
+            isExtensionDatastore: deps.isExtensionDatastore,
+          },
+        };
+        yield {
+          kind: "completed",
+          data: {
+            namespace,
+            datastorePath,
+            reverse: input.reverse,
+            migratedDirectories: [],
+            totalFiles: 0,
+            totalBytes: 0,
+            isExtensionDatastore: deps.isExtensionDatastore,
+          },
         };
         return;
       }

--- a/src/libswamp/datastores/namespace_migrate_test.ts
+++ b/src/libswamp/datastores/namespace_migrate_test.ts
@@ -69,16 +69,22 @@ Deno.test("datastoreNamespaceMigrate: errors when no namespace configured", asyn
   }
 });
 
-Deno.test("datastoreNamespaceMigrate: errors when no data directories exist", async () => {
+Deno.test("datastoreNamespaceMigrate: yields preview and completed when no data directories exist", async () => {
   const ctx = createLibSwampContext({});
   const deps = makeDeps();
   const events = await collect<NamespaceMigrateEvent>(
     datastoreNamespaceMigrate(ctx, deps, { confirm: false, reverse: false }),
   );
-  assertEquals(events.length, 1);
-  assertEquals(events[0].kind, "error");
-  if (events[0].kind === "error") {
-    assertStringIncludes(events[0].error.message, "No data directories found");
+  assertEquals(events.length, 2);
+  assertEquals(events[0].kind, "preview");
+  if (events[0].kind === "preview") {
+    assertEquals(events[0].data.directories.length, 0);
+    assertEquals(events[0].data.totalFiles, 0);
+    assertEquals(events[0].data.totalBytes, 0);
+  }
+  assertEquals(events[1].kind, "completed");
+  if (events[1].kind === "completed") {
+    assertEquals(events[1].data.migratedDirectories.length, 0);
   }
 });
 

--- a/src/presentation/renderers/datastore_namespace_migrate.ts
+++ b/src/presentation/renderers/datastore_namespace_migrate.ts
@@ -39,6 +39,16 @@ class LogNamespaceMigrateRenderer implements Renderer<NamespaceMigrateEvent> {
   handlers(): EventHandlers<NamespaceMigrateEvent> {
     return {
       preview: (e) => {
+        if (e.data.directories.length === 0) {
+          const hint = e.data.reverse
+            ? " If data was pushed to a remote, run 'swamp datastore sync --pull' first."
+            : "";
+          writeOutput(
+            `Nothing to migrate — data is already in the namespace directory.${hint}`,
+          );
+          return;
+        }
+
         const direction = e.data.reverse ? "Reverse migration" : "Migration";
         const lines = [
           bold(`${direction} preview (namespace: "${e.data.namespace}")`),


### PR DESCRIPTION
## Summary

- `swamp datastore namespace migrate --confirm` now exits 0 with an informational message when there are no root-level data directories to move, instead of erroring with exit code 1
- This happens legitimately when a namespace was configured at setup time (data goes directly to `cachePath/{ns}/` via `DefaultDatastorePathResolver`), so nothing needs migrating
- The command is now safe to run unconditionally as an idempotent operation

## Test Plan

- Updated unit test to verify preview + completed events (instead of error) when no directories exist
- All 10054 existing tests pass
- Manually verified with compiled binary:
  - `migrate --confirm` with no root-level dirs → exit 0, "Nothing to migrate — data is already in the namespace directory."
  - `migrate` (dry-run) → same message, exit 0
  - `migrate --confirm --json` → clean JSON with `directories: []`, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)