### PR TITLE
fix(extensions): allow extensionless legal files in additionalFiles

### DIFF
--- a/.claude/skills/swamp/references/extension/references/quality/rubric.md
+++ b/.claude/skills/swamp/references/extension/references/quality/rubric.md
@@ -131,12 +131,14 @@ nested entry like `additionalFiles: [legal/LICENSE]` lands at
 `<root>/files/legal/LICENSE` and earns zero. Use a bare basename and, if your
 source layout requires it, opt into `paths.base: manifest`.
 
-Recognized license filenames (case-sensitive matches):
+Recognized license filenames (case-sensitive matches). `LICENSE` variants are
+preferred; `COPYING` variants are also accepted:
 
 ```
 LICENSE, LICENSE.md, LICENSE.txt, LICENSE.MD, LICENSE.TXT,
 License, License.md, License.txt,
-license, license.md, license.txt
+license, license.md, license.txt,
+COPYING, COPYING.md, COPYING.txt
 ```
 
 ### `repository-verified` (2 pts)

--- a/.claude/skills/swamp/references/extension/references/quality/rubric.md
+++ b/.claude/skills/swamp/references/extension/references/quality/rubric.md
@@ -136,8 +136,7 @@ Recognized license filenames (case-sensitive matches):
 ```
 LICENSE, LICENSE.md, LICENSE.txt, LICENSE.MD, LICENSE.TXT,
 License, License.md, License.txt,
-license, license.md, license.txt,
-COPYING, COPYING.md, COPYING.txt
+license, license.md, license.txt
 ```
 
 ### `repository-verified` (2 pts)

