### PR TITLE
fix(data): stop catalog backfill deleting rows for numeric data names (swamp-club#1580)

### DIFF
--- a/design/data-query.md
+++ b/design/data-query.md
@@ -332,10 +332,28 @@ The catalog builds up incrementally:
    retries. The `populated` flag is not set by scoped backfill.
 3. **Full backfill on first query** — on the first call to
    `DataQueryService.query()`, if the catalog is not marked as populated, a
-   one-time `findAllGlobal()` runs, bulk-inserts all existing metadata, and
-   sets a `populated` flag in the `catalog_meta` table.
+   one-time `findAllGlobal()` runs, commits every row it found, and sets a
+   `populated` flag in the `catalog_meta` table.
 4. **Self-healing** — if `_catalog.db` is deleted or corrupted, the next query
    triggers a backfill automatically.
+
+Full backfill **replaces** rather than inserts. It commits through
+`bulkReplaceNamespace()` (or `bulkReplaceAll()` when no namespace is
+configured), each of which deletes the existing rows before writing the new
+set. Backfill is therefore only as correct as `findAllGlobal()` is complete:
+anything the on-disk walk fails to see is not left stale in the index, it is
+deleted from it. A gap in the walk is data loss in the catalog, not a missing
+entry — and because the walk runs before the predicate is applied, a query that
+matches nothing can still delete rows.
+
+Data on disk is never touched by backfill, so the loss is recoverable, but it
+does not recover on its own: the `populated` flag stays set, and `data get` and
+`data list` keep working, so nothing surfaces the gap. `swamp doctor datastores`
+compares the index against the on-disk walk and reports any shortfall, and
+`swamp doctor datastores --repair -y` removes `_catalog.db` so the next query
+rebuilds it. That rebuild also clears foreign-namespace rows fetched by
+`swamp datastore catalog pull` — they describe data that is not on local disk,
+so a local walk cannot recreate them; re-pull to restore them.
 
 ### Remote Datastores (S3)
 

--- a/src/cli/commands/doctor_datastores.ts
+++ b/src/cli/commands/doctor_datastores.ts
@@ -457,7 +457,7 @@ export const doctorDatastoresCommand = withRemoteOptions(
     )
     .option(
       "--repair",
-      "Preview and repair datastore issues: root-level unmigrated data and foreign namespace contamination (add -y to execute).",
+      "Preview and repair datastore issues: catalog index completeness, root-level unmigrated data, and foreign namespace contamination (add -y to execute).",
     )
     .option(
       "-y, --yes",

--- a/src/cli/commands/doctor_datastores.ts
+++ b/src/cli/commands/doctor_datastores.ts
@@ -19,17 +19,22 @@
 
 import { Command } from "@cliffy/command";
 import {
+  type CatalogCompletenessSummary,
+  type CatalogShortfall,
   consumeStream,
   createLibSwampContext,
   doctorDatastores,
   type DoctorDatastoresData,
   type DoctorDatastoresDeps,
+  repairCatalogIndex,
+  type RepairCatalogIndexDeps,
   repairDatastoreContamination,
   type RepairDatastoresDeps,
   repairUnmigratedData,
   type RepairUnmigratedDataDeps,
 } from "../../libswamp/mod.ts";
 import {
+  createCatalogIndexRepairRenderer,
   createDoctorDatastoresRenderer,
   createRepairDatastoresRenderer,
   createUnmigratedDataRepairRenderer,
@@ -61,8 +66,20 @@ import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_mark
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { resolveDatastoreConfig } from "../resolve_datastore.ts";
 import { RUNS_INDEX_FILENAME } from "../../infrastructure/persistence/workflow_run_index.ts";
-import { catalogDbPath } from "../../infrastructure/persistence/repository_factory.ts";
-import { swampPath } from "../../infrastructure/persistence/paths.ts";
+import {
+  catalogDbPath,
+  createCatalogStore,
+  createUnifiedDataRepository,
+  namespaceFromResolver,
+} from "../../infrastructure/persistence/repository_factory.ts";
+import { DefaultDatastorePathResolver } from "../../infrastructure/persistence/default_datastore_path_resolver.ts";
+import type { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import type { UnifiedDataRepository } from "../../domain/data/repositories.ts";
+import type { Namespace } from "../../domain/data/namespace.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
 import { join } from "@std/path";
 import {
   compareFiles,
@@ -163,6 +180,105 @@ async function createDoctorDatastoresDeps(
         dryRun: true,
       });
     },
+    checkCatalogCompleteness: () => checkCatalogCompleteness(repoDir),
+  };
+}
+
+/**
+ * Compares the local catalog index against the on-disk data walk, per model
+ * type, counting only latest-version records on both sides.
+ *
+ * Reads the catalog directly rather than issuing a data query: a query would
+ * trigger the catalog backfill, which repairs the exact condition being
+ * measured — the diagnostic would then always report health. Exported so that
+ * property can be tested against a real damaged catalog rather than a fake.
+ *
+ * Only shortfalls are reported. A type with more indexed rows than the walk
+ * can see is not a shortfall — that is what foreign-namespace rows look like.
+ */
+export async function compareCatalogToDisk(
+  catalogStore: CatalogStore,
+  dataRepo: UnifiedDataRepository,
+  namespace: Namespace,
+): Promise<CatalogCompletenessSummary> {
+  const diskByType = new Map<string, number>();
+  for (const record of await dataRepo.findAllGlobal()) {
+    const type = record.modelType.normalized;
+    diskByType.set(type, (diskByType.get(type) ?? 0) + 1);
+  }
+  const catalogByType = catalogStore.latestRowCountsByType(namespace);
+
+  const shortfalls: CatalogShortfall[] = [];
+  let diskRecords = 0;
+  let catalogRecords = 0;
+  for (const [typeNormalized, onDisk] of diskByType) {
+    const indexed = catalogByType.get(typeNormalized) ?? 0;
+    diskRecords += onDisk;
+    catalogRecords += indexed;
+    if (indexed < onDisk) {
+      shortfalls.push({
+        typeNormalized,
+        diskRecords: onDisk,
+        catalogRecords: indexed,
+      });
+    }
+  }
+
+  return { diskRecords, catalogRecords, shortfalls };
+}
+
+async function checkCatalogCompleteness(
+  repoDir: string,
+): Promise<CatalogCompletenessSummary | null> {
+  const markerRepo = new RepoMarkerRepository();
+  const marker = await markerRepo.read(RepoPath.create(repoDir));
+  const config = await resolveDatastoreConfig(marker, undefined, repoDir);
+  const datastoreResolver = new DefaultDatastorePathResolver(repoDir, config);
+  const catalogStore = createCatalogStore(repoDir, datastoreResolver);
+
+  try {
+    const namespace = namespaceFromResolver(datastoreResolver);
+    const dataRepo = createUnifiedDataRepository(
+      repoDir,
+      catalogStore,
+      datastoreResolver.localPath(SWAMP_SUBDIRS.data),
+      undefined,
+      namespace,
+    );
+    return await compareCatalogToDisk(catalogStore, dataRepo, namespace);
+  } finally {
+    // Release the SQLite handle before any repair removes the file — Windows
+    // refuses to delete a database that still has an open connection.
+    catalogStore.close();
+  }
+}
+
+/**
+ * Removes the catalog database and its SQLite sidecars, so the next data query
+ * rebuilds the index from disk.
+ */
+async function removeCatalogDb(repoDir: string): Promise<void> {
+  const dbPath = catalogDbPath(repoDir);
+  for (const suffix of ["", "-journal", "-wal", "-shm"]) {
+    try {
+      await Deno.remove(dbPath + suffix);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) throw error;
+    }
+  }
+}
+
+/**
+ * Catalog repair deps.
+ *
+ * Deliberately free of the namespace and custom-datastore requirements the
+ * other repairs carry: the catalog is a local index, and a plain local repo is
+ * exactly where an incomplete one goes unnoticed.
+ */
+function createCatalogRepairDeps(repoDir: string): RepairCatalogIndexDeps {
+  return {
+    checkCompleteness: () => checkCatalogCompleteness(repoDir),
+    invalidateCatalog: () => removeCatalogDb(repoDir),
   };
 }
 
