### PR TITLE
feat(access): add `swamp access group list-idp` to enumerate IdP groups (swamp-club#1611)

### DIFF
--- a/src/cli/commands/access_group.ts
+++ b/src/cli/commands/access_group.ts
@@ -49,7 +49,10 @@ import {
   GroupSchema,
 } from "../../domain/models/access/group_model.ts";
 import type { DataRecord } from "../../domain/data/data_record.ts";
-import { createAccessGroupListRenderer } from "../../presentation/renderers/access_group.ts";
+import {
+  createAccessGroupIdpRenderer,
+  createAccessGroupListRenderer,
+} from "../../presentation/renderers/access_group.ts";
 import {
   buildModelMethodRunDeps,
   LOCAL_PRINCIPAL,
@@ -62,7 +65,10 @@ import {
   resolveServeUrl,
   runModelMethodOverServer,
 } from "../../cli/remote_run.ts";
-import type { AccessGroupListResponse } from "../../serve/protocol.ts";
+import type {
+  AccessGroupListIdpResponse,
+  AccessGroupListResponse,
+} from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -553,6 +559,48 @@ const accessGroupMembersCommand = new Command()
     renderer.renderMembers(match.group);
   });
 
+const accessGroupListIdpCommand = new Command()
+  .name("list-idp")
+  .description(
+    "List IdP groups observed from authenticated users on a server",
+  )
+  .example(
+    "List IdP groups",
+    "swamp access group list-idp --server wss://swamp.example.com",
+  )
+  .option(
+    "--server <url:string>",
+    "Server to query (required; env: SWAMP_SERVE_URL)",
+  )
+  .option(
+    "--token <token:string>",
+    "Server token (falls back to stored credential or SWAMP_SERVER_TOKEN)",
+  )
+  .action(async function (options: AnyOptions) {
+    const server = resolveServeUrl(options.server as string | undefined);
+    if (!server) {
+      throw new UserError(
+        "--server is required: IdP groups only exist on a swamp serve instance",
+      );
+    }
+
+    const ctx = createContext(options as GlobalOptions, [
+      "access",
+      "group",
+      "list-idp",
+    ]);
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
+    );
+    const response = await requestServerResponse<AccessGroupListIdpResponse>(
+      { server, ...(token ? { token } : {}) },
+      { type: "access.group.list-idp" },
+    );
+    const renderer = createAccessGroupIdpRenderer(ctx.outputMode);
+    renderer.renderList(response.groups);
+  });
+
 export const accessGroupCommand = new Command()
   .name("group")
   .description("Manage local groups")
@@ -561,4 +609,5 @@ export const accessGroupCommand = new Command()
   .command("add-member", accessGroupAddMemberCommand)
   .command("remove-member", accessGroupRemoveMemberCommand)
   .command("list", accessGroupListCommand)
+  .command("list-idp", accessGroupListIdpCommand)
   .command("members", accessGroupMembersCommand);

--- a/src/cli/commands/access_group_test.ts
+++ b/src/cli/commands/access_group_test.ts
@@ -142,3 +142,37 @@ Deno.test("accessGroupCommand: members has --server option", async () => {
   const serverOpt = options.find((o) => o.name === "server");
   assertEquals(serverOpt !== undefined, true);
 });
+
+Deno.test("accessGroupCommand: has list-idp subcommand", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const cmd = commands.find((c) => c.getName() === "list-idp");
+  assertEquals(cmd !== undefined, true);
+});
+
+Deno.test("accessGroupCommand: list-idp has --server option", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const listIdpCmd = commands.find((c) => c.getName() === "list-idp")!;
+  const options = listIdpCmd.getOptions();
+  const serverOpt = options.find((o) => o.name === "server");
+  assertEquals(serverOpt !== undefined, true);
+});
+
+Deno.test("accessGroupCommand: list-idp has --token option", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const listIdpCmd = commands.find((c) => c.getName() === "list-idp")!;
+  const options = listIdpCmd.getOptions();
+  const tokenOpt = options.find((o) => o.name === "token");
+  assertEquals(tokenOpt !== undefined, true);
+});
+
+Deno.test("accessGroupCommand: list-idp has no --repo-dir option", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const listIdpCmd = commands.find((c) => c.getName() === "list-idp")!;
+  const options = listIdpCmd.getOptions();
+  const repoDirOpt = options.find((o) => o.name === "repo-dir");
+  assertEquals(repoDirOpt, undefined);
+});

--- a/src/presentation/renderers/access_group.ts
+++ b/src/presentation/renderers/access_group.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { Group } from "../../domain/models/access/group_model.ts";
+import type { AccessGroupIdpEntry } from "../../serve/protocol.ts";
 import type { OutputMode } from "../output/output.ts";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
 
