### PR TITLE
fix(worker): stop retrying on permanent auth failures

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -953,6 +953,26 @@ re-dispatch never race into double execution:
 Transparent re-dispatch (or mid-step resume) of a write-bearing step is a later
 feature that must first solve write idempotency. It is not promised in v1.
 
+### Pre-enrollment failure handling
+
+When the control socket closes before enrollment completes (e.g. HTTP 401/403
+from token auth, or a network-level rejection), the worker treats it as a
+connection error and applies two guards:
+
+- **Permanent failure detection.** If the error message matches a known
+  permanent pattern (token revoked/expired/not-found, protocol mismatch,
+  enrollment allowance exhausted), the worker stops immediately with a clear
+  error. These conditions cannot be fixed by retrying.
+
+- **Consecutive failure cap.** If the error does not match a known pattern, the
+  worker retries up to 3 times. After 3 consecutive pre-enrollment failures, it
+  stops. The counter resets when enrollment succeeds, so transient blips during
+  an established session do not accumulate.
+
+Post-enrollment socket drops (the worker was enrolled and executing dispatches)
+continue to use exponential backoff and reconnect normally — a brief network
+interruption during a session should not terminate the worker.
+
 ## Security and trust
 
 The proxy-everything model with shipped code is a net security improvement over

--- a/src/worker/connect.ts
+++ b/src/worker/connect.ts
@@ -59,6 +59,9 @@ const REFRESH_FRACTION = 2 / 3;
 const RECONNECT_BASE_DELAY_MS = 1_000;
 const RECONNECT_MAX_DELAY_MS = 30_000;
 
+/** Give up after this many consecutive connection failures before enrollment. */
+const MAX_PRE_ENROLL_FAILURES = 3;
+
 export type WorkerStatusEvent =
   | { kind: "connecting"; url: string; attempt: number }
   | { kind: "enrolled"; workerId: string; reconnect: boolean }
@@ -197,6 +200,7 @@ export async function runWorker(
 
   let attempt = 0;
   let delayMs = RECONNECT_BASE_DELAY_MS;
+  let consecutivePreEnrollFailures = 0;
   while (!(options.signal?.aborted ?? false) && drainReason === null) {
     attempt++;
     options.onStatus?.({ kind: "connecting", url: options.url, attempt });
@@ -236,6 +240,7 @@ export async function runWorker(
           }
         },
       });
+      consecutivePreEnrollFailures = 0;
       options.onStatus?.({ kind: "disconnected", reason: outcome });
       delayMs = RECONNECT_BASE_DELAY_MS;
     } catch (error) {
@@ -243,6 +248,14 @@ export async function runWorker(
       if (isPermanentEnrollmentFailure(message)) {
         options.onStatus?.({ kind: "stopped", reason: message });
         throw error;
+      }
+      consecutivePreEnrollFailures++;
+      if (consecutivePreEnrollFailures >= MAX_PRE_ENROLL_FAILURES) {
+        const reason =
+          `connection failed ${MAX_PRE_ENROLL_FAILURES} consecutive times before enrollment — giving up (last error: ${message})`;
+        logger.error(reason);
+        options.onStatus?.({ kind: "stopped", reason });
+        throw new Error(reason);
       }
       options.onStatus?.({ kind: "disconnected", reason: message });
     }
@@ -298,7 +311,9 @@ function isPermanentEnrollmentFailure(message: string): boolean {
     message.includes("expired") ||
     message.includes("does not match") ||
     message.includes("already bound") ||
-    message.includes("protocol version");
+    message.includes("protocol version") ||
+    message.includes("does not exist") ||
+    message.includes("allowance exhausted");
 }
 
 function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
@@ -468,11 +483,12 @@ function connectOnce(args: ConnectOnceArgs): Promise<string> {
       }
       const detail = connectErrorDetail ||
         (parts.length > 0 ? ` (${parts.join(": ")})` : "");
-      finish(
-        enrolled
-          ? `control socket closed${detail}`
-          : `socket closed before enrollment${detail}`,
-      );
+      if (enrolled) {
+        finish(`control socket closed${detail}`);
+      } else {
+        const reason = `socket closed before enrollment${detail}`;
+        finish(reason, new Error(reason));
+      }
     };
 
     socket.onerror = (event: Event) => {

--- a/src/worker/connect_test.ts
+++ b/src/worker/connect_test.ts
@@ -199,6 +199,144 @@ Deno.test("runWorker: a stable cache directory keeps the machine id across resta
   }
 });
 
