### PR TITLE
feat(serve): add --hydration-timeout to configure startup cache pull duration

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -383,6 +383,9 @@ export function collectServeExtraArgs(options: AnyOptions): string[] {
       options.reconciliationInterval as string,
     );
   }
+  if (options.hydrationTimeout) {
+    args.push("--hydration-timeout", options.hydrationTimeout as string);
+  }
   return args;
 }
 
@@ -590,6 +593,10 @@ const daemonEnableCommand = new Command()
   .option(
     "--reconciliation-interval <duration:string>",
     "Peer reconciliation scan interval (default: 60s, env: SWAMP_RECONCILIATION_INTERVAL)",
+  )
+  .option(
+    "--hydration-timeout <duration:string>",
+    "Startup cache hydration timeout (default: 60s, env: SWAMP_HYDRATION_TIMEOUT)",
   )
   .example("Enable daemon", "swamp serve daemon enable")
   .example(
@@ -933,6 +940,12 @@ export const serveCommand = new Command()
       "Only effective with a control-plane-capable datastore (env: SWAMP_RECONCILIATION_INTERVAL)",
   )
   .option(
+    "--hydration-timeout <duration:string>",
+    "Maximum time to wait for initial datastore cache hydration at startup. " +
+      "Accepts seconds (60), explicit units (60s, 5m). Default: 60s. " +
+      "Increase for large repos where the initial pull takes longer (env: SWAMP_HYDRATION_TIMEOUT)",
+  )
+  .option(
     "--max-concurrent-runs <count:integer>",
     "Maximum number of concurrent detached runs across all principals. Default: 100. " +
       "(env: SWAMP_MAX_CONCURRENT_RUNS)",
@@ -1052,6 +1065,11 @@ export const serveCommand = new Command()
     const reconciliationIntervalMs = reconciliationIntervalRaw !== undefined
       ? parseTimeout(reconciliationIntervalRaw, "--reconciliation-interval")
       : undefined;
+
+    const hydrationTimeoutRaw = merged.hydrationTimeout;
+    const hydrationTimeoutMs = hydrationTimeoutRaw !== undefined
+      ? parseTimeout(hydrationTimeoutRaw, "--hydration-timeout")
+      : 60_000;
 
     const maxConcurrentRuns = merged.maxConcurrentRuns;
     if (
@@ -1444,7 +1462,7 @@ export const serveCommand = new Command()
       await hydrateLocalCache({
         syncService,
         catalogInvalidate: () => repoContext.catalogStore.invalidate(),
-        signal: AbortSignal.timeout(60_000),
+        signal: AbortSignal.timeout(hydrationTimeoutMs),
         namespace: serveNamespace,
       });
 

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -40,6 +40,7 @@ export const SERVE_ENV_MAP: Readonly<Record<string, string>> = {
   heartbeatInterval: "SWAMP_HEARTBEAT_INTERVAL",
   staleTtl: "SWAMP_STALE_TTL",
   reconciliationInterval: "SWAMP_RECONCILIATION_INTERVAL",
+  hydrationTimeout: "SWAMP_HYDRATION_TIMEOUT",
   groupRefreshInterval: "SWAMP_GROUP_REFRESH_INTERVAL",
   maxConcurrentRuns: "SWAMP_MAX_CONCURRENT_RUNS",
   maxRunsPerPrincipal: "SWAMP_MAX_RUNS_PER_PRINCIPAL",
@@ -95,6 +96,7 @@ export interface ServeConfigFile {
   "max-concurrent-runs"?: number;
   "max-runs-per-principal"?: number;
   "max-run-duration"?: string;
+  "hydration-timeout"?: string;
 }
 
 // ── Known Keys ────────────────────────────────────────────────────────
@@ -121,6 +123,7 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
   "max-concurrent-runs",
   "max-runs-per-principal",
   "max-run-duration",
+  "hydration-timeout",
 ]);
 
 const KNOWN_AUTH_KEYS = new Set([
@@ -314,6 +317,7 @@ function validateConfigValues(
     ["heartbeat-interval", raw["heartbeat-interval"]],
     ["stale-ttl", raw["stale-ttl"]],
     ["reconciliation-interval", raw["reconciliation-interval"]],
+    ["hydration-timeout", raw["hydration-timeout"]],
   ];
   for (const [name, value] of stringFields) {
     if (value !== undefined && typeof value !== "string") {
@@ -521,6 +525,7 @@ export interface MergedServeOptions {
   maxConcurrentRuns?: number;
   maxRunsPerPrincipal?: number;
   maxRunDuration?: string;
+  hydrationTimeout?: string;
 }
 
 export function mergeServeOptions(
@@ -829,6 +834,13 @@ export function mergeServeOptions(
     undefined,
   );
 
+  const hydrationTimeout = resolveString(
+    "hydration-timeout",
+    cliOptions.hydrationTimeout as string | undefined,
+    config?.["hydration-timeout"],
+    undefined,
+  );
+
   // Webhooks: CLI --webhook flags replace config file webhooks entirely
   let webhook: string[] | undefined;
   let webhookEndpoints: WebhookEndpoint[] | undefined;
@@ -872,5 +884,6 @@ export function mergeServeOptions(
     maxConcurrentRuns,
     maxRunsPerPrincipal,
     maxRunDuration,
+    hydrationTimeout,
   };
 }

--- a/src/serve/serve_config_test.ts
+++ b/src/serve/serve_config_test.ts
@@ -755,3 +755,44 @@ Deno.test("mergeServeOptions: whitespace-only env var for max-concurrent-runs is
   );
   assertEquals(merged.maxConcurrentRuns, undefined);
 });
+
+Deno.test("mergeServeOptions: hydration-timeout from CLI flag", () => {
+  const merged = mergeServeOptions(
+    null,
+    { hydrationTimeout: "5m" },
+    new Set(["hydration-timeout"]),
+    () => undefined,
+  );
+  assertEquals(merged.hydrationTimeout, "5m");
+});
+
+Deno.test("mergeServeOptions: hydration-timeout from config file", () => {
+  const config: ServeConfigFile = { "hydration-timeout": "10m" };
+  const merged = mergeServeOptions(
+    config,
+    {},
+    new Set<string>(),
+    () => undefined,
+  );
+  assertEquals(merged.hydrationTimeout, "10m");
+});
+
+Deno.test("mergeServeOptions: hydration-timeout from env var", () => {
+  const merged = mergeServeOptions(
+    null,
+    {},
+    new Set<string>(),
+    (name) => name === "SWAMP_HYDRATION_TIMEOUT" ? "3m" : undefined,
+  );
+  assertEquals(merged.hydrationTimeout, "3m");
+});
+
+Deno.test("mergeServeOptions: hydration-timeout defaults to undefined", () => {
+  const merged = mergeServeOptions(
+    null,
+    {},
+    new Set<string>(),
+    () => undefined,
+  );
+  assertEquals(merged.hydrationTimeout, undefined);
+});


### PR DESCRIPTION
## Summary

- The initial datastore hydration at `swamp serve` startup was hardcoded to 60 seconds, which times out on large repos
- Adds a `--hydration-timeout` option configurable via CLI flag, `hydration-timeout` in `.swamp/serve.yaml`, or `SWAMP_HYDRATION_TIMEOUT` env var
- Defaults to 60s for backwards compatibility; accepts duration strings like `5m`, `300s`, etc.

## Test Plan

- Added 4 unit tests for the config merge layer (CLI flag, config file, env var, default)
- Verified all existing `serve_config` and `boot_reconciliation` tests pass (102 total)
- `deno check`, `deno lint`, `deno fmt` all clean