@@ -82,5 +83,49 @@ export function createAccessGroupListRenderer(
       return new JsonAccessGroupListRenderer();
     case "log":
       return new LogAccessGroupListRenderer();
+  }
+}
+
+// ── IdP group rendering ──────────────────────────────────────────────
+
+export interface AccessGroupIdpRenderer {
+  renderList(groups: AccessGroupIdpEntry[]): void;
+}
+
+class LogAccessGroupIdpRenderer implements AccessGroupIdpRenderer {
+  renderList(groups: AccessGroupIdpEntry[]): void {
+    if (groups.length === 0) {
+      writeOutput("No IdP groups found.");
+      return;
+    }
+
+    const header = `${"GROUP".padEnd(40)}  ${
+      "ACTIVE TOKENS".padEnd(14)
+    }  LAST SEEN`;
+    writeOutput(header);
+
+    for (const group of groups) {
+      const name = group.name.padEnd(40);
+      const count = String(group.activeTokenCount).padEnd(14);
+      const lastSeen = group.lastSeenAt.slice(0, 10);
+      writeOutput(`${name}  ${count}  ${lastSeen}`);
+    }
+  }
+}
+
+class JsonAccessGroupIdpRenderer implements AccessGroupIdpRenderer {
+  renderList(groups: AccessGroupIdpEntry[]): void {
+    writeOutput(JSON.stringify(groups, null, 2));
+  }
+}
+
+export function createAccessGroupIdpRenderer(
+  mode: OutputMode,
+): AccessGroupIdpRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonAccessGroupIdpRenderer();
+    case "log":
+      return new LogAccessGroupIdpRenderer();
   }
 }

--- a/src/presentation/renderers/access_group_test.ts
+++ b/src/presentation/renderers/access_group_test.ts
@@ -17,9 +17,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertStringIncludes } from "@std/assert";
-import { createAccessGroupListRenderer } from "./access_group.ts";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  createAccessGroupIdpRenderer,
+  createAccessGroupListRenderer,
+} from "./access_group.ts";
 import type { Group } from "../../domain/models/access/group_model.ts";
