### PR TITLE
fix(serve): follow symlinks in grants directory loader (swamp-club#1609)

### DIFF
--- a/src/domain/access/grant_file.ts
+++ b/src/domain/access/grant_file.ts
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { getLogger } from "@logtape/logtape";
 import { join } from "@std/path";
 import { parse as parseYaml } from "@std/yaml";
 import { z } from "zod";
@@ -195,12 +196,23 @@ export async function readGrantFiles(
   }
 
   const files = dirEntries
-    .filter((e) => e.isFile && isGrantFileExtension(e.name))
+    .filter((e) => (e.isFile || e.isSymlink) && isGrantFileExtension(e.name))
     .sort((a, b) => a.name.localeCompare(b.name));
 
+  const logger = getLogger(["swamp", "access", "grant-file"]);
   for (const file of files) {
     const path = join(grantsDir, file.name);
-    const content = await Deno.readTextFile(path);
+    let content: string;
+    try {
+      content = await Deno.readTextFile(path);
+    } catch (error) {
+      logger.warn`Skipping grant file ${file.name}: ${error}`;
+      results.set(file.name, {
+        entries: [],
+        errors: [{ filename: file.name, message: `Failed to read: ${error}` }],
+      });
+      continue;
+    }
     results.set(
       file.name,
       parseGrantFile(file.name, content, validateCondition),

--- a/src/domain/access/grant_file_test.ts
+++ b/src/domain/access/grant_file_test.ts
@@ -322,6 +322,117 @@ Deno.test("readGrantFiles: returns empty map when directory does not exist", asy
   assertEquals(results.size, 0);
 });
 
+Deno.test("readGrantFiles: loads symlinked YAML files", async () => {
+  await withTempDir(async (dir) => {
+    const realDir = join(dir, "real");
+    const grantsDir = join(dir, "grants");
+    await ensureDir(realDir);
+    await ensureDir(grantsDir);
+    await Deno.writeTextFile(
+      join(realDir, "team.yaml"),
+      `grants:\n  - subject: "user:adam"\n    effect: allow\n    actions: [run]\n    resource: "workflow:*"`,
+    );
+    await Deno.symlink(
+      join(realDir, "team.yaml"),
+      join(grantsDir, "team.yaml"),
+      { type: "file" },
+    );
+
+    const results = await readGrantFiles(grantsDir);
+    assertEquals(results.size, 1);
+    assertEquals(results.has("team.yaml"), true);
+    assertEquals(results.get("team.yaml")!.entries.length, 1);
+    assertEquals(results.get("team.yaml")!.errors.length, 0);
+  });
+});
+
+Deno.test("readGrantFiles: ignores symlinks to non-YAML files", async () => {
+  await withTempDir(async (dir) => {
+    const realDir = join(dir, "real");
+    const grantsDir = join(dir, "grants");
+    await ensureDir(realDir);
+    await ensureDir(grantsDir);
+    await Deno.writeTextFile(join(realDir, "notes.txt"), "not a grant file");
+    await Deno.symlink(
+      join(realDir, "notes.txt"),
+      join(grantsDir, "notes.txt"),
+      { type: "file" },
+    );
+
+    const results = await readGrantFiles(grantsDir);
+    assertEquals(results.size, 0);
+  });
+});
+
+Deno.test("readGrantFiles: ignores symlinked directories", async () => {
+  await withTempDir(async (dir) => {
+    const realDir = join(dir, "real");
+    const grantsDir = join(dir, "grants");
+    await ensureDir(realDir);
+    await ensureDir(grantsDir);
+    await Deno.writeTextFile(
+      join(grantsDir, "team.yaml"),
+      `grants:\n  - subject: "user:adam"\n    effect: allow\n    actions: [run]\n    resource: "workflow:*"`,
+    );
+    await Deno.symlink(realDir, join(grantsDir, "subdir"), { type: "dir" });
+
+    const results = await readGrantFiles(grantsDir);
+    assertEquals(results.size, 1);
+    assertEquals(results.has("team.yaml"), true);
+  });
+});
+
+Deno.test("readGrantFiles: handles broken symlinks gracefully", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "grants");
+    await ensureDir(grantsDir);
+    await Deno.writeTextFile(
+      join(grantsDir, "good.yaml"),
+      `grants:\n  - subject: "user:adam"\n    effect: allow\n    actions: [run]\n    resource: "workflow:*"`,
+    );
+    await Deno.symlink(
+      join(dir, "nonexistent.yaml"),
+      join(grantsDir, "broken.yaml"),
+      { type: "file" },
+    );
+
+    const results = await readGrantFiles(grantsDir);
+    assertEquals(results.size, 2);
+    assertEquals(results.get("good.yaml")!.entries.length, 1);
+    assertEquals(results.get("good.yaml")!.errors.length, 0);
+    assertEquals(results.get("broken.yaml")!.entries.length, 0);
+    assertEquals(results.get("broken.yaml")!.errors.length, 1);
+    assertStringIncludes(
+      results.get("broken.yaml")!.errors[0].message,
+      "Failed to read",
+    );
+  });
+});
+
+Deno.test("readGrantFiles: ignores dot-prefixed symlinks (K8s ConfigMap internals)", async () => {
+  await withTempDir(async (dir) => {
+    const realDir = join(dir, "..2024_01_01_120000");
+    const grantsDir = join(dir, "grants");
+    await ensureDir(realDir);
+    await ensureDir(grantsDir);
+    await Deno.writeTextFile(
+      join(realDir, "team.yaml"),
+      `grants:\n  - subject: "user:adam"\n    effect: allow\n    actions: [run]\n    resource: "workflow:*"`,
+    );
+    await Deno.symlink(realDir, join(grantsDir, "..data"), { type: "dir" });
+    await Deno.symlink(
+      join(realDir, "team.yaml"),
+      join(grantsDir, "team.yaml"),
+      { type: "file" },
+    );
+
+    const results = await readGrantFiles(grantsDir);
+    assertEquals(results.size, 1);
+    assertEquals(results.has("team.yaml"), true);
+    assertEquals(results.has("..data"), false);
+  });
+});
+
 Deno.test("readGrantFiles: returns empty map for empty directory", async () => {
   await withTempDir(async (dir) => {
     const grantsDir = join(dir, "grants");


### PR DESCRIPTION
## Summary

- Fix grants directory loader to follow symlinks by changing the filter from `e.isFile` to `(e.isFile || e.isSymlink)` in `readGrantFiles`
- Add per-file error handling around `Deno.readTextFile` so broken symlinks log a warning and produce an error entry instead of crashing the entire grants load
- Add 5 new test cases covering: symlinked YAML files loaded, symlinks to non-YAML ignored, symlinked directories ignored, broken symlinks handled gracefully, K8s dot-prefixed entries excluded

Fixes swamp-club#1609

## Test Plan

- [x] Reproduced: symlinked `.yaml` file returns `isFile: false, isSymlink: true` from `Deno.readDir()`, causing `readGrantFiles` to return 0 files
- [x] Verified fix: same scenario now loads the symlinked grant file
- [x] All 26 grant_file tests pass (21 existing + 5 new)
- [x] `deno check`, `deno lint`, `deno fmt` pass
- [x] Pre-existing test failures in `oauth_client_test.ts` and `active_run_registry_test.ts` are unrelated (confirmed by running on clean main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)