### PR TITLE
feat(serve): add --grants-dir for loading grants from a directory

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -316,6 +316,9 @@ export function collectServeExtraArgs(options: AnyOptions): string[] {
   if (options.grantsFile) {
     args.push("--grants-file", options.grantsFile as string);
   }
+  if (options.grantsDir) {
+    args.push("--grants-dir", options.grantsDir as string);
+  }
   if (options.grantReload && options.grantReload !== "manual") {
     args.push("--grant-reload", options.grantReload as string);
   }
@@ -517,6 +520,10 @@ const daemonEnableCommand = new Command()
   .option(
     "--grants-file <path:string>",
     "Path to an external grants YAML file loaded at startup",
+  )
+  .option(
+    "--grants-dir <path:string>",
+    "Path to a directory of grants YAML files loaded at startup",
   )
   .option(
     "--grant-reload <mode:string>",
@@ -841,6 +848,10 @@ export const serveCommand = new Command()
   .option(
     "--grants-file <path:string>",
     "Path to an external grants YAML file loaded at startup (env: SWAMP_GRANTS_FILE)",
+  )
+  .option(
+    "--grants-dir <path:string>",
+    "Path to a directory of grants YAML files loaded at startup (env: SWAMP_GRANTS_DIR)",
   )
   .option(
     "--grant-reload <mode:string>",
@@ -2000,6 +2011,82 @@ export const serveCommand = new Command()
       }
     }
 
+    const externalGrantsDirPath = merged.grantsDir
+      ? (isAbsolute(merged.grantsDir)
+        ? merged.grantsDir
+        : resolve(merged.grantsDir))
+      : undefined;
+    if (externalGrantsDirPath) {
+      let dirEntries: Deno.DirEntry[];
+      try {
+        dirEntries = [];
+        for await (const entry of Deno.readDir(externalGrantsDirPath)) {
+          dirEntries.push(entry);
+        }
+      } catch (cause) {
+        if (cause instanceof Deno.errors.NotFound) {
+          throw new UserError(
+            `External grants directory not found: ${externalGrantsDirPath}`,
+          );
+        }
+        throw new UserError(
+          `Failed to read external grants directory ${externalGrantsDirPath}: ${cause}`,
+        );
+      }
+
+      const yamlFiles = dirEntries
+        .filter((e) =>
+          (e.isFile || e.isSymlink) &&
+          (e.name.endsWith(".yaml") || e.name.endsWith(".yml")) &&
+          !e.name.startsWith(".")
+        )
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+      let totalLoaded = 0;
+      for (const file of yamlFiles) {
+        const filePath = join(externalGrantsDirPath, file.name);
+        let content: string;
+        try {
+          content = await Deno.readTextFile(filePath);
+        } catch (cause) {
+          throw new UserError(
+            `Failed to read grants file ${filePath}: ${cause}`,
+          );
+        }
+
+        if (content.trim().length === 0) continue;
+
+        const result = parseGrantFile(
+          filePath,
+          content,
+          validateGrantCondition,
+        );
+        if (result.errors.length > 0) {
+          const errorMessages = result.errors.map((e) => {
+            const loc = e.entryIndex !== undefined
+              ? `${e.filename} entry ${e.entryIndex + 1}`
+              : e.filename;
+            return `  ${loc}: ${e.message}`;
+          });
+          throw new UserError(
+            `Grants directory file validation failed — refusing to start:\n${
+              errorMessages.join("\n")
+            }`,
+          );
+        }
+        validEntries.set(filePath, result.entries);
+        totalLoaded += result.entries.length;
+      }
+
+      if (totalLoaded > 0) {
+        logger
+          .info`Loaded ${totalLoaded} grant(s) from ${yamlFiles.length} file(s) in external grants directory ${externalGrantsDirPath}`;
+      } else {
+        logger
+          .info`External grants directory ${externalGrantsDirPath} contains no grants`;
+      }
+    }
+
     const fileGrantStore = createFileGrantStore(
       repoContext.definitionRepo,
       autoDefRepo,
@@ -2035,6 +2122,7 @@ export const serveCommand = new Command()
       grantsDirectoryPoller = new GrantsDirectoryPoller({
         grantsDir,
         externalGrantsFile: externalGrantsFilePath,
+        externalGrantsDir: externalGrantsDirPath,
         validateCondition: validateGrantCondition,
         fileGrantStore,
         policySnapshotLoader,
@@ -2255,6 +2343,7 @@ export const serveCommand = new Command()
         instanceId,
         staleTtlMs,
         grantsFile: externalGrantsFilePath,
+        grantsDir: externalGrantsDirPath,
         hotReload: merged.hotReload,
         ...(Object.keys(resolvedUserNames).length > 0
           ? { resolvedUserNames }

--- a/src/domain/access/grants_directory_poller.ts
+++ b/src/domain/access/grants_directory_poller.ts
@@ -38,6 +38,7 @@ const DEFAULT_POLL_INTERVAL_MS = 30_000;
 export interface GrantsDirectoryPollerOptions {
   grantsDir: string;
   externalGrantsFile?: string;
+  externalGrantsDir?: string;
   validateCondition?: ConditionValidator;
   fileGrantStore: FileGrantStore;
   policySnapshotLoader: PolicySnapshotLoader;
@@ -47,6 +48,7 @@ export interface GrantsDirectoryPollerOptions {
 export class GrantsDirectoryPoller {
   readonly #grantsDir: string;
   readonly #externalGrantsFile: string | undefined;
+  readonly #externalGrantsDir: string | undefined;
   readonly #validateCondition: ConditionValidator | undefined;
   readonly #fileGrantStore: FileGrantStore;
   readonly #policySnapshotLoader: PolicySnapshotLoader;
@@ -59,6 +61,7 @@ export class GrantsDirectoryPoller {
   constructor(options: GrantsDirectoryPollerOptions) {
     this.#grantsDir = options.grantsDir;
     this.#externalGrantsFile = options.externalGrantsFile;
+    this.#externalGrantsDir = options.externalGrantsDir;
     this.#validateCondition = options.validateCondition;
     this.#fileGrantStore = options.fileGrantStore;
     this.#policySnapshotLoader = options.policySnapshotLoader;
@@ -142,6 +145,53 @@ export class GrantsDirectoryPoller {
         }
       }
 
+      if (this.#externalGrantsDir) {
+        try {
+          const dirEntries: Deno.DirEntry[] = [];
+          for await (const entry of Deno.readDir(this.#externalGrantsDir)) {
+            dirEntries.push(entry);
+          }
+          const yamlFiles = dirEntries
+            .filter((e) =>
+              (e.isFile || e.isSymlink) &&
+              (e.name.endsWith(".yaml") || e.name.endsWith(".yml")) &&
+              !e.name.startsWith(".")
+            )
+            .sort((a, b) => a.name.localeCompare(b.name));
+
+          for (const file of yamlFiles) {
+            const filePath = join(this.#externalGrantsDir, file.name);
+            try {
+              const content = await Deno.readTextFile(filePath);
+              if (content.trim().length === 0) continue;
+              const result = parseGrantFile(
+                filePath,
+                content,
+                this.#validateCondition,
+              );
+              if (result.errors.length > 0) {
+                for (const error of result.errors) {
+                  const loc = error.entryIndex !== undefined
+                    ? `${error.filename} entry ${error.entryIndex + 1}`
+                    : error.filename;
+                  logger
+                    .warn`External grants dir file error during auto-reload: ${loc}: ${error.message}`;
+                }
+              }
+              validEntries.set(filePath, result.entries);
+            } catch (error) {
+              logger
+                .warn`Failed to read external grants dir file ${filePath} during auto-reload: ${error}`;
+            }
+          }
+        } catch (error) {
+          if (!(error instanceof Deno.errors.NotFound)) {
+            logger
+              .warn`Failed to read external grants directory during auto-reload: ${error}`;
+          }
+        }
+      }
+
       const reconcileResult = await reconcileAllFileGrants(
         validEntries,
         this.#fileGrantStore,
@@ -203,6 +253,36 @@ export class GrantsDirectoryPoller {
         parts.push(`EXTERNAL:${content}`);
       } catch {
         parts.push("EXTERNAL:ERROR");
+      }
+    }
+
+    if (this.#externalGrantsDir) {
+      try {
+        const dirEntries: Deno.DirEntry[] = [];
+        for await (const entry of Deno.readDir(this.#externalGrantsDir)) {
+          dirEntries.push(entry);
+        }
+        const files = dirEntries
+          .filter((e) =>
+            (e.isFile || e.isSymlink) &&
+            (e.name.endsWith(".yaml") || e.name.endsWith(".yml")) &&
+            !e.name.startsWith(".")
+          )
+          .sort((a, b) => a.name.localeCompare(b.name));
+
+        for (const file of files) {
+          const path = join(this.#externalGrantsDir, file.name);
+          try {
+            const content = await Deno.readTextFile(path);
+            parts.push(`EXTDIR:${file.name}:${content}`);
+          } catch {
+            parts.push(`EXTDIR:${file.name}:ERROR`);
+          }
+        }
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw error;
+        }
       }
     }
 

--- a/src/domain/access/grants_directory_poller_test.ts
+++ b/src/domain/access/grants_directory_poller_test.ts
@@ -342,3 +342,99 @@ Deno.test("GrantsDirectoryPoller: ignores dot-prefixed files", async () => {
     assertEquals(mock.loadCalls, 0, "load() should not have been called");
   });
 });
+
+Deno.test("GrantsDirectoryPoller: external grants dir changes detected", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "grants");
+    await ensureDir(grantsDir);
+    const extDir = join(dir, "ext-grants");
+    await ensureDir(extDir);
+    await Deno.writeTextFile(join(extDir, "team.yaml"), VALID_GRANT_YAML);
+
+    const store = createMockFileGrantStore();
+    const mock = createMockLoader();
+
+    const poller = new GrantsDirectoryPoller({
+      grantsDir,
+      externalGrantsDir: extDir,
+      fileGrantStore: store,
+      policySnapshotLoader: mock.loader,
+      pollIntervalMs: 50,
+    });
+
+    await poller.start();
+    mock.reset();
+
+    const modifiedYaml =
+      `grants:\n  - subject: "user:sarah"\n    effect: deny\n    actions: [run]\n    resource: "workflow:*"`;
+    await Deno.writeTextFile(join(extDir, "team.yaml"), modifiedYaml);
+
+    await delay(200);
+    await poller.stop();
+
+    assertEquals(mock.loadCalls > 0, true, "load() should have been called");
+  });
+});
+
+Deno.test("GrantsDirectoryPoller: new file in external grants dir triggers reconcile", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "grants");
+    await ensureDir(grantsDir);
+    const extDir = join(dir, "ext-grants");
+    await ensureDir(extDir);
+
+    const store = createMockFileGrantStore();
+    const mock = createMockLoader();
+
+    const poller = new GrantsDirectoryPoller({
+      grantsDir,
+      externalGrantsDir: extDir,
+      fileGrantStore: store,
+      policySnapshotLoader: mock.loader,
+      pollIntervalMs: 50,
+    });
+
+    await poller.start();
+    mock.reset();
+    store.writeCalls = 0;
+
+    await Deno.writeTextFile(join(extDir, "new-team.yaml"), VALID_GRANT_YAML);
+
+    await delay(200);
+    await poller.stop();
+
+    assertEquals(mock.loadCalls > 0, true, "load() should have been called");
+    assertEquals(store.writeCalls > 0, true, "grants should have been written");
+  });
+});
+
+Deno.test("GrantsDirectoryPoller: unchanged external grants dir produces no reconcile", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "grants");
+    await ensureDir(grantsDir);
+    const extDir = join(dir, "ext-grants");
+    await ensureDir(extDir);
+    await Deno.writeTextFile(join(extDir, "team.yaml"), VALID_GRANT_YAML);
+
+    const store = createMockFileGrantStore();
+    const mock = createMockLoader();
+
+    const poller = new GrantsDirectoryPoller({
+      grantsDir,
+      externalGrantsDir: extDir,
+      fileGrantStore: store,
+      policySnapshotLoader: mock.loader,
+      pollIntervalMs: 50,
+    });
+
+    await poller.start();
+    mock.reset();
+    store.writeCalls = 0;
+
+    await delay(200);
+    await poller.stop();
+
+    assertEquals(mock.loadCalls, 0, "load() should not have been called");
+    assertEquals(store.writeCalls, 0, "no grants should have been written");
+  });
+});

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -622,6 +622,68 @@ export async function handleAccessReload(
       }
     }
 
