### PR TITLE
fix(quest): drop GenesisHeartbeat the server no longer sends

### DIFF
--- a/src/domain/quest/genesis_pass.ts
+++ b/src/domain/quest/genesis_pass.ts
@@ -66,14 +66,6 @@ export interface GenesisChallenge {
   readonly done: boolean;
 }
 
-/** A single event in the display-only XP heartbeat stream. */
-export interface GenesisHeartbeat {
-  readonly kind: "drip" | "spike";
-  readonly amount: number;
-  readonly label: string;
-  readonly at: string;
-}
-
 /** Summary of the next tier above the operative's current position. */
 export interface GenesisNextTier {
   readonly n: number;
@@ -104,5 +96,4 @@ export interface GenesisPass {
   readonly ladderFraction: number;
   readonly tiers: GenesisTier[];
   readonly challenges: GenesisChallenge[];
-  readonly heartbeat: GenesisHeartbeat[];
 }


### PR DESCRIPTION
## Summary

- Remove the `GenesisHeartbeat` interface and `heartbeat` member from `GenesisPass` in `src/domain/quest/genesis_pass.ts`
- The server removed this field from the Genesis pass JSON in lab #1587 — the CLI type was stale
- Nothing imported the type or read the field; pure type hygiene

Fixes swamp-club#1588

## Test Plan

- `deno check` passes — no compile errors from the removal
- `deno fmt` and `deno lint` clean
- Grep confirms `GenesisHeartbeat` had zero imports outside `genesis_pass.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)