+/**
+ * A socket that immediately closes without calling onopen — simulates
+ * an HTTP-level rejection (401, 403, 429) where the WebSocket upgrade
+ * never completes.
+ */
+class RejectingSocket {
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: ((event: CloseEvent | Event | undefined) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(readonly errorMessage?: string) {
+    queueMicrotask(() => {
+      if (this.errorMessage) {
+        const event = new ErrorEvent("error", {
+          message: this.errorMessage,
+        });
+        this.onerror?.(event);
+      }
+      this.onclose?.(undefined);
+    });
+  }
+
+  send(_data: string): void {}
+  close(): void {}
+}
+
+Deno.test("runWorker: pre-enrollment failures stop after 3 consecutive attempts", async () => {
+  const events: WorkerStatusEvent[] = [];
+  let socketCount = 0;
+  const error = await assertRejects(
+    () =>
+      runWorker({
+        url: "ws://test:1",
+        token: "ci.s",
+        swampVersion: "1.2.3",
+        onStatus: (event) => events.push(event),
+        createSocket: () => {
+          socketCount++;
+          return new RejectingSocket() as unknown as WebSocket;
+        },
+      }),
+    Error,
+  );
+  assertStringIncludes(error.message, "3 consecutive times");
+  assertEquals(socketCount, 3);
+  assertEquals(events.at(-1)?.kind, "stopped");
+});
+
+Deno.test("runWorker: HTTP 401 stops after 3 consecutive attempts", async () => {
+  const events: WorkerStatusEvent[] = [];
+  let socketCount = 0;
+  const error = await assertRejects(
+    () =>
+      runWorker({
+        url: "ws://test:1",
+        token: "ci.s",
+        swampVersion: "1.2.3",
+        onStatus: (event) => events.push(event),
+        createSocket: () => {
+          socketCount++;
+          return new RejectingSocket(
+            "failed to connect to WebSocket: Invalid status code: 401",
+          ) as unknown as WebSocket;
+        },
+      }),
+    Error,
+  );
+  assertStringIncludes(error.message, "3 consecutive times");
+  assertEquals(socketCount, 3);
+  assertEquals(events.at(-1)?.kind, "stopped");
+});
+
+Deno.test("runWorker: 'does not exist' enrollment failure stops immediately", async () => {
+  const events: WorkerStatusEvent[] = [];
+  const error = await assertRejects(
+    () =>
+      runWorker({
+        url: "ws://test:1",
+        token: "dead.token",
+        swampVersion: "1.2.3",
+        onStatus: (event) => events.push(event),
+        createSocket: () =>
+          new FakeSocket((channel) => {
+            channel.register(RemoteMethod.enroll, () =>
+              Promise.reject(
+                new RpcError({
+                  code: "invalid_token",
+                  message: "Enrollment token 'dead' does not exist",
+                }),
+              ));
+          }) as unknown as WebSocket,
+      }),
+    Error,
+  );
+  assertStringIncludes(error.message, "does not exist");
+  assertEquals(events.at(-1)?.kind, "stopped");
+});
+
+Deno.test("runWorker: pre-enrollment failure counter resets after successful enrollment", async () => {
+  const events: WorkerStatusEvent[] = [];
+  let socketCount = 0;
+  const controller = new AbortController();
+
+  const done = runWorker({
+    url: "ws://test:1",
+    token: "ci.s",
+    swampVersion: "1.2.3",
+    signal: controller.signal,
+    onStatus: (event) => {
+      events.push(event);
+      if (event.kind === "enrolled") {
+        controller.abort();
+      }
+    },
+    createSocket: () => {
+      socketCount++;
+      // First two attempts fail before enrollment, third succeeds.
+      if (socketCount <= 2) {
+        return new RejectingSocket() as unknown as WebSocket;
+      }
+      const socket = new FakeSocket((channel) => {
+        channel.register(
+          RemoteMethod.enroll,
+          () => Promise.resolve(enrollResult("ci")),
+        );
+      });
+      return socket as unknown as WebSocket;
+    },
+  });
+
+  await done;
+  assertEquals(socketCount, 3);
+  const kinds = events.map((e) => e.kind);
+  assertEquals(kinds.includes("enrolled"), true);
+  assertEquals(kinds.at(-1), "stopped");
+});
+
 Deno.test("runWorker: permanent enrollment failures stop the loop", async () => {
   const events: WorkerStatusEvent[] = [];
   const error = await assertRejects(


### PR DESCRIPTION
## Summary

- Workers retried forever on permanent auth failures (bad token, revoked token, model not found) because pre-enrollment socket closes resolved `connectOnce` instead of rejecting — resetting backoff to 1s every time and bypassing `isPermanentEnrollmentFailure`
- Pre-enrollment socket closes now reject `connectOnce` so the catch path runs, exponential backoff works, and permanent failure patterns are evaluated
- Added "does not exist" and "allowance exhausted" to `isPermanentEnrollmentFailure` for token-not-found and enrollment cap scenarios
- Added a consecutive pre-enrollment failure counter (max 3) that stops the worker when the failure reason is opaque (e.g. HTTP 401/429 where the WebSocket API hides the response body)

## Test Plan

- [x] Added 4 new unit tests: 3-attempt cap, HTTP 401 3-attempt cap, "does not exist" immediate stop, counter reset after successful enrollment
- [x] All 8 worker connect tests pass
- [x] Reproduced the bug: `swamp serve --auth-mode token` + `swamp worker connect` with invalid server token retried every 1s indefinitely
- [x] Verified the fix: same scenario now stops after 3 attempts with exit code 1 and clear error message
- [x] Verified known permanent failures (token revoked/expired/not-found) still stop immediately on first attempt
- [x] Full `deno check` passes, no type errors introduced

Closes swamp-club#1617