### PR TITLE
fix(serve): add filesystem polling to --grant-reload auto (swamp-club#1610)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -116,6 +116,7 @@ import {
   type PolicyReloadMode,
   PolicySnapshotLoader,
 } from "../../domain/access/policy_snapshot_loader.ts";
+import { GrantsDirectoryPoller } from "../../domain/access/grants_directory_poller.ts";
 import {
   createAdminGrantStore,
   materializeAdmins,
@@ -2026,6 +2027,18 @@ export const serveCommand = new Command()
       mode: grantReloadMode,
     });
 
+    let grantsDirectoryPoller: GrantsDirectoryPoller | null = null;
+    if (grantReloadMode === "auto") {
+      grantsDirectoryPoller = new GrantsDirectoryPoller({
+        grantsDir,
+        externalGrantsFile: externalGrantsFilePath,
+        validateCondition: validateGrantCondition,
+        fileGrantStore,
+        policySnapshotLoader,
+      });
+      await grantsDirectoryPoller.start();
+    }
+
     const cancelRegistry = new RunCancelRegistry();
     const detachRuns = merged.detachRuns;
     const activeRunRegistry = new ActiveRunRegistry({
@@ -3145,6 +3158,9 @@ export const serveCommand = new Command()
       }
       if (collectiveRefreshService) {
         await collectiveRefreshService.dispose();
+      }
+      if (grantsDirectoryPoller) {
+        await grantsDirectoryPoller.stop();
       }
       await policySnapshotLoader.dispose();
       // Final telemetry flush, after runs have drained so their entries are

--- a/src/domain/access/grants_directory_poller.ts
+++ b/src/domain/access/grants_directory_poller.ts
@@ -1,0 +1,215 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getLogger } from "@logtape/logtape";
+import { join } from "@std/path";
+import {
+  type ConditionValidator,
+  type GrantFileEntry,
+  parseGrantFile,
+  readGrantFiles,
+} from "./grant_file.ts";
+import {
+  type FileGrantStore,
+  reconcileAllFileGrants,
+} from "./grant_file_reconciler.ts";
+import type { PolicySnapshotLoader } from "./policy_snapshot_loader.ts";
+
+const logger = getLogger(["swamp", "domain", "access", "grants-poller"]);
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+
+export interface GrantsDirectoryPollerOptions {
+  grantsDir: string;
+  externalGrantsFile?: string;
+  validateCondition?: ConditionValidator;
+  fileGrantStore: FileGrantStore;
+  policySnapshotLoader: PolicySnapshotLoader;
+  pollIntervalMs?: number;
+}
+
+export class GrantsDirectoryPoller {
+  readonly #grantsDir: string;
+  readonly #externalGrantsFile: string | undefined;
+  readonly #validateCondition: ConditionValidator | undefined;
+  readonly #fileGrantStore: FileGrantStore;
+  readonly #policySnapshotLoader: PolicySnapshotLoader;
+  readonly #pollIntervalMs: number;
+  #timer: ReturnType<typeof setInterval> | null = null;
+  #contentHash: string = "";
+  #pendingReconcile: Promise<void> = Promise.resolve();
+  #reconciling = false;
+
+  constructor(options: GrantsDirectoryPollerOptions) {
+    this.#grantsDir = options.grantsDir;
+    this.#externalGrantsFile = options.externalGrantsFile;
+    this.#validateCondition = options.validateCondition;
+    this.#fileGrantStore = options.fileGrantStore;
+    this.#policySnapshotLoader = options.policySnapshotLoader;
+    this.#pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  }
+
+  async start(): Promise<void> {
+    if (this.#timer) return;
+    this.#contentHash = await this.#computeContentHash();
+    this.#timer = setInterval(() => {
+      this.#poll();
+    }, this.#pollIntervalMs);
+    const intervalSec = this.#pollIntervalMs / 1000;
+    logger
+      .info`Grants directory poller started (interval: ${intervalSec}s)`;
+  }
+
+  async stop(): Promise<void> {
+    if (this.#timer) {
+      clearInterval(this.#timer);
+      this.#timer = null;
+    }
+    await this.#pendingReconcile;
+  }
+
+  #poll(): void {
+    if (this.#reconciling) return;
+
+    this.#pendingReconcile = this.#pendingReconcile.then(() =>
+      this.#checkAndReconcile()
+    );
+  }
+
+  async #checkAndReconcile(): Promise<void> {
+    this.#reconciling = true;
+    try {
+      const newHash = await this.#computeContentHash();
+      if (newHash === this.#contentHash) return;
+
+      logger.info`Grants directory change detected, reconciling`;
+
+      const grantFileResults = await readGrantFiles(
+        this.#grantsDir,
+        this.#validateCondition,
+      );
+
+      const validEntries = new Map<string, GrantFileEntry[]>();
+      for (const [filename, result] of grantFileResults) {
+        if (result.errors.length > 0) {
+          for (const error of result.errors) {
+            const loc = error.entryIndex !== undefined
+              ? `${error.filename} entry ${error.entryIndex + 1}`
+              : error.filename;
+            logger
+              .warn`Grant file error during auto-reload: ${loc}: ${error.message}`;
+          }
+        }
+        validEntries.set(filename, result.entries);
+      }
+
+      if (this.#externalGrantsFile) {
+        try {
+          const content = await Deno.readTextFile(this.#externalGrantsFile);
+          if (content.trim().length > 0) {
+            const externalResult = parseGrantFile(
+              this.#externalGrantsFile,
+              content,
+              this.#validateCondition,
+            );
+            if (externalResult.errors.length > 0) {
+              for (const error of externalResult.errors) {
+                logger
+                  .warn`External grants file error during auto-reload: ${error.message}`;
+              }
+            }
+            validEntries.set(this.#externalGrantsFile, externalResult.entries);
+          }
+        } catch (error) {
+          logger
+            .warn`Failed to read external grants file during auto-reload: ${error}`;
+        }
+      }
+
+      const reconcileResult = await reconcileAllFileGrants(
+        validEntries,
+        this.#fileGrantStore,
+      );
+
+      if (
+        reconcileResult.totalCreated > 0 ||
+        reconcileResult.totalRevoked > 0 ||
+        reconcileResult.totalReactivated > 0
+      ) {
+        logger
+          .info`Grants auto-reload reconciled (${reconcileResult.filesProcessed} file(s)): ${reconcileResult.totalCreated} created, ${reconcileResult.totalRevoked} revoked, ${reconcileResult.totalReactivated} reactivated, ${reconcileResult.totalUnchanged} unchanged`;
+      }
+
+      await this.#policySnapshotLoader.load();
+      this.#contentHash = newHash;
+    } catch (error) {
+      logger.error`Grants directory poll failed: ${error}`;
+    } finally {
+      this.#reconciling = false;
+    }
+  }
+
+  async #computeContentHash(): Promise<string> {
+    const parts: string[] = [];
+
+    try {
+      const dirEntries: Deno.DirEntry[] = [];
+      for await (const entry of Deno.readDir(this.#grantsDir)) {
+        dirEntries.push(entry);
+      }
+
+      const files = dirEntries
+        .filter((e) =>
+          (e.isFile || e.isSymlink) &&
+          (e.name.endsWith(".yaml") || e.name.endsWith(".yml")) &&
+          !e.name.startsWith(".")
+        )
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+      for (const file of files) {
+        const path = join(this.#grantsDir, file.name);
+        try {
+          const content = await Deno.readTextFile(path);
+          parts.push(`${file.name}:${content}`);
+        } catch {
+          parts.push(`${file.name}:ERROR`);
+        }
+      }
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+
+    if (this.#externalGrantsFile) {
+      try {
+        const content = await Deno.readTextFile(this.#externalGrantsFile);
+        parts.push(`EXTERNAL:${content}`);
+      } catch {
+        parts.push("EXTERNAL:ERROR");
+      }
+    }
+
+    const data = new TextEncoder().encode(parts.join("\n"));
+    const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+    const hashArray = new Uint8Array(hashBuffer);
+    return Array.from(hashArray).map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  }
+}

--- a/src/domain/access/grants_directory_poller_test.ts
+++ b/src/domain/access/grants_directory_poller_test.ts
@@ -1,0 +1,344 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { GrantsDirectoryPoller } from "./grants_directory_poller.ts";
+import type { FileGrantStore } from "./grant_file_reconciler.ts";
+import type { PolicySnapshotLoader } from "./policy_snapshot_loader.ts";
+import type { Grant } from "../models/access/grant_model.ts";
+
+const VALID_GRANT_YAML =
+  `grants:\n  - subject: "user:adam"\n    effect: allow\n    actions: [run]\n    resource: "workflow:*"`;
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-poller-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+function createMockFileGrantStore(): FileGrantStore & { writeCalls: number } {
+  const mock = {
+    writeCalls: 0,
+    queryFileGrants() {
+      return Promise.resolve(
+        new Map<
+          string,
+          { grant: Grant; modelId: string; instanceName: string }
+        >(),
+      );
+    },
+    ensureDefinition(_instanceName: string) {
+      return Promise.resolve(crypto.randomUUID());
+    },
+    writeGrant(
+      _modelId: string,
+      _instanceName: string,
+      _grant: Grant,
+    ) {
+      mock.writeCalls++;
+      return Promise.resolve();
+    },
+  };
+  return mock;
+}
+
+function createMockLoader(): {
+  loader: PolicySnapshotLoader;
+  loadCalls: number;
+  reset: () => void;
+} {
+  const state = { loadCalls: 0 };
+  const loader = {
+    load() {
+      state.loadCalls++;
+      return Promise.resolve(
+        undefined as unknown as ReturnType<PolicySnapshotLoader["load"]>,
+      );
+    },
+  } as unknown as PolicySnapshotLoader;
+  return {
+    loader,
+    get loadCalls() {
+      return state.loadCalls;
+    },
+    reset() {
+      state.loadCalls = 0;
+    },
+  };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+Deno.test("GrantsDirectoryPoller: start and stop lifecycle", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "grants");
+    await ensureDir(grantsDir);
+
+    const store = createMockFileGrantStore();
+    const mock = createMockLoader();
+
+    const poller = new GrantsDirectoryPoller({
+      grantsDir,
+      fileGrantStore: store,
+      policySnapshotLoader: mock.loader,
+      pollIntervalMs: 60_000,
+    });
+
+    await poller.start();
+    await poller.stop();
+  });
+});
+
+Deno.test("GrantsDirectoryPoller: detects new file and triggers reconcile + load", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "grants");
+    await ensureDir(grantsDir);
+
+    const store = createMockFileGrantStore();
+    const mock = createMockLoader();
+
+    const poller = new GrantsDirectoryPoller({
+      grantsDir,
+      fileGrantStore: store,
+      policySnapshotLoader: mock.loader,
+      pollIntervalMs: 50,
+    });
+
+    await poller.start();
+
+    await Deno.writeTextFile(join(grantsDir, "team.yaml"), VALID_GRANT_YAML);
+
+    await delay(200);
+    await poller.stop();
+
+    assertEquals(mock.loadCalls > 0, true, "load() should have been called");
+    assertEquals(store.writeCalls > 0, true, "grants should have been written");
+  });
+});
+
+Deno.test("GrantsDirectoryPoller: detects modified file content", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "grants");
+    await ensureDir(grantsDir);
+    await Deno.writeTextFile(join(grantsDir, "team.yaml"), VALID_GRANT_YAML);
+
+    const store = createMockFileGrantStore();
+    const mock = createMockLoader();
+
+    const poller = new GrantsDirectoryPoller({
+      grantsDir,
+      fileGrantStore: store,
+      policySnapshotLoader: mock.loader,
+      pollIntervalMs: 50,
+    });
+
+    await poller.start();
+    mock.reset();
+    store.writeCalls = 0;
+
+    const modifiedYaml =
+      `grants:\n  - subject: "user:sarah"\n    effect: allow\n    actions: [read]\n    resource: "data:*"`;
+    await Deno.writeTextFile(join(grantsDir, "team.yaml"), modifiedYaml);
+
+    await delay(200);
+    await poller.stop();
+
+    assertEquals(mock.loadCalls > 0, true, "load() should have been called");
+  });
+});
+
+Deno.test("GrantsDirectoryPoller: detects removed file", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "grants");
+    await ensureDir(grantsDir);
+    await Deno.writeTextFile(join(grantsDir, "team.yaml"), VALID_GRANT_YAML);
+
+    const store = createMockFileGrantStore();
+    const mock = createMockLoader();
+
+    const poller = new GrantsDirectoryPoller({
+      grantsDir,
+      fileGrantStore: store,
+      policySnapshotLoader: mock.loader,
+      pollIntervalMs: 50,
+    });
+
+    await poller.start();
+    mock.reset();
+
+    await Deno.remove(join(grantsDir, "team.yaml"));
+
+    await delay(200);
+    await poller.stop();
+
+    assertEquals(mock.loadCalls > 0, true, "load() should have been called");
+  });
+});
+
+Deno.test("GrantsDirectoryPoller: unchanged files produce no reconcile", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "grants");
+    await ensureDir(grantsDir);
+    await Deno.writeTextFile(join(grantsDir, "team.yaml"), VALID_GRANT_YAML);
+
+    const store = createMockFileGrantStore();
+    const mock = createMockLoader();
+
+    const poller = new GrantsDirectoryPoller({
+      grantsDir,
+      fileGrantStore: store,
+      policySnapshotLoader: mock.loader,
+      pollIntervalMs: 50,
+    });
+
+    await poller.start();
+    mock.reset();
+    store.writeCalls = 0;
+
+    await delay(200);
+    await poller.stop();
+
+    assertEquals(mock.loadCalls, 0, "load() should not have been called");
+    assertEquals(store.writeCalls, 0, "no grants should have been written");
+  });
+});
+
+Deno.test("GrantsDirectoryPoller: external grants file changes detected", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "grants");
+    await ensureDir(grantsDir);
+    const externalFile = join(dir, "external-grants.yaml");
+    await Deno.writeTextFile(externalFile, VALID_GRANT_YAML);
+
+    const store = createMockFileGrantStore();
+    const mock = createMockLoader();
+
+    const poller = new GrantsDirectoryPoller({
+      grantsDir,
+      externalGrantsFile: externalFile,
+      fileGrantStore: store,
+      policySnapshotLoader: mock.loader,
+      pollIntervalMs: 50,
+    });
+
+    await poller.start();
+    mock.reset();
+
+    const modifiedYaml =
+      `grants:\n  - subject: "user:sarah"\n    effect: deny\n    actions: [run]\n    resource: "workflow:*"`;
+    await Deno.writeTextFile(externalFile, modifiedYaml);
+
+    await delay(200);
+    await poller.stop();
+
+    assertEquals(mock.loadCalls > 0, true, "load() should have been called");
+  });
+});
+
+Deno.test("GrantsDirectoryPoller: handles missing grants directory gracefully", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "nonexistent-grants");
+
+    const store = createMockFileGrantStore();
+    const mock = createMockLoader();
+
+    const poller = new GrantsDirectoryPoller({
+      grantsDir,
+      fileGrantStore: store,
+      policySnapshotLoader: mock.loader,
+      pollIntervalMs: 50,
+    });
+
+    await poller.start();
+    await delay(150);
+    await poller.stop();
+  });
+});
+
+Deno.test("GrantsDirectoryPoller: ignores non-YAML files", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "grants");
+    await ensureDir(grantsDir);
+    await Deno.writeTextFile(join(grantsDir, "readme.txt"), "not a grant file");
+
+    const store = createMockFileGrantStore();
+    const mock = createMockLoader();
+
+    const poller = new GrantsDirectoryPoller({
+      grantsDir,
+      fileGrantStore: store,
+      policySnapshotLoader: mock.loader,
+      pollIntervalMs: 50,
+    });
+
+    await poller.start();
+    mock.reset();
+
+    await Deno.writeTextFile(
+      join(grantsDir, "readme.txt"),
+      "modified non-yaml",
+    );
+
+    await delay(200);
+    await poller.stop();
+
+    assertEquals(mock.loadCalls, 0, "load() should not have been called");
+  });
+});
+
+Deno.test("GrantsDirectoryPoller: ignores dot-prefixed files", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "grants");
+    await ensureDir(grantsDir);
+
+    const store = createMockFileGrantStore();
+    const mock = createMockLoader();
+
+    const poller = new GrantsDirectoryPoller({
+      grantsDir,
+      fileGrantStore: store,
+      policySnapshotLoader: mock.loader,
+      pollIntervalMs: 50,
+    });
+
+    await poller.start();
+    mock.reset();
+
+    await Deno.writeTextFile(
+      join(grantsDir, ".hidden.yaml"),
+      VALID_GRANT_YAML,
+    );
+
+    await delay(200);
+    await poller.stop();
+
+    assertEquals(mock.loadCalls, 0, "load() should not have been called");
+  });
+});

