### PR TITLE
fix(cli): improve "Too many arguments" error with quoting hint

### DIFF
--- a/src/cli/unknown_command_handler.ts
+++ b/src/cli/unknown_command_handler.ts
@@ -183,21 +183,98 @@ function buildContextSuggestions(
 }
 
 /**
- * Cliffy error handler that intercepts "Unknown command" errors and provides
- * context-aware suggestions.
+ * Extracts positional arguments from the raw CLI args for a given command path.
+ *
+ * Walks past the command-path segments, then collects non-flag tokens
+ * (anything not starting with `-`). Flag *values* (the token after a
+ * `--flag <value>` pair) are skipped by consuming the next token when a
+ * flag is seen.
+ */
+export function extractPositionalArgs(
+  rawArgs: string[],
+  commandPath: string,
+): string[] {
+  const pathSegments = commandPath.split(" ");
+  let i = 0;
+  for (const segment of pathSegments) {
+    while (i < rawArgs.length && rawArgs[i].startsWith("-")) {
+      i++;
+      if (i < rawArgs.length && !rawArgs[i].startsWith("-")) {
+        i++;
+      }
+    }
+    if (i < rawArgs.length && rawArgs[i] === segment) {
+      i++;
+    }
+  }
+
+  const positional: string[] = [];
+  while (i < rawArgs.length) {
+    if (rawArgs[i] === "--") {
+      break;
+    }
+    if (rawArgs[i].startsWith("-")) {
+      i++;
+      if (i < rawArgs.length && !rawArgs[i].startsWith("-")) {
+        i++;
+      }
+      continue;
+    }
+    positional.push(rawArgs[i]);
+    i++;
+  }
+  return positional;
+}
+
+/**
+ * Builds a helpful error message when a command receives too many positional
+ * arguments — typically because the user passed an unquoted multi-word value.
+ */
+export function buildTooManyArgumentsMessage(
+  cmd: Command,
+  rawArgs: string[],
+): string {
+  const commandPath = cmd.getPath();
+  const positional = extractPositionalArgs(rawArgs, commandPath);
+  const quoted = positional.join(" ");
+
+  if (positional.length >= 2) {
+    return `Too many arguments.\n\n` +
+      `  If your argument contains spaces, wrap it in quotes:\n` +
+      `    ${commandPath} "${quoted}"`;
+  }
+
+  return `Too many arguments.\n\n` +
+    `  Run "${commandPath} --help" for usage.`;
+}
+
+/**
+ * Cliffy error handler that intercepts "Unknown command" and "Too many
+ * arguments" errors and provides context-aware suggestions.
  *
  * Cliffy's `getErrorHandler()` only checks the current command and its
  * immediate parent, so this handler must be attached to each command that
  * should provide improved error messages.
  */
 export function unknownCommandErrorHandler(error: Error, cmd: Command): void {
-  if (
-    error instanceof ValidationError &&
-    error.message.startsWith("Unknown command")
-  ) {
-    const unknownName = extractUnknownName(error.message);
-    if (unknownName) {
-      const message = buildUnknownCommandMessage(unknownName, cmd);
+  if (error instanceof ValidationError) {
+    if (error.message.startsWith("Unknown command")) {
+      const unknownName = extractUnknownName(error.message);
+      if (unknownName) {
+        const message = buildUnknownCommandMessage(unknownName, cmd);
+        if (getOutputModeFromArgs(Deno.args) === "json") {
+          const jsonError = buildErrorJson(new Error(message));
+          // deno-lint-ignore no-console
+          console.error(JSON.stringify(jsonError, null, 2));
+          Deno.exit(2);
+        }
+        console.error(red(`error: ${message}`));
+        Deno.exit(2);
+      }
+    }
+
+    if (error.message.startsWith("Too many arguments")) {
+      const message = buildTooManyArgumentsMessage(cmd, Deno.args);
       if (getOutputModeFromArgs(Deno.args) === "json") {
         const jsonError = buildErrorJson(new Error(message));
         // deno-lint-ignore no-console

--- a/src/cli/unknown_command_handler_test.ts
+++ b/src/cli/unknown_command_handler_test.ts
@@ -20,7 +20,9 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { Command } from "@cliffy/command";
 import {
+  buildTooManyArgumentsMessage,
   buildUnknownCommandMessage,
+  extractPositionalArgs,
   extractUnknownName,
   getSubcommandNames,
 } from "./unknown_command_handler.ts";
@@ -166,4 +168,67 @@ Deno.test("buildUnknownCommandMessage - output context suggestions", () => {
   assertStringIncludes(msg, "swamp model output get my-server");
   assertStringIncludes(msg, "swamp model output search");
   assertStringIncludes(msg, "swamp model output logs my-server");
+});
+
+Deno.test("extractPositionalArgs - extracts args after command path", () => {
+  const args = ["extension", "search", "home", "assistant"];
+  const result = extractPositionalArgs(args, "extension search");
+  assertEquals(result, ["home", "assistant"]);
+});
+
+Deno.test("extractPositionalArgs - skips flags and their values", () => {
+  const args = ["extension", "search", "home", "assistant", "--json"];
+  const result = extractPositionalArgs(args, "extension search");
+  assertEquals(result, ["home", "assistant"]);
+});
+
+Deno.test("extractPositionalArgs - skips flag values between positional args", () => {
+  const args = [
+    "extension",
+    "search",
+    "--collective",
+    "myorg",
+    "home",
+    "assistant",
+  ];
+  const result = extractPositionalArgs(args, "extension search");
+  assertEquals(result, ["home", "assistant"]);
+});
+
+Deno.test("extractPositionalArgs - handles flags before command path", () => {
+  const args = ["--json", "extension", "search", "home", "assistant"];
+  const result = extractPositionalArgs(args, "extension search");
+  assertEquals(result, ["home", "assistant"]);
+});
+
+Deno.test("extractPositionalArgs - returns empty for no positional args", () => {
+  const args = ["extension", "search"];
+  const result = extractPositionalArgs(args, "extension search");
+  assertEquals(result, []);
+});
+
+Deno.test("buildTooManyArgumentsMessage - suggests quoting multi-word input", () => {
+  const cmd = new Command().name("search");
+  // Simulate cmd.getPath() returning the full path
+  const parent = new Command().name("extension").command("search", cmd);
+  // Force Cliffy to set the path by accessing the child through parent
+  const searchCmd = parent.getCommand("search")!;
+  const msg = buildTooManyArgumentsMessage(
+    searchCmd,
+    ["extension", "search", "home", "assistant"],
+  );
+  assertStringIncludes(msg, "Too many arguments");
+  assertStringIncludes(msg, "wrap it in quotes");
+  assertStringIncludes(msg, '"home assistant"');
+});
+
+Deno.test("buildTooManyArgumentsMessage - single extra arg shows help fallback", () => {
+  const cmd = new Command().name("search");
+  const parent = new Command().name("extension").command("search", cmd);
+  const searchCmd = parent.getCommand("search")!;
+  const msg = buildTooManyArgumentsMessage(
+    searchCmd,
+    ["extension", "search", "aws"],
+  );
+  assertStringIncludes(msg, "--help");
 });


### PR DESCRIPTION
## Summary

- Intercepts Cliffy's "Too many arguments" `ValidationError` in the existing `unknownCommandErrorHandler` and produces a helpful message suggesting the user quote multi-word arguments
- Reconstructs the intended command from `Deno.args` to show an example with the quoted form
- Works for all commands that accept positional arguments — no per-command changes needed since Cliffy bubbles the error to the parent handler

**Before:**
```
error: Too many arguments: assistant
```

**After:**
```
error: Too many arguments.

  If your argument contains spaces, wrap it in quotes:
    swamp extension search "home assistant"
```

Closes swamp-club#1563

## Test Plan

- Unit tests for `extractPositionalArgs` (5 cases: basic, flags, flag values between args, flags before command path, empty)
- Unit tests for `buildTooManyArgumentsMessage` (multi-word suggestion, single-arg fallback)
- Manual verification: compiled binary tested with `swamp extension search home assistant` and `swamp model search my cool model` — both show the quoting hint
- JSON output mode verified: `swamp extension search home assistant --json` produces structured error with the hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)