### PR TITLE
fix(serve): make server token definitions durable across pod restarts

### DIFF
--- a/src/cli/commands/access_token_mint.ts
+++ b/src/cli/commands/access_token_mint.ts
@@ -167,24 +167,36 @@ export const accessTokenMintCommand = new Command()
         );
       }
 
-      if (syncService) {
-        await syncService.markDirty();
-        await syncService.pushChanged();
+      renderServerTokenCreate(data, cliCtx.outputMode);
 
-        repoContext.catalogStore.invalidate();
-        const verifyResult = await findDefinitionByIdOrName(
-          repoContext.definitionRepo,
-          name,
-        );
-        if (!verifyResult) {
+      if (syncService) {
+        try {
+          await syncService.markDirty();
+          await syncService.pushChanged();
+
+          repoContext.catalogStore.invalidate();
+          const verifyResult = await findDefinitionByIdOrName(
+            repoContext.definitionRepo,
+            name,
+          );
+          if (!verifyResult) {
+            cliCtx.logger.warn(
+              "Server token {name} was minted but its definition could not be read back — it may not survive a pod restart. Re-mint the token if authentication fails after restart.",
+              { name },
+            );
+          }
+        } catch (syncError) {
           cliCtx.logger.warn(
-            "Server token {name} was minted but its definition could not be read back — it may not survive a pod restart. Re-mint the token if authentication fails after restart.",
-            { name },
+            "Sync failed after minting token {name} — token is local only and may not survive a pod restart: {error}",
+            {
+              name,
+              error: syncError instanceof Error
+                ? syncError.message
+                : String(syncError),
+            },
           );
         }
       }
-
-      renderServerTokenCreate(data, cliCtx.outputMode);
     } finally {
       if (flushModelLocks) {
         try {

--- a/src/cli/commands/access_token_mint.ts
+++ b/src/cli/commands/access_token_mint.ts
@@ -166,6 +166,24 @@ export const accessTokenMintCommand = new Command()
           `Minting token '${name}' ended without completing`,
         );
       }
+
+      if (syncService) {
+        await syncService.markDirty();
+        await syncService.pushChanged();
+
+        repoContext.catalogStore.invalidate();
+        const verifyResult = await findDefinitionByIdOrName(
+          repoContext.definitionRepo,
+          name,
+        );
+        if (!verifyResult) {
+          cliCtx.logger.warn(
+            "Server token {name} was minted but its definition could not be read back — it may not survive a pod restart. Re-mint the token if authentication fails after restart.",
+            { name },
+          );
+        }
+      }
+
       renderServerTokenCreate(data, cliCtx.outputMode);
     } finally {
       if (flushModelLocks) {

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -151,11 +151,13 @@ import {
 } from "../../infrastructure/persistence/paths.ts";
 import { DefaultDatastorePathResolver } from "../../infrastructure/persistence/default_datastore_path_resolver.ts";
 import {
+  checkTokenHealth,
   cleanupExpiredClaims,
   hydrateLocalCache,
   reconcileRemoteInterruptedRuns,
   replayPendingRuns,
   sweepStaleRecords,
+  sweepTokenConsistency,
 } from "../../serve/boot_reconciliation.ts";
 import {
   DEFAULT_HEARTBEAT_INTERVAL_MS,
@@ -1552,6 +1554,16 @@ export const serveCommand = new Command()
       "control_plane",
       tokenSecretsProvider,
     );
+
+    await checkTokenHealth({
+      tokenSecretsProvider,
+      hasRemoteControlPlane,
+    });
+
+    await sweepTokenConsistency({
+      repoContext,
+      tokenSecretsProvider,
+    });
 
     let oauthClientSecret = "";
     const resolvedUserNames: Record<string, string> = {};

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1555,7 +1555,7 @@ export const serveCommand = new Command()
       tokenSecretsProvider,
     );
 
-    await checkTokenHealth({
+    const healthResult = await checkTokenHealth({
       tokenSecretsProvider,
       hasRemoteControlPlane,
     });
@@ -1563,6 +1563,7 @@ export const serveCommand = new Command()
     await sweepTokenConsistency({
       repoContext,
       tokenSecretsProvider,
+      knownUndecryptable: new Set(healthResult.undecryptable),
     });
 
     let oauthClientSecret = "";

--- a/src/serve/boot_reconciliation.ts
+++ b/src/serve/boot_reconciliation.ts
@@ -683,6 +683,7 @@ export interface TokenConsistencyDeps {
   tokenSecretsProvider: VaultProvider & VaultDeleteProvider & {
     list(): Promise<string[]>;
   };
+  knownUndecryptable?: Set<string>;
 }
 
 export interface TokenInconsistency {
@@ -704,6 +705,21 @@ export async function sweepTokenConsistency(
 ): Promise<TokenConsistencyResult> {
   const inconsistencies: TokenInconsistency[] = [];
 
+  try {
+    return await sweepTokenConsistencyInner(deps, inconsistencies);
+  } catch (err) {
+    logger.warn(
+      "Token consistency sweep failed — skipping: {error}",
+      { error: err instanceof Error ? err.message : String(err) },
+    );
+    return { inconsistencies: [] };
+  }
+}
+
+async function sweepTokenConsistencyInner(
+  deps: TokenConsistencyDeps,
+  inconsistencies: TokenInconsistency[],
+): Promise<TokenConsistencyResult> {
   let secretKeys: string[];
   try {
     const allKeys = await deps.tokenSecretsProvider.list();
@@ -768,9 +784,19 @@ export async function sweepTokenConsistency(
     }
   }
 
+  const knownUndecryptable = deps.knownUndecryptable ?? new Set();
   for (const tokenName of definitionNames) {
     if (!secretTokenNames.has(tokenName)) continue;
     const key = `${SERVER_TOKEN_SECRET_KEY_PREFIX}${tokenName}`;
+    if (knownUndecryptable.has(key)) {
+      inconsistencies.push({
+        mode: "undecryptable-secret",
+        tokenName,
+        detail:
+          "Secret exists but cannot be decrypted — encryption key may have been lost or rotated",
+      });
+      continue;
+    }
     try {
       await deps.tokenSecretsProvider.get(key);
     } catch (err) {

--- a/src/serve/boot_reconciliation.ts
+++ b/src/serve/boot_reconciliation.ts
@@ -39,6 +39,14 @@ import { InstanceHeartbeatService } from "./instance_heartbeat.ts";
 import { cleanupActiveRunsForInstance } from "./active_run_tracker.ts";
 import type { PendingRunEntry } from "../infrastructure/persistence/run_tracker_store.ts";
 import { isSensitiveHeader } from "./webhook.ts";
+import {
+  SERVER_TOKEN_MODEL_TYPE,
+  SERVER_TOKEN_SECRET_KEY_PREFIX,
+} from "../domain/models/access/server_token_model.ts";
+import type {
+  VaultDeleteProvider,
+  VaultProvider,
+} from "../domain/vaults/vault_provider.ts";
 
 const logger = getSwampLogger(["serve", "boot-reconciliation"]);
 
@@ -592,6 +600,227 @@ export async function cleanupExpiredClaims(
     }
   }
   return cleaned;
+}
+
+// ── Token Durability Health Check ───────────────────────────────────
+
+export interface TokenHealthCheckDeps {
+  tokenSecretsProvider: VaultProvider & VaultDeleteProvider & {
+    list(): Promise<string[]>;
+  };
+  hasRemoteControlPlane: boolean;
+}
+
+export interface TokenHealthResult {
+  totalSecrets: number;
+  undecryptable: string[];
+  localOnlyWarning: boolean;
+}
+
+export async function checkTokenHealth(
+  deps: TokenHealthCheckDeps,
+): Promise<TokenHealthResult> {
+  const result: TokenHealthResult = {
+    totalSecrets: 0,
+    undecryptable: [],
+    localOnlyWarning: false,
+  };
+
+  let secretKeys: string[];
+  try {
+    secretKeys = await deps.tokenSecretsProvider.list();
+  } catch (err) {
+    logger.warn(
+      "Token health check: failed to list secrets: {error}",
+      { error: err instanceof Error ? err.message : String(err) },
+    );
+    return result;
+  }
+
+  const tokenSecretKeys = secretKeys.filter((k) =>
+    k.startsWith(SERVER_TOKEN_SECRET_KEY_PREFIX)
+  );
+  result.totalSecrets = tokenSecretKeys.length;
+
+  if (tokenSecretKeys.length === 0) return result;
+
+  if (!deps.hasRemoteControlPlane) {
+    result.localOnlyWarning = true;
+    logger.warn(
+      "Token secrets ({count}) are stored in a local-only control plane — they will be lost if this pod restarts. Configure a remote datastore to make tokens durable.",
+      { count: tokenSecretKeys.length },
+    );
+  }
+
+  for (const key of tokenSecretKeys) {
+    try {
+      await deps.tokenSecretsProvider.get(key);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes("not found")) continue;
+      result.undecryptable.push(key);
+      logger.error(
+        "Token health check: secret {key} is undecryptable — the encryption key may have been lost or rotated. Affected token will fail authentication.",
+        { key },
+      );
+    }
+  }
+
+  if (result.undecryptable.length > 0) {
+    logger.error(
+      "Token health check: {count} of {total} token secret(s) are undecryptable — re-mint affected tokens",
+      { count: result.undecryptable.length, total: tokenSecretKeys.length },
+    );
+  }
+
+  return result;
+}
+
+// ── Three-Layer Token Consistency Sweep ─────────────────────────────
+
+export interface TokenConsistencyDeps {
+  repoContext: RepositoryContext;
+  tokenSecretsProvider: VaultProvider & VaultDeleteProvider & {
+    list(): Promise<string[]>;
+  };
+}
+
+export interface TokenInconsistency {
+  mode:
+    | "orphaned-secret"
+    | "orphaned-data"
+    | "undecryptable-secret"
+    | "missing-secret";
+  tokenName: string;
+  detail: string;
+}
+
+export interface TokenConsistencyResult {
+  inconsistencies: TokenInconsistency[];
+}
+
+export async function sweepTokenConsistency(
+  deps: TokenConsistencyDeps,
+): Promise<TokenConsistencyResult> {
+  const inconsistencies: TokenInconsistency[] = [];
+
+  let secretKeys: string[];
+  try {
+    const allKeys = await deps.tokenSecretsProvider.list();
+    secretKeys = allKeys.filter((k) =>
+      k.startsWith(SERVER_TOKEN_SECRET_KEY_PREFIX)
+    );
+  } catch {
+    return { inconsistencies };
+  }
+
+  const secretTokenNames = new Set(
+    secretKeys.map((k) => k.slice(SERVER_TOKEN_SECRET_KEY_PREFIX.length)),
+  );
+
+  const dataItems = await loadAttrsForType(
+    deps.repoContext.unifiedDataRepo,
+    SERVER_TOKEN_MODEL_TYPE,
+  );
+  const dataTokenNames = new Set(
+    dataItems.map((item) => item.modelName).filter(Boolean),
+  );
+
+  const allTokenNames = new Set([...secretTokenNames, ...dataTokenNames]);
+  const definitionNames = new Set<string>();
+  for (const tokenName of allTokenNames) {
+    const def = await deps.repoContext.definitionRepo.findByName(
+      SERVER_TOKEN_MODEL_TYPE,
+      tokenName,
+    );
+    if (def) definitionNames.add(tokenName);
+  }
+
+  for (const tokenName of secretTokenNames) {
+    if (!definitionNames.has(tokenName)) {
+      inconsistencies.push({
+        mode: "orphaned-secret",
+        tokenName,
+        detail:
+          "Secret exists in _token-secrets but no definition found in auto-definitions",
+      });
+    }
+  }
+
+  for (const tokenName of dataTokenNames) {
+    if (!definitionNames.has(tokenName)) {
+      inconsistencies.push({
+        mode: "orphaned-data",
+        tokenName,
+        detail: "Token data exists but no definition found in auto-definitions",
+      });
+    }
+  }
+
+  for (const tokenName of definitionNames) {
+    if (!secretTokenNames.has(tokenName)) {
+      inconsistencies.push({
+        mode: "missing-secret",
+        tokenName,
+        detail:
+          "Definition and data exist but no secret found in _token-secrets — token will fail authentication",
+      });
+    }
+  }
+
+  for (const tokenName of definitionNames) {
+    if (!secretTokenNames.has(tokenName)) continue;
+    const key = `${SERVER_TOKEN_SECRET_KEY_PREFIX}${tokenName}`;
+    try {
+      await deps.tokenSecretsProvider.get(key);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes("not found")) continue;
+      inconsistencies.push({
+        mode: "undecryptable-secret",
+        tokenName,
+        detail:
+          "Secret exists but cannot be decrypted — encryption key may have been lost or rotated",
+      });
+    }
+  }
+
+  inconsistencies.sort((a, b) => {
+    const order: Record<TokenInconsistency["mode"], number> = {
+      "undecryptable-secret": 0,
+      "missing-secret": 1,
+      "orphaned-secret": 2,
+      "orphaned-data": 3,
+    };
+    return order[a.mode] - order[b.mode];
+  });
+
+  for (const item of inconsistencies) {
+    const level = item.mode === "undecryptable-secret" ||
+        item.mode === "missing-secret"
+      ? "error"
+      : "warn";
+    if (level === "error") {
+      logger.error(
+        "Token consistency: [{mode}] {tokenName} — {detail}",
+        { mode: item.mode, tokenName: item.tokenName, detail: item.detail },
+      );
+    } else {
+      logger.warn(
+        "Token consistency: [{mode}] {tokenName} — {detail}",
+        { mode: item.mode, tokenName: item.tokenName, detail: item.detail },
+      );
+    }
+  }
+
+  if (inconsistencies.length > 0) {
+    logger.warn(
+      "Token consistency sweep found {count} inconsistency/ies across server tokens",
+      { count: inconsistencies.length },
+    );
+  }
+
+  return { inconsistencies };
 }
 
 async function loadAttrsForType(

--- a/src/serve/boot_reconciliation_test.ts
+++ b/src/serve/boot_reconciliation_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals } from "@std/assert";
 import {
   type BootReconciliationDeps,
+  checkTokenHealth,
   CLAIM_TTL_MS,
   cleanupExpiredClaims,
   hydrateLocalCache,
@@ -29,6 +30,8 @@ import {
   replayPendingRuns,
   type ReplayPendingRunsDeps,
   sweepStaleRecords,
+  sweepTokenConsistency,
+  type TokenConsistencyDeps,
   type TransitionInput,
 } from "./boot_reconciliation.ts";
 import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
@@ -1280,4 +1283,230 @@ Deno.test("hydrateLocalCache: does not invalidate catalog on failure", async () 
   const h = createHydrateDeps({ pullError: new Error("network error") });
   await hydrateLocalCache(h.deps);
   assertEquals(h.invalidated.length, 0);
+});
+
+// ── Token Health Check Tests ─────────────────────────────────────────
+
+function createMockTokenSecretsProvider(opts: {
+  keys?: string[];
+  undecryptableKeys?: Set<string>;
+  listError?: Error;
+}) {
+  const secrets = new Map<string, string>();
+  for (const k of opts.keys ?? []) {
+    secrets.set(k, `plaintext-${k}`);
+  }
+  return {
+    getName: () => "_token-secrets",
+    get: (key: string): Promise<string> => {
+      if (opts.undecryptableKeys?.has(key)) {
+        return Promise.reject(new Error("AES-GCM decryption failed"));
+      }
+      const val = secrets.get(key);
+      if (!val) return Promise.reject(new Error(`Secret '${key}' not found`));
+      return Promise.resolve(val);
+    },
+    put: (_key: string, _val: string): Promise<void> => Promise.resolve(),
+    delete: (_key: string): Promise<void> => Promise.resolve(),
+    list: (): Promise<string[]> => {
+      if (opts.listError) return Promise.reject(opts.listError);
+      return Promise.resolve([...secrets.keys()]);
+    },
+  };
+}
+
+Deno.test("checkTokenHealth: returns empty result when no secrets exist", async () => {
+  const provider = createMockTokenSecretsProvider({ keys: [] });
+  const result = await checkTokenHealth({
+    tokenSecretsProvider: provider,
+    hasRemoteControlPlane: true,
+  });
+  assertEquals(result.totalSecrets, 0);
+  assertEquals(result.undecryptable.length, 0);
+  assertEquals(result.localOnlyWarning, false);
+});
+
+Deno.test("checkTokenHealth: detects undecryptable secrets", async () => {
+  const provider = createMockTokenSecretsProvider({
+    keys: ["server-token-good", "server-token-bad", "server-token-also-bad"],
+    undecryptableKeys: new Set(["server-token-bad", "server-token-also-bad"]),
+  });
+  const result = await checkTokenHealth({
+    tokenSecretsProvider: provider,
+    hasRemoteControlPlane: true,
+  });
+  assertEquals(result.totalSecrets, 3);
+  assertEquals(result.undecryptable.length, 2);
+  assertEquals(result.undecryptable.includes("server-token-bad"), true);
+  assertEquals(result.undecryptable.includes("server-token-also-bad"), true);
+});
+
+Deno.test("checkTokenHealth: warns on local-only control plane with tokens", async () => {
+  const provider = createMockTokenSecretsProvider({
+    keys: ["server-token-worker"],
+  });
+  const result = await checkTokenHealth({
+    tokenSecretsProvider: provider,
+    hasRemoteControlPlane: false,
+  });
+  assertEquals(result.localOnlyWarning, true);
+  assertEquals(result.totalSecrets, 1);
+});
+
+Deno.test("checkTokenHealth: no warning on local-only control plane without tokens", async () => {
+  const provider = createMockTokenSecretsProvider({ keys: [] });
+  const result = await checkTokenHealth({
+    tokenSecretsProvider: provider,
+    hasRemoteControlPlane: false,
+  });
+  assertEquals(result.localOnlyWarning, false);
+});
+
+Deno.test("checkTokenHealth: ignores non-token secrets", async () => {
+  const provider = createMockTokenSecretsProvider({
+    keys: ["oauth-access-token-foo", "oauth-client-secret"],
+  });
+  const result = await checkTokenHealth({
+    tokenSecretsProvider: provider,
+    hasRemoteControlPlane: true,
+  });
+  assertEquals(result.totalSecrets, 0);
+});
+
+Deno.test("checkTokenHealth: handles list failure gracefully", async () => {
+  const provider = createMockTokenSecretsProvider({
+    listError: new Error("GCS timeout"),
+  });
+  const result = await checkTokenHealth({
+    tokenSecretsProvider: provider,
+    hasRemoteControlPlane: true,
+  });
+  assertEquals(result.totalSecrets, 0);
+});
+
+// ── Token Consistency Sweep Tests ────────────────────────────────────
+
+function createMockConsistencyDeps(opts: {
+  secretKeys?: string[];
+  dataTokenNames?: string[];
+  definitionNames?: string[];
+  undecryptableKeys?: Set<string>;
+}): TokenConsistencyDeps {
+  const provider = createMockTokenSecretsProvider({
+    keys: (opts.secretKeys ?? []).map((n) => `server-token-${n}`),
+    undecryptableKeys: opts.undecryptableKeys
+      ? new Set([...opts.undecryptableKeys].map((n) => `server-token-${n}`))
+      : undefined,
+  });
+
+  const definitionSet = new Set(opts.definitionNames ?? []);
+
+  const dataItems = (opts.dataTokenNames ?? []).map((name) => ({
+    data: Data.create({
+      name: "token-main",
+      contentType: "application/json",
+      lifetime: "infinite" as const,
+      garbageCollection: 5,
+      tags: { modelName: name, type: "swamp/server-token" },
+      ownerDefinition: {
+        ownerType: "model-method" as const,
+        ownerRef: `def-${name}`,
+      },
+    }),
+    modelType: ModelType.create("swamp/server-token"),
+    modelId: `def-${name}`,
+  }));
+
+  return {
+    repoContext: {
+      definitionRepo: {
+        findByName: (_type: ModelType, name: string) =>
+          Promise.resolve(
+            definitionSet.has(name)
+              ? { name, id: `id-${name}`, type: "swamp/server-token" }
+              : null,
+          ),
+      },
+      unifiedDataRepo: {
+        findAllForType: () => Promise.resolve(dataItems),
+        getContent: (_mt: ModelType, _id: string, _name: string) =>
+          Promise.resolve(
+            encoder.encode(JSON.stringify({ state: "active" })),
+          ),
+      },
+    } as unknown as RepositoryContext,
+    tokenSecretsProvider: provider,
+  };
+}
+
+Deno.test("sweepTokenConsistency: detects orphaned secret", async () => {
+  const deps = createMockConsistencyDeps({
+    secretKeys: ["orphan-token"],
+    dataTokenNames: [],
+    definitionNames: [],
+  });
+  const result = await sweepTokenConsistency(deps);
+  assertEquals(result.inconsistencies.length, 1);
+  assertEquals(result.inconsistencies[0].mode, "orphaned-secret");
+  assertEquals(result.inconsistencies[0].tokenName, "orphan-token");
+});
+
+Deno.test("sweepTokenConsistency: detects orphaned data", async () => {
+  const deps = createMockConsistencyDeps({
+    secretKeys: [],
+    dataTokenNames: ["data-only-token"],
+    definitionNames: [],
+  });
+  const result = await sweepTokenConsistency(deps);
+  assertEquals(result.inconsistencies.length, 1);
+  assertEquals(result.inconsistencies[0].mode, "orphaned-data");
+  assertEquals(result.inconsistencies[0].tokenName, "data-only-token");
+});
+
+Deno.test("sweepTokenConsistency: detects missing secret", async () => {
+  const deps = createMockConsistencyDeps({
+    secretKeys: [],
+    dataTokenNames: ["def-token"],
+    definitionNames: ["def-token"],
+  });
+  const result = await sweepTokenConsistency(deps);
+  assertEquals(result.inconsistencies.length, 1);
+  assertEquals(result.inconsistencies[0].mode, "missing-secret");
+  assertEquals(result.inconsistencies[0].tokenName, "def-token");
+});
+
+Deno.test("sweepTokenConsistency: detects undecryptable secret", async () => {
+  const deps = createMockConsistencyDeps({
+    secretKeys: ["bad-token"],
+    dataTokenNames: ["bad-token"],
+    definitionNames: ["bad-token"],
+    undecryptableKeys: new Set(["bad-token"]),
+  });
+  const result = await sweepTokenConsistency(deps);
+  assertEquals(result.inconsistencies.length, 1);
+  assertEquals(result.inconsistencies[0].mode, "undecryptable-secret");
+});
+
+Deno.test("sweepTokenConsistency: reports no issues for consistent tokens", async () => {
+  const deps = createMockConsistencyDeps({
+    secretKeys: ["good-token"],
+    dataTokenNames: ["good-token"],
+    definitionNames: ["good-token"],
+  });
+  const result = await sweepTokenConsistency(deps);
+  assertEquals(result.inconsistencies.length, 0);
+});
+
+Deno.test("sweepTokenConsistency: orders by severity", async () => {
+  const deps = createMockConsistencyDeps({
+    secretKeys: ["orphan", "undecryptable"],
+    dataTokenNames: ["missing-secret-token"],
+    definitionNames: ["missing-secret-token", "undecryptable"],
+    undecryptableKeys: new Set(["undecryptable"]),
+  });
+  const result = await sweepTokenConsistency(deps);
+  const modes = result.inconsistencies.map((i) => i.mode);
+  assertEquals(modes[0], "undecryptable-secret");
+  assertEquals(modes[1], "missing-secret");
+  assertEquals(modes[2], "orphaned-secret");
 });

--- a/src/serve/device_auth_handler.ts
+++ b/src/serve/device_auth_handler.ts
@@ -43,6 +43,8 @@ import { VaultService } from "../domain/vaults/vault_service.ts";
 import { TOKEN_SECRETS_VAULT_NAME } from "../domain/vaults/control_plane_vault_provider.ts";
 import { YamlDefinitionRepository } from "../infrastructure/persistence/yaml_definition_repository.ts";
 import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
+import { findDefinitionByIdOrName } from "../domain/models/model_lookup.ts";
+import { join } from "@std/path";
 
 const logger = getSwampLogger(["serve", "device-auth"]);
 
@@ -314,6 +316,14 @@ async function mintServerTokenImpl(
       type: SERVER_TOKEN_MODEL_TYPE.normalized,
       name: tokenName,
     });
+    const defPath = join(
+      repoContext.autoDefinitionsDir,
+      SERVER_TOKEN_MODEL_TYPE.toDirectoryPath(),
+      `${def.id}.yaml`,
+    );
+    if (repoContext.markDirty) {
+      await repoContext.markDirty(defPath);
+    }
     const autoDefRepo = new YamlDefinitionRepository(
       repoDir,
       repoContext.eventBus,
@@ -357,6 +367,18 @@ async function mintServerTokenImpl(
   if (syncService) {
     await syncService.markDirty();
     await syncService.pushChanged();
+
+    repoContext.catalogStore.invalidate();
+    const verifyResult = await findDefinitionByIdOrName(
+      repoContext.definitionRepo,
+      tokenName,
+    );
+    if (!verifyResult) {
+      logger.warn(
+        "OAuth server token {name} was minted but its definition could not be read back — it may not survive a pod restart",
+        { name: tokenName },
+      );
+    }
   }
 
   logger.info("Minted OAuth server token {name} for {principal}", {


### PR DESCRIPTION
## Summary

Fixes swamp-club#1616. Server tokens minted during `swamp serve` (via OAuth
login) had their definition YAML written to local disk without per-path sync
tracking. On pod restart with ephemeral storage, the definition was lost — the
token secret and data survived in S3 but authentication failed permanently with
"Model not found."

**Changes:**

- **Per-path markDirty** on the definition YAML in `mintServerTokenImpl` so the
  sync service tracks it individually (previously relied on a bulk markDirty
  fallback)
- **Round-trip verification** after `pushChanged` in both mint paths — reads the
  definition back via the same lookup `authenticateServerToken` uses and warns
  if not found
- **CLI access-token-mint sync** — added `markDirty` + `pushChanged` for parity
  with the OAuth path (same bug, different code path)
- **Token health check at startup** — detects undecryptable secrets (encryption
  key loss/rotation) and warns when secrets are stored in a local-only control
  plane
- **Three-layer consistency sweep at startup** — cross-references definitions,
  data, and secrets; logs inconsistencies ordered by severity
  (undecryptable-secret > missing-secret > orphaned-secret > orphaned-data).
  Log-and-warn only, no auto-deletion.

## Test Plan

- [x] 12 new unit tests covering token health check (6) and consistency sweep (6)
- [x] All 103 existing serve tests pass (boot_reconciliation + device_auth_handler + token_auth)
- [x] Full type check, lint, format pass
- [x] **E2E verified**: Minio S3 backend → `swamp serve --auth-mode oauth --allowed-collectives swamp-internal --admins stack72` → OAuth device flow login → token minted → kill serve → delete local cache → restart serve → hydrate from S3 → `swamp data search --server ws://...` authenticates with the same token → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)