--- a/src/domain/access/mod.ts
+++ b/src/domain/access/mod.ts
@@ -47,6 +47,8 @@ export {
   readGrantFiles,
 } from "./grant_file.ts";
 
+export { GrantsDirectoryPoller } from "./grants_directory_poller.ts";
+
 export {
   createFileGrantStore,
   type FileGrantStore,


### PR DESCRIPTION
## Summary

- Add `GrantsDirectoryPoller` that polls the grants directory (and optional `--grants-file`) every 30 seconds, computes a SHA-256 content hash, and only reconciles + reloads the policy snapshot when the hash changes
- Wire the poller into serve startup/shutdown when `--grant-reload auto` is set
- Polling chosen over `Deno.watchFs` because inotify does not reliably detect Kubernetes ConfigMap symlink swaps (Deno bug #27560), following the proven pattern used by Thanos reloader and prometheus-config-reloader

Fixes swamp-club#1610

## Test Plan

- [x] 9 new unit tests covering: start/stop lifecycle, new/modified/removed file detection, no-op on unchanged files, external grants file changes, missing directory handling, non-YAML and dot-prefixed file filtering
- [x] All 187 access domain tests pass (including 9 new)
- [x] Manual verification: started `swamp serve --auth-mode oauth --grant-reload auto`, added a grant YAML file — poller detected and reconciled within 30s
- [x] Manual verification: simulated K8s ConfigMap symlink swap (`..data` → new timestamped directory) — poller detected content change through symlink chain, revoked old grants, created new grants
- [x] `deno check`, `deno lint`, `deno fmt` pass
- [x] `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)