### PR TITLE
fix(models): propagate I/O errors instead of misreporting as broken definitions

### DIFF
--- a/src/infrastructure/persistence/extension_workflow_repository.ts
+++ b/src/infrastructure/persistence/extension_workflow_repository.ts
@@ -20,6 +20,7 @@
 import { walk } from "@std/fs/walk";
 import { getLogger } from "@logtape/logtape";
 import { parse as parseYaml } from "@std/yaml";
+import { isIoError } from "./io_errors.ts";
 import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import {
   createWorkflowId,
@@ -81,10 +82,17 @@ export class ExtensionWorkflowRepository implements WorkflowRepository {
               seenNames.add(workflow.name);
               workflows.push(workflow);
             }
-          } catch (parseError) {
-            const errorMsg = parseError instanceof Error
-              ? parseError.message
-              : String(parseError);
+          } catch (error) {
+            if (isIoError(error)) {
+              throw new UserError(
+                `Failed to read extension workflow ${entry.path}: ${
+                  error instanceof Error ? error.message : error
+                }. If the open-file limit was reached, raise it with 'ulimit -n'.`,
+              );
+            }
+            const errorMsg = error instanceof Error
+              ? error.message
+              : String(error);
             logger
               .warn`Skipping broken extension workflow ${entry.path}: ${errorMsg}`;
           }
@@ -145,12 +153,18 @@ export class ExtensionWorkflowRepository implements WorkflowRepository {
             if (data.id === id) {
               return entry.path;
             }
-          } catch {
-            // Skip broken files
+          } catch (error) {
+            if (isIoError(error)) {
+              throw new UserError(
+                `Failed to read extension workflow ${entry.path}: ${
+                  error instanceof Error ? error.message : error
+                }. If the open-file limit was reached, raise it with 'ulimit -n'.`,
+              );
+            }
           }
         }
-      } catch {
-        // Directory doesn't exist
+      } catch (error) {
+        if (error instanceof UserError) throw error;
       }
     }
     return null;

--- a/src/infrastructure/persistence/io_errors.ts
+++ b/src/infrastructure/persistence/io_errors.ts
@@ -1,0 +1,52 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+const IO_ERROR_CODES = new Set([
+  "EMFILE",
+  "ENFILE",
+  "EACCES",
+  "EIO",
+  "ENOSPC",
+  "EROFS",
+  "EPERM",
+]);
+
+/**
+ * Distinguishes I/O and resource-exhaustion errors from YAML parse/validation
+ * errors. Only parse errors belong in the "skip this file and keep going" path;
+ * I/O errors must propagate so callers can surface an actionable message.
+ */
+export function isIoError(error: unknown): boolean {
+  if (error == null || typeof error !== "object") return false;
+  const e = error as Record<string, unknown>;
+
+  if (typeof e.code === "string" && IO_ERROR_CODES.has(e.code)) {
+    return true;
+  }
+
+  if (typeof e.message === "string") {
+    for (const code of IO_ERROR_CODES) {
+      if (e.message.includes(code)) return true;
+    }
+    if (e.message.includes("Too many open files")) return true;
+    if (e.message.includes("Permission denied")) return true;
+  }
+
+  return false;
+}

--- a/src/infrastructure/persistence/io_errors_test.ts
+++ b/src/infrastructure/persistence/io_errors_test.ts
@@ -1,0 +1,112 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { isIoError } from "./io_errors.ts";
+
+Deno.test("isIoError: returns true for EMFILE error with code property", () => {
+  const error = Object.assign(new Error("Too many open files"), {
+    code: "EMFILE",
+  });
+  assertEquals(isIoError(error), true);
+});
+
+Deno.test("isIoError: returns true for ENFILE error with code property", () => {
+  const error = Object.assign(new Error("File table overflow"), {
+    code: "ENFILE",
+  });
+  assertEquals(isIoError(error), true);
+});
+
+Deno.test("isIoError: returns true for EACCES error with code property", () => {
+  const error = Object.assign(new Error("Permission denied"), {
+    code: "EACCES",
+  });
+  assertEquals(isIoError(error), true);
+});
+
+Deno.test("isIoError: returns true for EIO error with code property", () => {
+  const error = Object.assign(new Error("Input/output error"), {
+    code: "EIO",
+  });
+  assertEquals(isIoError(error), true);
+});
+
+Deno.test("isIoError: returns true for ENOSPC error with code property", () => {
+  const error = Object.assign(new Error("No space left on device"), {
+    code: "ENOSPC",
+  });
+  assertEquals(isIoError(error), true);
+});
+
+Deno.test("isIoError: returns true for EMFILE in message without code property", () => {
+  const error = new Error("Error: Too many open files (os error 24) EMFILE");
+  assertEquals(isIoError(error), true);
+});
+
+Deno.test("isIoError: returns true for 'Too many open files' in message", () => {
+  const error = new Error("Too many open files (os error 24)");
+  assertEquals(isIoError(error), true);
+});
+
+Deno.test("isIoError: returns true for 'Permission denied' in message", () => {
+  const error = new Error("Permission denied (os error 13)");
+  assertEquals(isIoError(error), true);
+});
+
+Deno.test("isIoError: returns false for YAML parse error", () => {
+  const error = new SyntaxError("Unexpected token in YAML at line 3");
+  assertEquals(isIoError(error), false);
+});
+
+Deno.test("isIoError: returns false for generic Error", () => {
+  const error = new Error("Invalid definition data");
+  assertEquals(isIoError(error), false);
+});
+
+Deno.test("isIoError: returns false for TypeError", () => {
+  const error = new TypeError("Cannot read property 'name' of undefined");
+  assertEquals(isIoError(error), false);
+});
+
+Deno.test("isIoError: returns false for null", () => {
+  assertEquals(isIoError(null), false);
+});
+
+Deno.test("isIoError: returns false for undefined", () => {
+  assertEquals(isIoError(undefined), false);
+});
+
+Deno.test("isIoError: returns false for non-object", () => {
+  assertEquals(isIoError("EMFILE"), false);
+});
+
+Deno.test("isIoError: returns true for EPERM error with code property", () => {
+  const error = Object.assign(new Error("Operation not permitted"), {
+    code: "EPERM",
+  });
+  assertEquals(isIoError(error), true);
+});
+
+Deno.test("isIoError: returns true for EROFS error with code property", () => {
+  const error = Object.assign(new Error("Read-only file system"), {
+    code: "EROFS",
+  });
+  assertEquals(isIoError(error), true);
+});

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -22,6 +22,7 @@ import { join } from "@std/path";
 import { getLogger } from "@logtape/logtape";
 import { atomicWriteTextFile } from "./atomic_write.ts";
 import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
