### PR TITLE
fix(expressions): invalidate data.latest() cache after step writes

### DIFF
--- a/.claude/skills/swamp/references/data/references/examples.md
+++ b/.claude/skills/swamp/references/data/references/examples.md
@@ -13,19 +13,19 @@
 
 ## CEL Expression Quick Reference
 
-| Expression Pattern                                           | Description                                 |
-| ------------------------------------------------------------ | ------------------------------------------- |
-| `model.<name>.resource.<spec>.<instance>.attributes.<field>` | Cross-model resource reference (PREFERRED)  |
-| `model.<name>.resource.result.result.attributes.stdout`      | command/shell stdout                        |
-| `model.<name>.file.<spec>.<instance>.path`                   | File path reference                         |
-| `self.name`                                                  | Current model's name                        |
-| `inputs.<name>`                                              | Workflow or model runtime input             |
-| `env.<VAR_NAME>`                                             | Environment variable                        |
-| `vault.get("<vault-name>", "<key>")`                         | Vault secret                                |
-| `data.version("<model>", "<name>", <version>)`               | Specific version of data                    |
-| `data.latest("<model>", "<name>")`                           | Latest version (snapshot at workflow start) |
-| `data.findByTag("<key>", "<value>")`                         | Find data by tag                            |
-| `data.findBySpec("<model>", "<spec>")`                       | Find all instances from a spec              |
+| Expression Pattern                                           | Description                                |
+| ------------------------------------------------------------ | ------------------------------------------ |
+| `model.<name>.resource.<spec>.<instance>.attributes.<field>` | Cross-model resource reference (PREFERRED) |
+| `model.<name>.resource.result.result.attributes.stdout`      | command/shell stdout                       |
+| `model.<name>.file.<spec>.<instance>.path`                   | File path reference                        |
+| `self.name`                                                  | Current model's name                       |
+| `inputs.<name>`                                              | Workflow or model runtime input            |
+| `env.<VAR_NAME>`                                             | Environment variable                       |
+| `vault.get("<vault-name>", "<key>")`                         | Vault secret                               |
+| `data.version("<model>", "<name>", <version>)`               | Specific version of data                   |
+| `data.latest("<model>", "<name>")`                           | Latest version (sees current-run writes)   |
+| `data.findByTag("<key>", "<value>")`                         | Find data by tag                           |
+| `data.findBySpec("<model>", "<spec>")`                       | Find all instances from a spec             |
 
 ## CEL Path Patterns by Model Type
 

