### PR TITLE
fix(serve): record and flush telemetry for daemon-executed workflow runs (swamp-club#1591)

### DIFF
--- a/design/high-level.md
+++ b/design/high-level.md
@@ -50,6 +50,33 @@ filesystem path or S3. See [./datastores.md] for details.
 
 See [./repo.md] for detailed architecture documentation.
 
+### Telemetry Flushing
+
+Telemetry is spooled to a user-level directory and flushed to the remote
+endpoint over HTTP. Where that flush happens depends on the process shape:
+
+- **CLI invocations** flush once, in the teardown that runs after the command
+  completes, and then apply the retention policy — including a hard cap that
+  drops entries undelivered for a week. That is safe for a process that will
+  be started again shortly.
+- **`swamp serve`** cannot use that path at all: its teardown is reached only
+  at process exit, so a daemon running for weeks would never flush. It runs
+  its own flush loop instead (`src/serve/telemetry_flush.ts`), draining on an
+  interval and once more on shutdown.
+
+The daemon deliberately prunes only entries it has already delivered, plus
+quarantined ones. It never applies the hard retention cap: a daemon that has
+been unable to reach the endpoint for a week must keep that telemetry rather
+than destroy work that is still perfectly sendable.
+
+Two properties matter for a flusher that retries forever rather than once.
+Entries carry an `insert_id` so the ingest queue can deduplicate a re-POST
+instead of counting the invocation twice. And an entry the endpoint
+persistently rejects is quarantined after bounded retries, because
+`findUnflushed` returns oldest-first and a batch is all-or-nothing — without
+an escape, one bad entry blocks every newer entry behind it indefinitely and
+the daemon delivers nothing while appearing to work.
+
 ## Models
 
 See [./models.md].

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -942,3 +942,35 @@ fields populated only at the model-method failure site (other yield
 sites — nesting depth, cycle detection, nested-workflow failure — leave
 them undefined so the bridge can distinguish structural failures from
 method failures).
+
+### Runs Executed by `swamp serve`
+
+Scheduled, webhook, and API-triggered runs record the same parent and child
+entries as an interactive `swamp workflow run`, with two differences.
+
+**The parent is the run, not the process.** The CLI allocates one invocation
+id per process, because for a CLI one process is one invocation. A daemon
+breaks that assumption: its own process-level entry is not written until it
+exits, possibly weeks later, so hanging children off it would leave every
+child with a dangling `parentInvocationId` for the daemon's entire uptime.
+Each serve-executed run therefore forks its own service
+(`TelemetryService.forkForRun`) and records a per-run parent shaped like the
+`swamp workflow run` invocation it stands in for, with the workflow name
+redacted exactly as the CLI redacts it.
+
+**Entries carry a `triggerSource`** of `schedule`, `webhook`, or `api`.
+Interactive runs leave the field unset, so their events are unchanged. The
+field is deliberately not called `source`: the telemetry backend derives a
+field by that name from the recorded command, and overloading it would
+collide two independently-owned concerns.
+
+Because a run reports failure through its event stream rather than by
+throwing — input validation, a failed step, and cancellation all return
+normally — the outcome is read from the stream. A run that did not reach
+`succeeded` records an error parent, which matters because only successful
+invocations are counted downstream.
+
+The composition lives in `src/serve/telemetry.ts`; the sink is threaded
+through `executeWorkflowWithLocks` in `src/serve/deps.ts`, which is the
+single path all three trigger types share. Callers that supply no trigger
+source (libswamp consumers, tests) produce no telemetry at all.

--- a/integration/scheduled_trigger_inputs_test.ts
+++ b/integration/scheduled_trigger_inputs_test.ts
@@ -42,6 +42,14 @@ import { StepTask } from "../src/domain/workflows/step_task.ts";
 import { YamlWorkflowRepository } from "../src/infrastructure/persistence/yaml_workflow_repository.ts";
 import { requireInitializedRepoUnlocked } from "../src/cli/repo_context.ts";
 import { executeWorkflowWithLocks } from "../src/serve/deps.ts";
+import type { WorkflowTriggerSource } from "../src/domain/telemetry/mod.ts";
+import type { TelemetryEntry } from "../src/domain/telemetry/telemetry_entry.ts";
+import type { TelemetryRepository } from "../src/domain/telemetry/repositories.ts";
+import { TelemetryService } from "../src/domain/telemetry/telemetry_service.ts";
+import {
+  clearActiveTelemetryService,
+  setActiveTelemetryService,
+} from "../src/cli/telemetry_integration.ts";
 
 // Import models barrel to trigger built-in registration.
 import "../src/domain/models/models.ts";
@@ -85,6 +93,7 @@ function shellWorkflow(
 async function runViaLocks(
   repoDir: string,
   workflowName: string,
+  options?: { triggerSource?: WorkflowTriggerSource },
 ): Promise<WorkflowRunEvent[]> {
   const {
     repoDir: resolvedRepoDir,
@@ -102,8 +111,62 @@ async function runViaLocks(
     new AbortController().signal,
     (event) => events.push(event),
     syncService,
+    undefined,
+    options,
   );
   return events;
+}
+
+/**
+ * Minimal spool that records what the run wrote, so the assertions can look
+ * at real entries rather than at a mocked sink.
+ */
+class RecordingRepository implements TelemetryRepository {
+  saved: TelemetryEntry[] = [];
+  save(entry: TelemetryEntry): Promise<void> {
+    this.saved.push(entry);
+    return Promise.resolve();
+  }
+  findByDate(): Promise<TelemetryEntry[]> {
+    return Promise.resolve([]);
+  }
+  findByDateRange(): Promise<TelemetryEntry[]> {
+    return Promise.resolve([]);
+  }
+  deleteOlderThan(): Promise<number> {
+    return Promise.resolve(0);
+  }
+  deleteAllOlderThan(): Promise<number> {
+    return Promise.resolve(0);
+  }
+  findUnflushed(): Promise<TelemetryEntry[]> {
+    return Promise.resolve([]);
+  }
+  markFlushed(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  quarantine(): Promise<void> {
+    return Promise.resolve();
+  }
+  deleteQuarantinedOlderThan(): Promise<number> {
+    return Promise.resolve(0);
+  }
+}
+
+/**
+ * Installs an active telemetry service for `fn`, mirroring what runCli does
+ * for the lifetime of a `swamp serve` process.
+ */
+async function withTelemetry(
+  fn: (repo: RecordingRepository) => Promise<void>,
+): Promise<void> {
+  const repo = new RecordingRepository();
+  setActiveTelemetryService(new TelemetryService(repo, "test"));
+  try {
+    await fn(repo);
+  } finally {
+    clearActiveTelemetryService();
+  }
 }
 
 async function withRepo(
@@ -176,6 +239,102 @@ Deno.test({
       );
 
       assertEquals(errorEvent?.error.code, "input_validation_failed");
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "scheduled run: records a parent invocation plus child method invocations",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    // The whole point of swamp-club#1591: before this, a serve-executed run
+    // produced no telemetry at all. Driven through executeWorkflowWithLocks
+    // because the sink, the deps factory, and the run generator all have to
+    // agree — no unit test spans that.
+    await withRepo(async (repoDir) => {
+      const workflow = shellWorkflow("scheduled-telemetry", {
+        schedule: "0 3 * * *",
+        inputs: { projectId: "a6b254a2-0b57-4d0f-bf8b-fef767ab119e" },
+      });
+      await new YamlWorkflowRepository(repoDir).save(workflow);
+
+      await withTelemetry(async (repo) => {
+        const events = await runViaLocks(repoDir, workflow.name, {
+          triggerSource: "schedule",
+        });
+        assertEquals(events.at(-1)?.kind, "completed");
+
+        const parents = repo.saved.filter((e) => !e.parentInvocationId);
+        const children = repo.saved.filter((e) => e.parentInvocationId);
+
+        assertEquals(parents.length, 1);
+        assertEquals(parents[0].invocation.command, "workflow");
+        assertEquals(parents[0].invocation.subcommand, "run");
+        assertEquals(parents[0].result.status, "success");
+
+        // Every entry is attributed to the scheduler, and the children hang
+        // off this run rather than off the daemon's process invocation.
+        for (const entry of repo.saved) {
+          assertEquals(entry.triggerSource, "schedule");
+        }
+        assertEquals(children.length > 0, true);
+        for (const child of children) {
+          assertEquals(child.parentInvocationId, parents[0].id);
+          assertEquals(child.workflowContext?.workflowName, workflow.name);
+        }
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "scheduled run: records nothing when no trigger source is supplied",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    // Library and test callers pass no trigger source, and the interactive
+    // CLI has its own binding — neither may start emitting from here.
+    await withRepo(async (repoDir) => {
+      const workflow = shellWorkflow("untriggered-telemetry", {
+        schedule: "0 3 * * *",
+        inputs: { projectId: "a6b254a2-0b57-4d0f-bf8b-fef767ab119e" },
+      });
+      await new YamlWorkflowRepository(repoDir).save(workflow);
+
+      await withTelemetry(async (repo) => {
+        const events = await runViaLocks(repoDir, workflow.name);
+        assertEquals(events.at(-1)?.kind, "completed");
+        assertEquals(repo.saved.length, 0);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "scheduled run: a failed run records an error parent invocation",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    // Only successes credit downstream, so a failing scheduled run must be
+    // recorded as an error rather than silently omitted.
+    await withRepo(async (repoDir) => {
+      const workflow = shellWorkflow("failing-telemetry", {
+        schedule: "0 3 * * *",
+      });
+      await new YamlWorkflowRepository(repoDir).save(workflow);
+
+      await withTelemetry(async (repo) => {
+        await runViaLocks(repoDir, workflow.name, {
+          triggerSource: "schedule",
+        });
+
+        const parents = repo.saved.filter((e) => !e.parentInvocationId);
+        assertEquals(parents.length, 1);
+        assertEquals(parents[0].result.status, "error");
+        assertEquals(parents[0].triggerSource, "schedule");
+      });
     });
   },
 });

--- a/integration/webhook_payload_inputs_test.ts
+++ b/integration/webhook_payload_inputs_test.ts
@@ -46,12 +46,52 @@ import { YamlWorkflowRepository } from "../src/infrastructure/persistence/yaml_w
 import { YamlEvaluatedWorkflowRepository } from "../src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
 import { requireInitializedRepoUnlocked } from "../src/cli/repo_context.ts";
 import { executeWorkflowWithLocks } from "../src/serve/deps.ts";
+import type { TelemetryEntry } from "../src/domain/telemetry/telemetry_entry.ts";
+import type { TelemetryRepository } from "../src/domain/telemetry/repositories.ts";
+import { TelemetryService } from "../src/domain/telemetry/telemetry_service.ts";
+import {
+  clearActiveTelemetryService,
+  setActiveTelemetryService,
+} from "../src/cli/telemetry_integration.ts";
 
 // Import models barrel to trigger built-in registration.
 import "../src/domain/models/models.ts";
 import { initializeLogging } from "../src/infrastructure/logging/logger.ts";
 
 await initializeLogging({});
+
+/** Minimal spool that records what a run wrote. */
+class RecordingRepository implements TelemetryRepository {
+  saved: TelemetryEntry[] = [];
+  save(entry: TelemetryEntry): Promise<void> {
+    this.saved.push(entry);
+    return Promise.resolve();
+  }
+  findByDate(): Promise<TelemetryEntry[]> {
+    return Promise.resolve([]);
+  }
+  findByDateRange(): Promise<TelemetryEntry[]> {
+    return Promise.resolve([]);
+  }
+  deleteOlderThan(): Promise<number> {
+    return Promise.resolve(0);
+  }
+  deleteAllOlderThan(): Promise<number> {
+    return Promise.resolve(0);
+  }
+  findUnflushed(): Promise<TelemetryEntry[]> {
+    return Promise.resolve([]);
+  }
+  markFlushed(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  quarantine(): Promise<void> {
+    return Promise.resolve();
+  }
+  deleteQuarantinedOlderThan(): Promise<number> {
+    return Promise.resolve(0);
+  }
+}
 
 const requiredInputSchema = {
   type: "object" as const,
@@ -112,6 +152,8 @@ async function runWebhook(
     new AbortController().signal,
     (event) => events.push(event),
     syncService,
+    undefined,
+    { triggerSource: "webhook" },
   );
   return events;
 }
@@ -226,6 +268,58 @@ Deno.test({
           route: "/hooks/linear",
         })
       );
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "webhook run: records telemetry attributed to the webhook trigger, without the payload",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withRepo(async (repoDir) => {
+      const workflow = webhookWorkflow("webhook-telemetry", {
+        identifier: "${{ webhook.body.data.issue.identifier }}",
+      });
+      await new YamlWorkflowRepository(repoDir).save(workflow);
+
+      const repo = new RecordingRepository();
+      setActiveTelemetryService(new TelemetryService(repo, "test"));
+      try {
+        const events = await runWebhook(repoDir, workflow.name, {
+          body: {
+            data: { issue: { identifier: "PLT-2001" } },
+            secret: "super-secret-token",
+          },
+          headers: { authorization: "Bearer should-never-be-recorded" },
+          route: "/hooks/linear",
+        });
+        assertEquals(events.at(-1)?.kind, "completed");
+
+        // Exactly one parent entry for the run, attributed to the webhook
+        // trigger. The status is deliberately not asserted here: this
+        // fixture's step passes an input the shell model does not accept, so
+        // the run fails — the surrounding tests only ever asserted that the
+        // payload value reached the evaluated workflow. Success and failure
+        // statuses are pinned in the scheduled tests, where the fixture runs
+        // clean.
+        const parents = repo.saved.filter((e) => !e.parentInvocationId);
+        assertEquals(parents.length, 1);
+        assertEquals(parents[0].triggerSource, "webhook");
+        assertEquals(parents[0].invocation.command, "workflow");
+        assertEquals(parents[0].invocation.subcommand, "run");
+
+        // Webhook payloads are attacker-influenced and must never reach
+        // telemetry. Serve-side entries are generated with no human present,
+        // so this is asserted rather than assumed.
+        const serialized = JSON.stringify(repo.saved.map((e) => e.toData()));
+        assertEquals(serialized.includes("super-secret-token"), false);
+        assertEquals(serialized.includes("should-never-be-recorded"), false);
+        assertEquals(serialized.includes("PLT-2001"), false);
+      } finally {
+        clearActiveTelemetryService();
+      }
     });
   },
 });

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -51,6 +51,10 @@ import {
 } from "../../serve/token_auth.ts";
 import { parsePrincipal } from "../../domain/access/principal.ts";
 import { executeWorkflowWithLocks } from "../../serve/deps.ts";
+import { DaemonTelemetryFlushService } from "../../serve/telemetry_flush.ts";
+import { getActiveTelemetryContext } from "../telemetry_integration.ts";
+import { HttpTelemetrySender } from "../../infrastructure/telemetry/http_telemetry_sender.ts";
+import { USER_AGENT } from "../load_identity.ts";
 import { CapabilityService } from "../../serve/capability_service.ts";
 import { WorkerGateway } from "../../serve/worker_gateway.ts";
 import { dispatchFleetProbe } from "../../serve/fleet_probe_dispatch.ts";
@@ -2242,6 +2246,7 @@ export const serveCommand = new Command()
       };
 
     const ac = new AbortController();
+    let telemetryFlushService: DaemonTelemetryFlushService | null = null;
     const enableSchedule = merged.schedule;
     const webhookFlags: string[] = merged.webhook ?? [];
 
@@ -2262,6 +2267,7 @@ export const serveCommand = new Command()
             onEvent,
             syncService,
             runTracker,
+            { triggerSource: "schedule" },
           ),
         pendingRunHook: {
           enqueue: (entry) => {
@@ -3141,6 +3147,12 @@ export const serveCommand = new Command()
         await collectiveRefreshService.dispose();
       }
       await policySnapshotLoader.dispose();
+      // Final telemetry flush, after runs have drained so their entries are
+      // included. Must happen BEFORE ac.abort(), which releases
+      // `await server.finished` and with it the CLI's own teardown flush.
+      if (telemetryFlushService) {
+        await telemetryFlushService.stop();
+      }
       rejectionGuard.dispose();
       setRemoteStepDispatcher(null);
       ac.abort();
@@ -3311,6 +3323,51 @@ export const serveCommand = new Command()
         FIRE_RECORD_REAP_INTERVAL_MS,
       );
       Deno.unrefTimer(reaperTimer);
+    }
+
+    // Telemetry flush loop. A daemon reaches the CLI's teardown flush only at
+    // process exit, so without this everything it spools sits unsent for the
+    // life of the process. Absent context = telemetry disabled for this run
+    // (--no-telemetry, marker opt-out, user-level opt-out); serve then stays
+    // as silent as it has always been.
+    const telemetryContext = getActiveTelemetryContext();
+    if (telemetryContext) {
+      const distinctId = telemetryContext.userId ?? telemetryContext.repoId;
+      if (distinctId) {
+        telemetryFlushService = new DaemonTelemetryFlushService(
+          telemetryContext.service,
+          {
+            sender: new HttpTelemetrySender(
+              telemetryContext.telemetryEndpoint,
+              USER_AGENT,
+            ),
+            distinctId,
+            repoId: telemetryContext.repoId,
+            authToken: telemetryContext.authToken ?? undefined,
+            keepFlushed: telemetryContext.keepFlushed,
+          },
+        );
+        telemetryFlushService.start();
+        // Log the identity the daemon will report under. A serve process
+        // running with a different HOME than the operator's shell resolves a
+        // different user identity, and its runs then credit an account nobody
+        // is looking at — indistinguishable at the UI from not reporting at
+        // all. The token is never logged, only whether one was found.
+        logger.info(
+          "Telemetry: flushing to {endpoint} as {identity} (authenticated: {authenticated})",
+          {
+            endpoint: telemetryContext.telemetryEndpoint,
+            identity: distinctId,
+            authenticated: telemetryContext.authToken !== null,
+          },
+        );
+      } else {
+        logger.warn(
+          "Telemetry: no user or repo identity resolved — scheduled runs will not be reported",
+        );
+      }
+    } else {
+      logger.info("Telemetry: disabled for this process");
     }
 
     isReady = true;

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -128,12 +128,15 @@ import { JsonTelemetryRepository } from "../infrastructure/persistence/json_tele
 import { HttpTelemetrySender } from "../infrastructure/telemetry/http_telemetry_sender.ts";
 import {
   buildInvocationContext,
+  clearActiveTelemetryContext,
   clearActiveTelemetryService,
   extractCommandInfo,
   isExternalDatastoreConfigured,
   isTelemetryDisabled,
   projectEnvSnapshot,
+  setActiveTelemetryContext,
   setActiveTelemetryService,
+  type TelemetryContext,
 } from "./telemetry_integration.ts";
 import type { CommandInvocationData } from "../domain/telemetry/command_invocation.ts";
 import { UserIdentityRepository } from "../infrastructure/persistence/user_identity_repository.ts";
@@ -1123,20 +1126,6 @@ export function resolveTelemetryEndpoint(
 
 import { resolveTrustedCollectives } from "../libswamp/mod.ts";
 
-interface TelemetryContext {
-  service: TelemetryService;
-  userId: string | null;
-  /**
-   * Repo-specific identifier, present only when the run happened inside a
-   * swamp repo. Undefined for repo-less runs — the event is then keyed solely
-   * by the user identity (userId).
-   */
-  repoId: string | undefined;
-  telemetryEndpoint: string;
-  keepFlushed: boolean;
-  authToken: string | null;
-}
-
 /**
  * Initialize the telemetry service for this invocation.
  *
@@ -1323,6 +1312,9 @@ export async function runCli(args: string[]): Promise<void> {
   // outer try/finally below regardless of how the invocation ends.
   if (telemetryCtx) {
     setActiveTelemetryService(telemetryCtx.service);
+    // `swamp serve` reaches the teardown flush below only at process exit,
+    // so it runs its own flush loop and needs these same credentials.
+    setActiveTelemetryContext(telemetryCtx);
   }
 
   // Read marker once for log level, extension loading, and auto-resolver.
@@ -1618,9 +1610,9 @@ export async function runCli(args: string[]): Promise<void> {
               keepFlushed: telemetryCtx.keepFlushed,
               signal: AbortSignal.timeout(2000),
             });
-            if (!flushResult.ok) {
-              const detail = flushResult.reason
-                ? ` (${flushResult.reason})`
+            if (!flushResult.result.ok) {
+              const detail = flushResult.result.reason
+                ? ` (${flushResult.result.reason})`
                 : "";
               logger.warn(
                 `Telemetry flush failed${detail} — entries are queued locally and will retry on the next invocation`,
@@ -1816,5 +1808,6 @@ export async function runCli(args: string[]): Promise<void> {
     // invocation finishes — runCli is the single setter and must be the
     // single clearer.
     clearActiveTelemetryService();
+    clearActiveTelemetryContext();
   }
 }

--- a/src/cli/telemetry_integration.ts
+++ b/src/cli/telemetry_integration.ts
@@ -55,6 +55,30 @@ export function isExternalDatastoreConfigured(
 let activeTelemetryService: TelemetryService | null = null;
 
 /**
+ * Everything needed to flush the spool to the remote endpoint, resolved once
+ * per invocation in `initTelemetryService`.
+ *
+ * Published alongside the service because `swamp serve` cannot rely on the
+ * CLI teardown to flush — a daemon reaches teardown only at process exit, so
+ * it needs to run its own flush loop, and that needs the same credentials.
+ */
+export interface TelemetryContext {
+  service: TelemetryService;
+  userId: string | null;
+  /**
+   * Repo-specific identifier, present only when the run happened inside a
+   * swamp repo. Undefined for repo-less runs — the event is then keyed solely
+   * by the user identity (userId).
+   */
+  repoId: string | undefined;
+  telemetryEndpoint: string;
+  keepFlushed: boolean;
+  authToken: string | null;
+}
+
+let activeTelemetryContext: TelemetryContext | null = null;
+
+/**
  * Sets the active TelemetryService for the current CLI invocation.
  * Call from runCli only — not from individual commands.
  */
@@ -75,6 +99,30 @@ export function clearActiveTelemetryService(): void {
  */
 export function getActiveTelemetryService(): TelemetryService | null {
   return activeTelemetryService;
+}
+
+/**
+ * Sets the active telemetry context for the current CLI invocation.
+ * Call from runCli only.
+ */
+export function setActiveTelemetryContext(context: TelemetryContext): void {
+  activeTelemetryContext = context;
+}
+
+/**
+ * Clears the active telemetry context. Call from runCli's finally block —
+ * the context holds an auth token and must not outlive the invocation.
+ */
+export function clearActiveTelemetryContext(): void {
+  activeTelemetryContext = null;
+}
+
+/**
+ * Returns the active telemetry context, or null when telemetry is disabled
+ * for this invocation.
+ */
+export function getActiveTelemetryContext(): TelemetryContext | null {
+  return activeTelemetryContext;
 }
 
 /**

--- a/src/domain/telemetry/mod.ts
+++ b/src/domain/telemetry/mod.ts
@@ -47,6 +47,12 @@ export {
 } from "./workflow_context.ts";
 
 export {
+  isWorkflowTriggerSource,
+  WORKFLOW_TRIGGER_SOURCES,
+  type WorkflowTriggerSource,
+} from "./trigger_source.ts";
+
+export {
   type AgentHarnessDetection,
   type DetectableAiTool,
   detectAgentHarness,

--- a/src/domain/telemetry/repositories.ts
+++ b/src/domain/telemetry/repositories.ts
@@ -80,8 +80,38 @@ export interface TelemetryRepository {
    * Marks a telemetry entry as flushed (sent to remote endpoint).
    * By default, deletes the file. If keepFlushed is true, renames to .flushed.json.
    *
+   * Returns whether the entry was actually marked. A `false` return means the
+   * entry is still on disk and will be read again by the next `findUnflushed`
+   * — harmless for a one-shot CLI run, but a caller that flushes repeatedly
+   * must not re-send it or the same invocation is counted once per attempt.
+   *
    * @param entry - The entry to mark as flushed
    * @param keepFlushed - If true, rename instead of delete
+   * @returns true if the entry was marked, false if the operation failed
    */
-  markFlushed(entry: TelemetryEntry, keepFlushed?: boolean): Promise<void>;
+  markFlushed(entry: TelemetryEntry, keepFlushed?: boolean): Promise<boolean>;
+
+  /**
+   * Sets an entry aside as undeliverable, excluding it from future
+   * `findUnflushed` results without deleting it.
+   *
+   * The escape hatch for a permanently-rejected entry. `findUnflushed`
+   * returns the oldest entries first and a batch is only marked after the
+   * whole batch sends, so without this a single entry the endpoint always
+   * rejects blocks every newer entry behind it forever.
+   *
+   * @param entry - The entry to quarantine
+   */
+  quarantine(entry: TelemetryEntry): Promise<void>;
+
+  /**
+   * Deletes quarantined entries older than the given date.
+   *
+   * Quarantined entries are, by definition, not deliverable, so unlike
+   * unflushed entries they are not worth retaining indefinitely.
+   *
+   * @param date - Delete quarantined entries older than this date
+   * @returns The number of entries deleted
+   */
+  deleteQuarantinedOlderThan(date: Date): Promise<number>;
 }

--- a/src/domain/telemetry/telemetry_entry.ts
+++ b/src/domain/telemetry/telemetry_entry.ts
@@ -46,6 +46,10 @@ import {
   workflowContextFromData,
   workflowContextToData,
 } from "./workflow_context.ts";
+import {
+  isWorkflowTriggerSource,
+  type WorkflowTriggerSource,
+} from "./trigger_source.ts";
 
 /**
  * Properties required to create a new TelemetryEntry.
@@ -62,14 +66,15 @@ export interface CreateTelemetryEntryProps {
   invocationContext?: InvocationContextData;
   parentInvocationId?: string;
   workflowContext?: WorkflowContextData;
+  triggerSource?: WorkflowTriggerSource;
 }
 
 /**
  * Data transfer object for TelemetryEntry.
  *
- * `invocationContext`, `parentInvocationId`, and `workflowContext` are
- * optional so entries written before each field was introduced still decode
- * without loss.
+ * `invocationContext`, `parentInvocationId`, `workflowContext`, and
+ * `triggerSource` are optional so entries written before each field was
+ * introduced still decode without loss.
  */
 export interface TelemetryEntryData {
   id: string;
@@ -84,6 +89,7 @@ export interface TelemetryEntryData {
   invocationContext?: InvocationContextData;
   parentInvocationId?: string;
   workflowContext?: WorkflowContextData;
+  triggerSource?: WorkflowTriggerSource;
 }
 
 /**
@@ -103,6 +109,7 @@ export class TelemetryEntry {
     readonly invocationContext?: InvocationContext,
     readonly parentInvocationId?: TelemetryId,
     readonly workflowContext?: WorkflowContext,
+    readonly triggerSource?: WorkflowTriggerSource,
   ) {}
 
   /**
@@ -131,6 +138,7 @@ export class TelemetryEntry {
       props.workflowContext
         ? workflowContextFromData(props.workflowContext)
         : undefined,
+      props.triggerSource,
     );
   }
 
@@ -156,6 +164,11 @@ export class TelemetryEntry {
         : undefined,
       data.workflowContext
         ? workflowContextFromData(data.workflowContext)
+        : undefined,
+      // Spool files are on disk and may be hand-edited or written by a newer
+      // version, so an unrecognised value is dropped rather than trusted.
+      isWorkflowTriggerSource(data.triggerSource)
+        ? data.triggerSource
         : undefined,
     );
   }
@@ -183,6 +196,9 @@ export class TelemetryEntry {
     }
     if (this.workflowContext) {
       data.workflowContext = workflowContextToData(this.workflowContext);
+    }
+    if (this.triggerSource) {
+      data.triggerSource = this.triggerSource;
     }
     return data;
   }

--- a/src/domain/telemetry/telemetry_entry_test.ts
+++ b/src/domain/telemetry/telemetry_entry_test.ts
@@ -348,3 +348,99 @@ Deno.test("TelemetryEntry.fromData decodes legacy entries without parentInvocati
   assertEquals("parentInvocationId" in roundTripped, false);
   assertEquals("workflowContext" in roundTripped, false);
 });
+
+Deno.test("TelemetryEntry round-trips triggerSource through toData/fromData", () => {
+  const entry = TelemetryEntry.create({
+    invocation: {
+      command: "workflow",
+      subcommand: "run",
+      args: ["<REDACTED>"],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: { status: "success", exitCode: 0 },
+    startedAt: new Date("2026-02-05T12:00:00.000Z"),
+    completedAt: new Date("2026-02-05T12:00:05.000Z"),
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+    triggerSource: "schedule",
+  });
+
+  assertEquals(entry.triggerSource, "schedule");
+  const data = entry.toData();
+  assertEquals(data.triggerSource, "schedule");
+  assertEquals(TelemetryEntry.fromData(data).triggerSource, "schedule");
+});
+
+Deno.test("TelemetryEntry omits triggerSource for interactive invocations", () => {
+  // The CLI never sets a trigger source, so its events must stay
+  // byte-identical to what shipped before the field existed.
+  const entry = TelemetryEntry.create({
+    invocation: {
+      command: "model",
+      subcommand: "create",
+      args: [],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: { status: "success", exitCode: 0 },
+    startedAt: new Date("2026-02-05T12:00:00.000Z"),
+    completedAt: new Date("2026-02-05T12:00:01.000Z"),
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+  });
+
+  assertEquals(entry.triggerSource, undefined);
+  assertEquals("triggerSource" in entry.toData(), false);
+});
+
+Deno.test("TelemetryEntry.fromData decodes legacy entries without triggerSource", () => {
+  const legacyData: TelemetryEntryData = {
+    id: "legacy-3",
+    invocation: {
+      command: "workflow",
+      subcommand: "run",
+      args: ["<REDACTED>"],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: { status: "success", exitCode: 0 },
+    startedAt: "2026-02-05T12:00:00.000Z",
+    completedAt: "2026-02-05T12:00:05.000Z",
+    durationMs: 5000,
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+  };
+
+  const entry = TelemetryEntry.fromData(legacyData);
+  assertEquals(entry.triggerSource, undefined);
+  assertEquals("triggerSource" in entry.toData(), false);
+});
+
+Deno.test("TelemetryEntry.fromData drops an unrecognised triggerSource", () => {
+  // A spool file can be hand-edited or written by a newer version; an unknown
+  // value must not reach the wire as though it were a known one.
+  const data = {
+    id: "unknown-source",
+    invocation: {
+      command: "workflow",
+      subcommand: "run",
+      args: [],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: { status: "success", exitCode: 0 },
+    startedAt: "2026-02-05T12:00:00.000Z",
+    completedAt: "2026-02-05T12:00:05.000Z",
+    durationMs: 5000,
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+    triggerSource: "telepathy",
+  } as unknown as TelemetryEntryData;
+
+  assertEquals(TelemetryEntry.fromData(data).triggerSource, undefined);
+});

--- a/src/domain/telemetry/telemetry_service.ts
+++ b/src/domain/telemetry/telemetry_service.ts
@@ -32,6 +32,7 @@ import {
   createSuccessResult,
   type InvocationResultData,
 } from "./invocation_result.ts";
+import type { WorkflowTriggerSource } from "./trigger_source.ts";
 import { UserError } from "../errors.ts";
 
 /** Default flush batch size */
@@ -48,6 +49,43 @@ export interface TelemetryFlushConfig {
   batchSize?: number;
   keepFlushed?: boolean;
   signal?: AbortSignal;
+  /**
+   * Entry ids the caller has already sent successfully but could not mark
+   * as flushed. They are still on disk, so `findUnflushed` keeps returning
+   * them; skipping them here prevents a repeatedly-flushing caller from
+   * sending the same invocation once per attempt.
+   */
+  skipIds?: ReadonlySet<string>;
+}
+
+/**
+ * Configuration for sending one specific entry, bypassing batch selection.
+ */
+export interface TelemetrySingleFlushConfig {
+  entry: TelemetryEntry;
+  sender: TelemetrySender;
+  distinctId: string;
+  repoId?: string;
+  authToken?: string;
+  keepFlushed?: boolean;
+  signal?: AbortSignal;
+}
+
+/**
+ * Result of a flush, from the service's point of view.
+ *
+ * Distinct from {@link TelemetryFlushResult}, which is the *sender's*
+ * vocabulary and knows nothing about the local spool. Marking is a
+ * persistence concern, so it is reported here rather than being folded into
+ * the sender's contract.
+ */
+export interface TelemetryFlushOutcome {
+  /** The sender's verdict for the batch it attempted. */
+  result: TelemetryFlushResult;
+  /** Ids that were accepted by the endpoint but could not be marked flushed. */
+  unmarkedIds: string[];
+  /** Entries sent in this flush. Zero means the spool was already drained. */
+  sentCount: number;
 }
 
 /**
@@ -85,6 +123,14 @@ const DEFAULT_RETENTION_DAYS = 2;
 const HARD_RETENTION_DAYS = 7;
 
 /**
+ * Retention for quarantined entries in days. Longer than the flushed
+ * retention because a quarantined entry is evidence — the reason an endpoint
+ * refuses a payload is usually only visible in the payload — but bounded,
+ * since unlike unflushed entries it is not data we still expect to deliver.
+ */
+const QUARANTINE_RETENTION_DAYS = 30;
+
+/**
  * Service for recording and analyzing CLI telemetry.
  *
  * The optional `invocationContext` is captured once at construction time —
@@ -101,13 +147,56 @@ const HARD_RETENTION_DAYS = 7;
 export class TelemetryService {
   readonly invocationId: TelemetryId;
 
+  /**
+   * Tail of the serialized flush chain. Every operation that reads
+   * unflushed entries and marks them queues behind this, so two callers
+   * holding this same service can never both read the same batch before
+   * either marks it — which would send every entry in it twice. `swamp
+   * serve` has exactly that shape at shutdown, when its daemon flush loop
+   * and the CLI teardown flush overlap.
+   *
+   * The lock protects one service over one spool. Services produced by
+   * {@link forkForRun} share the spool but not this field, which is safe
+   * only because forks are write-only — see forkForRun.
+   */
+  #flushChain: Promise<unknown> = Promise.resolve();
+
   constructor(
     private readonly repository: TelemetryRepository,
     private readonly swampVersion: string,
     private readonly invocationContext?: InvocationContextData,
     invocationId?: TelemetryId,
+    private readonly triggerSource?: WorkflowTriggerSource,
   ) {
     this.invocationId = invocationId ?? generateTelemetryId();
+  }
+
+  /**
+   * Creates a sibling service for one workflow run executed by a daemon.
+   *
+   * The CLI assumes one process is one invocation, so `invocationId` is
+   * allocated once per process. A long-lived `swamp serve` breaks that
+   * assumption: its unit of invocation is a workflow run, and its own
+   * process-level entry is not written until exit — possibly weeks later.
+   * A fork gives each run its own identity to parent its child method
+   * invocations to, sharing this service's repository, version, and
+   * invocation context.
+   *
+   * IMPORTANT: forks are WRITE-ONLY. They record entries; they must never
+   * flush. Flushing is serialized by a per-instance mutex (see
+   * {@link #flushInFlight}), and a fork does not share it — so a fork that
+   * flushed could race the root service over the same spool and send a batch
+   * twice. If a fork ever needs to flush, move the lock down to the
+   * repository first.
+   */
+  forkForRun(triggerSource?: WorkflowTriggerSource): TelemetryService {
+    return new TelemetryService(
+      this.repository,
+      this.swampVersion,
+      this.invocationContext,
+      generateTelemetryId(),
+      triggerSource ?? this.triggerSource,
+    );
   }
 
   /**
@@ -130,6 +219,7 @@ export class TelemetryService {
       denoVersion: Deno.version.deno,
       platform: Deno.build.os,
       invocationContext: this.invocationContext,
+      triggerSource: this.triggerSource,
     });
 
     await this.repository.save(entry);
@@ -162,6 +252,7 @@ export class TelemetryService {
       denoVersion: Deno.version.deno,
       platform: Deno.build.os,
       invocationContext: this.invocationContext,
+      triggerSource: this.triggerSource,
     });
 
     await this.repository.save(entry);
@@ -217,6 +308,7 @@ export class TelemetryService {
       invocationContext: this.invocationContext,
       parentInvocationId,
       workflowContext,
+      triggerSource: this.triggerSource,
     });
 
     await this.repository.save(entry);
@@ -252,31 +344,152 @@ export class TelemetryService {
   }
 
   /**
+   * Removes flushed telemetry entries older than the retention period, and
+   * quarantined entries past their (longer) retention. Never touches
+   * unflushed entries.
+   *
+   * This is the only cleanup a long-lived daemon may run.
+   * {@link cleanupOldTelemetry} also applies `HARD_RETENTION_DAYS`, which
+   * deletes UNFLUSHED entries — safe for a CLI process that will be started
+   * again shortly, and destructive for a daemon that has been unable to reach
+   * the endpoint for a week, since it would discard telemetry that is still
+   * perfectly sendable. Undelivered data on disk beats silently discarded
+   * data, so the daemon keeps unflushed entries indefinitely.
+   *
+   * @param retentionDays - Number of days to retain flushed entries (default: 2)
+   */
+  async pruneFlushedTelemetry(
+    retentionDays: number = DEFAULT_RETENTION_DAYS,
+  ): Promise<void> {
+    const flushedCutoff = new Date();
+    flushedCutoff.setDate(flushedCutoff.getDate() - retentionDays);
+
+    const quarantineCutoff = new Date();
+    quarantineCutoff.setDate(
+      quarantineCutoff.getDate() - QUARANTINE_RETENTION_DAYS,
+    );
+
+    try {
+      await Promise.all([
+        this.repository.deleteOlderThan(flushedCutoff),
+        this.repository.deleteQuarantinedOlderThan(quarantineCutoff),
+      ]);
+    } catch (error) {
+      if (Deno.env.get("SWAMP_DEBUG")) {
+        console.error("[Telemetry] Prune failed:", error);
+      }
+    }
+  }
+
+  /**
+   * Sets an entry aside as undeliverable so it stops blocking newer entries.
+   */
+  async quarantineEntry(entry: TelemetryEntry): Promise<void> {
+    await this.repository.quarantine(entry);
+  }
+
+  /**
    * Flushes unflushed telemetry entries to a remote endpoint.
-   * Returns a result indicating whether the flush succeeded and, on failure,
-   * the reason. Never throws.
+   * Returns the sender's verdict plus any entries that were accepted but
+   * could not be marked flushed. Never throws.
+   *
+   * Concurrent calls on the same service are serialized: a caller arriving
+   * while a flush is running awaits that flush rather than starting a second
+   * one. Without this, two callers can both read the same unflushed batch
+   * before either marks it and send every entry twice — the shape `swamp
+   * serve` produces at shutdown, when its daemon flush loop and the CLI
+   * teardown flush overlap.
    *
    * @param config - Flush configuration with sender and distinctId
    */
-  async flushTelemetry(
+  flushTelemetry(
     config: TelemetryFlushConfig,
-  ): Promise<TelemetryFlushResult> {
-    const batchSize = config.batchSize ?? DEFAULT_FLUSH_BATCH_SIZE;
-    const keepFlushed = config.keepFlushed ?? false;
+  ): Promise<TelemetryFlushOutcome> {
+    return this.#serialize(async () => {
+      const batchSize = config.batchSize ?? DEFAULT_FLUSH_BATCH_SIZE;
+      const keepFlushed = config.keepFlushed ?? false;
 
-    try {
-      return await this.doFlush(
-        config.sender,
-        config.distinctId,
-        batchSize,
-        keepFlushed,
-        config.repoId,
-        config.authToken,
-        config.signal,
-      );
-    } catch {
-      return { ok: false, reason: "unexpected error" };
-    }
+      try {
+        return await this.doFlush(
+          config.sender,
+          config.distinctId,
+          batchSize,
+          keepFlushed,
+          config.repoId,
+          config.authToken,
+          config.signal,
+          config.skipIds,
+        );
+      } catch {
+        return {
+          result: { ok: false, reason: "unexpected error" },
+          unmarkedIds: [],
+          sentCount: 0,
+        };
+      }
+    });
+  }
+
+  /**
+   * Returns unflushed entries excluding ones the caller has already
+   * delivered, for callers that need to retry a stuck batch entry by entry.
+   */
+  async findUnflushedForIsolation(
+    limit: number,
+    skipIds?: ReadonlySet<string>,
+  ): Promise<TelemetryEntry[]> {
+    const entries = await this.repository.findUnflushed(limit);
+    return skipIds?.size
+      ? entries.filter((entry) => !skipIds.has(entry.id))
+      : entries;
+  }
+
+  /**
+   * Sends a single entry, marking it flushed on success.
+   *
+   * Used to find the offender in a batch the endpoint keeps rejecting: a
+   * batch is all-or-nothing, so one bad entry hides behind the same failure
+   * as its blameless neighbours until they are sent apart.
+   */
+  flushEntry(
+    config: TelemetrySingleFlushConfig,
+  ): Promise<TelemetryFlushOutcome> {
+    return this.#serialize(async () => {
+      try {
+        const result = await config.sender.sendBatch(
+          [config.entry],
+          config.distinctId,
+          config.repoId,
+          config.authToken,
+          config.signal,
+        );
+        const unmarkedIds: string[] = [];
+        if (result.ok) {
+          const marked = await this.repository.markFlushed(
+            config.entry,
+            config.keepFlushed ?? false,
+          );
+          if (!marked) unmarkedIds.push(config.entry.id);
+        }
+        return { result, unmarkedIds, sentCount: result.ok ? 1 : 0 };
+      } catch {
+        return {
+          result: { ok: false, reason: "unexpected error" },
+          unmarkedIds: [],
+          sentCount: 0,
+        };
+      }
+    });
+  }
+
+  /**
+   * Runs `fn` after every previously-queued flush operation has settled.
+   */
+  #serialize<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.#flushChain.then(fn, fn);
+    // Swallow on the chain only — the caller still sees the real outcome.
+    this.#flushChain = run.then(() => {}, () => {});
+    return run;
   }
 
   private async doFlush(
@@ -287,9 +500,17 @@ export class TelemetryService {
     repoId?: string,
     authToken?: string,
     signal?: AbortSignal,
-  ): Promise<TelemetryFlushResult> {
-    const entries = await this.repository.findUnflushed(batchSize);
-    if (entries.length === 0) return { ok: true };
+    skipIds?: ReadonlySet<string>,
+  ): Promise<TelemetryFlushOutcome> {
+    const found = await this.repository.findUnflushed(batchSize);
+    // Entries the caller already delivered but could not mark are still on
+    // disk. Re-sending them would count the same invocation twice.
+    const entries = skipIds?.size
+      ? found.filter((entry) => !skipIds.has(entry.id))
+      : found;
+    if (entries.length === 0) {
+      return { result: { ok: true }, unmarkedIds: [], sentCount: 0 };
+    }
 
     const result = await sender.sendBatch(
       entries,
@@ -298,12 +519,14 @@ export class TelemetryService {
       authToken,
       signal,
     );
+    const unmarkedIds: string[] = [];
     if (result.ok) {
       for (const entry of entries) {
-        await this.repository.markFlushed(entry, keepFlushed);
+        const marked = await this.repository.markFlushed(entry, keepFlushed);
+        if (!marked) unmarkedIds.push(entry.id);
       }
     }
-    return result;
+    return { result, unmarkedIds, sentCount: result.ok ? entries.length : 0 };
   }
 
   /**

--- a/src/domain/telemetry/telemetry_service_test.ts
+++ b/src/domain/telemetry/telemetry_service_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertExists } from "@std/assert";
 import { TelemetryService } from "./telemetry_service.ts";
 import type { TelemetryRepository } from "./repositories.ts";
 import type {
@@ -32,8 +32,12 @@ class MockTelemetryRepository implements TelemetryRepository {
   mockEntries: TelemetryEntry[] = [];
   mockUnflushedEntries: TelemetryEntry[] = [];
   flushedEntries: TelemetryEntry[] = [];
+  quarantinedEntries: TelemetryEntry[] = [];
   deletedBefore: Date | null = null;
   deleteAllBefore: Date | null = null;
+  deletedQuarantinedBefore: Date | null = null;
+  /** When true, markFlushed reports failure without recording the entry. */
+  markFlushedFails = false;
 
   save(entry: TelemetryEntry): Promise<void> {
     this.savedEntries.push(entry);
@@ -65,9 +69,20 @@ class MockTelemetryRepository implements TelemetryRepository {
     return Promise.resolve(this.mockUnflushedEntries);
   }
 
-  markFlushed(entry: TelemetryEntry, _keepFlushed?: boolean): Promise<void> {
+  markFlushed(entry: TelemetryEntry, _keepFlushed?: boolean): Promise<boolean> {
+    if (this.markFlushedFails) return Promise.resolve(false);
     this.flushedEntries.push(entry);
+    return Promise.resolve(true);
+  }
+
+  quarantine(entry: TelemetryEntry): Promise<void> {
+    this.quarantinedEntries.push(entry);
     return Promise.resolve();
+  }
+
+  deleteQuarantinedOlderThan(date: Date): Promise<number> {
+    this.deletedQuarantinedBefore = date;
+    return Promise.resolve(2);
   }
 }
 
@@ -286,7 +301,7 @@ Deno.test("TelemetryService.flushTelemetry sends unflushed entries and marks the
     distinctId: "repo-uuid",
   });
 
-  assertEquals(result.ok, true);
+  assertEquals(result.result.ok, true);
   assertEquals(sender.sentBatches.length, 1);
   assertEquals(sender.sentBatches[0].entries.length, 2);
   assertEquals(sender.sentBatches[0].distinctId, "repo-uuid");
@@ -310,8 +325,8 @@ Deno.test("TelemetryService.flushTelemetry propagates failure reason from sender
     distinctId: "repo-uuid",
   });
 
-  assertEquals(result.ok, false);
-  assertEquals(result.reason, "HTTP 401");
+  assertEquals(result.result.ok, false);
+  assertEquals(result.result.reason, "HTTP 401");
   assertEquals(sender.sentBatches.length, 1);
   assertEquals(repo.flushedEntries.length, 0);
 });
@@ -328,7 +343,7 @@ Deno.test("TelemetryService.flushTelemetry returns ok when no unflushed entries"
     distinctId: "repo-uuid",
   });
 
-  assertEquals(result.ok, true);
+  assertEquals(result.result.ok, true);
   assertEquals(sender.sentBatches.length, 0);
   assertEquals(repo.flushedEntries.length, 0);
 });