+    if (ctx.grantsDir) {
+      try {
+        const dirEntries: Deno.DirEntry[] = [];
+        for await (const entry of Deno.readDir(ctx.grantsDir)) {
+          dirEntries.push(entry);
+        }
+        const yamlFiles = dirEntries
+          .filter((e) =>
+            (e.isFile || e.isSymlink) &&
+            (e.name.endsWith(".yaml") || e.name.endsWith(".yml")) &&
+            !e.name.startsWith(".")
+          )
+          .sort((a, b) => a.name.localeCompare(b.name));
+
+        for (const file of yamlFiles) {
+          const filePath = join(ctx.grantsDir, file.name);
+          try {
+            const content = await Deno.readTextFile(filePath);
+            if (content.trim().length === 0) continue;
+            const result = parseGrantFile(
+              filePath,
+              content,
+              validateGrantCondition,
+            );
+            if (result.errors.length > 0) {
+              allErrors.push(...result.errors);
+            } else {
+              validEntries.set(filePath, result.entries);
+            }
+          } catch (error) {
+            logger
+              .error`Failed to read external grants dir file ${filePath}: ${error}`;
+            allErrors.push({
+              filename: filePath,
+              message: `Failed to read: ${error}`,
+            });
+          }
+        }
+      } catch (error) {
+        logger
+          .error`Failed to read external grants directory ${ctx.grantsDir}: ${error}`;
+        allErrors.push({
+          filename: "external-grants-dir",
+          message: "Failed to read external grants directory",
+        });
+      }
+
+      if (allErrors.length > 0) {
+        send(socket, {
+          type: "access.reload",
+          id: requestId,
+          payload: {
+            success: false,
+            grantCount: 0,
+            groupCount: 0,
+            errors: formatGrantFileErrors(allErrors),
+          },
+        });
+        return;
+      }
+    }
+
     const autoDefDir = join(ctx.repoDir, ".swamp", "auto-definitions");
     const autoDefRepo = new YamlDefinitionRepository(
       ctx.repoDir,

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -105,6 +105,8 @@ export interface ConnectionContext {
   staleTtlMs?: number;
   /** Resolved path to external grants file, if --grants-file was provided. */
   grantsFile?: string;
+  /** Resolved path to external grants directory, if --grants-dir was provided. */
+  grantsDir?: string;
   /** Whether --hot-reload is enabled — gates serve.reload over WebSocket. */
   hotReload?: boolean;
   /** Inverted resolvedAdmins map: OAuth sub → username. Populated at startup in OAuth mode. */

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -33,6 +33,7 @@ export const SERVE_ENV_MAP: Readonly<Record<string, string>> = {
   certFile: "SWAMP_SERVE_CERT_FILE",
   keyFile: "SWAMP_SERVE_KEY_FILE",
   grantsFile: "SWAMP_GRANTS_FILE",
+  grantsDir: "SWAMP_GRANTS_DIR",
   wsIdleTimeout: "SWAMP_WS_IDLE_TIMEOUT",
   queueTimeout: "SWAMP_QUEUE_TIMEOUT",
   verifyOnEnroll: "SWAMP_VERIFY_ON_ENROLL",
@@ -86,6 +87,7 @@ export interface ServeConfigFile {
   "trust-proxy"?: boolean;
   "trusted-hosts"?: string[];
   "grants-file"?: string;
+  "grants-dir"?: string;
   "grant-reload"?: string;
   "ws-idle-timeout"?: string;
   "queue-timeout"?: string;
@@ -113,6 +115,7 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
   "trust-proxy",
   "trusted-hosts",
   "grants-file",
+  "grants-dir",
   "grant-reload",
   "ws-idle-timeout",
   "queue-timeout",
@@ -311,6 +314,7 @@ function validateConfigValues(
 
   const stringFields: [string, unknown][] = [
     ["grants-file", raw["grants-file"]],
+    ["grants-dir", raw["grants-dir"]],
     ["grant-reload", raw["grant-reload"]],
     ["ws-idle-timeout", raw["ws-idle-timeout"]],
     ["queue-timeout", raw["queue-timeout"]],
@@ -499,6 +503,7 @@ export interface MergedServeOptions {
   certFile?: string;
   keyFile?: string;
   grantsFile?: string;
+  grantsDir?: string;
   grantReload: string;
   webhook?: string[];
   webhookEndpoints?: WebhookEndpoint[];
@@ -665,6 +670,13 @@ export function mergeServeOptions(
     "grants-file",
     cliOptions.grantsFile as string | undefined,
     config?.["grants-file"],
+    undefined,
+  );
+
+  const grantsDir = resolveString(
+    "grants-dir",
+    cliOptions.grantsDir as string | undefined,
+    config?.["grants-dir"],
     undefined,
   );
 
@@ -858,6 +870,7 @@ export function mergeServeOptions(
     certFile,
     keyFile,
     grantsFile,
+    grantsDir,
     grantReload,
     webhook,
     webhookEndpoints,

--- a/src/serve/serve_config_test.ts
+++ b/src/serve/serve_config_test.ts
@@ -634,6 +634,83 @@ Deno.test("loadServeConfig: non-string grants-file produces error", () => {
   });
 });
 
+// ── grants-dir merge ──────────────────────────────────────────────────
+
+Deno.test("mergeServeOptions: grants-dir CLI flag wins over config and env", () => {
+  const config: ServeConfigFile = { "grants-dir": "/from/config" };
+  const cliOptions = { grantsDir: "/from/cli" };
+  const explicitFlags = new Set(["grants-dir"]);
+  const envLookup = () => undefined;
+
+  const merged = mergeServeOptions(
+    config,
+    cliOptions,
+    explicitFlags,
+    envLookup,
+  );
+  assertEquals(merged.grantsDir, "/from/cli");
+});
+
+Deno.test("mergeServeOptions: grants-dir env var wins over config when CLI not explicit", () => {
+  const config: ServeConfigFile = { "grants-dir": "/from/config" };
+  const cliOptions = {};
+  const explicitFlags = new Set<string>();
+  const envLookup = (name: string) =>
+    name === "SWAMP_GRANTS_DIR" ? "/from/env" : undefined;
+
+  const merged = mergeServeOptions(
+    config,
+    cliOptions,
+    explicitFlags,
+    envLookup,
+  );
+  assertEquals(merged.grantsDir, "/from/env");
+});
+
+Deno.test("mergeServeOptions: grants-dir from config when no CLI or env", () => {
+  const config: ServeConfigFile = { "grants-dir": "/from/config" };
+  const cliOptions = {};
+  const explicitFlags = new Set<string>();
+  const envLookup = () => undefined;
+
+  const merged = mergeServeOptions(
+    config,
+    cliOptions,
+    explicitFlags,
+    envLookup,
+  );
+  assertEquals(merged.grantsDir, "/from/config");
+});
+
+Deno.test("mergeServeOptions: grants-dir undefined when not specified anywhere", () => {
+  const cliOptions = {};
+  const explicitFlags = new Set<string>();
+  const envLookup = () => undefined;
+
+  const merged = mergeServeOptions(null, cliOptions, explicitFlags, envLookup);
+  assertEquals(merged.grantsDir, undefined);
+});
+
+Deno.test("loadServeConfig: grants-dir field is parsed", () => {
+  withTempDir((dir) => {
+    writeConfig(dir, { "grants-dir": "/etc/swamp/grants/" });
+    const config = loadServeConfig(undefined, dir);
+    assertNotEquals(config, null);
+    assertEquals(config!["grants-dir"], "/etc/swamp/grants/");
+  });
+});
+
+Deno.test("loadServeConfig: non-string grants-dir produces error", () => {
+  withTempDir((dir) => {
+    writeConfig(dir, { "grants-dir": 42 });
+    assertThrows(
+      () => loadServeConfig(undefined, dir),
+      Error,
+      "expected string",
+    );
+  });
+});
+
 // ── mergeServeOptions: new concurrency/duration fields ────────────────
 
 Deno.test("mergeServeOptions: max-concurrent-runs from CLI flag", () => {


### PR DESCRIPTION
## Summary

Closes swamp-club#1608

- Add `--grants-dir <path>` (env: `SWAMP_GRANTS_DIR`) to `swamp serve` that loads all `.yaml`/`.yml` files from a directory as grant sources
- Additive with `--grants-file` and repo-level `grants/` — files in the external directory are keyed by full resolved path to avoid basename collisions
- Missing directory is fatal at startup; empty directory is accepted; non-YAML and dot-prefixed files silently skipped
- `--grant-reload auto` watches the external directory for changes alongside existing sources
- Supported in CLI flags, env var, serve config file, and daemon mode

## Test Plan

- `serve_config_test.ts`: 6 new tests for merge priority (CLI > env > config), config parsing, and validation
- `grants_directory_poller_test.ts`: 3 new tests for external dir change detection, new file reconcile, and unchanged no-op
- All existing tests pass (12 poller, 61 config, 19 daemon)
- `deno check`, `deno lint`, `deno fmt` all clean
- Manually verified with compiled binary:
  - Happy path: 2 grants loaded from 2 files, reconciled with full-path sources
  - Missing directory: fatal startup error
  - Invalid YAML in directory: fatal startup error identifying the file
  - Empty directory: accepted with info log