--- a/src/domain/extensions/extension_rubric_scorer.ts
+++ b/src/domain/extensions/extension_rubric_scorer.ts
@@ -363,8 +363,7 @@ export function composeScore(
       1,
       factors.hasLicenseFile,
       {
-        remediation:
-          "Add a LICENSE / LICENSE.md / LICENSE.txt / COPYING entry to " +
+        remediation: "Add a LICENSE / LICENSE.md / LICENSE.txt entry to " +
           "`additionalFiles:` as a bare basename — entries are copied " +
           "verbatim to `extension/files/<entry>` in the archive, so " +
           "nested paths won't earn the factor. For per-directory layouts " +

--- a/src/domain/extensions/extension_safety_analyzer.ts
+++ b/src/domain/extensions/extension_safety_analyzer.ts
@@ -111,6 +111,16 @@ export const ALLOWED_EXTENSIONS = new Set([
   ".txt",
 ]);
 
+export const LEGAL_BASENAMES = new Set([
+  "AUTHORS",
+  "CONTRIBUTORS",
+  "COPYING",
+  "COPYING-EXCEPTION",
+  "LICENSE",
+  "NOTICE",
+  "PATENTS",
+]);
+
 const MAX_FILE_COUNT = 150;
 const MAX_INDIVIDUAL_FILE_SIZE = 1_000_000; // 1 MB
 const MAX_TOTAL_SIZE = 10_000_000; // 10 MB
@@ -156,10 +166,12 @@ export async function analyzeExtensionSafety(
       continue;
     }
 
-    // Check allowed extensions (exempt files skip this check)
+    // Check allowed extensions (exempt files and legal basenames skip this check)
     const ext = extname(file).toLowerCase();
     const isExempt = exemptFromExtensionCheck?.has(file) ?? false;
-    if (!isExempt && !ALLOWED_EXTENSIONS.has(ext)) {
+    if (
+      !isExempt && !ALLOWED_EXTENSIONS.has(ext) && !LEGAL_BASENAMES.has(name)
+    ) {
       errors.push({
         file,
         message: `File extension "${ext}" is not allowed. Allowed: ${

--- a/src/domain/extensions/extension_safety_analyzer_test.ts
+++ b/src/domain/extensions/extension_safety_analyzer_test.ts
@@ -244,7 +244,7 @@ Deno.test("analyzeExtensionSafety: legal basenames pass without exemption", asyn
       assertEquals(result.errors, [], `${name} should pass safety analysis`);
     }
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 

--- a/src/domain/extensions/extension_safety_analyzer_test.ts
+++ b/src/domain/extensions/extension_safety_analyzer_test.ts
@@ -234,6 +234,20 @@ Deno.test("analyzeExtensionSafety: extensionless file rejected when not exempt",
   }
 });
 
+Deno.test("analyzeExtensionSafety: legal basenames pass without exemption", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    for (const name of ["COPYING", "COPYING-EXCEPTION", "LICENSE", "NOTICE"]) {
+      const filePath = join(tmpDir, name);
+      await Deno.writeTextFile(filePath, "Legal text\n");
+      const result = await analyzeExtensionSafety([filePath]);
+      assertEquals(result.errors, [], `${name} should pass safety analysis`);
+    }
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
 Deno.test("analyzeExtensionSafety: exempt files still checked for hidden names", async () => {
   await withTempFiles(
     { ".hidden": "secret\n" },

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { dirname, extname, join, relative } from "@std/path";
+import { basename, dirname, extname, join, relative } from "@std/path";
 import { stringify as stringifyYaml } from "@std/yaml";
 import { createTarGz } from "../../infrastructure/archive/tar_archive.ts";
 import { extractBareSpecifierNames } from "../../domain/models/bundle.ts";
@@ -29,6 +29,7 @@ import type {
 } from "../../domain/extensions/extension_content.ts";
 import {
   ALLOWED_EXTENSIONS,
+  LEGAL_BASENAMES,
   type SafetyCheckResult,
   type SafetyIssue,
 } from "../../domain/extensions/extension_safety_analyzer.ts";
@@ -622,7 +623,7 @@ export async function extensionPushPrepare(
   // error can name the manifest field and suggest `binaries`.
   for (const file of input.additionalFilePaths) {
     const ext = extname(file).toLowerCase();
-    if (!ALLOWED_EXTENSIONS.has(ext)) {
+    if (!ALLOWED_EXTENSIONS.has(ext) && !LEGAL_BASENAMES.has(basename(file))) {
       const rel = relative(input.repoDir, file);
       throw validationFailed(
         `File "${rel}" in additionalFiles has extension "${ext}" which is not allowed. ` +

--- a/src/libswamp/extensions/push_test.ts
+++ b/src/libswamp/extensions/push_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
 import { assertPathEquals } from "../../infrastructure/persistence/path_test_helpers.ts";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
@@ -246,8 +247,8 @@ Deno.test("extensionPushPrepare: additionalFiles with disallowed extension sugge
 Deno.test("extensionPushPrepare: additionalFiles with legal basenames pass pre-check", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {
-    const copyingPath = `${tmpDir}/COPYING`;
-    const licensePath = `${tmpDir}/LICENSE`;
+    const copyingPath = join(tmpDir, "COPYING");
+    const licensePath = join(tmpDir, "LICENSE");
     await Deno.writeTextFile(copyingPath, "Legal text\n");
     await Deno.writeTextFile(licensePath, "Legal text\n");
 

--- a/src/libswamp/extensions/push_test.ts
+++ b/src/libswamp/extensions/push_test.ts
@@ -243,6 +243,31 @@ Deno.test("extensionPushPrepare: additionalFiles with disallowed extension sugge
   assertStringIncludes(error.message, ".bin");
 });
 
+Deno.test("extensionPushPrepare: additionalFiles with legal basenames pass pre-check", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const copyingPath = `${tmpDir}/COPYING`;
+    const licensePath = `${tmpDir}/LICENSE`;
+    await Deno.writeTextFile(copyingPath, "Legal text\n");
+    await Deno.writeTextFile(licensePath, "Legal text\n");
+
+    const deps = makePrepareDeps();
+    const input = makePrepareInput({
+      repoDir: tmpDir,
+      additionalFilePaths: [copyingPath, licensePath],
+      manifest: makeManifest({
+        additionalFiles: ["COPYING", "LICENSE"],
+      }),
+      dryRun: true,
+    });
+
+    const result = await extensionPushPrepare(ctx, deps, input);
+    assertEquals(result.isDryRun, true);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
 Deno.test("extensionPushPrepare: safety errors throw SwampError", async () => {
   const deps = makePrepareDeps({
     analyzeExtensionSafety: () =>


### PR DESCRIPTION
## Summary

- Add a `LEGAL_BASENAMES` allowlist (`COPYING`, `COPYING-EXCEPTION`, `LICENSE`, `NOTICE`, `AUTHORS`, `CONTRIBUTORS`, `PATENTS`) to the extension safety analyzer and push pre-check so extensionless legal files pass `additionalFiles` validation
- Remove `COPYING` from the rubric scorer remediation text and skill reference docs — `LICENSE` is the standard recommendation; `COPYING` is still *recognized* if present

Closes swamp-club#1564

## Test Plan

- [x] New unit test: safety analyzer accepts legal basenames without exemption
- [x] New unit test: push pre-check passes `additionalFiles` with legal basenames
- [x] Existing test: non-legal extensionless files (`mudroom`) still rejected
- [x] Reproduction verified: `swamp extension push --dry-run` succeeds with `COPYING` and `COPYING-EXCEPTION` in `additionalFiles`
- [x] Full test suite passes (10,075 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: mgreten <mgreten@users.noreply.github.com>