@@ -256,16 +372,7 @@ async function createRepairDeps(
       }
       return invalidated;
     },
-    invalidateCatalog: async () => {
-      const dbPath = catalogDbPath(repoDir);
-      for (const suffix of ["", "-journal", "-wal", "-shm"]) {
-        try {
-          await Deno.remove(dbPath + suffix);
-        } catch (error) {
-          if (!(error instanceof Deno.errors.NotFound)) throw error;
-        }
-      }
-    },
+    invalidateCatalog: () => removeCatalogDb(repoDir),
   };
 }
 
@@ -431,7 +538,38 @@ export const doctorDatastoresCommand = withRemoteOptions(
       }
     }
 
-    const deps = await createRepairDeps(repoDir);
+    // Catalog repair runs before contamination repair: contamination repair
+    // ends by invalidating the catalog itself, so running it first would leave
+    // the completeness check comparing against a catalog that no longer exists.
+    const catalogRenderer = createCatalogIndexRepairRenderer(cliCtx.outputMode);
+    await consumeStream(
+      repairCatalogIndex(libCtx, createCatalogRepairDeps(repoDir), {
+        confirm: Boolean(options.yes),
+      }),
+      catalogRenderer.handlers(),
+    );
+    if (catalogRenderer.overallStatus === "fail") {
+      exitCode = 1;
+    }
+
+    let contaminationDeps: RepairDatastoresDeps | null = null;
+    try {
+      contaminationDeps = await createRepairDeps(repoDir);
+    } catch (error) {
+      if (error instanceof UserError) {
+        cliCtx.logger
+          .debug`Skipping namespace contamination repair: ${error.message}`;
+      } else {
+        throw error;
+      }
+    }
+
+    if (!contaminationDeps) {
+      if (exitCode !== 0) Deno.exit(1);
+      return;
+    }
+
+    const deps = contaminationDeps;
     const renderer = createRepairDatastoresRenderer(cliCtx.outputMode);
 
     await consumeStream(

--- a/src/cli/commands/doctor_datastores_test.ts
+++ b/src/cli/commands/doctor_datastores_test.ts
@@ -1,0 +1,211 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDirSync } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
+import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { SOLO_NAMESPACE } from "../../domain/data/namespace.ts";
+import { compareCatalogToDisk } from "./doctor_datastores.ts";
+
+/**
+ * Writes a data item to disk the way the repository lays it out:
+ * `{type-segments}/{model-id}/{data-name}/{version}/metadata.yaml`.
+ */
+function writeDataItem(
+  repoDir: string,
+  typeSegments: string[],
+  modelId: string,
+  dataName: string,
+  index: number,
+): void {
+  const nameDir = join(
+    repoDir,
+    ".swamp",
+    "data",
+    ...typeSegments,
+    modelId,
+    dataName,
+  );
+  const versionDir = join(nameDir, "1");
+  ensureDirSync(versionDir);
+  Deno.writeTextFileSync(
+    join(versionDir, "raw"),
+    JSON.stringify({ hello: "world" }),
+  );
+  Deno.writeTextFileSync(
+    join(versionDir, "metadata.yaml"),
+    stringifyYaml({
+      name: dataName,
+      id: `00000000-0000-1000-8000-0000000002${String(index).padStart(2, "0")}`,
+      version: 1,
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      streaming: false,
+      tags: { type: "resource", specName: "result", modelName: "shows" },
+      ownerDefinition: { ownerType: "model-method", ownerRef: "test" },
+      createdAt: "2026-01-01T00:00:00.000Z",
+    }),
+  );
+  Deno.writeTextFileSync(join(nameDir, "latest"), "1");
+}
+
+function withFixture(
+  fn: (repoDir: string, catalog: CatalogStore) => Promise<void>,
+): () => Promise<void> {
+  return async () => {
+    const repoDir = Deno.makeTempDirSync({ prefix: "swamp-doctor-catalog-" });
+    const catalog = new CatalogStore(
+      join(repoDir, ".swamp", "data", "_catalog.db"),
+    );
+    try {
+      await fn(repoDir, catalog);
+    } finally {
+      catalog.close();
+      try {
+        Deno.removeSync(repoDir, { recursive: true });
+      } catch {
+        // Windows may still hold the SQLite handle; the temp dir is disposable.
+      }
+    }
+  };
+}
+
+Deno.test(
+  "compareCatalogToDisk: reports the shortfall for a model missing from the index",
+  withFixture(async (repoDir, catalog) => {
+    // The exact shape from swamp-club#1580: a scoped type whose data names are
+    // bare integers, present on disk, absent from the catalog.
+    for (const [i, name] of ["207333", "124364", "289324"].entries()) {
+      writeDataItem(repoDir, ["@scope", "shows"], "model-001", name, i);
+    }
+    // Catalog claims to be fully built and holds nothing.
+    catalog.markPopulated();
+
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalog,
+    );
+
+    const summary = await compareCatalogToDisk(
+      catalog,
+      dataRepo,
+      SOLO_NAMESPACE,
+    );
+
+    assertEquals(summary.diskRecords, 3);
+    assertEquals(summary.catalogRecords, 0);
+    assertEquals(summary.shortfalls.length, 1);
+    assertEquals(summary.shortfalls[0].typeNormalized, "@scope/shows");
+    assertEquals(summary.shortfalls[0].diskRecords, 3);
+    assertEquals(summary.shortfalls[0].catalogRecords, 0);
+  }),
+);
+
+Deno.test(
+  "compareCatalogToDisk: does not modify the catalog it is measuring",
+  withFixture(async (repoDir, catalog) => {
+    for (const [i, name] of ["207333", "124364"].entries()) {
+      writeDataItem(repoDir, ["@scope", "shows"], "model-001", name, i);
+    }
+    catalog.markPopulated();
+
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalog,
+    );
+
+    const rowsBefore = catalog.count();
+    const populatedBefore = catalog.isPopulated();
+
+    await compareCatalogToDisk(catalog, dataRepo, SOLO_NAMESPACE);
+
+    // A diagnostic that triggers backfill repairs what it measures and then
+    // reports health — the damaged state must survive being looked at.
+    assertEquals(catalog.count(), rowsBefore);
+    assertEquals(catalog.isPopulated(), populatedBefore);
+
+    // And it is still detectable on a second run.
+    const second = await compareCatalogToDisk(
+      catalog,
+      dataRepo,
+      SOLO_NAMESPACE,
+    );
+    assertEquals(second.shortfalls.length, 1);
+  }),
+);
+
+Deno.test(
+  "compareCatalogToDisk: a fully indexed catalog reports no shortfall",
+  withFixture(async (repoDir, catalog) => {
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalog,
+    );
+
+    // Saving through the repository writes disk and catalog together, which is
+    // what a healthy repo looks like.
+    for (const name of ["207333", "recommendations"]) {
+      writeDataItem(repoDir, ["@scope", "shows"], "model-001", name, 0);
+    }
+    for (const record of await dataRepo.findAllGlobal()) {
+      catalog.upsert({
+        id: record.data.id,
+        namespace: SOLO_NAMESPACE,
+        type_normalized: record.modelType.normalized,
+        model_id: record.modelId,
+        model_name: "shows",
+        data_name: record.data.name,
+        version: 1,
+        is_latest: 1,
+        spec_name: "result",
+        data_type: "resource",
+        content_type: "application/json",
+        lifetime: "infinite",
+        owner_type: "model-method",
+        owner_ref: "test",
+        streaming: 0,
+        size: 0,
+        created_at: "2026-01-01T00:00:00.000Z",
+        tags: "{}",
+        workflow_run_id: "",
+        workflow_name: "",
+        job_name: "",
+        step_name: "",
+        source: "",
+      });
+    }
+
+    const summary = await compareCatalogToDisk(
+      catalog,
+      dataRepo,
+      SOLO_NAMESPACE,
+    );
+
+    assertEquals(summary.diskRecords, 2);
+    assertEquals(summary.catalogRecords, 2);
+    assertEquals(summary.shortfalls.length, 0);
+  }),
+);

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -1492,3 +1492,91 @@ Deno.test("DataQueryService: content stays raw string for non-JSON records", () 
   assertEquals(results[0].content, "hello world");
   catalog.close();
 });
