### PR TITLE
fix(workflows): bypass workflowNameStrict for scoped @collective/name

### DIFF
--- a/src/domain/workflows/workflow.ts
+++ b/src/domain/workflows/workflow.ts
@@ -65,7 +65,7 @@ const workflowNameBase = z.string().min(1).refine(
 
 const workflowNameStrict = workflowNameBase
   .refine(
-    (name) => name.includes("/") || WORKFLOW_NAME_PATTERN.test(name),
+    (name) => WORKFLOW_NAME_PATTERN.test(name),
     {
       message:
         "Workflow name must be lowercase alphanumeric with hyphens (e.g. 'deploy-pipeline'). Must start with a letter or number.",
@@ -196,8 +196,13 @@ export class Workflow {
       reports: props.reports,
     };
 
-    // Strict name validation on creation — enforces kebab-case and max length
-    workflowNameStrict.parse(data.name);
+    // Scoped @collective/name is validated by workflowNameBase (in the schema);
+    // unscoped names additionally enforce kebab-case and max length.
+    if (data.name.includes("/")) {
+      workflowNameBase.parse(data.name);
+    } else {
+      workflowNameStrict.parse(data.name);
+    }
 
     // Only validate full schema if jobs exist (jobs.min(1) requires at least one)
     if (jobs.length > 0) {


### PR DESCRIPTION
## Summary

Follow-up to #2108. The Zod refinement chain fix (`name.includes("/") || WORKFLOW_NAME_PATTERN.test(name)`) was confirmed present in release binaries via `strings` but still failed on Linux CI across 5 consecutive releases — the scoped name `@test/my-workflow` was rejected despite the code being correct.

Rather than relying on the Zod refinement chain (which may have a bundler/V8 snapshot interaction on Linux), this moves the branch to the call site:

- **Scoped names** (`@collective/name`): validated by `workflowNameBase` only, which already enforces the `@scope/name` regex and path traversal checks
- **Unscoped names**: validated by `workflowNameStrict` (kebab-case + max length), same as before

This also reverts `workflowNameStrict` to its original strict form since scoped names no longer flow through it.

## Test Plan

- All 84 related tests pass (workflow domain + yaml repo tests)
- Locally verified `swamp workflow create '@test/my-workflow'` succeeds