--- a/.claude/skills/swamp/references/data/references/expressions.md
+++ b/.claude/skills/swamp/references/data/references/expressions.md
@@ -105,8 +105,8 @@ manifest: ${{ data.query('tags.role == "manifest"', '{"name": name, "version": v
   and across workflow runs (persisted data).
 - `model.<name>.file.<specName>.<instanceName>` — accesses file metadata (path,
   size, contentType). Same behavior as resource expressions.
-- `data.latest(modelName, dataName)` — reads persisted data snapshot taken at
-  workflow start.
+- `data.latest(modelName, dataName)` — reads the latest persisted data for a
+  model. Sees writes made by earlier steps in the same workflow run.
 - Use `data.version()` function for specific versions
 - Use `data.findByTag()` to query across models
 - See the workflow skill's

--- a/.claude/skills/swamp/references/model/references/examples.md
+++ b/.claude/skills/swamp/references/model/references/examples.md
@@ -13,7 +13,7 @@
 
 | Expression Pattern                                           | Description                               | Example Value                 |
 | ------------------------------------------------------------ | ----------------------------------------- | ----------------------------- |
-| `data.latest("<model>", "<name>").attributes.<field>`        | Latest data (PREFERRED, sync disk read)   | VPC ID, subnet CIDR, etc.     |
+| `data.latest("<model>", "<name>").attributes.<field>`        | Latest data (sees current-run writes)     | VPC ID, subnet CIDR, etc.     |
 | `data.latest("<model>", "<name>").?attributes.?<field>`      | Null-safe — returns null if missing       | Prior cycle findings          |
 | `data.version("<model>", "<name>", N).attributes.<field>`    | Specific version of data                  | Rollback to version 1         |
 | `data.findBySpec("<model>", "<spec>")`                       | Find all instances from a spec            | All subnets from scanner      |

--- a/.claude/skills/swamp/references/workflow/references/data-chaining.md
+++ b/.claude/skills/swamp/references/workflow/references/data-chaining.md
@@ -316,6 +316,10 @@ First run: both steps execute. Second run: both guards are truthy (data exists),
 both steps skip. If `lookup-ami` succeeded but `create-instance` failed, re-run
 skips the lookup and retries only the create.
 
+Guards see writes made by earlier steps in the same run — a guard that reads
+`data.latest("x", "y")` after a prior step wrote to those coordinates will see
+the freshly written data.
+
 ### Skip based on value comparison
 
 ```yaml

--- a/.claude/skills/swamp/references/workflow/references/execution-semantics.md
+++ b/.claude/skills/swamp/references/workflow/references/execution-semantics.md
@@ -55,11 +55,16 @@ follows this sequence:
 
 1. **Dependency conditions** — `dependsOn` conditions are checked. If not met,
    the step is skipped with reason `"dependency"`.
-2. **Expression context** — the step's expression context is built, including
-   `self.*` for forEach steps, `inputs.*`, `data.*`, and `run.*`.
+2. **Expression context** — the step receives a shallow copy of the run-wide
+   expression context, including `self.*` for forEach steps, `inputs.*`,
+   `data.*`, and `run.*`. The `data` namespace is shared across all steps —
+   `data.latest()` results are cached per-coordinate, and the cache is
+   invalidated when a model method step writes data, so subsequent steps (and
+   their guards) see fresh values.
 3. **Guard evaluation** — if the step declares a `guard` expression, it is
    evaluated. A truthy result skips the step with reason `"guarded"` (already
    done). A falsy result proceeds to execution. A CEL error fails the step.
+   Guards see writes made by earlier steps in the same run.
 4. **Task execution** — the step's task runs (model method, nested workflow,
    manual approval, or assert).
 

--- a/integration/workflow_data_latest_test.ts
+++ b/integration/workflow_data_latest_test.ts
@@ -1,0 +1,203 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { CLI_ARGS, initializeTestRepo } from "./test_helpers.ts";
+import { Workflow } from "../src/domain/workflows/workflow.ts";
+import { Job } from "../src/domain/workflows/job.ts";
+import { Step } from "../src/domain/workflows/step.ts";
+import { StepTask } from "../src/domain/workflows/step_task.ts";
+import { TriggerCondition } from "../src/domain/workflows/trigger_condition.ts";
+import { YamlWorkflowRepository } from "../src/infrastructure/persistence/yaml_workflow_repository.ts";
+import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
+import { Definition } from "../src/domain/definitions/definition.ts";
+import { SHELL_MODEL_TYPE } from "../src/domain/models/command/shell/shell_model.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-data-latest-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+async function runCliCommand(
+  args: string[],
+  cwd: string,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [...CLI_ARGS, ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd,
+  });
+
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}
+
+Deno.test("workflow run: data.latest() sees writes from earlier steps after guard caches null", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const producer = Definition.create({
+      name: "producer",
+      methods: { execute: { arguments: { run: "echo producer-output" } } },
+    });
+    await definitionRepo.save(SHELL_MODEL_TYPE, producer);
+
+    const repo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "guard-then-consume",
+      jobs: [
+        Job.create({
+          name: "main",
+          steps: [
+            Step.create({
+              name: "produce",
+              guard: '${{ data.latest("producer", "result") }}',
+              task: StepTask.model("producer", "execute"),
+            }),
+            Step.create({
+              name: "consume",
+              dependsOn: [{
+                step: "produce",
+                condition: TriggerCondition.completed(),
+              }],
+              task: StepTask.assert(
+                'data.latest("producer", "result") != null',
+                "data.latest must see the data written by the produce step",
+              ),
+            }),
+          ],
+        }),
+      ],
+    });
+    await repo.save(workflow);
+
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "guard-then-consume",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Workflow should succeed. stderr: ${result.stderr}\nstdout: ${result.stdout}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.status, "succeeded");
+    assertEquals(output.jobs[0].steps[0].status, "succeeded");
+    assertEquals(output.jobs[0].steps[1].status, "succeeded");
+  });
+});
+
+Deno.test("workflow run: data.latest() sees writes regardless of read ordering", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const stamper = Definition.create({
+      name: "stamper",
+      methods: { execute: { arguments: { run: "echo stamped" } } },
+    });
+    await definitionRepo.save(SHELL_MODEL_TYPE, stamper);
+
+    const repo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "read-order-independent",
+      jobs: [
+        Job.create({
+          name: "main",
+          steps: [
+            Step.create({
+              name: "early-read",
+              task: StepTask.assert(
+                'data.latest("stamper", "result") == null || data.latest("stamper", "result") != null',
+                "early read — touches the coordinates before the write",
+              ),
+            }),
+            Step.create({
+              name: "write",
+              dependsOn: [{
+                step: "early-read",
+                condition: TriggerCondition.succeeded(),
+              }],
+              task: StepTask.model("stamper", "execute"),
+            }),
+            Step.create({
+              name: "late-read",
+              dependsOn: [{
+                step: "write",
+                condition: TriggerCondition.completed(),
+              }],
+              task: StepTask.assert(
+                'data.latest("stamper", "result") != null',
+                "late read must see the data written by the write step",
+              ),
+            }),
+          ],
+        }),
+      ],
+    });
+    await repo.save(workflow);
+
+    const result = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "read-order-independent",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Workflow should succeed. stderr: ${result.stderr}\nstdout: ${result.stdout}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.status, "succeeded");
+    assertEquals(output.jobs[0].steps[0].status, "succeeded");
+    assertEquals(output.jobs[0].steps[1].status, "succeeded");
+    assertEquals(output.jobs[0].steps[2].status, "succeeded");
+  });
+});

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -238,6 +238,13 @@ export interface DataNamespace {
     predicate: string,
     select?: string,
   ): Promise<DataRecord[] | unknown[]>;
+
+  /**
+   * Invalidate the cached `latest()` result for a specific model+data
+   * coordinate so subsequent reads re-fetch from disk. Called by the
+   * workflow engine after a step writes data.
+   */
+  invalidateLatest?(modelName: string, dataName: string): void;
 }
 
 /**
@@ -911,6 +918,14 @@ export class ModelResolver {
       ): Promise<DataRecord[] | unknown[]> => {
         if (!this.dataQueryService) return [];
         return await this.dataQueryService.query(predicate, { select });
+      },
+      invalidateLatest: (modelName: string, dataName: string): void => {
+        const suffix = `\0${modelName}\0${dataName}`;
+        for (const key of latestCache.keys()) {
+          if (key.endsWith(suffix)) {
+            latestCache.delete(key);
+          }
+        }
       },
     };
   }

--- a/src/domain/expressions/model_resolver_test.ts
+++ b/src/domain/expressions/model_resolver_test.ts
@@ -1173,3 +1173,237 @@ Deno.test("workers.connected() returns empty array when all workers disconnected
     catalog.close();
   });
 });
+
+// ============================================================================
+// invalidateLatest() causes re-read of written coordinate
+// ============================================================================
+
+Deno.test("invalidateLatest: re-reads coordinate after invalidation", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalog,
+    );
+    const type = ModelType.create("test/model");
+
+    const model = Definition.create({
+      name: "cached-model",
+      globalArguments: {},
+    });
+    await defRepo.save(type, model);
+
+    const data = Data.create({
+      name: "result",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", modelName: "cached-model" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      data,
+      new TextEncoder().encode(JSON.stringify({ value: "old" })),
+    );
+
+    const dqs = new DataQueryService(catalog, dataRepo);
+    await dqs.query('name == ""');
+
+    const resolver = new ModelResolver(defRepo, {
+      repoDir,
+      dataRepo,
+      dataQueryService: dqs,
+    });
+    const ctx = await resolver.buildContext();
+    assertExists(ctx.data);
+
+    const first = await ctx.data.latest("cached-model", "result");
+    assertExists(first);
+    assertEquals(first.attributes.value, "old");
+
+    await dataRepo.save(
+      type,
+      model.id,
+      data,
+      new TextEncoder().encode(JSON.stringify({ value: "new" })),
+    );
+
+    const stale = await ctx.data.latest("cached-model", "result");
+    assertExists(stale);
+    assertEquals(stale.attributes.value, "old");
+
+    ctx.data.invalidateLatest!("cached-model", "result");
+
+    const fresh = await ctx.data.latest("cached-model", "result");
+    assertExists(fresh);
+    assertEquals(fresh.attributes.value, "new");
+    catalog.close();
+  });
+});
+
+// ============================================================================
+// invalidateLatest() only affects the targeted coordinate
+// ============================================================================
+
+Deno.test("invalidateLatest: other coordinates remain cached", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalog,
+    );
+    const type = ModelType.create("test/model");
+
+    const modelA = Definition.create({
+      name: "model-a",
+      globalArguments: {},
+    });
+    await defRepo.save(type, modelA);
+
+    const modelB = Definition.create({
+      name: "model-b",
+      globalArguments: {},
+    });
+    await defRepo.save(type, modelB);
+
+    const dataA = Data.create({
+      name: "result",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", modelName: "model-a" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      modelA.id,
+      dataA,
+      new TextEncoder().encode(JSON.stringify({ from: "a-v1" })),
+    );
+
+    const dataB = Data.create({
+      name: "result",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", modelName: "model-b" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      modelB.id,
+      dataB,
+      new TextEncoder().encode(JSON.stringify({ from: "b-v1" })),
+    );
+
+    const dqs = new DataQueryService(catalog, dataRepo);
+    await dqs.query('name == ""');
+
+    const resolver = new ModelResolver(defRepo, {
+      repoDir,
+      dataRepo,
+      dataQueryService: dqs,
+    });
+    const ctx = await resolver.buildContext();
+    assertExists(ctx.data);
+
+    await ctx.data.latest("model-a", "result");
+    await ctx.data.latest("model-b", "result");
+
+    await dataRepo.save(
+      type,
+      modelA.id,
+      dataA,
+      new TextEncoder().encode(JSON.stringify({ from: "a-v2" })),
+    );
+    await dataRepo.save(
+      type,
+      modelB.id,
+      dataB,
+      new TextEncoder().encode(JSON.stringify({ from: "b-v2" })),
+    );
+
+    ctx.data.invalidateLatest!("model-a", "result");
+
+    const freshA = await ctx.data.latest("model-a", "result");
+    assertExists(freshA);
+    assertEquals(freshA.attributes.from, "a-v2");
+
+    const staleB = await ctx.data.latest("model-b", "result");
+    assertExists(staleB);
+    assertEquals(staleB.attributes.from, "b-v1");
+
+    catalog.close();
+  });
+});
+
+// ============================================================================
+// invalidateLatest() clears cached null (miss)
+// ============================================================================
+
+Deno.test("invalidateLatest: clears cached null so new data is visible", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalog,
+    );
+    const type = ModelType.create("test/model");
+
+    const model = Definition.create({
+      name: "late-writer",
+      globalArguments: {},
+    });
+    await defRepo.save(type, model);
+
+    const dqs = new DataQueryService(catalog, dataRepo);
+    await dqs.query('name == ""');
+
+    const resolver = new ModelResolver(defRepo, {
+      repoDir,
+      dataRepo,
+      dataQueryService: dqs,
+    });
+    const ctx = await resolver.buildContext();
+    assertExists(ctx.data);
+
+    const miss = await ctx.data.latest("late-writer", "result");
+    assertEquals(miss, null);
+
+    const data = Data.create({
+      name: "result",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", modelName: "late-writer" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      data,
+      new TextEncoder().encode(JSON.stringify({ appeared: true })),
+    );
+
+    const stillNull = await ctx.data.latest("late-writer", "result");
+    assertEquals(stillNull, null);
+
+    ctx.data.invalidateLatest!("late-writer", "result");
+
+    const found = await ctx.data.latest("late-writer", "result");
+    assertExists(found);
+    assertEquals(found.attributes.appeared, true);
+    catalog.close();
+  });
+});

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -3041,6 +3041,17 @@ export class WorkflowExecutionService {
           }
         }
 
+        // Invalidate data.latest() cache entries for data written by this
+        // step so subsequent steps (and their guards) see fresh values.
+        if (stepExprContext?.data?.invalidateLatest && stepDataHandles) {
+          for (const handle of stepDataHandles) {
+            const modelName = handle.tags["modelName"];
+            if (modelName) {
+              stepExprContext.data.invalidateLatest(modelName, handle.name);
+            }
+          }
+        }
+
         // Update expression context for subsequent steps (only when not using --last-evaluated)
         if (stepExprContext && taskOutput.model) {
           // Create model entry if it doesn't exist


### PR DESCRIPTION
## Summary

- Add targeted `invalidateLatest(modelName, dataName)` to `DataNamespace` interface — invalidates only the specific cache entries whose coordinates were written to, preserving cache hits for unwritten coordinates
- Wire invalidation from `execution_service.ts` after model method steps write data, using the `dataHandles` already available at step completion
- Fix five doc references that inconsistently described `data.latest()` behavior (some said "snapshot at workflow start", others said "sees current-run data")

Closes swamp-club#1621

## Test Plan

- [x] 3 unit tests in `model_resolver_test.ts`: re-read after invalidation, targeted invalidation preserves other coordinates, cached null is cleared
- [x] 2 integration tests in `workflow_data_latest_test.ts`: guard-then-consume pattern (Reproduction A) and read-ordering independence (Reproduction B)
- [x] Verified against original reproduction at `/tmp/swamp-repro-issue-1621` — previously failing workflow now succeeds
- [x] `deno check`, `deno lint`, `deno fmt` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)