+
+// ============================================================================
+// Backfill must not delete rows for models the predicate never mentions.
+//
+// Full backfill commits with a replace, not an insert, so any model the disk
+// walk fails to see is deleted from the catalog rather than merely left
+// unindexed. A model whose data names are bare integers used to be invisible to
+// that walk, which meant *any* query — including one matching nothing — wiped
+// its rows. See swamp-club#1580.
+//
+// The type must be scoped (`@scope/name`) to reproduce: with a single-segment
+// type the misclassified branch is skipped by the `childSegments.length >= 2`
+// guard in collectAllData, so only multi-segment types are affected — which is
+// every model that comes from an extension.
+// ============================================================================
+
+Deno.test("DataQueryService: a non-matching query preserves rows for models with numeric data names", async () => {
+  const dir = Deno.makeTempDirSync({ prefix: "swamp-query-numeric-names-" });
+  const dbPath = join(dir, ".swamp", "data", "_catalog.db");
+  const catalog = new CatalogStore(dbPath);
+  // Do NOT mark populated — the query must trigger a full backfill, which is
+  // the destructive path.
+
+  const numericNames = ["207333", "124364"];
+  for (const [index, name] of numericNames.entries()) {
+    const dataDir = join(
+      dir,
+      ".swamp",
+      "data",
+      "@scope",
+      "shows",
+      "model-001",
+      name,
+      "1",
+    );
+    ensureDirSync(dataDir);
+    Deno.writeTextFileSync(
+      join(dataDir, "raw"),
+      JSON.stringify({ hello: "world" }),
+    );
+    Deno.writeTextFileSync(
+      join(dataDir, "metadata.yaml"),
+      stringifyYaml({
+        name,
+        id: `00000000-0000-1000-8000-00000000010${index}`,
+        version: 1,
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 10,
+        streaming: false,
+        tags: { type: "resource", specName: "result", modelName: "shows" },
+        ownerDefinition: { ownerType: "model-method", ownerRef: "test" },
+        createdAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+    Deno.writeTextFileSync(
+      join(
+        dir,
+        ".swamp",
+        "data",
+        "@scope",
+        "shows",
+        "model-001",
+        name,
+        "latest",
+      ),
+      "1",
+    );
+  }
+
+  const dataRepo = new FileSystemUnifiedDataRepository(dir, undefined, catalog);
+  const service = new DataQueryService(catalog, dataRepo);
+
+  // A predicate that matches nothing at all, and never mentions this model.
+  const results = await service.query(
+    'name == "__nonexistent__"',
+  ) as DataRecord[];
+  assertEquals(results.length, 0);
+
+  // The query returning nothing is correct. Deleting the rows is the bug.
+  assertEquals(
+    catalog.count(),
+    numericNames.length,
+    "backfill dropped rows for a model the predicate never mentioned",
+  );
+
+  catalog.close();
+});

--- a/src/infrastructure/persistence/catalog_store.ts
+++ b/src/infrastructure/persistence/catalog_store.ts
@@ -623,6 +623,36 @@ export class CatalogStore {
   }
 
   /**
+   * Counts latest-version rows grouped by normalized model type, optionally
+   * scoped to a namespace.
+   *
+   * Exists so `swamp doctor datastores` can compare the index against what the
+   * on-disk walk sees without going through {@link DataQueryService} — a query
+   * triggers the very backfill being diagnosed, which would repair (or, on a
+   * broken walk, further damage) the state before it could be reported.
+   */
+  latestRowCountsByType(namespace?: string): Map<string, number> {
+    const stmt = namespace !== undefined
+      ? this.db.prepare(
+        `SELECT type_normalized, COUNT(*) as cnt FROM catalog
+           WHERE is_latest = 1 AND namespace = ?
+           GROUP BY type_normalized`,
+      )
+      : this.db.prepare(
+        `SELECT type_normalized, COUNT(*) as cnt FROM catalog
+           WHERE is_latest = 1
+           GROUP BY type_normalized`,
+      );
+    const rows =
+      (namespace !== undefined
+        ? stmt.all(namespace)
+        : stmt.all()) as unknown as Array<
+          { type_normalized: string; cnt: number }
+        >;
+    return new Map(rows.map((r) => [r.type_normalized, r.cnt]));
+  }
+
+  /**
    * Returns true if the catalog has been fully populated (backfill complete).
    */
   isPopulated(): boolean {

--- a/src/infrastructure/persistence/catalog_store_test.ts
+++ b/src/infrastructure/persistence/catalog_store_test.ts
@@ -855,6 +855,59 @@ Deno.test("bulkReplaceNamespace: does not touch global populated flag", () => {
   store.close();
 });
 
+Deno.test("latestRowCountsByType: counts latest rows per type within a namespace", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  store.upsert(makeRow({
+    namespace: "own",
+    type_normalized: "@scope/shows",
+    data_name: "207333",
+    version: 2,
+    is_latest: 1,
+  }));
+  // An older version of the same item must not be counted twice.
+  store.upsert(makeRow({
+    namespace: "own",
+    type_normalized: "@scope/shows",
+    data_name: "207333",
+    version: 1,
+    is_latest: 0,
+  }));
+  store.upsert(makeRow({
+    namespace: "own",
+    type_normalized: "@scope/other",
+    data_name: "thing",
+    is_latest: 1,
+  }));
+  // A foreign namespace's rows belong to another repo's disk, not ours.
+  store.upsert(makeRow({
+    namespace: "security",
+    type_normalized: "@scope/shows",
+    data_name: "scan",
+    is_latest: 1,
+  }));
+
+  const counts = store.latestRowCountsByType("own");
+  assertEquals(counts.get("@scope/shows"), 1);
+  assertEquals(counts.get("@scope/other"), 1);
+  assertEquals(counts.size, 2);
+
+  const allNamespaces = store.latestRowCountsByType();
+  assertEquals(allNamespaces.get("@scope/shows"), 2);
+
+  store.close();
+});
+
+Deno.test("latestRowCountsByType: returns an empty map for an empty catalog", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  assertEquals(store.latestRowCountsByType("own").size, 0);
+
+  store.close();
+});
+
 Deno.test("bulkUpsertForeign: upserts foreign rows and records lastSynced", () => {
   const dbPath = makeTempDbPath();
   const store = new CatalogStore(dbPath);

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -68,6 +68,36 @@ function looksLikeModelId(name: string): boolean {
 }
 
 /**
+ * A purely numeric directory name is ambiguous: it is the version directory of
+ * a data item, but it is equally a legitimate *data name* — models that key
+ * resources by an external numeric id (a TMDB id, an issue number) produce
+ * `{model-id}/{207333}/{2}/`. Depth alone cannot tell the two apart, so the
+ * tree walk has to confirm that a numeric directory actually holds a version's
+ * `metadata.yaml` before treating its grandparent as a model-id directory.
+ *
+ * Without this check the walk mistakes the *type* directory for a model-id
+ * directory, derives an invalid ModelType from the truncated path, and silently
+ * drops every data item under that model — which the catalog backfill then
+ * treats as "this model has no data" and deletes from the catalog.
+ */
+async function hasVersionMetadata(versionDir: string): Promise<boolean> {
+  try {
+    const stat = await Deno.stat(join(versionDir, "metadata.yaml"));
+    return stat.isFile;
+  } catch {
+    return false;
+  }
+}
+
+function hasVersionMetadataSync(versionDir: string): boolean {
+  try {
+    return Deno.statSync(join(versionDir, "metadata.yaml")).isFile;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * File system implementation of UnifiedDataRepository.
  *
  * Storage layout:
@@ -293,7 +323,12 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
               results.push({ data, modelType, modelId });
             }
           } catch {
-            // Skip invalid model types
+            // Not a valid model type — every data item below this directory is
+            // dropped from the walk. Logged because a silent drop here reads
+            // downstream as "this model has no data", which the catalog
+            // backfill then commits by deleting the model's rows.
+            logger
+              .debug`Skipping ${childPath} during walk: ${typeStr} is not a valid model type. If data is missing from data query, run swamp doctor datastores --repair.`;
           }
         } else {
           // Keep recursing deeper into type directories
@@ -387,7 +422,8 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
         const childPath = join(dir, entry.name);
         try {
           for await (const subEntry of Deno.readDir(childPath)) {
-            if (subEntry.isDirectory && /^\d+$/.test(subEntry.name)) {
+            if (!subEntry.isDirectory || !/^\d+$/.test(subEntry.name)) continue;
+            if (await hasVersionMetadata(join(childPath, subEntry.name))) {
               return true;
             }
           }
@@ -1661,7 +1697,9 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
               results.push({ data, modelType, modelId });
             }
           } catch {
-            // Skip invalid model types
+            // See collectAllData — a silent drop here becomes a catalog delete.
+            logger
+              .debug`Skipping ${childPath} during walk: ${typeStr} is not a valid model type. If data is missing from data query, run swamp doctor datastores --repair.`;
           }
         } else {
           this.collectAllDataSync(childPath, childSegments, results);
@@ -1681,7 +1719,8 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
         const childPath = join(dir, entry.name);
         try {
           for (const subEntry of Deno.readDirSync(childPath)) {
-            if (subEntry.isDirectory && /^\d+$/.test(subEntry.name)) {
+            if (!subEntry.isDirectory || !/^\d+$/.test(subEntry.name)) continue;
+            if (hasVersionMetadataSync(join(childPath, subEntry.name))) {
               return true;
             }
           }

--- a/src/infrastructure/persistence/unified_data_repository_test.ts
+++ b/src/infrastructure/persistence/unified_data_repository_test.ts
@@ -1416,3 +1416,87 @@ Deno.test("save: write-time pruning emits markDirty for each pruned version", as
     }
   }
 });
+
+// ============================================================================
+// Numeric data names — models that key resources by an external numeric id
+// (TMDB id, issue number) produce `{model-id}/{207333}/{1}/`, which the tree
+// walk must not confuse with `{model-id}/{data-name}/{version}/`.
+// ============================================================================
+
+Deno.test(
+  "findAllGlobal: finds data whose names are purely numeric",
+  async () => {
+    await withDataRepo(async (repo) => {
+      for (const name of ["207333", "124364", "289324"]) {
+        await repo.save(
+          testType,
+          "model-1",
+          makeData(name),
+          new TextEncoder().encode("x"),
+        );
+      }
+
+      const found = await repo.findAllGlobal();
+
+      assertEquals(found.length, 3);
+      assertEquals(
+        found.map((f) => f.data.name).sort(),
+        ["124364", "207333", "289324"],
+      );
+      // The type must survive the walk intact — deriving it from a truncated
+      // path is what silently drops these records.
+      for (const f of found) {
+        assertEquals(f.modelType.normalized, testType.normalized);
+        assertEquals(f.modelId, "model-1");
+      }
+    });
+  },
+);
+
+Deno.test(
+  "findAllGlobalSync: finds data whose names are purely numeric",
+  async () => {
+    await withDataRepo(async (repo) => {
+      await repo.save(
+        testType,
+        "model-1",
+        makeData("207333"),
+        new TextEncoder().encode("x"),
+      );
+
+      const found = repo.findAllGlobalSync();
+
+      assertEquals(found.length, 1);
+      assertEquals(found[0].data.name, "207333");
+      assertEquals(found[0].modelType.normalized, testType.normalized);
+      assertEquals(found[0].modelId, "model-1");
+    });
+  },
+);
+
+Deno.test(
+  "findAllGlobal: numeric and named data coexist under one model",
+  async () => {
+    await withDataRepo(async (repo) => {
+      await repo.save(
+        testType,
+        "model-1",
+        makeData("207333"),
+        new TextEncoder().encode("x"),
+      );
+      await repo.save(
+        testType,
+        "model-1",
+        makeData("recommendations"),
+        new TextEncoder().encode("y"),
+      );
+
+      const found = await repo.findAllGlobal();
+
+      assertEquals(
+        found.map((f) => f.data.name).sort(),
+        ["207333", "recommendations"],
+      );
+    });
+  },
+);

--- a/src/libswamp/datastores/doctor_datastores.ts
+++ b/src/libswamp/datastores/doctor_datastores.ts
@@ -43,6 +43,27 @@ export interface VaultMismatchFinding {
   vaultType: string;
 }
 
+/** A model type whose on-disk data is not fully represented in the catalog. */
+export interface CatalogShortfall {
+  typeNormalized: string;
+  diskRecords: number;
+  catalogRecords: number;
+}
+
+/**
+ * Comparison of the local catalog index against the on-disk data walk.
+ *
+ * The catalog is a local index of data on disk. When the walk can see records
+ * the index does not have, queries silently under-report — and because full
+ * backfill commits with a replace rather than an insert, the gap is destructive
+ * rather than merely stale. See design/data-query.md.
+ */
+export interface CatalogCompletenessSummary {
+  diskRecords: number;
+  catalogRecords: number;
+  shortfalls: ReadonlyArray<CatalogShortfall>;
+}
+
 /** Foreign namespace objects detected under the repo's own namespace. */
 export interface NamespaceContaminationFinding {
   foreignNamespaces: ReadonlyArray<{ namespace: string; objectCount: number }>;
@@ -56,6 +77,7 @@ export interface DoctorDatastoresData {
   healthFindings: DatastoreHealthFinding[];
   vaultMismatchFindings: VaultMismatchFinding[];
   contaminationFinding?: NamespaceContaminationFinding;
+  catalogCompletenessFinding?: CatalogCompletenessSummary;
 }
 
 export type DoctorDatastoresEvent =
@@ -76,6 +98,14 @@ export interface DoctorDatastoresDeps {
   checkNamespaceContamination?: (
     config: DatastoreConfig,
   ) => Promise<NamespaceContaminationSummary | null>;
+  /**
+   * Compares the local catalog index against the on-disk walk.
+   *
+   * Implementations must read the catalog directly and never issue a data
+   * query — querying triggers backfill, and a diagnostic that repairs what it
+   * measures always reports health.
+   */
+  checkCatalogCompleteness?: () => Promise<CatalogCompletenessSummary | null>;
 }
 
 /**
@@ -101,6 +131,7 @@ export async function* doctorDatastores(
       const healthFindings: DatastoreHealthFinding[] = [];
       const vaultMismatchFindings: VaultMismatchFinding[] = [];
       let contaminationFinding: NamespaceContaminationFinding | undefined;
+      let catalogCompletenessFinding: CatalogCompletenessSummary | undefined;
 
       // Health check
       const { healthy, message } = await deps.checkHealth(config);
@@ -158,6 +189,31 @@ export async function* doctorDatastores(
         }
       }
 
+      // Catalog completeness check — the catalog is a local index, so this
+      // runs for every repo, with or without a namespace or remote datastore.
+      if (deps.checkCatalogCompleteness) {
+        const summary = await deps.checkCatalogCompleteness();
+        if (summary && summary.shortfalls.length > 0) {
+          catalogCompletenessFinding = summary;
+          const missing = summary.diskRecords - summary.catalogRecords;
+          healthFindings.push({
+            check: "catalog_completeness",
+            passed: false,
+            message:
+              `Catalog index is missing ${missing} record(s) across ${summary.shortfalls.length} model type(s) ` +
+              `that exist on disk. Queries against them return nothing. ` +
+              `Run 'swamp doctor datastores --repair' to preview a rebuild.`,
+          });
+        } else if (summary) {
+          healthFindings.push({
+            check: "catalog_completeness",
+            passed: true,
+            message:
+              `Catalog index covers all ${summary.diskRecords} record(s) on disk`,
+          });
+        }
+      }
+
       // Vault mismatch check — only relevant for custom (remote) datastores
       if (isCustom) {
         const vaults = await deps.getVaultConfigs();
@@ -179,6 +235,7 @@ export async function* doctorDatastores(
           healthFindings,
           vaultMismatchFindings,
           contaminationFinding,
+          catalogCompletenessFinding,
         },
       };
     })(),
@@ -486,6 +543,92 @@ export async function* repairUnmigratedData(
         },
         namespace,
       };
+    })(),
+  );
+}
+
+// ============================================================================
+// Repair: local catalog index rebuild
+// ============================================================================
+
+export interface CatalogIndexRepairResult {
+  shortfalls: ReadonlyArray<CatalogShortfall>;
+  missingRecords: number;
+}
+
+export type RepairCatalogIndexEvent =
+  | { kind: "scanning" }
+  | { kind: "preview"; completeness: CatalogCompletenessSummary }
+  | { kind: "step"; description: string }
+  | { kind: "completed"; result: CatalogIndexRepairResult }
+  | { kind: "not_needed" }
+  | { kind: "error"; error: SwampError };
+
+export interface RepairCatalogIndexDeps {
+  checkCompleteness: () => Promise<CatalogCompletenessSummary | null>;
+  /** Removes the catalog database so the next query rebuilds it from disk. */
+  invalidateCatalog: () => Promise<void>;
+}
+
+/**
+ * Detect and repair a local catalog index that under-reports what is on disk.
+ *
+ * Repair is a deletion, not a rebuild: the catalog database is removed and the
+ * next data query backfills it from the on-disk walk. That keeps the repair
+ * honest — it cannot paper over a walk that is still wrong — but it also drops
+ * foreign-namespace rows, which only `swamp datastore catalog pull` can
+ * restore, so the caller is told.
+ */
+export async function* repairCatalogIndex(
+  _ctx: LibSwampContext,
+  deps: RepairCatalogIndexDeps,
+  options: { confirm: boolean },
+): AsyncGenerator<RepairCatalogIndexEvent> {
+  yield* withGeneratorSpan(
+    "swamp.doctor.datastores.repair.catalog",
+    {},
+    (async function* () {
+      yield { kind: "scanning" };
+
+      const completeness = await deps.checkCompleteness();
+      if (!completeness || completeness.shortfalls.length === 0) {
+        yield { kind: "not_needed" };
+        return;
+      }
+
+      if (!options.confirm) {
+        yield { kind: "preview", completeness };
+        return;
+      }
+
+      try {
+        yield {
+          kind: "step",
+          description:
+            "Removing the catalog index (rebuilds on the next data query)",
+        };
+        await deps.invalidateCatalog();
+
+        yield {
+          kind: "completed",
+          result: {
+            shortfalls: completeness.shortfalls,
+            missingRecords: completeness.diskRecords -
+              completeness.catalogRecords,
+          },
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        yield {
+          kind: "error",
+          error: {
+            code: "catalog_repair_failed",
+            message:
+              `Could not remove the catalog index: ${message}. No changes were made.`,
+            cause: err instanceof Error ? err : undefined,
+          },
+        };
+      }
     })(),
   );
 }

--- a/src/libswamp/datastores/doctor_datastores_test.ts
+++ b/src/libswamp/datastores/doctor_datastores_test.ts
@@ -22,9 +22,12 @@ import { join, SEPARATOR } from "@std/path";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
+  type CatalogCompletenessSummary,
   doctorDatastores,
   type DoctorDatastoresDeps,
   type DoctorDatastoresEvent,
+  repairCatalogIndex,
+  type RepairCatalogIndexEvent,
   repairDatastoreContamination,
   type RepairDatastoresDeps,
   type RepairDatastoresEvent,
@@ -807,4 +810,214 @@ Deno.test("repairUnmigratedData: emits step events during confirm", async () => 
   assertEquals(steps.length, 2);
   assertStringIncludes(steps[0].description, "data/");
   assertStringIncludes(steps[1].description, "outputs/");
+});
+
+// ============================================================================
+// Catalog completeness check and repair (swamp-club#1580)
+// ============================================================================
+
+const completeSummary: CatalogCompletenessSummary = {
+  diskRecords: 42,
+  catalogRecords: 42,
+  shortfalls: [],
+};
+
+const shortSummary: CatalogCompletenessSummary = {
+  diskRecords: 330,
+  catalogRecords: 16,
+  shortfalls: [
+    {
+      typeNormalized: "@keeb/rottentomatoes",
+      diskRecords: 314,
+      catalogRecords: 0,
+    },
+  ],
+};
+
+Deno.test("doctorDatastores: reports a complete catalog as passing", async () => {
+  const deps: DoctorDatastoresDeps = {
+    ...makeDeps(
+      filesystemConfig,
+      { healthy: true, message: "Datastore is accessible", latencyMs: 1 },
+      [],
+    ),
+    checkCatalogCompleteness: () => Promise.resolve(completeSummary),
+  };
+
+  const events = await collect<DoctorDatastoresEvent>(
+    doctorDatastores(createLibSwampContext(), deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    const finding = completed.data.healthFindings.find(
+      (f) => f.check === "catalog_completeness",
+    );
+    assertEquals(finding?.passed, true);
+    assertStringIncludes(finding?.message ?? "", "42");
+    assertEquals(completed.data.catalogCompletenessFinding, undefined);
+  }
+});
+
+Deno.test("doctorDatastores: reports a short catalog and names the remedy", async () => {
+  const deps: DoctorDatastoresDeps = {
+    ...makeDeps(
+      filesystemConfig,
+      { healthy: true, message: "Datastore is accessible", latencyMs: 1 },
+      [],
+    ),
+    checkCatalogCompleteness: () => Promise.resolve(shortSummary),
+  };
+
+  const events = await collect<DoctorDatastoresEvent>(
+    doctorDatastores(createLibSwampContext(), deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    const finding = completed.data.healthFindings.find(
+      (f) => f.check === "catalog_completeness",
+    );
+    assertEquals(finding?.passed, false);
+    assertStringIncludes(finding?.message ?? "", "314");
+    assertStringIncludes(
+      finding?.message ?? "",
+      "swamp doctor datastores --repair",
+    );
+    assertEquals(
+      completed.data.catalogCompletenessFinding?.shortfalls.length,
+      1,
+    );
+  }
+});
+
+// The catalog is a local index. A plain local repo with no namespace and no
+// remote datastore is exactly where an incomplete one goes unnoticed, so the
+// check must not be gated the way the migration and contamination checks are.
+Deno.test("doctorDatastores: catalog check runs without a namespace or custom datastore", async () => {
+  const deps: DoctorDatastoresDeps = {
+    ...makeDeps(
+      filesystemConfig,
+      { healthy: true, message: "Datastore is accessible", latencyMs: 1 },
+      [],
+    ),
+    checkCatalogCompleteness: () => Promise.resolve(shortSummary),
+    checkUnmigratedData: () =>
+      Promise.resolve({ unmigrated: false, directories: [] }),
+    checkNamespaceContamination: () => Promise.resolve(null),
+  };
+
+  const events = await collect<DoctorDatastoresEvent>(
+    doctorDatastores(createLibSwampContext(), deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.isCustom, false);
+    // No namespace configured, so neither namespace check contributed.
+    assertEquals(
+      completed.data.healthFindings.some((f) =>
+        f.check === "namespace_migration"
+      ),
+      false,
+    );
+    assertEquals(
+      completed.data.healthFindings.some((f) =>
+        f.check === "catalog_completeness"
+      ),
+      true,
+    );
+  }
+});
+
+Deno.test("repairCatalogIndex: no shortfall means nothing to repair", async () => {
+  let invalidated = 0;
+  const events = await collect<RepairCatalogIndexEvent>(
+    repairCatalogIndex(
+      createLibSwampContext(),
+      {
+        checkCompleteness: () => Promise.resolve(completeSummary),
+        invalidateCatalog: () => {
+          invalidated++;
+          return Promise.resolve();
+        },
+      },
+      { confirm: true },
+    ),
+  );
+
+  assertEquals(events.some((e) => e.kind === "not_needed"), true);
+  assertEquals(invalidated, 0, "a healthy catalog must not be deleted");
+});
+
+Deno.test("repairCatalogIndex: previews without deleting when not confirmed", async () => {
+  let invalidated = 0;
+  const events = await collect<RepairCatalogIndexEvent>(
+    repairCatalogIndex(
+      createLibSwampContext(),
+      {
+        checkCompleteness: () => Promise.resolve(shortSummary),
+        invalidateCatalog: () => {
+          invalidated++;
+          return Promise.resolve();
+        },
+      },
+      { confirm: false },
+    ),
+  );
+
+  const preview = events.find((e) => e.kind === "preview");
+  assertEquals(preview?.kind, "preview");
+  if (preview?.kind === "preview") {
+    assertEquals(preview.completeness.shortfalls.length, 1);
+  }
+  assertEquals(invalidated, 0, "preview must not touch the catalog");
+});
+
+Deno.test("repairCatalogIndex: invalidates the catalog exactly once when confirmed", async () => {
+  const callLog: string[] = [];
+  const events = await collect<RepairCatalogIndexEvent>(
+    repairCatalogIndex(
+      createLibSwampContext(),
+      {
+        checkCompleteness: () => {
+          callLog.push("checkCompleteness");
+          return Promise.resolve(shortSummary);
+        },
+        invalidateCatalog: () => {
+          callLog.push("invalidateCatalog");
+          return Promise.resolve();
+        },
+      },
+      { confirm: true },
+    ),
+  );
+
+  assertEquals(callLog, ["checkCompleteness", "invalidateCatalog"]);
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.result.missingRecords, 314);
+    assertEquals(completed.result.shortfalls.length, 1);
+  }
+});
+
+Deno.test("repairCatalogIndex: reports a failed deletion without claiming success", async () => {
+  const events = await collect<RepairCatalogIndexEvent>(
+    repairCatalogIndex(
+      createLibSwampContext(),
+      {
+        checkCompleteness: () => Promise.resolve(shortSummary),
+        invalidateCatalog: () =>
+          Promise.reject(new Deno.errors.PermissionDenied("locked")),
+      },
+      { confirm: true },
+    ),
+  );
+
+  assertEquals(events.some((e) => e.kind === "completed"), false);
+  const errorEvent = events.find((e) => e.kind === "error");
+  assertEquals(errorEvent?.kind, "error");
+  if (errorEvent?.kind === "error") {
+    assertStringIncludes(errorEvent.error.message, "No changes were made");
+  }
 });

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -234,12 +234,18 @@ export {
   type VaultRequiredFinding,
 } from "./models/doctor_vaults.ts";
 export {
+  type CatalogCompletenessSummary,
+  type CatalogIndexRepairResult,
+  type CatalogShortfall,
   type DatastoreHealthFinding,
   doctorDatastores,
   type DoctorDatastoresData,
   type DoctorDatastoresDeps,
   type DoctorDatastoresEvent,
   type NamespaceContaminationFinding,
+  repairCatalogIndex,
+  type RepairCatalogIndexDeps,
+  type RepairCatalogIndexEvent,
   repairDatastoreContamination,
   type RepairDatastoresDeps,
   type RepairDatastoresEvent,

--- a/src/presentation/renderers/doctor_datastores.ts
+++ b/src/presentation/renderers/doctor_datastores.ts
@@ -505,7 +505,9 @@ class LogCatalogIndexRepairRenderer implements CatalogIndexRepairRenderer {
       completed: (e) => {
         this.overallStatus = "pass";
         writeOutput(
-          `\n${green("✓")} ${bold("Catalog index rebuild scheduled:")}`,
+          `\n${green("✓")} ${
+            bold("Catalog index invalidated — will rebuild on next query:")
+          }`,
         );
         writeOutput(
           `  ${e.result.missingRecords.toLocaleString()} missing record(s) across ${e.result.shortfalls.length} model type(s) will be re-indexed on the next data query`,

--- a/src/presentation/renderers/doctor_datastores.ts
+++ b/src/presentation/renderers/doctor_datastores.ts
@@ -21,6 +21,7 @@ import { bold, dim, green, red, yellow } from "@std/fmt/colors";
 import type {
   DoctorDatastoresEvent,
   EventHandlers,
+  RepairCatalogIndexEvent,
   RepairDatastoresEvent,
   RepairUnmigratedDataEvent,
 } from "../../libswamp/mod.ts";
@@ -85,6 +86,25 @@ class LogDoctorDatastoresRenderer implements DoctorDatastoresRenderer {
           );
         }
 
+        // Render catalog shortfall details when present
+        if (data.catalogCompletenessFinding) {
+          const cc = data.catalogCompletenessFinding;
+          writeOutput(`\n${red("Catalog index incomplete:")}`);
+          for (const s of cc.shortfalls) {
+            writeOutput(
+              `  ${
+                bold(s.typeNormalized)
+              }: ${s.catalogRecords.toLocaleString()} indexed of ${s.diskRecords.toLocaleString()} on disk`,
+            );
+          }
+          writeOutput(
+            dim(
+              "\n  Data on disk is intact — only the query index is short.\n" +
+                "  Run 'swamp doctor datastores --repair' to preview a rebuild.",
+            ),
+          );
+        }
+
         // Render vault mismatch advisory (yellow, does not cause failure)
         if (data.vaultMismatchFindings.length > 0) {
           writeOutput(
@@ -136,6 +156,8 @@ class JsonDoctorDatastoresRenderer implements DoctorDatastoresRenderer {
               healthFindings: data.healthFindings,
               vaultMismatchFindings: data.vaultMismatchFindings,
               contaminationFinding: data.contaminationFinding ?? null,
+              catalogCompletenessFinding: data.catalogCompletenessFinding ??
+                null,
             },
             null,
             2,
@@ -434,5 +456,130 @@ export function createUnmigratedDataRepairRenderer(
       return new JsonUnmigratedDataRepairRenderer();
     case "log":
       return new LogUnmigratedDataRepairRenderer();
+  }
+}
+
+// ============================================================================
+// Catalog index repair renderer
+// ============================================================================
+
+export type CatalogIndexRepairStatus = "pass" | "fail" | "preview";
+
+export interface CatalogIndexRepairRenderer {
+  handlers(): EventHandlers<RepairCatalogIndexEvent>;
+  readonly overallStatus: CatalogIndexRepairStatus;
+}
+
+/** Shown after any repair that drops the catalog database. */
+const FOREIGN_ROWS_NOTICE =
+  "Rebuilding the index also clears rows pulled from other namespaces " +
+  "(they describe data that is not on local disk, so the rebuild cannot " +
+  "recreate them). Restore them with: swamp datastore catalog pull";
+
+class LogCatalogIndexRepairRenderer implements CatalogIndexRepairRenderer {
+  overallStatus: CatalogIndexRepairStatus = "pass";
+
+  handlers(): EventHandlers<RepairCatalogIndexEvent> {
+    return {
+      scanning: () => {
+        writeOutput(dim("Comparing the catalog index against data on disk…"));
+      },
+      preview: (e) => {
+        this.overallStatus = "preview";
+        const { completeness } = e;
+        writeOutput(`\n${bold("Catalog index rebuild:")}`);
+        for (const s of completeness.shortfalls) {
+          writeOutput(
+            `  ${s.typeNormalized}: index ${s.catalogRecords.toLocaleString()} of ${s.diskRecords.toLocaleString()} record(s) on disk`,
+          );
+        }
+        writeOutput(
+          `  Remove the catalog index (rebuilds on the next data query)`,
+        );
+        writeOutput(dim(`\n  ${FOREIGN_ROWS_NOTICE}`));
+        writeOutput(dim("\n  Run with -y to proceed."));
+      },
+      step: (e) => {
+        writeOutput(`  ${e.description}`);
+      },
+      completed: (e) => {
+        this.overallStatus = "pass";
+        writeOutput(
+          `\n${green("✓")} ${bold("Catalog index rebuild scheduled:")}`,
+        );
+        writeOutput(
+          `  ${e.result.missingRecords.toLocaleString()} missing record(s) across ${e.result.shortfalls.length} model type(s) will be re-indexed on the next data query`,
+        );
+        writeOutput(dim(`\n  ${FOREIGN_ROWS_NOTICE}`));
+      },
+      not_needed: () => {
+        this.overallStatus = "pass";
+        writeOutput(dim("Catalog index matches data on disk."));
+      },
+      error: (e) => {
+        this.overallStatus = "fail";
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonCatalogIndexRepairRenderer implements CatalogIndexRepairRenderer {
+  overallStatus: CatalogIndexRepairStatus = "pass";
+
+  handlers(): EventHandlers<RepairCatalogIndexEvent> {
+    return {
+      scanning: () => {},
+      preview: (e) => {
+        this.overallStatus = "preview";
+        console.log(
+          JSON.stringify(
+            {
+              status: "catalog_preview",
+              completeness: e.completeness,
+              foreignRowsNotice: FOREIGN_ROWS_NOTICE,
+            },
+            null,
+            2,
+          ),
+        );
+      },
+      step: () => {},
+      completed: (e) => {
+        this.overallStatus = "pass";
+        console.log(
+          JSON.stringify(
+            {
+              status: "catalog_completed",
+              result: e.result,
+              foreignRowsNotice: FOREIGN_ROWS_NOTICE,
+            },
+            null,
+            2,
+          ),
+        );
+      },
+      not_needed: () => {
+        this.overallStatus = "pass";
+        console.log(
+          JSON.stringify({ status: "catalog_not_needed" }, null, 2),
+        );
+      },
+      error: (e) => {
+        this.overallStatus = "fail";
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createCatalogIndexRepairRenderer(
+  mode: OutputMode,
+): CatalogIndexRepairRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonCatalogIndexRepairRenderer();
+    case "log":
+      return new LogCatalogIndexRepairRenderer();
   }
 }


### PR DESCRIPTION
## Summary

Fixes swamp-club#1580.

`isModelIdDirectory` / `isModelIdDirectorySync` treated any numeric grandchild directory as proof of a version directory. A data name that is a bare integer — a TMDB id, an issue number — is indistinguishable from a version under that heuristic, so the walk misread the **type** directory as the model-id directory, handed `ModelType.create` a truncated path, and a bare `catch {}` discarded every record under that model.

Backfill then committed that short row set through `bulkReplaceNamespace` / `bulkReplaceAll`, which DELETE before reinserting. So *any* `swamp data query` — including one whose predicate matched nothing and never mentioned the model — deleted its catalog rows. Writes repopulated them, the next query deleted them again. Disk was never touched and `data get` / `data list` kept working, which is why it went unnoticed from May.

**The fix:** only a directory that actually contains `metadata.yaml` is a version directory. `207333/` does not; `207333/2/` does. Confirmed before classifying the grandparent, in both walkers — they carried identical copies of the heuristic, and fixing one would have left the other dropping records.

Worth noting for triage of similar reports: **only scoped types reproduce.** `collectAllData` guards the misclassified branch with `childSegments.length >= 2`, so a single-segment type is accidentally immune. Every extension-provided model is scoped, so real-world exposure is unchanged.

## Recovery for already-damaged installs

Fixing the walk does not restore rows already deleted — backfill only runs when `isPopulated()` is false, so an affected repo keeps serving a truncated catalog indefinitely. Rather than force a rebuild on every user (a `CATALOG_SCHEMA_VERSION` bump would have done that, at the cost of a cold backfill for everyone), recovery is **opt-in**:

- `swamp doctor datastores` gains a `catalog_completeness` check comparing the index against the on-disk walk, reporting any model type with records on disk but missing from the index.
- `swamp doctor datastores --repair` previews; `--repair -y` removes `_catalog.db` so the next query rebuilds it.

The check reads `CatalogStore` directly and never issues a data query — a query would trigger the very backfill being diagnosed and would always report health. There is a test asserting the catalog is byte-unchanged after the check, so that property survives refactoring.

**Two behavior notes for reviewers:**

1. The catalog is a *local* index, so neither the check nor its repair is gated behind a namespace or a custom datastore. On such a repo `--repair` previously failed with "Repair is only available for custom datastores with a namespace configured"; it now runs the catalog repair and skips the contamination repair, mirroring how the unmigrated-data repair is already treated in the same function. A plain local repo is precisely the one this fix targets.
2. Rebuilding the index also clears foreign-namespace rows pulled by `swamp datastore catalog pull` — they describe data not on local disk, so a local walk cannot recreate them and nothing re-pulls automatically. Both the preview and the completion output say so and name the restore command.

Also in here: the swallowed misclassification is now a debug log naming the rejected type and the remedy command (that silent `catch {}` is why 314 resources vanished quietly for three months), and `design/data-query.md` no longer describes full backfill as additive when it replaces.

## Test Plan

Every new test was confirmed to **fail against unpatched source**, at two layers:

- **Cause** — three tests in `unified_data_repository_test.ts` (numeric names async asserting `modelType.normalized` and `modelId`, numeric names sync as a separate code path, numeric coexisting with named). Unpatched: 39 passed / 3 failed, all returning 0 records. Patched: 42 passed.
- **Symptom** — `data_query_service_test.ts`: a predicate matching nothing must not delete rows for a model it never mentioned, asserting on `catalog.count()` rather than query results. Unpatched: 45 passed / 1 failed. Patched: 46 passed.
- **Recovery** — five tests in `doctor_datastores_test.ts` (complete catalog, short catalog naming the remedy, check running with no namespace and no custom datastore, preview not deleting, `invalidateCatalog` called exactly once, failed deletion reporting an error rather than claiming success), plus three in a new `src/cli/commands/doctor_datastores_test.ts` running the real comparison against a real damaged catalog fixture, and two for `CatalogStore.latestRowCountsByType`.

Full suite: **10091 passed, 0 failed**. `deno check` (main graph), `deno lint`, `deno fmt`, `deno run compile` clean.

End to end against a real damaged catalog (rows deleted, `populated` still set — the state an affected user is left in):

```
$ swamp data query 'modelName == "rottentomatoes"'
No matching data found.                       # the silent symptom

$ swamp doctor datastores                     # exit 1
✗ Catalog index is missing 4 record(s) across 1 model type(s) that exist on disk.
  @keeb/rottentomatoes: 0 indexed of 4 on disk

$ swamp doctor datastores --repair            # previews, db still present
$ swamp doctor datastores --repair -y         # removes it
$ swamp data query 'modelName == "rottentomatoes"'
4 results

# rows then survive an unrelated, a neutral, and a targeting query
$ swamp doctor datastores                     # exit 0
✓ Catalog index covers all 4 record(s) on disk
```

Verified in both `log` and `--json` output modes.

## Follow-ups filed

- swamp-club#1581 — backfill reconciles against the local cache, not the datastore. This is the amplifier that turns any walk gap into deletion rather than omission, and it is unfixed here. Under `hydrationStrategy: lazy` it also makes this PR's completeness check a no-op, since nothing is materialized locally.
- swamp-club#1583 — `content/manual/reference/doctor.md` needs the new check, the repair, and both behavior notes above.
- swamp-uat#342, swamp-uat#343 — end-to-end coverage for the query-must-not-delete invariant and for the new doctor path.
- swamp-club#1582 — unrelated, found in passing: `reconcile_from_disk_bench.ts` fails a bare `deno check`, so CLAUDE.md's first verification command always fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)