### PR TITLE
fix(models): render context.logger.warning and error output in model method run

### DIFF
--- a/src/domain/models/in_process_executor.ts
+++ b/src/domain/models/in_process_executor.ts
@@ -49,7 +49,10 @@ export function wrapLoggerWithOutput(
   if (!onEvent) return logger;
   return new Proxy(logger, {
     get(target, prop, receiver) {
-      if (prop === "info" || prop === "warn") {
+      if (
+        prop === "info" || prop === "warn" || prop === "warning" ||
+        prop === "error"
+      ) {
         return (...args: unknown[]) => {
           const original = Reflect.get(target, prop, receiver) as (
             ...a: unknown[]
@@ -78,7 +81,9 @@ export function wrapLoggerWithOutput(
           onEvent({
             type: "output",
             line,
-            stream: prop === "warn" ? "stderr" : "stdout",
+            stream: prop === "warn" || prop === "warning" || prop === "error"
+              ? "stderr"
+              : "stdout",
           });
         };
       }

--- a/src/domain/models/in_process_executor_test.ts
+++ b/src/domain/models/in_process_executor_test.ts
@@ -19,7 +19,10 @@
 
 import { assertEquals } from "@std/assert";
 import { createExtensionCelEnvironment } from "../../infrastructure/cel/cel_evaluator.ts";
-import { InProcessExecutor } from "./in_process_executor.ts";
+import {
+  InProcessExecutor,
+  wrapLoggerWithOutput,
+} from "./in_process_executor.ts";
 import type { MethodExecutor } from "./in_process_executor.ts";
 import type { ExecutionRequest } from "./execution_envelope.ts";
 import { Definition } from "../definitions/definition.ts";
@@ -741,4 +744,73 @@ Deno.test("InProcessExecutor: does not wire gate methods when no workflowGateSer
 
   assertEquals(hasApprove, false);
   assertEquals(hasReject, false);
+});
+
+// ---------- wrapLoggerWithOutput Tests ----------
+
+Deno.test("wrapLoggerWithOutput: returns logger unchanged when onEvent is undefined", () => {
+  const logger = getLogger(["test", "wrap-noop"]);
+  const result = wrapLoggerWithOutput(logger, undefined);
+  assertEquals(result, logger);
+});
+
+Deno.test("wrapLoggerWithOutput: info emits stdout event", () => {
+  const logger = getLogger(["test", "wrap-info"]);
+  const events: { type: string; line: string; stream: string }[] = [];
+  const wrapped = wrapLoggerWithOutput(logger, (e) => {
+    if (e.type === "output") events.push(e);
+  });
+  wrapped.info("hello from info");
+  assertEquals(events.length, 1);
+  assertEquals(events[0].line, "hello from info");
+  assertEquals(events[0].stream, "stdout");
+});
+
+Deno.test("wrapLoggerWithOutput: warn emits stderr event", () => {
+  const logger = getLogger(["test", "wrap-warn"]);
+  const events: { type: string; line: string; stream: string }[] = [];
+  const wrapped = wrapLoggerWithOutput(logger, (e) => {
+    if (e.type === "output") events.push(e);
+  });
+  wrapped.warn("hello from warn");
+  assertEquals(events.length, 1);
+  assertEquals(events[0].line, "hello from warn");
+  assertEquals(events[0].stream, "stderr");
+});
+
+Deno.test("wrapLoggerWithOutput: warning emits stderr event", () => {
+  const logger = getLogger(["test", "wrap-warning"]);
+  const events: { type: string; line: string; stream: string }[] = [];
+  const wrapped = wrapLoggerWithOutput(logger, (e) => {
+    if (e.type === "output") events.push(e);
+  });
+  wrapped.warning("hello from warning");
+  assertEquals(events.length, 1);
+  assertEquals(events[0].line, "hello from warning");
+  assertEquals(events[0].stream, "stderr");
+});
+
+Deno.test("wrapLoggerWithOutput: error emits stderr event", () => {
+  const logger = getLogger(["test", "wrap-error"]);
+  const events: { type: string; line: string; stream: string }[] = [];
+  const wrapped = wrapLoggerWithOutput(logger, (e) => {
+    if (e.type === "output") events.push(e);
+  });
+  wrapped.error("hello from error");
+  assertEquals(events.length, 1);
+  assertEquals(events[0].line, "hello from error");
+  assertEquals(events[0].stream, "stderr");
+});
+
+Deno.test("wrapLoggerWithOutput: tagged template interpolation works", () => {
+  const logger = getLogger(["test", "wrap-template"]);
+  const events: { type: string; line: string; stream: string }[] = [];
+  const wrapped = wrapLoggerWithOutput(logger, (e) => {
+    if (e.type === "output") events.push(e);
+  });
+  const count = 42;
+  wrapped.info`found ${count} items`;
+  assertEquals(events.length, 1);
+  assertEquals(events[0].line, "found 42 items");
+  assertEquals(events[0].stream, "stdout");
 });


### PR DESCRIPTION
## Summary

- `wrapLoggerWithOutput` proxy in `in_process_executor.ts` only intercepted `"info"` and `"warn"` calls, missing LogTape's `"warning"` alias and `"error"` level. Messages at these levels went only to the run log file and were invisible in terminal output unless `--verbose` was passed.
- Added `"warning"` and `"error"` to the proxy intercept list, routing both to `stderr` (matching `"warn"` behavior).
- The remote worker path (`remote_method_context.ts`) imports the same `wrapLoggerWithOutput`, so both in-process and remote execution are fixed.

Closes swamp-club#1570

## Test Plan

- [x] Added 6 unit tests for `wrapLoggerWithOutput`: noop passthrough, info/stdout, warn/stderr, warning/stderr, error/stderr, tagged template interpolation
- [x] Reproduced in scratch repo (`/tmp/swamp-repro-issue-1570`) — `.warning()` output now appears at default log level
- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt` — passes
- [x] `deno run test` — 10,081 passed, 0 failed
- [x] `deno run compile` — binary compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)