### PR TITLE
fix(serve): await in-flight drain in stop() (swamp-club#1604)

### DIFF
--- a/src/domain/telemetry/telemetry_service.ts
+++ b/src/domain/telemetry/telemetry_service.ts
@@ -184,7 +184,7 @@ export class TelemetryService {
    *
    * IMPORTANT: forks are WRITE-ONLY. They record entries; they must never
    * flush. Flushing is serialized by a per-instance mutex (see
-   * {@link #flushInFlight}), and a fork does not share it — so a fork that
+   * {@link #flushChain}), and a fork does not share it — so a fork that
    * flushed could race the root service over the same spool and send a batch
    * twice. If a fork ever needs to flush, move the lock down to the
    * repository first.

--- a/src/serve/telemetry_flush.ts
+++ b/src/serve/telemetry_flush.ts
@@ -81,7 +81,7 @@ export class DaemonTelemetryFlushService {
   readonly #credentials: TelemetryFlushCredentials;
   readonly #intervalMs: number;
   #timer: ReturnType<typeof setInterval> | null = null;
-  #running = false;
+  #drainPromise: Promise<void> | null = null;
   #stopped = false;
   #tickCount = 0;
   #consecutiveFailures = 0;
@@ -124,9 +124,8 @@ export class DaemonTelemetryFlushService {
       clearInterval(this.#timer);
       this.#timer = null;
     }
-    // Set before the final flush so no timer callback already in flight can
-    // start another drain behind it.
     this.#stopped = true;
+    if (this.#drainPromise) await this.#drainPromise;
     await this.#drain();
   }
 
@@ -145,37 +144,45 @@ export class DaemonTelemetryFlushService {
 
   /**
    * Sends batches until the spool is empty, a send fails, or the per-tick cap
-   * is reached.
+   * is reached. Only one drain runs at a time — concurrent callers return
+   * immediately. {@link stop} awaits {@link #drainPromise} so it never misses
+   * an in-flight drain started by the timer.
    */
   async #drain(): Promise<void> {
-    if (this.#running) return;
-    this.#running = true;
-    try {
-      for (let batch = 0; batch < MAX_BATCHES_PER_TICK; batch++) {
-        const outcome = await this.#flushOnce();
-        if (!outcome.result.ok) {
-          this.#consecutiveFailures++;
-          logger.warn(
-            "Telemetry flush failed ({reason}) — {failures} consecutive; entries stay queued",
-            {
-              reason: outcome.result.reason ?? "unknown",
-              failures: this.#consecutiveFailures,
-            },
-          );
-          if (this.#consecutiveFailures >= FAILURES_BEFORE_ISOLATION) {
-            await this.#isolateStuckBatch();
+    if (this.#drainPromise) return;
+
+    this.#drainPromise = (async () => {
+      try {
+        for (let batch = 0; batch < MAX_BATCHES_PER_TICK; batch++) {
+          const outcome = await this.#flushOnce();
+          if (!outcome.result.ok) {
+            this.#consecutiveFailures++;
+            logger.warn(
+              "Telemetry flush failed ({reason}) — {failures} consecutive; entries stay queued",
+              {
+                reason: outcome.result.reason ?? "unknown",
+                failures: this.#consecutiveFailures,
+              },
+            );
+            if (this.#consecutiveFailures >= FAILURES_BEFORE_ISOLATION) {
+              await this.#isolateStuckBatch();
+            }
+            return;
           }
-          return;
+          this.#consecutiveFailures = 0;
+          if (outcome.sentCount === 0) return;
         }
-        this.#consecutiveFailures = 0;
-        if (outcome.sentCount === 0) return;
+      } catch (error) {
+        logger.warn("Telemetry flush loop error: {error}", {
+          error: error instanceof Error ? error.message : String(error),
+        });
       }
-    } catch (error) {
-      logger.warn("Telemetry flush loop error: {error}", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+    })();
+
+    try {
+      await this.#drainPromise;
     } finally {
-      this.#running = false;
+      this.#drainPromise = null;
     }
   }
 

--- a/src/serve/telemetry_flush_test.ts
+++ b/src/serve/telemetry_flush_test.ts
@@ -251,6 +251,56 @@ Deno.test("DaemonTelemetryFlushService: never applies the hard retention cap", a
   assertEquals(repo.deleteAllCalled, false);
 });
 
+Deno.test("DaemonTelemetryFlushService: stop() awaits an in-flight timer drain before its own", async () => {
+  // Reproduces the race from swamp-club#1604: a timer-triggered drain is
+  // in progress when stop() is called, and an entry is written between the
+  // drain's read and stop()'s final flush. Without the fix, stop()'s
+  // #drain() would return immediately (guarded by #running/#drainPromise)
+  // and the entry would be stranded.
+  const repo = new FakeRepository();
+  const sender = new FakeSender();
+
+  let resolveGate!: () => void;
+  const gate = new Promise<void>((r) => {
+    resolveGate = r;
+  });
+  let sendCalls = 0;
+  const originalSendBatch = sender.sendBatch.bind(sender);
+  sender.sendBatch = async (entries: TelemetryEntry[]) => {
+    sendCalls++;
+    if (sendCalls === 1) await gate;
+    return originalSendBatch(entries);
+  };
+
+  repo.entries.push(entry("before-stop"));
+
+  const service = new DaemonTelemetryFlushService(
+    new TelemetryService(repo, "1.0.0"),
+    { sender, distinctId: "user-1", keepFlushed: false },
+    { intervalMs: 1 },
+  );
+
+  service.start();
+  // Let the timer fire and the drain enter the blocked sendBatch.
+  while (sendCalls === 0) {
+    await new Promise((r) => setTimeout(r, 5));
+  }
+
+  // The drain is now blocked inside sendBatch. Add a new entry that only
+  // stop()'s final drain can pick up.
+  repo.entries.push(entry("during-drain"));
+
+  // stop() must await the in-flight drain, then run its own to catch
+  // "during-drain".
+  const stopPromise = service.stop();
+  resolveGate();
+  await stopPromise;
+
+  assertEquals(sender.countOf("before-stop"), 1);
+  assertEquals(sender.countOf("during-drain"), 1);
+  assertEquals(repo.entries.length, 0);
+});
+
 Deno.test("DaemonTelemetryFlushService: stop() prevents any further flushing", async () => {
   // Nothing may start a flush after shutdown begins, or it could race the
   // CLI's own teardown flush over the same spool.

--- a/src/serve/telemetry_flush_test.ts
+++ b/src/serve/telemetry_flush_test.ts
@@ -253,10 +253,9 @@ Deno.test("DaemonTelemetryFlushService: never applies the hard retention cap", a
 
 Deno.test("DaemonTelemetryFlushService: stop() awaits an in-flight timer drain before its own", async () => {
   // Reproduces the race from swamp-club#1604: a timer-triggered drain is
-  // in progress when stop() is called, and an entry is written between the
-  // drain's read and stop()'s final flush. Without the fix, stop()'s
-  // #drain() would return immediately (guarded by #running/#drainPromise)
-  // and the entry would be stranded.
+  // in progress when stop() is called. Without the fix, stop()'s #drain()
+  // returns immediately (guarded out) and stop() resolves while the drain
+  // is still running — shutdown proceeds before telemetry is delivered.
   const repo = new FakeRepository();
   const sender = new FakeSender();
 
@@ -281,21 +280,29 @@ Deno.test("DaemonTelemetryFlushService: stop() awaits an in-flight timer drain b
   );
 
   service.start();
-  // Let the timer fire and the drain enter the blocked sendBatch.
   while (sendCalls === 0) {
     await new Promise((r) => setTimeout(r, 5));
   }
 
-  // The drain is now blocked inside sendBatch. Add a new entry that only
-  // stop()'s final drain can pick up.
   repo.entries.push(entry("during-drain"));
 
-  // stop() must await the in-flight drain, then run its own to catch
-  // "during-drain".
-  const stopPromise = service.stop();
+  // stop() must NOT resolve while the in-flight drain is blocked.
+  let stopDone = false;
+  const stopPromise = service.stop().then(() => {
+    stopDone = true;
+  });
+
+  await new Promise((r) => setTimeout(r, 20));
+  assertEquals(
+    stopDone,
+    false,
+    "stop() must not resolve while drain is in-flight",
+  );
+
   resolveGate();
   await stopPromise;
 
+  assertEquals(stopDone, true);
   assertEquals(sender.countOf("before-stop"), 1);
   assertEquals(sender.countOf("during-drain"), 1);
   assertEquals(repo.entries.length, 0);


### PR DESCRIPTION
## Summary

- **Fix race condition** in `DaemonTelemetryFlushService.stop()`: when a timer-triggered `#drain()` was already running, `stop()`'s own drain was a no-op due to the `#running` guard, potentially stranding telemetry entries written during the in-flight drain.
- **Replace `#running` boolean with `#drainPromise`**: serves as both the concurrency guard (`if (this.#drainPromise) return`) and an awaitable reference so `stop()` can wait for the in-flight drain to complete before performing its own final flush.
- **Fix stale docstring** in `TelemetryService.forkForRun`: `{@link #flushInFlight}` → `{@link #flushChain}`.

## Test Plan

- [x] New test: `stop() awaits an in-flight timer drain before its own` — simulates a slow drain using a deferred promise in the FakeSender, adds an entry while the drain is blocked, calls `stop()`, and asserts the entry is flushed
- [x] All 8 existing `telemetry_flush_test.ts` tests pass (no regressions)
- [x] `deno check` — type check passes
- [x] `deno lint` — lint passes
- [x] `deno fmt --check` — formatting passes

Closes swamp-club#1604