### PR TITLE
fix(serve): pass runTracker to webhook-triggered workflow runs

### DIFF
--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -650,6 +650,7 @@ export class WebhookService {
           }
         },
         this.deps.syncService,
+        this.deps.runTracker,
       );
 
       if (completedRun?.status === "failed") {


### PR DESCRIPTION
## Summary

- Webhook-triggered workflow runs called `executeWorkflowWithLocks` without passing `runTracker` as the 8th argument, so they were never registered in the `active_runs` table and were invisible to `swamp run history --all`
- Pass `this.deps.runTracker` (already available on `WebhookServiceDeps`) to `executeWorkflowWithLocks`, matching the behavior of the normal WebSocket-triggered path in `workflow_handlers.ts`

## Test Plan

- Compiled the binary and started `swamp serve` with `--webhook "/test-hook:webhook-test:mysecret:generic:x-secret:"`
- Triggered the webhook via `curl` with a valid HMAC signature
- Confirmed `swamp run history --all --json` now shows the webhook-triggered run with `runKind: workflow` and `status: completed`
- Confirmed `swamp workflow history get webhook-test --json` shows the full run details with step results
- All 44 existing webhook unit tests pass