+import type { AccessGroupIdpEntry } from "../../serve/protocol.ts";
 
 function makeGroup(overrides: Partial<Group> = {}): Group {
   return {
@@ -98,4 +102,64 @@ Deno.test("accessGroupListRenderer json: outputs JSON array", () => {
   }
   const parsed = JSON.parse(output.join(""));
   assertStringIncludes(parsed[0].name, "release-managers");
+});
+
+// ── IdP group renderer tests ─────────────────────────────────────────
+
+function makeIdpEntry(
+  overrides: Partial<AccessGroupIdpEntry> = {},
+): AccessGroupIdpEntry {
+  return {
+    name: "platform-eng",
+    activeTokenCount: 3,
+    lastSeenAt: "2026-08-10T12:00:00Z",
+    ...overrides,
+  };
+}
+
+Deno.test("accessGroupIdpRenderer log: shows header and data", () => {
+  const renderer = createAccessGroupIdpRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.renderList([makeIdpEntry()]);
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[0], "GROUP");
+  assertStringIncludes(output[0], "ACTIVE TOKENS");
+  assertStringIncludes(output[0], "LAST SEEN");
+  assertStringIncludes(output[1], "platform-eng");
+  assertStringIncludes(output[1], "3");
+  assertStringIncludes(output[1], "2026-08-10");
+});
+
+Deno.test("accessGroupIdpRenderer log: shows empty message", () => {
+  const renderer = createAccessGroupIdpRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.renderList([]);
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[0], "No IdP groups found");
+});
+
+Deno.test("accessGroupIdpRenderer json: outputs JSON array", () => {
+  const renderer = createAccessGroupIdpRenderer("json");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.renderList([makeIdpEntry(), makeIdpEntry({ name: "ops-team" })]);
+  } finally {
+    console.log = origLog;
+  }
+  const parsed = JSON.parse(output.join("")) as AccessGroupIdpEntry[];
+  assertEquals(parsed.length, 2);
+  assertEquals(parsed[0].name, "platform-eng");
+  assertEquals(parsed[1].name, "ops-team");
 });

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -102,6 +102,7 @@ import {
   handleAccessCheck,
   handleAccessGrantList,
   handleAccessGroupList,
+  handleAccessGroupListIdp,
   handleAccessReload,
   handleAccessTokenList,
   handleAccessTokenRevoke,
@@ -224,6 +225,11 @@ const AccessGroupListRequestSchema = z.object({
   payload: z.object({
     name: z.string().optional(),
   }).optional(),
+});
+
+const AccessGroupListIdpRequestSchema = z.object({
+  type: z.literal("access.group.list-idp"),
+  id: z.string().min(1).max(256),
 });
 
 const AccessCheckRequestSchema = z.object({
@@ -1109,6 +1115,7 @@ const ServerRequestSchema = z.discriminatedUnion("type", [
   ModelMethodRunRequestSchema,
   AccessGrantListRequestSchema,
   AccessGroupListRequestSchema,
+  AccessGroupListIdpRequestSchema,
   AccessCheckRequestSchema,
   AccessCanIRequestSchema,
   AccessReloadRequestSchema,
@@ -1408,6 +1415,14 @@ export function handleMessage(
         request.id,
         principal,
         request.payload,
+      );
+      break;
+    case "access.group.list-idp":
+      task = handleAccessGroupListIdp(
+        socket,
+        ctx,
+        request.id,
+        principal,
       );
       break;
     case "access.check":

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -26,6 +26,7 @@ import type {
   AccessCanIPayload,
   AccessCheckPayload,
   AccessGrantListPayload,
+  AccessGroupIdpEntry,
   AccessGroupListPayload,
   AccessReloadFileResult,
   AccessTokenRevokePayload,
@@ -82,6 +83,11 @@ import {
   serverTokenRotate,
   withDefaults,
 } from "../../libswamp/mod.ts";
+import type { DataRecord } from "../../domain/data/data_record.ts";
+import {
+  SERVER_TOKEN_MODEL_TYPE,
+  ServerTokenSchema,
+} from "../../domain/models/access/server_token_model.ts";
 
 export async function handleAccessGrantList(
   socket: WebSocket,
@@ -260,6 +266,79 @@ export async function handleAccessGroupList(
   } catch (error) {
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "access_group_list_failed", message);
+  }
+}
+
+export async function handleAccessGroupListIdp(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "read", {
+      kind: "access",
+      name: "group",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const TOKEN_DATA_NAME = "token-main";
+    const records = await ctx.repoContext.dataQueryService.query(
+      `modelType == "${SERVER_TOKEN_MODEL_TYPE.normalized}" && ` +
+        `name == "${TOKEN_DATA_NAME}"`,
+      { loadAttributes: true },
+    );
+
+    const nowMs = Date.now();
+    const groupMap = new Map<
+      string,
+      { activeTokenCount: number; lastSeenAt: string }
+    >();
+
+    for (const record of records as DataRecord[]) {
+      const parsed = ServerTokenSchema.safeParse(record.attributes);
+      if (!parsed.success) continue;
+      const token = parsed.data;
+
+      if (token.state !== "active") continue;
+      if (Date.parse(token.expiresAt) <= nowMs) continue;
+
+      const tokenLastSeen = token.lastUsedAt ?? token.createdAt;
+
+      for (const group of token.groups) {
+        const existing = groupMap.get(group);
+        if (existing) {
+          existing.activeTokenCount += 1;
+          if (tokenLastSeen > existing.lastSeenAt) {
+            existing.lastSeenAt = tokenLastSeen;
+          }
+        } else {
+          groupMap.set(group, {
+            activeTokenCount: 1,
+            lastSeenAt: tokenLastSeen,
+          });
+        }
+      }
+    }
+
+    const groups: AccessGroupIdpEntry[] = [...groupMap.entries()]
+      .map(([name, info]) => ({
+        name,
+        activeTokenCount: info.activeTokenCount,
+        lastSeenAt: info.lastSeenAt,
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    send(socket, {
+      type: "access.group.list-idp",
+      id: requestId,
+      payload: { groups },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "access_group_list_idp_failed", message);
   }
 }
 

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -583,6 +583,7 @@ export type ServerRequest =
   | { type: "model.method.run"; id: string; payload: ModelMethodRunPayload }
   | { type: "access.grant.list"; id: string; payload?: AccessGrantListPayload }
   | { type: "access.group.list"; id: string; payload?: AccessGroupListPayload }
+  | { type: "access.group.list-idp"; id: string }
   | { type: "access.check"; id: string; payload: AccessCheckPayload }
   | { type: "access.can-i"; id: string; payload: AccessCanIPayload }
   | { type: "access.reload"; id: string }
@@ -854,6 +855,16 @@ export interface AccessGrantListResponse {
 
 export interface AccessGroupListResponse {
   groups: Record<string, unknown>[];
+}
+
+export interface AccessGroupListIdpResponse {
+  groups: AccessGroupIdpEntry[];
+}
+
+export interface AccessGroupIdpEntry {
+  name: string;
+  activeTokenCount: number;
+  lastSeenAt: string;
 }
 
 export interface AccessCheckResponse {
@@ -1326,6 +1337,11 @@ export type ServerMessage =
     type: "access.group.list";
     id: string;
     payload: AccessGroupListResponse;
+  }
+  | {
+    type: "access.group.list-idp";
+    id: string;
+    payload: AccessGroupListIdpResponse;
   }
   | { type: "access.check"; id: string; payload: AccessCheckResponse }
   | { type: "access.can-i"; id: string; payload: AccessCanIResponse }


### PR DESCRIPTION
## Summary

- Adds `swamp access group list-idp --server <url>` subcommand that aggregates IdP groups from active server tokens
- Shows group name, active token count, and last-seen timestamp — gives operators observability into which IdP group claims the server has seen
- Server-only (errors clearly without `--server`); requires `read` on `access:group`
- Plumbed end-to-end: protocol types → Zod validation → server handler → connection dispatch → CLI command → renderer (log table + JSON)

## Test Plan

- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt` — passes
- [x] Renderer tests — 3 new tests (header/data, empty, JSON)
- [x] CLI command tests — 4 new tests (subcommand exists, `--server` option, `--token` option, no `--repo-dir`)
- [x] `--help` output verified via compiled binary
- [x] `--server` requirement verified (clear error without it)
- [x] Pre-existing test failures unchanged (65 on main, 65 on branch)

Closes swamp-club#1611