+import { isIoError } from "./io_errors.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { assertSafePath } from "./safe_path.ts";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
@@ -130,8 +131,16 @@ export class YamlDefinitionRepository implements DefinitionRepository {
             const content = await Deno.readTextFile(path);
             const data = parseYaml(content) as DefinitionData;
             definitions.push(Definition.fromData(data));
-          } catch (parseError) {
-            logger.warn`Skipping broken definition file ${path}: ${parseError}`;
+          } catch (error) {
+            if (isIoError(error)) {
+              throw new UserError(
+                `Failed to read definition file ${path}: ${
+                  error instanceof Error ? error.message : error
+                }. If the open-file limit was reached, raise it with 'ulimit -n'.`,
+              );
+            }
+            const msg = error instanceof Error ? error.message : String(error);
+            logger.warn`Skipping broken definition file ${path}: ${msg}`;
           }
         }
       }
@@ -172,8 +181,16 @@ export class YamlDefinitionRepository implements DefinitionRepository {
             const content = await Deno.readTextFile(path);
             const data = parseYaml(content) as DefinitionData;
             definitions.push(Definition.fromData(data));
-          } catch (parseError) {
-            logger.warn`Skipping broken definition file ${path}: ${parseError}`;
+          } catch (error) {
+            if (isIoError(error)) {
+              throw new UserError(
+                `Failed to read definition file ${path}: ${
+                  error instanceof Error ? error.message : error
+                }. If the open-file limit was reached, raise it with 'ulimit -n'.`,
+              );
+            }
+            const msg = error instanceof Error ? error.message : String(error);
+            logger.warn`Skipping broken definition file ${path}: ${msg}`;
           }
         }
       }
@@ -230,9 +247,16 @@ export class YamlDefinitionRepository implements DefinitionRepository {
               const typeStr = definition.type ?? pathSegments.join("/");
               return { definition, type: ModelType.create(typeStr) };
             }
-          } catch (parseError) {
-            logger
-              .warn`Skipping broken definition file ${fullPath}: ${parseError}`;
+          } catch (error) {
+            if (isIoError(error)) {
+              throw new UserError(
+                `Failed to read definition file ${fullPath}: ${
+                  error instanceof Error ? error.message : error
+                }. If the open-file limit was reached, raise it with 'ulimit -n'.`,
+              );
+            }
+            const msg = error instanceof Error ? error.message : String(error);
+            logger.warn`Skipping broken definition file ${fullPath}: ${msg}`;
           }
         } else if (entry.isDirectory) {
           // Recursively search subdirectories
@@ -294,9 +318,16 @@ export class YamlDefinitionRepository implements DefinitionRepository {
             // Prefer the type from the YAML, fall back to path-based type
             const typeStr = definition.type ?? pathSegments.join("/");
             results.push({ definition, type: ModelType.create(typeStr) });
-          } catch (parseError) {
-            logger
-              .warn`Skipping broken definition file ${fullPath}: ${parseError}`;
+          } catch (error) {
+            if (isIoError(error)) {
+              throw new UserError(
+                `Failed to read definition file ${fullPath}: ${
+                  error instanceof Error ? error.message : error
+                }. If the open-file limit was reached, raise it with 'ulimit -n'.`,
+              );
+            }
+            const msg = error instanceof Error ? error.message : String(error);
+            logger.warn`Skipping broken definition file ${fullPath}: ${msg}`;
           }
         } else if (entry.isDirectory) {
           // Recursively search subdirectories

--- a/src/infrastructure/persistence/yaml_definition_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository_test.ts
@@ -661,3 +661,80 @@ Deno.test("YamlDefinitionRepository.save passes through an unregistered type (sc
     assertNotEquals(await repo.findById(testType, definition.id), null);
   });
 });
