### PR TITLE
fix(data): switch catalog backfill from destructive replace to additive upsert (swamp-club#1581)

### DIFF
--- a/design/data-query.md
+++ b/design/data-query.md
@@ -337,23 +337,23 @@ The catalog builds up incrementally:
 4. **Self-healing** — if `_catalog.db` is deleted or corrupted, the next query
    triggers a backfill automatically.
 
-Full backfill **replaces** rather than inserts. It commits through
-`bulkReplaceNamespace()` (or `bulkReplaceAll()` when no namespace is
-configured), each of which deletes the existing rows before writing the new
-set. Backfill is therefore only as correct as `findAllGlobal()` is complete:
-anything the on-disk walk fails to see is not left stale in the index, it is
-deleted from it. A gap in the walk is data loss in the catalog, not a missing
-entry — and because the walk runs before the predicate is applied, a query that
-matches nothing can still delete rows.
+Full backfill **upserts** rather than replaces. It commits through
+`bulkUpsert()`, which uses `INSERT OR REPLACE` without a preceding `DELETE`.
+Rows the on-disk walk finds are added or updated; rows it cannot see are left
+untouched. This is critical for `hydrationStrategy: lazy`, where the local
+cache is intentionally incomplete — data lives in the remote datastore and is
+materialized on demand. Under the previous destructive replace semantics, a
+walk gap was data loss in the catalog; under additive upsert, a walk gap is a
+no-op for the rows it misses.
 
-Data on disk is never touched by backfill, so the loss is recoverable, but it
-does not recover on its own: the `populated` flag stays set, and `data get` and
-`data list` keep working, so nothing surfaces the gap. `swamp doctor datastores`
-compares the index against the on-disk walk and reports any shortfall, and
+The trade-off is that the catalog can accumulate orphaned rows for data that
+was genuinely deleted or renamed outside the write-through path (e.g. manual
+file deletion). Write-through handles normal deletes and renames, and
 `swamp doctor datastores --repair -y` removes `_catalog.db` so the next query
-rebuilds it. That rebuild also clears foreign-namespace rows fetched by
-`swamp datastore catalog pull` — they describe data that is not on local disk,
-so a local walk cannot recreate them; re-pull to restore them.
+rebuilds it from scratch for full reconciliation. That rebuild also clears
+foreign-namespace rows fetched by `swamp datastore catalog pull` — they
+describe data that is not on local disk, so a local walk cannot recreate
+them; re-pull to restore them.
 
 ### Remote Datastores (S3)
 

--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -542,12 +542,7 @@ export class DataQueryService {
       await new Promise<void>((resolve) => setTimeout(resolve, 0));
     }
 
-    const ns = this.dataRepo.namespace;
-    if (ns && ns.length > 0) {
-      this.catalogStore.bulkReplaceNamespace(ns, rows);
-    } else {
-      this.catalogStore.bulkReplaceAll(rows);
-    }
+    this.catalogStore.bulkUpsert(rows);
     this.catalogStore.markPopulated();
   }
 
@@ -608,12 +603,7 @@ export class DataQueryService {
         }
       }
     }
-    const syncNs = this.dataRepo.namespace;
-    if (syncNs && syncNs.length > 0) {
-      this.catalogStore.bulkReplaceNamespace(syncNs, rows);
-    } else {
-      this.catalogStore.bulkReplaceAll(rows);
-    }
+    this.catalogStore.bulkUpsert(rows);
     this.catalogStore.markPopulated();
   }
 

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -536,6 +536,68 @@ Deno.test("DataQueryService: backfill triggers on unpopulated catalog", async ()
   catalog.close();
 });
 
