### PR TITLE
fix(workflows): fix regressions in workflow-name filename PR

### DIFF
--- a/src/domain/workflows/workflow.ts
+++ b/src/domain/workflows/workflow.ts
@@ -65,7 +65,7 @@ const workflowNameBase = z.string().min(1).refine(
 
 const workflowNameStrict = workflowNameBase
   .refine(
-    (name) => WORKFLOW_NAME_PATTERN.test(name),
+    (name) => name.includes("/") || WORKFLOW_NAME_PATTERN.test(name),
     {
       message:
         "Workflow name must be lowercase alphanumeric with hyphens (e.g. 'deploy-pipeline'). Must start with a letter or number.",

--- a/src/domain/workflows/workflow_test.ts
+++ b/src/domain/workflows/workflow_test.ts
@@ -496,12 +496,9 @@ Deno.test("Workflow.create enforces max name length", () => {
   );
 });
 
-Deno.test("Workflow.create rejects scoped names (create is for user workflows)", () => {
-  assertThrows(
-    () => Workflow.create({ name: "@john/pod-inventory" }),
-    Error,
-    "lowercase alphanumeric",
-  );
+Deno.test("Workflow.create accepts scoped @collective/name", () => {
+  const workflow = Workflow.create({ name: "@john/pod-inventory" });
+  assertEquals(workflow.name, "@john/pod-inventory");
 });
 
 // Scoped @collective/name tests (via fromData — extension workflows)

--- a/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
@@ -121,8 +121,12 @@ export class YamlEvaluatedWorkflowRepository {
         const content = await Deno.readTextFile(namePath);
         const data = parseYaml(content) as WorkflowData;
         const workflow = Workflow.fromData(data);
-        this.idToActualPath.set(workflow.id as WorkflowId, namePath);
-        return workflow;
+        if (workflow.name !== name) {
+          // File content doesn't match filename — fall through to slow path
+        } else {
+          this.idToActualPath.set(workflow.id as WorkflowId, namePath);
+          return workflow;
+        }
       } catch (error) {
         if (!(error instanceof Deno.errors.NotFound)) {
           throw error;
@@ -174,9 +178,15 @@ export class YamlEvaluatedWorkflowRepository {
   }
 
   async delete(id: WorkflowId): Promise<void> {
+    // Populate cache so we discover name-based files on a cold instance
+    const workflow = await this.findById(id);
+
     const pathsToTry = new Set([this.getLegacyPath(id)]);
     const cachedPath = this.idToActualPath.get(id);
     if (cachedPath) pathsToTry.add(cachedPath);
+    if (workflow && isFilenameSafeName(workflow.name)) {
+      pathsToTry.add(this.getNamePath(workflow.name));
+    }
 
     for (const path of pathsToTry) {
       try {

--- a/src/infrastructure/persistence/yaml_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository.ts
@@ -105,8 +105,12 @@ export class YamlWorkflowRepository implements WorkflowRepository {
         const content = await Deno.readTextFile(namePath);
         const data = parseYaml(content) as WorkflowData;
         const workflow = Workflow.fromData(data);
-        this.idToActualPath.set(workflow.id as WorkflowId, namePath);
-        return workflow;
+        if (workflow.name !== name) {
+          // File content doesn't match filename — fall through to slow path
+        } else {
+          this.idToActualPath.set(workflow.id as WorkflowId, namePath);
+          return workflow;
+        }
       } catch (error) {
         if (!(error instanceof Deno.errors.NotFound)) {
           throw error;
@@ -171,8 +175,10 @@ export class YamlWorkflowRepository implements WorkflowRepository {
     const previousPath = this.idToActualPath.get(workflow.id);
 
     // Check if this is a new workflow or an update
+    const legacyPath = this.getLegacyPath(workflow.id);
     const isNew = !(await this.exists(targetPath)) &&
-      !(previousPath && await this.exists(previousPath));
+      !(previousPath && await this.exists(previousPath)) &&
+      !(await this.exists(legacyPath));
 
     const data = workflow.toData();
     // Remove undefined values since YAML can't stringify them
@@ -197,7 +203,6 @@ export class YamlWorkflowRepository implements WorkflowRepository {
     }
 
     // Also check the legacy UUID path if it wasn't the previousPath
-    const legacyPath = this.getLegacyPath(workflow.id);
     if (
       targetPath !== legacyPath && previousPath !== legacyPath &&
       await this.exists(legacyPath)

--- a/src/infrastructure/persistence/yaml_workflow_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository_test.ts
@@ -384,6 +384,33 @@ Deno.test("YamlWorkflowRepository.findByName uses fast path for filename-safe na
   });
 });
 
+Deno.test("YamlWorkflowRepository.findByName falls through when file name diverges from content", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlWorkflowRepository(dir);
+    const workflow = createTestWorkflow("deploy");
+
+    await repo.save(workflow);
+
+    // Simulate user editing the YAML name without renaming the file
+    const workflowsDir = join(dir, "workflows");
+    const filePath = join(workflowsDir, "workflow-deploy.yaml");
+    const content = await Deno.readTextFile(filePath);
+    await Deno.writeTextFile(
+      filePath,
+      content.replace("name: deploy", "name: staging"),
+    );
+
+    // findByName("deploy") should NOT return the mismatched workflow
+    const result = await repo.findByName("deploy");
+    assertEquals(result, null);
+
+    // findByName("staging") should find it via the slow path
+    const staging = await repo.findByName("staging");
+    assertNotEquals(staging, null);
+    assertEquals(staging!.name, "staging");
+  });
+});
+
 Deno.test("YamlWorkflowRepository.delete removes name-based file", async () => {
   await withTempDir(async (dir) => {
     const repo = new YamlWorkflowRepository(dir);


### PR DESCRIPTION
## Summary

Fixes four regressions introduced by #2106 (workflow-name.yaml filenames):

- **Scoped name creation broken**: `workflowNameStrict` rejected `@collective/name` at `Workflow.create()` time, breaking `swamp workflow create @test/my-workflow`. The strict validator now skips the kebab-case check for scoped names (which are already validated by `workflowNameBase`'s scoped-name regex). This was caught by UAT: https://github.com/swamp-club/swamp-uat/actions/runs/31410945101/job/93528575899
- **`findByName` fast path returned wrong workflow**: When a user edits the `name:` field inside a YAML file without renaming the file, `findByName("deploy")` would read `workflow-deploy.yaml` and return a workflow whose name is actually "staging". Both repos now verify `workflow.name === name` before returning from the fast path.
- **`YamlEvaluatedWorkflowRepository.delete` silent failure on cold cache**: Unlike the workflow repo (which calls `findById` first), the evaluated repo's `delete` only tried the legacy path and cache. After a restart, deleting an evaluated workflow stored as `workflow-{name}.yaml` silently did nothing. Now mirrors the workflow repo approach.
- **`isNew` emitted wrong event on cold cache with legacy file**: When saving a workflow that exists as a legacy UUID file but with a cold cache, `isNew` was `true` because neither `targetPath` nor `previousPath` existed. The check now also verifies the legacy path doesn't exist.

## Test Plan

- Added test: `findByName` falls through to slow path when file content name diverges from filename
- Updated test: `Workflow.create` now accepts scoped `@collective/name` (matching pre-#2106 behavior)
- Compiled binary and manually verified: name lookup, UUID lookup, scoped name create, name-mismatch rejection, delete of name-based and legacy files
- All 10076 tests pass