+
+// --- I/O error propagation tests ---
+
+Deno.test("YamlDefinitionRepository.findAll throws UserError on EMFILE", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const goodDef = createTestDefinition("good-def");
+    await repo.save(testType, goodDef);
+
+    const originalReadTextFile = Deno.readTextFile;
+    Deno.readTextFile = () => {
+      throw Object.assign(new Error("Too many open files (os error 24)"), {
+        code: "EMFILE",
+      });
+    };
+    try {
+      const error = await assertRejects(
+        () => repo.findAll(testType),
+        UserError,
+      );
+      assertStringIncludes(error.message, "Too many open files");
+      assertStringIncludes(error.message, "ulimit -n");
+    } finally {
+      Deno.readTextFile = originalReadTextFile;
+    }
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findByNameGlobal throws UserError on EMFILE", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const goodDef = createTestDefinition("good-def");
+    await repo.save(testType, goodDef);
+
+    const originalReadTextFile = Deno.readTextFile;
+    Deno.readTextFile = () => {
+      throw Object.assign(new Error("Too many open files (os error 24)"), {
+        code: "EMFILE",
+      });
+    };
+    try {
+      const error = await assertRejects(
+        () => repo.findByNameGlobal("good-def"),
+        UserError,
+      );
+      assertStringIncludes(error.message, "Too many open files");
+      assertStringIncludes(error.message, "ulimit -n");
+    } finally {
+      Deno.readTextFile = originalReadTextFile;
+    }
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findAllGlobal throws UserError on EACCES", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const goodDef = createTestDefinition("good-def");
+    await repo.save(testType, goodDef);
+
+    const originalReadTextFile = Deno.readTextFile;
+    Deno.readTextFile = () => {
+      throw Object.assign(new Error("Permission denied (os error 13)"), {
+        code: "EACCES",
+      });
+    };
+    try {
+      const error = await assertRejects(
+        () => repo.findAllGlobal(),
+        UserError,
+      );
+      assertStringIncludes(error.message, "Permission denied");
+      assertStringIncludes(error.message, "ulimit -n");
+    } finally {
+      Deno.readTextFile = originalReadTextFile;
+    }
+  });
+});

--- a/src/infrastructure/persistence/yaml_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository.ts
@@ -21,6 +21,7 @@ import { ensureDir } from "@std/fs";
 import { basename, join } from "@std/path";
 import { getLogger } from "@logtape/logtape";
 import { atomicWriteTextFile } from "./atomic_write.ts";
+import { isIoError } from "./io_errors.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import { assertSafePath } from "./safe_path.ts";
@@ -33,6 +34,7 @@ import {
   Workflow,
   type WorkflowData,
 } from "../../domain/workflows/workflow.ts";
+import { UserError } from "../../domain/errors.ts";
 import type { EventBus } from "../../domain/events/event_bus.ts";
 import {
   createWorkflowCreated,
@@ -140,10 +142,17 @@ export class YamlWorkflowRepository implements WorkflowRepository {
             const workflow = Workflow.fromData(data);
             this.idToActualPath.set(workflow.id as WorkflowId, path);
             workflows.push(workflow);
-          } catch (parseError) {
-            const errorMsg = parseError instanceof Error
-              ? parseError.message
-              : String(parseError);
+          } catch (error) {
+            if (isIoError(error)) {
+              throw new UserError(
+                `Failed to read workflow file ${path}: ${
+                  error instanceof Error ? error.message : error
+                }. If the open-file limit was reached, raise it with 'ulimit -n'.`,
+              );
+            }
+            const errorMsg = error instanceof Error
+              ? error.message
+              : String(error);
             const workflowName = this.tryExtractName(path);
 
             if (errorMsg.includes('type "shell" is no longer supported')) {


### PR DESCRIPTION
## Summary

Fixes swamp-club#1620.

- Add `isIoError` type guard that distinguishes I/O and resource-exhaustion errors (EMFILE, ENFILE, EACCES, EIO, ENOSPC, EROFS, EPERM) from YAML parse/validation errors
- Refactor catch blocks in `YamlDefinitionRepository` (4 sites), `YamlWorkflowRepository` (1 site), and `ExtensionWorkflowRepository` (2 sites) to re-throw I/O errors as `UserError` with an actionable message mentioning `ulimit -n`
- Fix error interpolation in definition repo log lines to extract `.message` instead of dumping the full Error object with stacktrace
- Fix bare `catch` in `ExtensionWorkflowRepository.findPath` that would have swallowed the re-thrown `UserError`

Parse/validation errors continue to be skipped and logged as before.

## Test Plan

- 16 new unit tests for `isIoError` covering all error codes, message-based detection, and negative cases
- 3 new unit tests for `YamlDefinitionRepository` verifying EMFILE aborts the walk and surfaces as `UserError` (on `findAll`, `findByNameGlobal`, `findAllGlobal`)
- All 42 tests in modified files pass
- `deno check`, `deno lint`, `deno fmt` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)