+Deno.test("DataQueryService: backfill preserves catalog rows the walk cannot see", async () => {
+  const dir = Deno.makeTempDirSync({
+    prefix: "swamp-query-backfill-preserve-",
+  });
+  const dbPath = join(dir, ".swamp", "data", "_catalog.db");
+  const catalog = new CatalogStore(dbPath);
+
+  // Seed a row that represents data in the remote datastore but not on local
+  // disk (e.g. lazy hydration — metadata not yet pulled).
+  catalog.upsert(makeRow({
+    data_name: "remote-only",
+    id: "00000000-0000-1000-8000-000000000099",
+  }));
+  // Do NOT mark as populated — the next query must trigger backfill.
+
+  // Create one data item on disk for the walk to find.
+  const dataDir = join(
+    dir,
+    ".swamp",
+    "data",
+    "test-model",
+    "model-001",
+    "on-disk",
+    "1",
+  );
+  ensureDirSync(dataDir);
+  Deno.writeTextFileSync(
+    join(dataDir, "raw"),
+    JSON.stringify({ found: true }),
+  );
+  Deno.writeTextFileSync(
+    join(dataDir, "metadata.yaml"),
+    stringifyYaml({
+      name: "on-disk",
+      id: "00000000-0000-1000-8000-000000000002",
+      version: 1,
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      streaming: false,
+      tags: { type: "resource", specName: "result", modelName: "ingest" },
+      ownerDefinition: { ownerType: "model-method", ownerRef: "test" },
+      createdAt: "2026-01-01T00:00:00.000Z",
+    }),
+  );
+  Deno.writeTextFileSync(
+    join(dir, ".swamp", "data", "test-model", "model-001", "on-disk", "latest"),
+    "1",
+  );
+
+  const dataRepo = new FileSystemUnifiedDataRepository(dir, undefined, catalog);
+  const service = new DataQueryService(catalog, dataRepo);
+
+  // Backfill runs — the walk finds "on-disk" but NOT "remote-only".
+  // With additive upsert, "remote-only" must survive.
+  const results = await service.query("true") as DataRecord[];
+  const names = results.map((r) => r.name).sort();
+  assertEquals(names, ["on-disk", "remote-only"]);
+  assertEquals(catalog.isPopulated(), true);
+  catalog.close();
+});
+
 Deno.test("DataQueryService: backfill stamps the repo namespace onto rebuilt rows", async () => {
   const dir = Deno.makeTempDirSync({ prefix: "swamp-query-backfill-ns-" });
   const dbPath = join(dir, ".swamp", "data", "_catalog.db");

--- a/src/infrastructure/persistence/catalog_store.ts
+++ b/src/infrastructure/persistence/catalog_store.ts
@@ -412,6 +412,58 @@ export class CatalogStore {
   }
 
   /**
+   * Upserts catalog rows without deleting anything first. Rows already
+   * present (by primary key) are updated; rows absent from the batch
+   * are left untouched. Used by backfill so data the on-disk walk
+   * cannot see — e.g. under lazy hydration — is preserved rather than
+   * deleted.
+   */
+  bulkUpsert(rows: readonly CatalogRow[]): void {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const stmt = this.db.prepare(`
+        INSERT OR REPLACE INTO catalog (
+          namespace, type_normalized, model_id, data_name, id, version, is_latest, model_name,
+          spec_name, data_type, content_type, lifetime, owner_type,
+          streaming, size, created_at, tags,
+          owner_ref, workflow_run_id, workflow_name, job_name, step_name, source
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      for (const row of rows) {
+        stmt.run(
+          row.namespace,
+          row.type_normalized,
+          row.model_id,
+          row.data_name,
+          row.id,
+          row.version,
+          row.is_latest,
+          row.model_name,
+          row.spec_name,
+          row.data_type,
+          row.content_type,
+          row.lifetime,
+          row.owner_type,
+          row.streaming,
+          row.size,
+          row.created_at,
+          row.tags,
+          row.owner_ref,
+          row.workflow_run_id,
+          row.workflow_name,
+          row.job_name,
+          row.step_name,
+          row.source,
+        );
+      }
+      this.db.exec("COMMIT");
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  /**
    * Upserts foreign catalog rows from a catalog export. Uses INSERT OR
    * REPLACE so existing foreign rows are updated in place. Records the
    * sync timestamp in catalog_meta as `foreign_synced:{namespace}`.

--- a/src/infrastructure/persistence/catalog_store_test.ts
+++ b/src/infrastructure/persistence/catalog_store_test.ts
@@ -1021,6 +1021,43 @@ Deno.test(
   },
 );
 
+Deno.test("CatalogStore: bulkUpsert inserts rows when absent", () => {
+  const store = new CatalogStore(makeTempDbPath());
+  const rows = [
+    makeRow({ data_name: "a", version: 1 }),
+    makeRow({ data_name: "b", version: 1 }),
+  ];
+  store.bulkUpsert(rows);
+  assertEquals(store.count(), 2);
+  store.close();
+});
+
+Deno.test("CatalogStore: bulkUpsert updates existing rows", () => {
+  const store = new CatalogStore(makeTempDbPath());
+  store.upsert(makeRow({ data_name: "a", version: 1, size: 100 }));
+  store.bulkUpsert([makeRow({ data_name: "a", version: 1, size: 999 })]);
+  const rows = [...store.iterate()];
+  assertEquals(rows.length, 1);
+  assertEquals(rows[0].size, 999);
+  store.close();
+});
+
+Deno.test(
+  "CatalogStore: bulkUpsert preserves rows not in upsert set",
+  () => {
+    const store = new CatalogStore(makeTempDbPath());
+    store.upsert(makeRow({ data_name: "existing", version: 1, size: 100 }));
+    store.bulkUpsert([makeRow({ data_name: "new", version: 1, size: 200 })]);
+    assertEquals(store.count(), 2);
+    const rows = [...store.iterate()];
+    const existing = rows.find((r) => r.data_name === "existing");
+    const added = rows.find((r) => r.data_name === "new");
+    assertEquals(existing?.size, 100);
+    assertEquals(added?.size, 200);
+    store.close();
+  },
+);
+
 Deno.test(
   "CatalogStore: findLatestRow scopes by namespace when provided",
   () => {

--- a/src/libswamp/datastores/doctor_datastores.ts
+++ b/src/libswamp/datastores/doctor_datastores.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import {
+  type CustomDatastoreConfig,
   type DatastoreConfig,
   DEFAULT_DATASTORE_SUBDIRS,
   isCustomDatastoreConfig,
@@ -54,9 +55,8 @@ export interface CatalogShortfall {
  * Comparison of the local catalog index against the on-disk data walk.
  *
  * The catalog is a local index of data on disk. When the walk can see records
- * the index does not have, queries silently under-report — and because full
- * backfill commits with a replace rather than an insert, the gap is destructive
- * rather than merely stale. See design/data-query.md.
+ * the index does not have, queries silently under-report.
+ * See design/data-query.md.
  */
 export interface CatalogCompletenessSummary {
   diskRecords: number;
@@ -192,6 +192,8 @@ export async function* doctorDatastores(
       // Catalog completeness check — the catalog is a local index, so this
       // runs for every repo, with or without a namespace or remote datastore.
       if (deps.checkCatalogCompleteness) {
+        const isLazy = isCustom &&
+          (config as CustomDatastoreConfig).hydrationStrategy === "lazy";
         const summary = await deps.checkCatalogCompleteness();
         if (summary && summary.shortfalls.length > 0) {
           catalogCompletenessFinding = summary;
@@ -205,11 +207,14 @@ export async function* doctorDatastores(
               `Run 'swamp doctor datastores --repair' to preview a rebuild.`,
           });
         } else if (summary) {
+          const qualifier = isLazy
+            ? " on disk (lazy hydration: only locally materialized data is checked)"
+            : " on disk";
           healthFindings.push({
             check: "catalog_completeness",
             passed: true,
             message:
-              `Catalog index covers all ${summary.diskRecords} record(s) on disk`,
+              `Catalog index covers all ${summary.diskRecords} record(s)${qualifier}`,
           });
         }
       }


### PR DESCRIPTION
## Summary

- Switch catalog backfill from destructive `bulkReplaceAll`/`bulkReplaceNamespace` (DELETE + INSERT) to additive `bulkUpsert` (INSERT OR REPLACE) so rows the on-disk walk cannot see are preserved rather than deleted
- Under `hydrationStrategy: lazy` the local cache is intentionally incomplete — data lives in the remote datastore and is materialized on demand — so the previous destructive semantics deleted catalog rows for data present in the remote but not locally cached
- Qualify the `doctor datastores` completeness check message under lazy hydration to clarify it only covers locally materialized data
- Update `design/data-query.md` Population Strategy section to document the new additive semantics

Closes swamp-club#1581

## Test Plan

- Added 3 unit tests for `CatalogStore.bulkUpsert`: inserts when absent, updates existing rows, preserves rows not in the upsert set
- Added integration test for `DataQueryService`: seeds a catalog row for data not on disk, runs backfill, asserts the row survives
- Verified fix against manual reproduction: created data, removed metadata from disk (simulating lazy hydration gap), cleared populated flag, confirmed all 8 catalog records survived (previously only 5 survived)
- All existing tests pass (49 catalog store, 47 data query service, 32 doctor datastores)

🤖 Generated with [Claude Code](https://claude.com/claude-code)