### PR TITLE
fix(bench): add missing getDenoEnv to DenoRuntime stub

### DIFF
--- a/src/libswamp/extensions/reconcile_from_disk_bench.ts
+++ b/src/libswamp/extensions/reconcile_from_disk_bench.ts
@@ -40,6 +40,7 @@ import "../../domain/models/models.ts";
 
 const testDenoRuntime: DenoRuntime = {
   ensureDeno: () => Promise.resolve(Deno.execPath()),
+  getDenoEnv: () => Deno.env.toObject(),
 };
 
 const MINIMAL_MODEL = (typeId: string) => `


### PR DESCRIPTION
## Summary

- Add missing `getDenoEnv()` method to the inline `DenoRuntime` stub in `reconcile_from_disk_bench.ts`, fixing `deno check` failure on the whole repo (swamp-club#1582)

## Test Plan

- `deno check src/libswamp/extensions/reconcile_from_disk_bench.ts` passes (was TS2741)
- `deno check` (whole repo) passes
- `deno lint` passes
- `deno run test` passes (10098 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)