@@ -569,4 +584,227 @@ Deno.test("TelemetryService.recordChildInvocation supports zero-duration entries
   assertEquals(repo.savedEntries[0].durationMs, 0);
   assertEquals(repo.savedEntries[0].result.status, "error");
   assertEquals(repo.savedEntries[0].workflowContext?.modelType, undefined);
+});
+
+Deno.test("TelemetryService stamps triggerSource on every record path", async () => {
+  const repo = new MockTelemetryRepository();
+  const service = new TelemetryService(
+    repo,
+    "1.0.0",
+    undefined,
+    undefined,
+    "schedule",
+  );
+  const invocation = {
+    command: "workflow",
+    subcommand: "run",
+    args: [],
+    optionKeys: [],
+    globalOptions: [],
+  };
+
+  await service.recordSuccess(invocation, new Date());
+  await service.recordError(invocation, new Date(), new Error("boom"));
+  await service.recordChildInvocation(
+    invocation,
+    new Date(),
+    new Date(),
+    null,
+    "parent-id",
+    { workflowName: "etl", runId: "r", jobName: "j", stepName: "s" },
+  );
+
+  assertEquals(repo.savedEntries.length, 3);
+  for (const entry of repo.savedEntries) {
+    assertEquals(entry.triggerSource, "schedule");
+  }
+});
+
+Deno.test("TelemetryService omits triggerSource when none is configured", async () => {
+  // The interactive CLI path must keep emitting exactly what it always has.
+  const repo = new MockTelemetryRepository();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  await service.recordSuccess(
+    {
+      command: "model",
+      subcommand: "create",
+      args: [],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    new Date(),
+  );
+
+  assertEquals(repo.savedEntries[0].triggerSource, undefined);
+});
+
+Deno.test("TelemetryService.forkForRun returns a distinct identity over the same repository", async () => {
+  const repo = new MockTelemetryRepository();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  const fork = service.forkForRun("webhook");
+
+  // A daemon's unit of invocation is a run, not a process, so each run needs
+  // its own id to parent its children to.
+  assertEquals(fork.invocationId === service.invocationId, false);
+
+  await fork.recordSuccess(
+    {
+      command: "workflow",
+      subcommand: "run",
+      args: ["<REDACTED>"],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    new Date(),
+  );
+
+  // Same spool as the parent service.
+  assertEquals(repo.savedEntries.length, 1);
+  assertEquals(repo.savedEntries[0].id, fork.invocationId);
+  assertEquals(repo.savedEntries[0].triggerSource, "webhook");
+});
+
+Deno.test("TelemetryService.pruneFlushedTelemetry never deletes unflushed entries", async () => {
+  // The executable form of the daemon retention decision. cleanupOldTelemetry
+  // also applies the hard cap, which deletes UNFLUSHED entries — safe for a
+  // CLI that will run again shortly, destructive for a daemon that has been
+  // unable to reach the endpoint for a week. If the daemon is ever rerouted
+  // through cleanupOldTelemetry, this test fails.
+  const repo = new MockTelemetryRepository();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  await service.pruneFlushedTelemetry();
+
+  assertExists(repo.deletedBefore);
+  assertExists(repo.deletedQuarantinedBefore);
+  assertEquals(repo.deleteAllBefore, null);
+});
+
+Deno.test("TelemetryService.cleanupOldTelemetry still applies the hard cap", async () => {
+  // The CLI path is unchanged: a short-lived process may still drop entries
+  // it has been unable to deliver for a week.
+  const repo = new MockTelemetryRepository();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  await service.cleanupOldTelemetry();
+
+  assertExists(repo.deletedBefore);
+  assertExists(repo.deleteAllBefore);
+});
+
+Deno.test("TelemetryService.flushTelemetry serializes concurrent flushes", async () => {
+  // Regression test for the shutdown double-send: serve's daemon flush loop
+  // and the CLI teardown flush both target this same service. If they can
+  // both read the unflushed batch before either marks it, every entry in it
+  // is sent twice. The guard has to live on the service, because neither
+  // caller can see the other's state.
+  const repo = new MockTelemetryRepository();
+  const sender = new MockTelemetrySender();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  const entry = TelemetryEntry.create({
+    invocation: {
+      command: "workflow",
+      subcommand: "run",
+      args: [],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: { status: "success", exitCode: 0 },
+    startedAt: new Date(),
+    completedAt: new Date(),
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+  });
+  repo.mockUnflushedEntries = [entry];
+
+  // findUnflushed reflects what markFlushed has removed, so a serialized
+  // second flush observes an empty spool.
+  const originalMarkFlushed = repo.markFlushed.bind(repo);
+  repo.markFlushed = (e: TelemetryEntry, keep?: boolean) => {
+    repo.mockUnflushedEntries = repo.mockUnflushedEntries.filter(
+      (candidate) => candidate.id !== e.id,
+    );
+    return originalMarkFlushed(e, keep);
+  };
+
+  const config = { sender, distinctId: "user-1" };
+  const [first, second] = await Promise.all([
+    service.flushTelemetry(config),
+    service.flushTelemetry(config),
+  ]);
+
+  assertEquals(sender.sentBatches.length, 1);
+  assertEquals(first.sentCount, 1);
+  assertEquals(second.sentCount, 0);
+});
+
+Deno.test("TelemetryService.flushTelemetry reports entries it could not mark", async () => {
+  // markFlushed failing leaves the entry on disk, so findUnflushed returns it
+  // again. A caller that flushes on a timer must know, or it re-sends the
+  // same invocation once per tick forever.
+  const repo = new MockTelemetryRepository();
+  const sender = new MockTelemetrySender();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  const entry = TelemetryEntry.create({
+    invocation: {
+      command: "workflow",
+      subcommand: "run",
+      args: [],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: { status: "success", exitCode: 0 },
+    startedAt: new Date(),
+    completedAt: new Date(),
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+  });
+  repo.mockUnflushedEntries = [entry];
+  repo.markFlushedFails = true;
+
+  const outcome = await service.flushTelemetry({
+    sender,
+    distinctId: "user-1",
+  });
+
+  assertEquals(outcome.result.ok, true);
+  assertEquals(outcome.unmarkedIds, [entry.id]);
+});
+
+Deno.test("TelemetryService.flushTelemetry skips ids the caller already delivered", async () => {
+  const repo = new MockTelemetryRepository();
+  const sender = new MockTelemetrySender();
+  const service = new TelemetryService(repo, "1.0.0");
+
+  const entry = TelemetryEntry.create({
+    invocation: {
+      command: "workflow",
+      subcommand: "run",
+      args: [],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: { status: "success", exitCode: 0 },
+    startedAt: new Date(),
+    completedAt: new Date(),
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+  });
+  repo.mockUnflushedEntries = [entry];
+
+  const outcome = await service.flushTelemetry({
+    sender,
+    distinctId: "user-1",
+    skipIds: new Set([entry.id]),
+  });
+
+  assertEquals(sender.sentBatches.length, 0);
+  assertEquals(outcome.sentCount, 0);
 });

--- a/src/domain/telemetry/trigger_source.ts
+++ b/src/domain/telemetry/trigger_source.ts
@@ -1,0 +1,53 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * What caused an invocation, when it was not a human at a terminal.
+ *
+ * Set only on invocations a long-lived `swamp serve` produced on its own:
+ * a cron-fired workflow, a verified inbound webhook, or an API/WebSocket
+ * request. Interactive CLI runs leave it `undefined`, which keeps the
+ * emitted event byte-identical to what the CLI has always sent.
+ *
+ * Deliberately NOT named `source`. The telemetry backend already derives a
+ * field by that name from the recorded command, and overloading it here
+ * would collide two independently-owned concerns in one key.
+ */
+export type WorkflowTriggerSource = "schedule" | "webhook" | "api";
+
+/** Every valid trigger source, for validation and exhaustive iteration. */
+export const WORKFLOW_TRIGGER_SOURCES: readonly WorkflowTriggerSource[] = [
+  "schedule",
+  "webhook",
+  "api",
+];
+
+/**
+ * Narrows an arbitrary value to a WorkflowTriggerSource.
+ *
+ * Used when decoding persisted entries: a spool file is on disk and can be
+ * hand-edited or written by a newer version, so the value is not trusted to
+ * be one of the known variants.
+ */
+export function isWorkflowTriggerSource(
+  value: unknown,
+): value is WorkflowTriggerSource {
+  return typeof value === "string" &&
+    (WORKFLOW_TRIGGER_SOURCES as readonly string[]).includes(value);
+}

--- a/src/domain/telemetry/trigger_source_test.ts
+++ b/src/domain/telemetry/trigger_source_test.ts
@@ -1,0 +1,42 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  isWorkflowTriggerSource,
+  WORKFLOW_TRIGGER_SOURCES,
+} from "./trigger_source.ts";
+
+Deno.test("isWorkflowTriggerSource: accepts every declared source", () => {
+  for (const source of WORKFLOW_TRIGGER_SOURCES) {
+    assertEquals(isWorkflowTriggerSource(source), true);
+  }
+});
+
+Deno.test("isWorkflowTriggerSource: rejects unknown and non-string values", () => {
+  // Spool files live on disk and may be hand-edited or written by a newer
+  // version, so decoding must not trust the value.
+  assertEquals(isWorkflowTriggerSource("interactive"), false);
+  assertEquals(isWorkflowTriggerSource("Schedule"), false);
+  assertEquals(isWorkflowTriggerSource(""), false);
+  assertEquals(isWorkflowTriggerSource(undefined), false);
+  assertEquals(isWorkflowTriggerSource(null), false);
+  assertEquals(isWorkflowTriggerSource(42), false);
+  assertEquals(isWorkflowTriggerSource({ triggerSource: "schedule" }), false);
+});

--- a/src/infrastructure/persistence/json_telemetry_repository.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository.ts
@@ -54,9 +54,7 @@ export class JsonTelemetryRepository implements TelemetryRepository {
       await assertSafePath(telemetryDir, this.baseDir);
       await ensureDir(telemetryDir);
 
-      const date = entry.startedAt.toISOString().split("T")[0];
-      const filename = `telemetry-${date}-${entry.id}.json`;
-      const path = join(telemetryDir, filename);
+      const path = join(telemetryDir, this.entryFilename(entry));
 
       const json = JSON.stringify(entry.toData(), null, 2);
       await atomicWriteTextFile(path, json);
@@ -214,7 +212,8 @@ export class JsonTelemetryRepository implements TelemetryRepository {
           dirEntry.isFile &&
           dirEntry.name.startsWith("telemetry-") &&
           dirEntry.name.endsWith(".json") &&
-          !dirEntry.name.endsWith(".flushed.json")
+          !dirEntry.name.endsWith(".flushed.json") &&
+          !dirEntry.name.endsWith(".quarantined.json")
         ) {
           filenames.push(dirEntry.name);
         }
@@ -250,27 +249,105 @@ export class JsonTelemetryRepository implements TelemetryRepository {
   /**
    * Marks a telemetry entry as flushed.
    * By default, deletes the file. If keepFlushed is true, renames to .flushed.json.
+   *
+   * Returns false when the delete or rename fails (a Windows file lock, a
+   * read-only spool, an interrupted rename). The entry then stays on disk and
+   * `findUnflushed` will return it again, so a repeatedly-flushing caller must
+   * use this result to avoid re-sending an entry the endpoint already accepted.
    */
   async markFlushed(
     entry: TelemetryEntry,
     keepFlushed?: boolean,
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       const telemetryDir = this.getTelemetryDir();
-      const date = entry.startedAt.toISOString().split("T")[0];
-      const filename = `telemetry-${date}-${entry.id}.json`;
-      const filePath = join(telemetryDir, filename);
+      const filePath = join(telemetryDir, this.entryFilename(entry));
 
       if (keepFlushed) {
-        const flushedFilename = `telemetry-${date}-${entry.id}.flushed.json`;
-        const flushedPath = join(telemetryDir, flushedFilename);
+        const flushedPath = join(
+          telemetryDir,
+          this.entryFilename(entry, ".flushed.json"),
+        );
         await Deno.rename(filePath, flushedPath);
       } else {
         await Deno.remove(filePath);
       }
+      return true;
     } catch {
-      // Silent failure
+      return false;
     }
+  }
+
+  /**
+   * Sets an entry aside as undeliverable by renaming it to
+   * `.quarantined.json`, which `findUnflushed` skips.
+   *
+   * The file is kept rather than deleted so a rejected entry can still be
+   * inspected — the reason an endpoint refuses a payload is usually only
+   * visible in the payload itself.
+   */
+  async quarantine(entry: TelemetryEntry): Promise<void> {
+    try {
+      const telemetryDir = this.getTelemetryDir();
+      await Deno.rename(
+        join(telemetryDir, this.entryFilename(entry)),
+        join(telemetryDir, this.entryFilename(entry, ".quarantined.json")),
+      );
+    } catch {
+      // Silent failure - quarantining is best-effort. A failure leaves the
+      // entry unflushed, which the caller's own retry accounting handles.
+    }
+  }
+
+  /**
+   * Deletes quarantined entries older than the given date.
+   */
+  async deleteQuarantinedOlderThan(date: Date): Promise<number> {
+    let deletedCount = 0;
+    const cutoffDateStr = date.toISOString().split("T")[0];
+
+    try {
+      const telemetryDir = this.getTelemetryDir();
+
+      for await (const entry of Deno.readDir(telemetryDir)) {
+        if (
+          !entry.isFile ||
+          !entry.name.startsWith("telemetry-") ||
+          !entry.name.endsWith(".quarantined.json")
+        ) {
+          continue;
+        }
+
+        const entryDateStr = entry.name.slice(
+          "telemetry-".length,
+          "telemetry-".length + 10,
+        );
+        if (entryDateStr >= cutoffDateStr) continue;
+
+        try {
+          await Deno.remove(join(telemetryDir, entry.name));
+          deletedCount++;
+        } catch {
+          // Skip files that can't be removed
+        }
+      }
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+
+    return deletedCount;
+  }
+
+  /**
+   * Filename for an entry's spool file. The `telemetry-YYYY-MM-DD-` prefix
+   * makes filenames chronologically sortable, which is what lets
+   * `findUnflushed` order by name instead of parsing every file.
+   */
+  private entryFilename(entry: TelemetryEntry, suffix = ".json"): string {
+    const date = entry.startedAt.toISOString().split("T")[0];
+    return `telemetry-${date}-${entry.id}${suffix}`;
   }
 
   private getTelemetryDir(): string {

--- a/src/infrastructure/persistence/json_telemetry_repository_test.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository_test.ts
@@ -454,6 +454,103 @@ Deno.test("JsonTelemetryRepository.markFlushed does not throw on non-existent fi
   });
 });
 
+Deno.test("JsonTelemetryRepository.markFlushed reports success and failure", async () => {
+  // A caller that flushes on a timer re-reads whatever is still on disk, so a
+  // silent mark failure becomes a duplicate event every interval.
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+    const entry = createTestEntry({
+      id: "mark-uuid",
+      date: new Date("2024-03-10T10:00:00Z"),
+    });
+    await repo.save(entry);
+
+    assertEquals(await repo.markFlushed(entry), true);
+    // Already gone — the second attempt cannot mark anything.
+    assertEquals(await repo.markFlushed(entry), false);
+  });
+});
+
+Deno.test("JsonTelemetryRepository.quarantine excludes an entry from findUnflushed", async () => {
+  // The escape hatch for a batch the endpoint always rejects. Without the
+  // exclusion the entry is read again forever and nothing behind it ships.
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+    const poison = createTestEntry({
+      id: "poison-uuid",
+      date: new Date("2024-03-10T10:00:00Z"),
+    });
+    const healthy = createTestEntry({
+      id: "healthy-uuid",
+      date: new Date("2024-03-11T10:00:00Z"),
+    });
+    await repo.save(poison);
+    await repo.save(healthy);
+
+    await repo.quarantine(poison);
+
+    const unflushed = await repo.findUnflushed(10);
+    assertEquals(unflushed.length, 1);
+    assertEquals(unflushed[0].id, "healthy-uuid");
+
+    // Kept on disk, not deleted: the reason an endpoint refuses a payload is
+    // usually only visible in the payload.
+    const telemetryDir = join(dir, ".swamp", "telemetry");
+    const files: string[] = [];
+    for await (const f of Deno.readDir(telemetryDir)) files.push(f.name);
+    assertEquals(
+      files.includes("telemetry-2024-03-10-poison-uuid.quarantined.json"),
+      true,
+    );
+  });
+});
+
+Deno.test("JsonTelemetryRepository.deleteQuarantinedOlderThan removes only aged quarantined entries", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+    const old = createTestEntry({
+      id: "old-uuid",
+      date: new Date("2024-01-01T10:00:00Z"),
+    });
+    const recent = createTestEntry({
+      id: "recent-uuid",
+      date: new Date("2024-03-10T10:00:00Z"),
+    });
+    const unflushed = createTestEntry({
+      id: "unflushed-uuid",
+      date: new Date("2024-01-01T10:00:00Z"),
+    });
+    await repo.save(old);
+    await repo.save(recent);
+    await repo.save(unflushed);
+    await repo.quarantine(old);
+    await repo.quarantine(recent);
+
+    const deleted = await repo.deleteQuarantinedOlderThan(
+      new Date("2024-02-01T00:00:00Z"),
+    );
+
+    assertEquals(deleted, 1);
+    const telemetryDir = join(dir, ".swamp", "telemetry");
+    const files: string[] = [];
+    for await (const f of Deno.readDir(telemetryDir)) files.push(f.name);
+    // The aged quarantined entry is gone; the recent one and the untouched
+    // unflushed entry both survive.
+    assertEquals(
+      files.includes("telemetry-2024-01-01-old-uuid.quarantined.json"),
+      false,
+    );
+    assertEquals(
+      files.includes("telemetry-2024-03-10-recent-uuid.quarantined.json"),
+      true,
+    );
+    assertEquals(
+      files.includes("telemetry-2024-01-01-unflushed-uuid.json"),
+      true,
+    );
+  });
+});
+
 Deno.test("JsonTelemetryRepository.deleteOlderThan preserves unflushed entries while removing flushed", async () => {
   await withTempDir(async (dir) => {
     const repo = new JsonTelemetryRepository(dir);

--- a/src/infrastructure/telemetry/http_telemetry_sender.ts
+++ b/src/infrastructure/telemetry/http_telemetry_sender.ts
@@ -45,9 +45,17 @@ export class HttpTelemetrySender implements TelemetrySender {
     authToken?: string,
     signal?: AbortSignal,
   ): Promise<TelemetryFlushResult> {
+    // `insert_id` is the ingest queue's idempotency key: it carries a unique
+    // index, so a re-POST of an entry that was already accepted (a retry after
+    // a lost 202, or a flush that raced another flusher) is deduplicated
+    // instead of becoming a second queue doc. Without it the server generates
+    // one per POST and the same invocation is counted twice in the downstream
+    // rollups. The entry id is already a stable per-invocation UUID, which is
+    // exactly the key we want.
     const events = entries.map((entry) => ({
       event: "cli_invocation",
       distinct_id: distinctId,
+      insert_id: entry.id,
       properties: {
         ...entry.toData(),
         ...(repoId ? { $repo_id: repoId } : {}),

--- a/src/infrastructure/telemetry/http_telemetry_sender_test.ts
+++ b/src/infrastructure/telemetry/http_telemetry_sender_test.ts
@@ -96,6 +96,56 @@ Deno.test("HttpTelemetrySender.sendBatch sends batch format for multiple entries
   await server.shutdown();
 });
 
+Deno.test("HttpTelemetrySender.sendBatch sends insert_id on both body shapes", async () => {
+  // insert_id is the ingest queue's idempotency key. Without it the server
+  // generates one per POST, so a retry of an already-accepted event becomes a
+  // second event and the invocation is counted twice downstream.
+  let capturedBody: string | undefined;
+
+  const server = Deno.serve({ port: 0 }, async (req: Request) => {
+    capturedBody = await req.text();
+    return new Response(JSON.stringify({ accepted: 1 }), { status: 202 });
+  });
+
+  const port = server.addr.port;
+  const sender = new HttpTelemetrySender(`http://localhost:${port}`);
+  const entry1 = createTestEntry("uuid-1", new Date("2024-03-10T10:00:00Z"));
+  const entry2 = createTestEntry("uuid-2", new Date("2024-03-10T11:00:00Z"));
+
+  await sender.sendBatch([entry1], "repo-uuid");
+  const single = JSON.parse(capturedBody!);
+  assertEquals(single.insert_id, "uuid-1");
+
+  await sender.sendBatch([entry1, entry2], "repo-uuid");
+  const batched = JSON.parse(capturedBody!);
+  assertEquals(batched.events[0].insert_id, "uuid-1");
+  assertEquals(batched.events[1].insert_id, "uuid-2");
+
+  await server.shutdown();
+});
+
+Deno.test("HttpTelemetrySender.sendBatch reuses the same insert_id when an entry is re-sent", async () => {
+  // The key must be stable across attempts, or the dedup it exists for cannot
+  // fire on the retry it is meant to catch.
+  const seen: string[] = [];
+
+  const server = Deno.serve({ port: 0 }, async (req: Request) => {
+    seen.push(JSON.parse(await req.text()).insert_id);
+    return new Response(JSON.stringify({ accepted: 1 }), { status: 202 });
+  });
+
+  const port = server.addr.port;
+  const sender = new HttpTelemetrySender(`http://localhost:${port}`);
+  const entry = createTestEntry("uuid-1", new Date("2024-03-10T10:00:00Z"));
+
+  await sender.sendBatch([entry], "repo-uuid");
+  await sender.sendBatch([entry], "repo-uuid");
+
+  assertEquals(seen, ["uuid-1", "uuid-1"]);
+
+  await server.shutdown();
+});
+
 Deno.test("HttpTelemetrySender.sendBatch returns reason on non-202 status", async () => {
   const server = Deno.serve({ port: 0 }, () => {
     return new Response(JSON.stringify({ error: "bad request" }), {

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -30,7 +30,10 @@ import type {
   WorkflowRunDeps,
   WorkflowRunEvent,
   WorkflowRunInput,
+  WorkflowTelemetrySink,
 } from "../libswamp/mod.ts";
+import type { WorkflowTriggerSource } from "../domain/telemetry/mod.ts";
+import { createRunTelemetry, type RunTelemetry } from "./telemetry.ts";
 import { createLibSwampContext, workflowRun } from "../libswamp/mod.ts";
 import {
   type DirectTypeResolver,
@@ -53,7 +56,10 @@ import { DefaultMethodExecutionService } from "../domain/models/method_execution
 import { VaultService } from "../domain/vaults/vault_service.ts";
 import { ExpressionEvaluationService } from "../domain/expressions/expression_evaluation_service.ts";
 import { DataQueryService } from "../domain/data/data_query_service.ts";
-import { runFileSink } from "../infrastructure/logging/logger.ts";
+import {
+  getSwampLogger,
+  runFileSink,
+} from "../infrastructure/logging/logger.ts";
 import {
   SWAMP_SUBDIRS,
   swampPath,
@@ -71,12 +77,22 @@ import {
   runWithParentTrace,
 } from "../infrastructure/tracing/mod.ts";
 
+const logger = getSwampLogger(["serve", "deps"]);
+
 export async function createWorkflowRunDeps(
   repoDir: string,
   repoContext: RepositoryContext,
   datastoreConfig: DatastoreConfig,
   stepLockHook?: StepLockHook,
   runTracker?: RunTrackerRepository,
+  options?: {
+    /**
+     * Records per-method telemetry for this run. Left undefined by callers
+     * that are not a serve-executed run (and by every caller when telemetry
+     * is disabled), in which case libswamp's bridge is never constructed.
+     */
+    telemetrySink?: WorkflowTelemetrySink;
+  },
 ): Promise<WorkflowRunDeps> {
   await Promise.all([
     modelRegistry.ensureLoaded(),
@@ -178,6 +194,7 @@ export async function createWorkflowRunDeps(
     catalogStore: repoContext.catalogStore,
     dataRepo: repoContext.unifiedDataRepo,
     definitionRepo: repoContext.definitionRepo,
+    telemetrySink: options?.telemetrySink,
   };
 }
 
@@ -299,6 +316,15 @@ export async function executeWorkflowWithLocks(
   onEvent: (event: WorkflowRunEvent) => void,
   syncService?: DatastoreSyncService,
   runTracker?: RunTrackerRepository,
+  options?: {
+    /**
+     * What caused this run. Supplied by serve's trigger sites (scheduled,
+     * webhook, API) so the run is recorded and distinguishable from
+     * interactive use. Omitted by library and test callers, which then
+     * produce no telemetry — the pre-existing behaviour.
+     */
+    triggerSource?: WorkflowTriggerSource;
+  },
 ): Promise<void> {
   // Pre-lookup workflow for trigger.inputs resolution
   const workflowRepo = repoContext.workflowRepo;
@@ -320,12 +346,20 @@ export async function executeWorkflowWithLocks(
     return result;
   };
 
+  // Undefined when no trigger source was supplied (library/test callers) or
+  // when telemetry is disabled for this process, in which case the run
+  // produces no telemetry at all — exactly as before this was wired.
+  const runTelemetry = options?.triggerSource
+    ? createRunTelemetry(options.triggerSource)
+    : undefined;
+
   const deps = await createWorkflowRunDeps(
     repoDir,
     repoContext,
     datastoreConfig,
     stepLockHook,
     runTracker,
+    { telemetrySink: runTelemetry?.sink },
   );
   const libCtx = createLibSwampContext({ signal });
 
@@ -359,20 +393,78 @@ export async function executeWorkflowWithLocks(
     }
     : input;
 
+  // A workflow run reports failure through the event stream, not by
+  // throwing: input validation, a failed step, and a cancellation all
+  // complete normally from the caller's point of view. Recording those as
+  // successes would credit work that did not happen, so the outcome is read
+  // from the stream rather than from control flow.
+  let streamError: string | undefined;
+  let finalStatus: string | undefined;
   const run = async () => {
     for await (const event of workflowRun(libCtx, deps, effectiveInput)) {
+      if (event.kind === "error") streamError = event.error.message;
+      if (event.kind === "completed" || event.kind === "cancelled") {
+        finalStatus = event.run.status;
+      }
       onEvent(event);
     }
   };
 
-  if (input.traceparent) {
-    const headers: Record<string, string> = {
-      traceparent: input.traceparent,
-    };
-    if (input.tracestate) headers.tracestate = input.tracestate;
-    const traceCtx = extractTraceContext(headers);
-    await runWithParentTrace(traceCtx, run);
-  } else {
-    await run();
+  const runTraced = async () => {
+    if (input.traceparent) {
+      const headers: Record<string, string> = {
+        traceparent: input.traceparent,
+      };
+      if (input.tracestate) headers.tracestate = input.tracestate;
+      const traceCtx = extractTraceContext(headers);
+      await runWithParentTrace(traceCtx, run);
+    } else {
+      await run();
+    }
+  };
+
+  if (!runTelemetry) {
+    await runTraced();
+    return;
+  }
+
+  // Record the run's own parent entry however it ends. Telemetry must never
+  // be able to fail a workflow run, so `finish` is isolated from the run's
+  // own error and the original error always propagates.
+  try {
+    await runTraced();
+  } catch (error) {
+    await finishRunTelemetry(
+      runTelemetry,
+      error instanceof Error ? error : new Error(String(error)),
+    );
+    throw error;
+  }
+
+  const failure = finalStatus === "succeeded" ? null : new Error(
+    streamError ?? `workflow run ${finalStatus ?? "did not complete"}`,
+  );
+  await finishRunTelemetry(runTelemetry, failure);
+}
+
+/**
+ * Closes out a run's telemetry without letting a telemetry failure surface
+ * as a workflow failure.
+ */
+async function finishRunTelemetry(
+  runTelemetry: RunTelemetry,
+  error: Error | null,
+): Promise<void> {
+  try {
+    await runTelemetry.finish(error);
+  } catch (telemetryError) {
+    logger.warn(
+      "Failed to record workflow run telemetry: {error}",
+      {
+        error: telemetryError instanceof Error
+          ? telemetryError.message
+          : String(telemetryError),
+      },
+    );
   }
 }

--- a/src/serve/deps_test.ts
+++ b/src/serve/deps_test.ts
@@ -1,0 +1,81 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { createWorkflowRunDeps } from "./deps.ts";
+import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
+import type { DatastoreConfig } from "../domain/datastore/datastore_config.ts";
+import type { WorkflowTelemetrySink } from "../libswamp/mod.ts";
+import { initializeLogging } from "../infrastructure/logging/logger.ts";
+
+// CLI-adjacent code needs logging initialized and the models barrel imported
+// before it can run.
+import "../domain/models/models.ts";
+
+await initializeLogging({});
+
+/**
+ * `createWorkflowRunDeps` only reads a handful of fields off the context to
+ * assemble the deps object, so a partial stub is enough to observe how the
+ * telemetry sink is threaded through.
+ */
+function stubRepoContext(): RepositoryContext {
+  return {
+    workflowRepo: {},
+    workflowRunRepo: {},
+    catalogStore: {},
+    unifiedDataRepo: { namespace: "test" },
+    definitionRepo: {},
+    autoDefinitionsDir: "/tmp/auto-definitions",
+    markDirty: () => {},
+    eventBus: {},
+  } as unknown as RepositoryContext;
+}
+
+const datastoreConfig = { type: "filesystem" } as unknown as DatastoreConfig;
+
+Deno.test("createWorkflowRunDeps: sets telemetrySink when one is supplied", async () => {
+  const sink: WorkflowTelemetrySink = {
+    parentInvocationId: "parent-1",
+    recordChildInvocation: () => Promise.resolve(),
+  };
+
+  const deps = await createWorkflowRunDeps(
+    "/tmp/repo",
+    stubRepoContext(),
+    datastoreConfig,
+    undefined,
+    undefined,
+    { telemetrySink: sink },
+  );
+
+  assertEquals(deps.telemetrySink, sink);
+});
+
+Deno.test("createWorkflowRunDeps: leaves telemetrySink undefined by default", async () => {
+  // Callers that are not a serve-executed run must stay a no-op — libswamp
+  // only constructs its telemetry bridge when the sink is present.
+  const deps = await createWorkflowRunDeps(
+    "/tmp/repo",
+    stubRepoContext(),
+    datastoreConfig,
+  );
+
+  assertEquals(deps.telemetrySink, undefined);
+});

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -189,6 +189,7 @@ export async function handleWorkflowRun(
         },
         ctx.syncService,
         ctx.runTracker,
+        { triggerSource: "api" },
       );
       send(socket, { type: "done", id: requestId });
     } catch (error) {
@@ -298,6 +299,7 @@ export async function handleWorkflowRun(
         },
         ctx.syncService,
         ctx.runTracker,
+        { triggerSource: "api" },
       );
       buffer.finish({ kind: "done" });
     } catch (error) {

--- a/src/serve/telemetry.ts
+++ b/src/serve/telemetry.ts
@@ -1,0 +1,111 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Telemetry for workflow runs that `swamp serve` executes on its own —
+ * scheduled fires, verified webhooks, and API/WebSocket requests.
+ *
+ * The interactive `swamp workflow run` command binds the active
+ * TelemetryService as a sink so each method invocation inside the run is
+ * recorded (see cli/commands/workflow_run.ts). Serve never did, so every
+ * run it executed was invisible: no parent entry, no child entries, nothing
+ * to flush. This is the serve-side counterpart of that binding.
+ */
+
+import type { WorkflowTelemetrySink } from "../libswamp/mod.ts";
+import type {
+  CommandInvocationData,
+  WorkflowTriggerSource,
+} from "../domain/telemetry/mod.ts";
+import { getActiveTelemetryService } from "../cli/telemetry_integration.ts";
+
+/**
+ * Telemetry scoped to a single serve-executed workflow run.
+ */
+export interface RunTelemetry {
+  /** Passed to libswamp so per-method child invocations are recorded. */
+  readonly sink: WorkflowTelemetrySink;
+  /**
+   * Records the run's own parent entry. Call exactly once, when the run
+   * settles.
+   *
+   * @param error - The error that ended the run, or null if it succeeded
+   */
+  finish(error: Error | null): Promise<void>;
+}
+
+/**
+ * The parent entry for a serve-executed run, shaped like the interactive
+ * `swamp workflow run` invocation it stands in for.
+ *
+ * The workflow name is redacted, matching the default sensitivity the CLI
+ * applies to positional arguments — serve-side entries are generated with no
+ * human present, so redaction cannot be reviewed at authoring time and the
+ * conservative default is the right one. The name still reaches telemetry via
+ * the child entries' `workflowContext`, exactly as it does for interactive
+ * runs.
+ */
+function buildRunInvocation(): CommandInvocationData {
+  return {
+    command: "workflow",
+    subcommand: "run",
+    args: ["<REDACTED>"],
+    optionKeys: [],
+    globalOptions: [],
+  };
+}
+
+/**
+ * Creates telemetry for one serve-executed workflow run, or `undefined` when
+ * telemetry is disabled for this process — `--no-telemetry`, the repo
+ * marker's `telemetryDisabled`, the user-level opt-out, or an initialization
+ * failure all leave no active service, and serve must then stay exactly as
+ * silent as it was before.
+ *
+ * Each run gets its own forked service so it can parent its child method
+ * invocations to a per-run identity. Hanging them off the daemon's own
+ * process invocation instead would leave every child pointing at an entry
+ * that is not written until serve exits — possibly weeks later.
+ *
+ * @param triggerSource - What caused this run (schedule, webhook, or api)
+ * @param startedAt - When the run began; defaults to now
+ */
+export function createRunTelemetry(
+  triggerSource: WorkflowTriggerSource,
+  startedAt: Date = new Date(),
+): RunTelemetry | undefined {
+  const service = getActiveTelemetryService();
+  if (!service) return undefined;
+
+  const runService = service.forkForRun(triggerSource);
+
+  return {
+    sink: {
+      parentInvocationId: runService.invocationId,
+      recordChildInvocation: runService.recordChildInvocation.bind(runService),
+    },
+    finish: async (error: Error | null): Promise<void> => {
+      if (error) {
+        await runService.recordError(buildRunInvocation(), startedAt, error);
+      } else {
+        await runService.recordSuccess(buildRunInvocation(), startedAt);
+      }
+    },
+  };
+}

--- a/src/serve/telemetry_flush.ts
+++ b/src/serve/telemetry_flush.ts
@@ -1,0 +1,254 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Periodic telemetry flushing for `swamp serve`.
+ *
+ * The CLI records and flushes in its teardown, after `cli.parse` returns.
+ * For a daemon that instant is process exit, so a `swamp serve` that runs
+ * for weeks never flushes anything it spooled. This service gives the daemon
+ * its own flush cadence, modelled on InstanceHeartbeatService.
+ */
+
+import type {
+  TelemetryFlushOutcome,
+  TelemetryService,
+} from "../domain/telemetry/telemetry_service.ts";
+import type { TelemetrySender } from "../domain/telemetry/telemetry_sender.ts";
+import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+
+const logger = getSwampLogger(["serve", "telemetry"]);
+
+/** How often the daemon attempts a flush. */
+export const DEFAULT_TELEMETRY_FLUSH_INTERVAL_MS = 60_000;
+
+/**
+ * Maximum batches sent per tick. `flushTelemetry` sends at most one batch per
+ * call, so draining a backlog needs several — but not without bound, or a
+ * large spool would hold the tick open indefinitely.
+ */
+const MAX_BATCHES_PER_TICK = 20;
+
+/** Ticks between prunes of already-flushed entries (~1 hour at the default). */
+const PRUNE_EVERY_N_TICKS = 60;
+
+/**
+ * Consecutive failures of the same batch before its entries are retried
+ * individually to find the one the endpoint refuses. High enough that an
+ * ordinary outage — a laptop asleep, an endpoint restart — never triggers
+ * isolation.
+ */
+const FAILURES_BEFORE_ISOLATION = 5;
+
+/**
+ * Individual send failures before an entry is quarantined. Applied only
+ * after isolation has already proven the batch is stuck.
+ */
+const FAILURES_BEFORE_QUARANTINE = 3;
+
+/** Timeout for a single flush attempt. */
+const FLUSH_TIMEOUT_MS = 10_000;
+
+export interface TelemetryFlushCredentials {
+  sender: TelemetrySender;
+  distinctId: string;
+  repoId?: string;
+  authToken?: string;
+  keepFlushed: boolean;
+}
+
+/**
+ * Flushes the telemetry spool on a timer for the lifetime of a daemon.
+ */
+export class DaemonTelemetryFlushService {
+  readonly #service: TelemetryService;
+  readonly #credentials: TelemetryFlushCredentials;
+  readonly #intervalMs: number;
+  #timer: ReturnType<typeof setInterval> | null = null;
+  #running = false;
+  #stopped = false;
+  #tickCount = 0;
+  #consecutiveFailures = 0;
+  /**
+   * Entries the endpoint accepted but that could not be removed from the
+   * spool. `findUnflushed` keeps returning them, so without this they would
+   * be re-sent on every tick — a duplicate event every interval, forever.
+   */
+  readonly #sentButUnmarked = new Set<string>();
+
+  constructor(
+    service: TelemetryService,
+    credentials: TelemetryFlushCredentials,
+    options?: { intervalMs?: number },
+  ) {
+    this.#service = service;
+    this.#credentials = credentials;
+    this.#intervalMs = options?.intervalMs ??
+      DEFAULT_TELEMETRY_FLUSH_INTERVAL_MS;
+  }
+
+  /**
+   * Starts the flush loop. The timer is unref'd so it never holds the
+   * process open on its own.
+   */
+  start(): void {
+    if (this.#timer !== null || this.#stopped) return;
+    this.#timer = setInterval(() => {
+      void this.#tick();
+    }, this.#intervalMs);
+    Deno.unrefTimer(this.#timer);
+  }
+
+  /**
+   * Stops the loop and performs one final flush, so a draining daemon does
+   * not strand the runs it just finished.
+   */
+  async stop(): Promise<void> {
+    if (this.#timer !== null) {
+      clearInterval(this.#timer);
+      this.#timer = null;
+    }
+    // Set before the final flush so no timer callback already in flight can
+    // start another drain behind it.
+    this.#stopped = true;
+    await this.#drain();
+  }
+
+  async #tick(): Promise<void> {
+    if (this.#stopped) return;
+    this.#tickCount++;
+    await this.#drain();
+
+    if (this.#tickCount % PRUNE_EVERY_N_TICKS === 0) {
+      // Prunes delivered and quarantined entries only. Never the hard
+      // retention cap: a daemon that has been unable to reach the endpoint
+      // for a week must keep that telemetry, not destroy it.
+      await this.#service.pruneFlushedTelemetry();
+    }
+  }
+
+  /**
+   * Sends batches until the spool is empty, a send fails, or the per-tick cap
+   * is reached.
+   */
+  async #drain(): Promise<void> {
+    if (this.#running) return;
+    this.#running = true;
+    try {
+      for (let batch = 0; batch < MAX_BATCHES_PER_TICK; batch++) {
+        const outcome = await this.#flushOnce();
+        if (!outcome.result.ok) {
+          this.#consecutiveFailures++;
+          logger.warn(
+            "Telemetry flush failed ({reason}) — {failures} consecutive; entries stay queued",
+            {
+              reason: outcome.result.reason ?? "unknown",
+              failures: this.#consecutiveFailures,
+            },
+          );
+          if (this.#consecutiveFailures >= FAILURES_BEFORE_ISOLATION) {
+            await this.#isolateStuckBatch();
+          }
+          return;
+        }
+        this.#consecutiveFailures = 0;
+        if (outcome.sentCount === 0) return;
+      }
+    } catch (error) {
+      logger.warn("Telemetry flush loop error: {error}", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      this.#running = false;
+    }
+  }
+
+  #flushOnce(): Promise<TelemetryFlushOutcome> {
+    return this.#service.flushTelemetry({
+      sender: this.#credentials.sender,
+      distinctId: this.#credentials.distinctId,
+      repoId: this.#credentials.repoId,
+      authToken: this.#credentials.authToken ?? undefined,
+      keepFlushed: this.#credentials.keepFlushed,
+      signal: AbortSignal.timeout(FLUSH_TIMEOUT_MS),
+      skipIds: this.#sentButUnmarked,
+    }).then((outcome) => {
+      for (const id of outcome.unmarkedIds) {
+        this.#sentButUnmarked.add(id);
+        logger.warn(
+          "Telemetry entry {id} was delivered but could not be removed from the spool; it will not be re-sent by this process",
+          { id },
+        );
+      }
+      return outcome;
+    });
+  }
+
+  /**
+   * Retries a persistently-failing batch one entry at a time and quarantines
+   * the ones that fail on their own.
+   *
+   * `findUnflushed` returns the oldest entries first and a batch is only
+   * marked after the whole batch sends, so a single entry the endpoint always
+   * rejects blocks every newer entry behind it indefinitely — the daemon
+   * would keep flushing on schedule and still deliver nothing. Isolating lets
+   * the queue advance at the cost of the one entry that cannot go.
+   */
+  async #isolateStuckBatch(): Promise<void> {
+    const entries = await this.#service.findUnflushedForIsolation(
+      MAX_BATCHES_PER_TICK,
+      this.#sentButUnmarked,
+    );
+    if (entries.length === 0) return;
+
+    for (const entry of entries) {
+      let failures = 0;
+      let delivered = false;
+      for (let attempt = 0; attempt < FAILURES_BEFORE_QUARANTINE; attempt++) {
+        const outcome = await this.#service.flushEntry({
+          entry,
+          sender: this.#credentials.sender,
+          distinctId: this.#credentials.distinctId,
+          repoId: this.#credentials.repoId,
+          authToken: this.#credentials.authToken ?? undefined,
+          keepFlushed: this.#credentials.keepFlushed,
+          signal: AbortSignal.timeout(FLUSH_TIMEOUT_MS),
+        });
+        if (outcome.result.ok) {
+          delivered = true;
+          for (const id of outcome.unmarkedIds) this.#sentButUnmarked.add(id);
+          break;
+        }
+        failures++;
+      }
+
+      if (!delivered && failures >= FAILURES_BEFORE_QUARANTINE) {
+        await this.#service.quarantineEntry(entry);
+        logger.warn(
+          "Telemetry entry {id} was rejected repeatedly and has been quarantined so newer entries can be sent",
+          { id: entry.id },
+        );
+        // One offender is enough for this pass — the rest of the queue gets
+        // a normal drain on the next tick.
+        break;
+      }
+    }
+    this.#consecutiveFailures = 0;
+  }
+}

--- a/src/serve/telemetry_flush_test.ts
+++ b/src/serve/telemetry_flush_test.ts
@@ -1,0 +1,268 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { DaemonTelemetryFlushService } from "./telemetry_flush.ts";
+import { TelemetryService } from "../domain/telemetry/telemetry_service.ts";
+import { TelemetryEntry } from "../domain/telemetry/telemetry_entry.ts";
+import type { TelemetryRepository } from "../domain/telemetry/repositories.ts";
+import type {
+  TelemetryFlushResult,
+  TelemetrySender,
+} from "../domain/telemetry/telemetry_sender.ts";
+
+/**
+ * In-memory spool that behaves like the real one: entries stay readable
+ * until they are marked, and marking removes them.
+ */
+class FakeRepository implements TelemetryRepository {
+  entries: TelemetryEntry[] = [];
+  quarantined: TelemetryEntry[] = [];
+  prunedFlushedBefore: Date | null = null;
+  prunedQuarantinedBefore: Date | null = null;
+  deleteAllCalled = false;
+  /** Ids whose markFlushed reports failure, leaving them on disk. */
+  unmarkableIds = new Set<string>();
+
+  save(entry: TelemetryEntry): Promise<void> {
+    this.entries.push(entry);
+    return Promise.resolve();
+  }
+
+  findByDate(): Promise<TelemetryEntry[]> {
+    return Promise.resolve([]);
+  }
+
+  findByDateRange(): Promise<TelemetryEntry[]> {
+    return Promise.resolve([]);
+  }
+
+  deleteOlderThan(date: Date): Promise<number> {
+    this.prunedFlushedBefore = date;
+    return Promise.resolve(0);
+  }
+
+  deleteAllOlderThan(): Promise<number> {
+    this.deleteAllCalled = true;
+    return Promise.resolve(0);
+  }
+
+  findUnflushed(limit: number): Promise<TelemetryEntry[]> {
+    return Promise.resolve(this.entries.slice(0, limit));
+  }
+
+  markFlushed(entry: TelemetryEntry): Promise<boolean> {
+    if (this.unmarkableIds.has(entry.id)) return Promise.resolve(false);
+    this.entries = this.entries.filter((e) => e.id !== entry.id);
+    return Promise.resolve(true);
+  }
+
+  quarantine(entry: TelemetryEntry): Promise<void> {
+    this.quarantined.push(entry);
+    this.entries = this.entries.filter((e) => e.id !== entry.id);
+    return Promise.resolve();
+  }
+
+  deleteQuarantinedOlderThan(date: Date): Promise<number> {
+    this.prunedQuarantinedBefore = date;
+    return Promise.resolve(0);
+  }
+}
+
+/** Sender that can be told to reject specific entries. */
+class FakeSender implements TelemetrySender {
+  sent: string[][] = [];
+  rejectIds = new Set<string>();
+  failEverything = false;
+
+  sendBatch(entries: TelemetryEntry[]): Promise<TelemetryFlushResult> {
+    this.sent.push(entries.map((e) => e.id));
+    if (this.failEverything) {
+      return Promise.resolve({ ok: false, reason: "network error" });
+    }
+    // A batch is all-or-nothing: one bad entry fails the whole send, which is
+    // exactly what hides the offender behind its blameless neighbours.
+    if (entries.some((e) => this.rejectIds.has(e.id))) {
+      return Promise.resolve({ ok: false, reason: "HTTP 400" });
+    }
+    return Promise.resolve({ ok: true });
+  }
+
+  /** Total individual entries sent, counting re-sends. */
+  totalSent(): number {
+    return this.sent.reduce((sum, batch) => sum + batch.length, 0);
+  }
+
+  countOf(id: string): number {
+    return this.sent.filter((batch) => batch.includes(id)).length;
+  }
+}
+
+function entry(id: string): TelemetryEntry {
+  return TelemetryEntry.create({
+    id,
+    invocation: {
+      command: "workflow",
+      subcommand: "run",
+      args: ["<REDACTED>"],
+      optionKeys: [],
+      globalOptions: [],
+    },
+    result: { status: "success", exitCode: 0 },
+    startedAt: new Date("2026-08-10T10:00:00Z"),
+    completedAt: new Date("2026-08-10T10:00:05Z"),
+    swampVersion: "1.0.0",
+    denoVersion: "2.1.0",
+    platform: "linux",
+  });
+}
+
+function build(
+  repo: FakeRepository,
+  sender: FakeSender,
+): DaemonTelemetryFlushService {
+  return new DaemonTelemetryFlushService(
+    new TelemetryService(repo, "1.0.0"),
+    { sender, distinctId: "user-1", keepFlushed: false },
+    { intervalMs: 60_000 },
+  );
+}
+
+Deno.test("DaemonTelemetryFlushService: an empty spool makes no network call", async () => {
+  const repo = new FakeRepository();
+  const sender = new FakeSender();
+  const service = build(repo, sender);
+
+  await service.stop();
+
+  assertEquals(sender.sent.length, 0);
+});
+
+Deno.test("DaemonTelemetryFlushService: drains a backlog larger than one batch", async () => {
+  // flushTelemetry sends at most one batch per call, so a backlog needs
+  // several within a single tick or it would take an hour to clear 100
+  // entries at a 60-second cadence.
+  const repo = new FakeRepository();
+  const sender = new FakeSender();
+  for (let i = 0; i < 60; i++) repo.entries.push(entry(`entry-${i}`));
+
+  await build(repo, sender).stop();
+
+  assertEquals(repo.entries.length, 0);
+  assertEquals(sender.totalSent(), 60);
+});
+
+Deno.test("DaemonTelemetryFlushService: stop() performs a final flush", async () => {
+  // A draining daemon must not strand the runs it just finished.
+  const repo = new FakeRepository();
+  const sender = new FakeSender();
+  repo.entries.push(entry("last-run"));
+
+  const service = build(repo, sender);
+  service.start();
+  await service.stop();
+
+  assertEquals(sender.countOf("last-run"), 1);
+  assertEquals(repo.entries.length, 0);
+});
+
+Deno.test("DaemonTelemetryFlushService: a send failure is swallowed and entries stay queued", async () => {
+  const repo = new FakeRepository();
+  const sender = new FakeSender();
+  sender.failEverything = true;
+  repo.entries.push(entry("kept"));
+
+  await build(repo, sender).stop();
+
+  // Not thrown, and not lost: the entry is still there to retry.
+  assertEquals(repo.entries.length, 1);
+});
+
+Deno.test("DaemonTelemetryFlushService: an entry that cannot be marked is not re-sent", async () => {
+  // markFlushed failing (a file lock, a read-only spool) leaves the entry on
+  // disk, so findUnflushed keeps returning it. Without the skip set this
+  // becomes a duplicate event every single tick, forever — permanent
+  // inflation of the counts this whole change exists to make correct.
+  // Asserted by counting sends across several flushes, not just one.
+  const repo = new FakeRepository();
+  const sender = new FakeSender();
+  repo.entries.push(entry("stuck"));
+  repo.unmarkableIds.add("stuck");
+
+  const service = build(repo, sender);
+  await service.stop();
+  await service.stop();
+  await service.stop();
+
+  assertEquals(sender.countOf("stuck"), 1);
+});
+
+Deno.test("DaemonTelemetryFlushService: a poison entry is quarantined and the queue advances", async () => {
+  // findUnflushed returns the oldest entries first and a batch is only marked
+  // after the whole batch sends, so one permanently-rejected entry blocks
+  // every newer entry behind it. The daemon would keep flushing on schedule
+  // and still deliver nothing. This asserts PROGRESS — that the healthy
+  // entries behind the poison one actually ship — because head-of-line
+  // blocking throws no error and would otherwise look like success.
+  const repo = new FakeRepository();
+  const sender = new FakeSender();
+  repo.entries.push(entry("poison"));
+  repo.entries.push(entry("healthy-1"));
+  repo.entries.push(entry("healthy-2"));
+  sender.rejectIds.add("poison");
+
+  const service = build(repo, sender);
+
+  // Enough passes to exhaust the isolation threshold, then drain.
+  for (let i = 0; i < 10; i++) await service.stop();
+
+  assertEquals(repo.quarantined.map((e) => e.id), ["poison"]);
+  assertEquals(sender.countOf("healthy-1") > 0, true);
+  assertEquals(sender.countOf("healthy-2") > 0, true);
+  assertEquals(repo.entries.length, 0);
+});
+
+Deno.test("DaemonTelemetryFlushService: never applies the hard retention cap", async () => {
+  // The daemon prunes delivered and quarantined entries only. Applying the
+  // hard cap would destroy undelivered telemetry that is still perfectly
+  // sendable — the exact loss this issue exists to prevent.
+  const repo = new FakeRepository();
+  const sender = new FakeSender();
+  const service = build(repo, sender);
+
+  await service.stop();
+
+  assertEquals(repo.deleteAllCalled, false);
+});
+
+Deno.test("DaemonTelemetryFlushService: stop() prevents any further flushing", async () => {
+  // Nothing may start a flush after shutdown begins, or it could race the
+  // CLI's own teardown flush over the same spool.
+  const repo = new FakeRepository();
+  const sender = new FakeSender();
+  const service = build(repo, sender);
+  service.start();
+  await service.stop();
+
+  repo.entries.push(entry("after-stop"));
+  service.start();
+  await new Promise((resolve) => setTimeout(resolve, 5));
+
+  assertEquals(sender.countOf("after-stop"), 0);
+});

--- a/src/serve/telemetry_test.ts
+++ b/src/serve/telemetry_test.ts
@@ -1,0 +1,177 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertExists } from "@std/assert";
+import { createRunTelemetry } from "./telemetry.ts";
+import { TelemetryService } from "../domain/telemetry/telemetry_service.ts";
+import type { TelemetryEntry } from "../domain/telemetry/telemetry_entry.ts";
+import type { TelemetryRepository } from "../domain/telemetry/repositories.ts";
+import {
+  clearActiveTelemetryService,
+  setActiveTelemetryService,
+} from "../cli/telemetry_integration.ts";
+
+class CapturingRepository implements TelemetryRepository {
+  saved: TelemetryEntry[] = [];
+
+  save(entry: TelemetryEntry): Promise<void> {
+    this.saved.push(entry);
+    return Promise.resolve();
+  }
+  findByDate(): Promise<TelemetryEntry[]> {
+    return Promise.resolve([]);
+  }
+  findByDateRange(): Promise<TelemetryEntry[]> {
+    return Promise.resolve([]);
+  }
+  deleteOlderThan(): Promise<number> {
+    return Promise.resolve(0);
+  }
+  deleteAllOlderThan(): Promise<number> {
+    return Promise.resolve(0);
+  }
+  findUnflushed(): Promise<TelemetryEntry[]> {
+    return Promise.resolve([]);
+  }
+  markFlushed(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  quarantine(): Promise<void> {
+    return Promise.resolve();
+  }
+  deleteQuarantinedOlderThan(): Promise<number> {
+    return Promise.resolve(0);
+  }
+}
+
+/** Installs an active service for the duration of `fn`. */
+async function withActiveService(
+  fn: (repo: CapturingRepository) => Promise<void>,
+): Promise<void> {
+  const repo = new CapturingRepository();
+  setActiveTelemetryService(new TelemetryService(repo, "1.0.0"));
+  try {
+    await fn(repo);
+  } finally {
+    clearActiveTelemetryService();
+  }
+}
+
+Deno.test("createRunTelemetry: returns undefined when telemetry is disabled", () => {
+  // --no-telemetry, the marker opt-out, the user-level opt-out, and an init
+  // failure all leave no active service. Serve must then stay exactly as
+  // silent as it was before any of this was wired.
+  clearActiveTelemetryService();
+  assertEquals(createRunTelemetry("schedule"), undefined);
+});
+
+Deno.test("createRunTelemetry: records a success parent entry on finish(null)", async () => {
+  await withActiveService(async (repo) => {
+    const telemetry = createRunTelemetry("schedule");
+    assertExists(telemetry);
+
+    await telemetry.finish(null);
+
+    assertEquals(repo.saved.length, 1);
+    const parent = repo.saved[0];
+    assertEquals(parent.invocation.command, "workflow");
+    assertEquals(parent.invocation.subcommand, "run");
+    assertEquals(parent.result.status, "success");
+    assertEquals(parent.triggerSource, "schedule");
+  });
+});
+
+Deno.test("createRunTelemetry: records an error parent entry on finish(error)", async () => {
+  await withActiveService(async (repo) => {
+    const telemetry = createRunTelemetry("webhook");
+    assertExists(telemetry);
+
+    await telemetry.finish(new Error("step failed"));
+
+    assertEquals(repo.saved.length, 1);
+    assertEquals(repo.saved[0].result.status, "error");
+    assertEquals(repo.saved[0].result.errorMessage, "step failed");
+    assertEquals(repo.saved[0].triggerSource, "webhook");
+  });
+});
+
+Deno.test("createRunTelemetry: children carry the run's parent invocation id", async () => {
+  await withActiveService(async (repo) => {
+    const telemetry = createRunTelemetry("api");
+    assertExists(telemetry);
+
+    await telemetry.sink.recordChildInvocation(
+      {
+        command: "model",
+        subcommand: "method",
+        args: ["run", "<REDACTED>", "enrich"],
+        optionKeys: [],
+        globalOptions: [],
+      },
+      new Date(),
+      new Date(),
+      null,
+      telemetry.sink.parentInvocationId,
+      {
+        workflowName: "nightly",
+        runId: "run-1",
+        jobName: "main",
+        stepName: "enrich",
+      },
+    );
+    await telemetry.finish(null);
+
+    const child = repo.saved[0];
+    const parent = repo.saved[1];
+    assertEquals(child.parentInvocationId, telemetry.sink.parentInvocationId);
+    // The parent is the run itself, not the daemon's process invocation —
+    // that entry is not written until serve exits, possibly weeks later.
+    assertEquals(parent.id, telemetry.sink.parentInvocationId);
+    assertEquals(child.triggerSource, "api");
+  });
+});
+
+Deno.test("createRunTelemetry: each run gets a distinct parent identity", async () => {
+  await withActiveService(() => {
+    const first = createRunTelemetry("schedule");
+    const second = createRunTelemetry("schedule");
+    assertExists(first);
+    assertExists(second);
+
+    assertEquals(
+      first.sink.parentInvocationId === second.sink.parentInvocationId,
+      false,
+    );
+    return Promise.resolve();
+  });
+});
+
+Deno.test("createRunTelemetry: the parent entry redacts the workflow name", async () => {
+  // Serve-side entries are generated with no human present, so redaction
+  // cannot be reviewed at authoring time. This matches what the interactive
+  // path records for the same command.
+  await withActiveService(async (repo) => {
+    const telemetry = createRunTelemetry("schedule");
+    assertExists(telemetry);
+
+    await telemetry.finish(null);
+
+    assertEquals(repo.saved[0].invocation.args, ["<REDACTED>"]);
+  });
+});

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -651,6 +651,7 @@ export class WebhookService {
         },
         this.deps.syncService,
         this.deps.runTracker,
+        { triggerSource: "webhook" },
       );
 
       if (completedRun?.status === "failed") {


### PR DESCRIPTION
## Summary

A long-lived `swamp serve` is telemetry-dark for its entire uptime. Scheduled, webhook, and API-triggered workflow runs record nothing, and the daemon has no flush path of its own — so swamp-club receives zero events for work that demonstrably happened. This is what reset a 32-day streak in swamp-club#1590.

Three independent layers, all verified against HEAD:

1. **Serve never wired the sink.** `WorkflowRunDeps.telemetrySink` had exactly one production binding — `src/cli/commands/workflow_run.ts:320`, the interactive command. `rg -n 'telemetry' src/serve/` returned zero matches, so every run through `executeWorkflowWithLocks` left the sink undefined and libswamp never constructed its bridge.
2. **Record and flush lived only in the CLI teardown** (`cli/mod.ts:1602`, `:1613`), after `cli.parse` returns. For a daemon that instant is process exit.
3. **Scheduled fires produced only an OTel span** (`scheduled_execution.ts:441`) — the operator's own OTLP endpoint, a pipeline entirely disjoint from `/ingest`.

Not a regression: `telemetrySink` arrived whole in #1349 and was wired only into `workflow_run.ts` in that same commit. Serve has been dark since the feature shipped.

## What changed

Serve forks a per-run `TelemetryService` for each triggered run, recording a parent invocation plus child method invocations, stamped with a new optional `triggerSource` of `schedule` / `webhook` / `api`. Interactive runs leave the field unset, so their events are byte-identical to before.

A daemon that retries forever needs guarantees a one-shot CLI never did:

- **`insert_id` is now sent** — the ingest queue's idempotency key. swamp has never sent one, so every retry after a lost 202 has been double-counted. This fixes latent inflation on the **interactive** path too, which is wider than this issue.
- **`markFlushed` reports failure** instead of swallowing it, and the loop skips entries it delivered but could not remove. Otherwise a locked or read-only spool re-sends the same invocation every 60 seconds, forever.
- **Poison entries are quarantined** after per-entry isolation. `findUnflushed` is oldest-first and a batch is all-or-nothing, so without an escape one bad entry blocks every newer entry behind it — the daemon flushes on schedule and delivers nothing.
- **The daemon never applies the hard retention cap.** It prunes delivered and quarantined entries only; applying the cap would destroy a week of still-sendable telemetry from a daemon that had been offline.
- **Flushes serialize on the service**, because the daemon loop and the CLI teardown flush hold the same instance through different references.

Run outcome is read from the **event stream**, not from control flow — a workflow reports failure by yielding, not throwing. Deriving success from "did not throw" recorded broken nightly jobs as successes, which matters because `swamp.cli_daily_mv` filters on `result.status = 'success'`.

Serve also logs the telemetry identity it resolved at startup. `distinct_id` comes from a HOME-relative identity file, so a daemon under a different HOME than the operator's shell credits an account nobody is watching — at the UI, indistinguishable from reporting nothing.

### Why this lands as one PR

Splitting the hardening into a follow-up was considered and rejected: shipping the flush loop without it would put a duplicate-event generator and a wedgeable queue in front of the deed and streak counts this exists to make correct — worse than the current silence.

## Test Plan

- `deno check`, `deno lint`, `deno fmt --check`, `deno run compile`, `deno run license-headers` — all clean
- **`deno run test`: 10147 passed, 0 failed**
- New unit coverage for the value object, entry round-trip and legacy decode, trigger-source stamping, `forkForRun`, the non-destructive prune (asserts the daemon path never deletes unflushed entries), concurrent-flush serialization, mark-failure reporting, quarantine + `findUnflushed` exclusion, and `insert_id` on both body shapes
- Flush-loop tests prove the two failure modes that throw nothing and would otherwise look like success: entries queued **behind** a poison entry still ship, and an unmarkable entry is not re-sent across repeated flushes
- Integration coverage in `scheduled_trigger_inputs_test.ts` and `webhook_payload_inputs_test.ts`, including an assertion that no webhook payload value, header, or secret reaches telemetry
- **Verified end to end against a live daemon**: a scheduled run delivered a `workflow run` parent and a linked `model method` child, both `triggerSource: schedule`, workflow name redacted, **while the process was still running**

## Related

- swamp-club#1590 — the originating report
- swamp-uat#344 — end-to-end daemon coverage (no existing test observes a long-lived process, which is why this went unnoticed)
- swamp-club lab#1597 — manual has no telemetry page; three serve/scheduling pages imply automated runs are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)