### PR TITLE
feat(serve): GC expired and revoked server tokens

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -249,46 +249,6 @@ initialized, the server refuses to start.
 Collectives are snapshotted at login time and become stale if the user's
 collective membership changes in swamp-club. Refresh is a later phase.
 
-### Server token garbage collection
-
-Every `swamp auth server-login` mints a new `oauth-<random>` server token with a
-30-day expiry. Old tokens are never rotated in place — each login creates a fresh
-token. Over time, expired and revoked tokens accumulate across four storage
-layers: the definition YAML in `.swamp/auto-definitions/`, the token data record,
-the token secret in `_token-secrets`, and the OAuth access token in
-`_token-secrets`.
-
-The `ServerTokenGcService` runs as a periodic timer inside `swamp serve`
-(alongside the reconciliation timer and fire record reaper). On each sweep it
-queries all `swamp/server-token` data records, identifies GC-eligible tokens, and
-deletes them across all four layers.
-
-A token is GC-eligible when:
-
-- **Revoked** — deleted immediately (revocation is a deliberate admin action).
-- **Expired** — deleted after a configurable grace period (default 1 hour past
-  `expiresAt`). The grace period avoids racing with token refreshes or clock
-  skew.
-
-Active tokens that are past their `expiresAt` are treated as effectively expired
-without first running the `expire` model method — matching the
-`effectiveTokenState` pattern used by `swamp access token list`.
-
-Configuration:
-
-- `--token-gc-interval` (default `1h`, env `SWAMP_TOKEN_GC_INTERVAL`) — sweep
-  interval. Set to `0` to disable.
-- `--token-gc-grace-period` (default `1h`, env `SWAMP_TOKEN_GC_GRACE_PERIOD`) —
-  how long after expiry before deletion.
-
-The service runs once synchronously at startup (after token secret migration and
-`sweepTokenConsistency`), then starts the periodic timer. It is disposed during
-server shutdown alongside the collective refresh service.
-
-Per-token errors are caught and logged — a failure to delete one token does not
-block the rest of the sweep. `sweepTokenConsistency` at next boot flags any
-inconsistencies left behind by partial deletions.
-
 v1 is swamp-club-specific: the OAuth client endpoint paths
 (`/api/auth/device/code`, `/api/auth/device/token`,
 `/api/auth/oauth2/userinfo`, `/api/auth/oauth2/register`) are hardcoded.
@@ -992,6 +952,26 @@ re-dispatch never race into double execution:
 
 Transparent re-dispatch (or mid-step resume) of a write-bearing step is a later
 feature that must first solve write idempotency. It is not promised in v1.
+
+### Pre-enrollment failure handling
+
+When the control socket closes before enrollment completes (e.g. HTTP 401/403
+from token auth, or a network-level rejection), the worker treats it as a
+connection error and applies two guards:
+
+- **Permanent failure detection.** If the error message matches a known
+  permanent pattern (token revoked/expired/not-found, protocol mismatch,
+  enrollment allowance exhausted), the worker stops immediately with a clear
+  error. These conditions cannot be fixed by retrying.
+
+- **Consecutive failure cap.** If the error does not match a known pattern, the
+  worker retries up to 3 times. After 3 consecutive pre-enrollment failures, it
+  stops. The counter resets when enrollment succeeds, so transient blips during
+  an established session do not accumulate.
+
+Post-enrollment socket drops (the worker was enrolled and executing dispatches)
+continue to use exponential backoff and reconnect normally — a brief network
+interruption during a session should not terminate the worker.
 
 ## Security and trust
 

--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -249,6 +249,46 @@ initialized, the server refuses to start.
 Collectives are snapshotted at login time and become stale if the user's
 collective membership changes in swamp-club. Refresh is a later phase.
 
+### Server token garbage collection
+
+Every `swamp auth server-login` mints a new `oauth-<random>` server token with a
+30-day expiry. Old tokens are never rotated in place — each login creates a fresh
+token. Over time, expired and revoked tokens accumulate across four storage
+layers: the definition YAML in `.swamp/auto-definitions/`, the token data record,
+the token secret in `_token-secrets`, and the OAuth access token in
+`_token-secrets`.
+
+The `ServerTokenGcService` runs as a periodic timer inside `swamp serve`
+(alongside the reconciliation timer and fire record reaper). On each sweep it
+queries all `swamp/server-token` data records, identifies GC-eligible tokens, and
+deletes them across all four layers.
+
+A token is GC-eligible when:
+
+- **Revoked** — deleted immediately (revocation is a deliberate admin action).
+- **Expired** — deleted after a configurable grace period (default 1 hour past
+  `expiresAt`). The grace period avoids racing with token refreshes or clock
+  skew.
+
+Active tokens that are past their `expiresAt` are treated as effectively expired
+without first running the `expire` model method — matching the
+`effectiveTokenState` pattern used by `swamp access token list`.
+
+Configuration:
+
+- `--token-gc-interval` (default `1h`, env `SWAMP_TOKEN_GC_INTERVAL`) — sweep
+  interval. Set to `0` to disable.
+- `--token-gc-grace-period` (default `1h`, env `SWAMP_TOKEN_GC_GRACE_PERIOD`) —
+  how long after expiry before deletion.
+
+The service runs once synchronously at startup (after token secret migration and
+`sweepTokenConsistency`), then starts the periodic timer. It is disposed during
+server shutdown alongside the collective refresh service.
+
+Per-token errors are caught and logged — a failure to delete one token does not
+block the rest of the sweep. `sweepTokenConsistency` at next boot flags any
+inconsistencies left behind by partial deletions.
+
 v1 is swamp-club-specific: the OAuth client endpoint paths
 (`/api/auth/device/code`, `/api/auth/device/token`,
 `/api/auth/oauth2/userinfo`, `/api/auth/oauth2/register`) are hardcoded.

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -3559,7 +3559,13 @@ export const serveCommand = new Command()
             );
           },
           deleteDefinition: async (definitionId) => {
-            await repoContext.definitionRepo.delete(
+            const gcAutoDefRepo = new YamlDefinitionRepository(
+              resolvedRepoDir,
+              repoContext.eventBus,
+              autoDefDir,
+              false,
+            );
+            await gcAutoDefRepo.delete(
               SERVER_TOKEN_MODEL_TYPE,
               definitionId as import("../../domain/definitions/definition.ts").DefinitionId,
             );

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -399,6 +399,15 @@ export function collectServeExtraArgs(options: AnyOptions): string[] {
   if (options.hydrationTimeout) {
     args.push("--hydration-timeout", options.hydrationTimeout as string);
   }
+  if (options.tokenGcInterval) {
+    args.push("--token-gc-interval", options.tokenGcInterval as string);
+  }
+  if (options.tokenGcGracePeriod) {
+    args.push(
+      "--token-gc-grace-period",
+      options.tokenGcGracePeriod as string,
+    );
+  }
   return args;
 }
 
@@ -614,6 +623,14 @@ const daemonEnableCommand = new Command()
   .option(
     "--hydration-timeout <duration:string>",
     "Startup cache hydration timeout (default: 60s, env: SWAMP_HYDRATION_TIMEOUT)",
+  )
+  .option(
+    "--token-gc-interval <duration:string>",
+    "Server token GC sweep interval (default: 1h, env: SWAMP_TOKEN_GC_INTERVAL)",
+  )
+  .option(
+    "--token-gc-grace-period <duration:string>",
+    "Grace period after token expiry before GC deletes it (default: 1h, env: SWAMP_TOKEN_GC_GRACE_PERIOD)",
   )
   .example("Enable daemon", "swamp serve daemon enable")
   .example(
@@ -967,6 +984,18 @@ export const serveCommand = new Command()
       "Increase for large repos where the initial pull takes longer (env: SWAMP_HYDRATION_TIMEOUT)",
   )
   .option(
+    "--token-gc-interval <duration:string>",
+    "How often to sweep and delete expired/revoked server tokens. " +
+      "Accepts seconds (3600), explicit units (1h, 30m), or 0 to disable. Default: 1h. " +
+      "Only effective with a control-plane-capable datastore (env: SWAMP_TOKEN_GC_INTERVAL)",
+  )
+  .option(
+    "--token-gc-grace-period <duration:string>",
+    "How long after token expiry before the GC deletes it. Revoked tokens are deleted immediately. " +
+      "Accepts seconds (3600), explicit units (1h, 30m). Default: 1h. " +
+      "(env: SWAMP_TOKEN_GC_GRACE_PERIOD)",
+  )
+  .option(
     "--max-concurrent-runs <count:integer>",
     "Maximum number of concurrent detached runs across all principals. Default: 100. " +
       "(env: SWAMP_MAX_CONCURRENT_RUNS)",
@@ -1091,6 +1120,20 @@ export const serveCommand = new Command()
     const hydrationTimeoutMs = hydrationTimeoutRaw !== undefined
       ? parseTimeout(hydrationTimeoutRaw, "--hydration-timeout")
       : 60_000;
+
+    const tokenGcIntervalRaw = merged.tokenGcInterval;
+    let tokenGcIntervalMs: number | undefined;
+    if (tokenGcIntervalRaw !== undefined) {
+      const normalized = tokenGcIntervalRaw.trim().toLowerCase();
+      tokenGcIntervalMs = normalized === "0"
+        ? 0
+        : parseTimeout(tokenGcIntervalRaw, "--token-gc-interval");
+    }
+
+    const tokenGcGracePeriodRaw = merged.tokenGcGracePeriod;
+    const tokenGcGracePeriodMs = tokenGcGracePeriodRaw !== undefined
+      ? parseTimeout(tokenGcGracePeriodRaw, "--token-gc-grace-period")
+      : undefined;
 
     const maxConcurrentRuns = merged.maxConcurrentRuns;
     if (
@@ -3264,6 +3307,9 @@ export const serveCommand = new Command()
       if (collectiveRefreshService) {
         await collectiveRefreshService.dispose();
       }
+      if (tokenGcService) {
+        await tokenGcService.dispose();
+      }
       if (grantsDirectoryPoller) {
         await grantsDirectoryPoller.stop();
       }
@@ -3444,6 +3490,85 @@ export const serveCommand = new Command()
         FIRE_RECORD_REAP_INTERVAL_MS,
       );
       Deno.unrefTimer(reaperTimer);
+    }
+
+    // Server token GC — periodic sweep to delete expired/revoked tokens
+    let tokenGcService:
+      | import("../../serve/server_token_gc_service.ts").ServerTokenGcService
+      | null = null;
+    {
+      const {
+        ServerTokenGcService: GcService,
+        DEFAULT_TOKEN_GC_INTERVAL_MS,
+        DEFAULT_TOKEN_GC_GRACE_PERIOD_MS,
+      } = await import("../../serve/server_token_gc_service.ts");
+      const { oauthAccessTokenKey } = await import(
+        "../../serve/device_auth_handler.ts"
+      );
+      const { serverTokenSecretKey } = await import(
+        "../../domain/models/access/server_token_model.ts"
+      );
+
+      const gcIntervalMs = tokenGcIntervalMs ?? DEFAULT_TOKEN_GC_INTERVAL_MS;
+      const gcGracePeriodMs = tokenGcGracePeriodMs ??
+        DEFAULT_TOKEN_GC_GRACE_PERIOD_MS;
+
+      if (gcIntervalMs > 0) {
+        tokenGcService = new GcService({
+          intervalMs: gcIntervalMs,
+          gracePeriodMs: gcGracePeriodMs,
+          listTokens: async () => {
+            const records = await repoContext.dataQueryService.query(
+              `modelType == "${SERVER_TOKEN_MODEL_TYPE.normalized}" && name == "token-main"`,
+              { loadAttributes: true },
+            ) as import("../../domain/data/data_record.ts").DataRecord[];
+            const tokens:
+              import("../../serve/server_token_gc_service.ts").TokenGcInfo[] =
+                [];
+            for (const record of records) {
+              const parsed = ServerTokenSchema.safeParse(record.attributes);
+              if (!parsed.success) continue;
+              const def = await repoContext.definitionRepo.findByName(
+                SERVER_TOKEN_MODEL_TYPE,
+                parsed.data.name,
+              );
+              if (!def) continue;
+              tokens.push({
+                name: parsed.data.name,
+                definitionId: def.id,
+                state: parsed.data.state,
+                expiresAt: parsed.data.expiresAt,
+                revokedAt: parsed.data.revokedAt,
+              });
+            }
+            return tokens;
+          },
+          deleteTokenSecret: async (tokenName) => {
+            await tokenSecretsProvider.delete(serverTokenSecretKey(tokenName));
+          },
+          deleteOAuthAccessToken: async (tokenName) => {
+            await tokenSecretsProvider.delete(
+              oauthAccessTokenKey(tokenName),
+            );
+          },
+          deleteTokenData: async (definitionId, _tokenName) => {
+            await repoContext.unifiedDataRepo.delete(
+              SERVER_TOKEN_MODEL_TYPE,
+              definitionId,
+              "token-main",
+            );
+          },
+          deleteDefinition: async (definitionId) => {
+            await repoContext.definitionRepo.delete(
+              SERVER_TOKEN_MODEL_TYPE,
+              definitionId as import("../../domain/definitions/definition.ts").DefinitionId,
+            );
+          },
+        });
+
+        await tokenGcService.runOnce();
+        tokenGcService.start();
+      }
     }
 
     // Telemetry flush loop. A daemon reaches the CLI's teardown flush only at

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -399,15 +399,6 @@ export function collectServeExtraArgs(options: AnyOptions): string[] {
   if (options.hydrationTimeout) {
     args.push("--hydration-timeout", options.hydrationTimeout as string);
   }
-  if (options.tokenGcInterval) {
-    args.push("--token-gc-interval", options.tokenGcInterval as string);
-  }
-  if (options.tokenGcGracePeriod) {
-    args.push(
-      "--token-gc-grace-period",
-      options.tokenGcGracePeriod as string,
-    );
-  }
   return args;
 }
 
@@ -623,14 +614,6 @@ const daemonEnableCommand = new Command()
   .option(
     "--hydration-timeout <duration:string>",
     "Startup cache hydration timeout (default: 60s, env: SWAMP_HYDRATION_TIMEOUT)",
-  )
-  .option(
-    "--token-gc-interval <duration:string>",
-    "Server token GC sweep interval (default: 1h, env: SWAMP_TOKEN_GC_INTERVAL)",
-  )
-  .option(
-    "--token-gc-grace-period <duration:string>",
-    "Grace period after token expiry before GC deletes it (default: 1h, env: SWAMP_TOKEN_GC_GRACE_PERIOD)",
   )
   .example("Enable daemon", "swamp serve daemon enable")
   .example(
@@ -984,18 +967,6 @@ export const serveCommand = new Command()
       "Increase for large repos where the initial pull takes longer (env: SWAMP_HYDRATION_TIMEOUT)",
   )
   .option(
-    "--token-gc-interval <duration:string>",
-    "How often to sweep and delete expired/revoked server tokens. " +
-      "Accepts seconds (3600), explicit units (1h, 30m), or 0 to disable. Default: 1h. " +
-      "Only effective with a control-plane-capable datastore (env: SWAMP_TOKEN_GC_INTERVAL)",
-  )
-  .option(
-    "--token-gc-grace-period <duration:string>",
-    "How long after token expiry before the GC deletes it. Revoked tokens are deleted immediately. " +
-      "Accepts seconds (3600), explicit units (1h, 30m). Default: 1h. " +
-      "(env: SWAMP_TOKEN_GC_GRACE_PERIOD)",
-  )
-  .option(
     "--max-concurrent-runs <count:integer>",
     "Maximum number of concurrent detached runs across all principals. Default: 100. " +
       "(env: SWAMP_MAX_CONCURRENT_RUNS)",
@@ -1120,20 +1091,6 @@ export const serveCommand = new Command()
     const hydrationTimeoutMs = hydrationTimeoutRaw !== undefined
       ? parseTimeout(hydrationTimeoutRaw, "--hydration-timeout")
       : 60_000;
-
-    const tokenGcIntervalRaw = merged.tokenGcInterval;
-    let tokenGcIntervalMs: number | undefined;
-    if (tokenGcIntervalRaw !== undefined) {
-      const normalized = tokenGcIntervalRaw.trim().toLowerCase();
-      tokenGcIntervalMs = normalized === "0"
-        ? 0
-        : parseTimeout(tokenGcIntervalRaw, "--token-gc-interval");
-    }
-
-    const tokenGcGracePeriodRaw = merged.tokenGcGracePeriod;
-    const tokenGcGracePeriodMs = tokenGcGracePeriodRaw !== undefined
-      ? parseTimeout(tokenGcGracePeriodRaw, "--token-gc-grace-period")
-      : undefined;
 
     const maxConcurrentRuns = merged.maxConcurrentRuns;
     if (
@@ -2431,13 +2388,15 @@ export const serveCommand = new Command()
             { triggerSource: "schedule" },
           ),
         pendingRunHook: {
-          enqueue: (entry) => {
+          enqueue: async (entry) => {
             runTracker.enqueuePendingRun(entry);
             if (controlPlaneStore) {
-              controlPlaneStore.put(
-                `pending-runs/${entry.id}`,
-                new TextEncoder().encode(JSON.stringify(entry)),
-              ).catch((err: unknown) => {
+              try {
+                await controlPlaneStore.put(
+                  `pending-runs/${entry.id}`,
+                  new TextEncoder().encode(JSON.stringify(entry)),
+                );
+              } catch (err: unknown) {
                 logger.warn(
                   "Control-plane dual-write failed for cron pending run {id}: {error}",
                   {
@@ -2445,15 +2404,17 @@ export const serveCommand = new Command()
                     error: err instanceof Error ? err.message : String(err),
                   },
                 );
-              });
+              }
             }
           },
-          delete: (id) => {
+          delete: async (id) => {
             runTracker.deletePendingRun(id);
             if (controlPlaneStore) {
-              controlPlaneStore.delete(
-                `pending-runs/${id}`,
-              ).catch((err: unknown) => {
+              try {
+                await controlPlaneStore.delete(
+                  `pending-runs/${id}`,
+                );
+              } catch (err: unknown) {
                 logger.warn(
                   "Control-plane delete failed for cron pending run {id}: {error}",
                   {
@@ -2461,7 +2422,7 @@ export const serveCommand = new Command()
                     error: err instanceof Error ? err.message : String(err),
                   },
                 );
-              });
+              }
             }
           },
         },
@@ -3307,9 +3268,6 @@ export const serveCommand = new Command()
       if (collectiveRefreshService) {
         await collectiveRefreshService.dispose();
       }
-      if (tokenGcService) {
-        await tokenGcService.dispose();
-      }
       if (grantsDirectoryPoller) {
         await grantsDirectoryPoller.stop();
       }
@@ -3490,91 +3448,6 @@ export const serveCommand = new Command()
         FIRE_RECORD_REAP_INTERVAL_MS,
       );
       Deno.unrefTimer(reaperTimer);
-    }
-
-    // Server token GC — periodic sweep to delete expired/revoked tokens
-    let tokenGcService:
-      | import("../../serve/server_token_gc_service.ts").ServerTokenGcService
-      | null = null;
-    {
-      const {
-        ServerTokenGcService: GcService,
-        DEFAULT_TOKEN_GC_INTERVAL_MS,
-        DEFAULT_TOKEN_GC_GRACE_PERIOD_MS,
-      } = await import("../../serve/server_token_gc_service.ts");
-      const { oauthAccessTokenKey } = await import(
-        "../../serve/device_auth_handler.ts"
-      );
-      const { serverTokenSecretKey } = await import(
-        "../../domain/models/access/server_token_model.ts"
-      );
-
-      const gcIntervalMs = tokenGcIntervalMs ?? DEFAULT_TOKEN_GC_INTERVAL_MS;
-      const gcGracePeriodMs = tokenGcGracePeriodMs ??
-        DEFAULT_TOKEN_GC_GRACE_PERIOD_MS;
-
-      if (gcIntervalMs > 0) {
-        tokenGcService = new GcService({
-          intervalMs: gcIntervalMs,
-          gracePeriodMs: gcGracePeriodMs,
-          listTokens: async () => {
-            const records = await repoContext.dataQueryService.query(
-              `modelType == "${SERVER_TOKEN_MODEL_TYPE.normalized}" && name == "token-main"`,
-              { loadAttributes: true },
-            ) as import("../../domain/data/data_record.ts").DataRecord[];
-            const tokens:
-              import("../../serve/server_token_gc_service.ts").TokenGcInfo[] =
-                [];
-            for (const record of records) {
-              const parsed = ServerTokenSchema.safeParse(record.attributes);
-              if (!parsed.success) continue;
-              const def = await repoContext.definitionRepo.findByName(
-                SERVER_TOKEN_MODEL_TYPE,
-                parsed.data.name,
-              );
-              if (!def) continue;
-              tokens.push({
-                name: parsed.data.name,
-                definitionId: def.id,
-                state: parsed.data.state,
-                expiresAt: parsed.data.expiresAt,
-                revokedAt: parsed.data.revokedAt,
-              });
-            }
-            return tokens;
-          },
-          deleteTokenSecret: async (tokenName) => {
-            await tokenSecretsProvider.delete(serverTokenSecretKey(tokenName));
-          },
-          deleteOAuthAccessToken: async (tokenName) => {
-            await tokenSecretsProvider.delete(
-              oauthAccessTokenKey(tokenName),
-            );
-          },
-          deleteTokenData: async (definitionId, _tokenName) => {
-            await repoContext.unifiedDataRepo.delete(
-              SERVER_TOKEN_MODEL_TYPE,
-              definitionId,
-              "token-main",
-            );
-          },
-          deleteDefinition: async (definitionId) => {
-            const gcAutoDefRepo = new YamlDefinitionRepository(
-              resolvedRepoDir,
-              repoContext.eventBus,
-              autoDefDir,
-              false,
-            );
-            await gcAutoDefRepo.delete(
-              SERVER_TOKEN_MODEL_TYPE,
-              definitionId as import("../../domain/definitions/definition.ts").DefinitionId,
-            );
-          },
-        });
-
-        await tokenGcService.runOnce();
-        tokenGcService.start();
-      }
     }
 
     // Telemetry flush loop. A daemon reaches the CLI's teardown flush only at

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -46,8 +46,6 @@ export const SERVE_ENV_MAP: Readonly<Record<string, string>> = {
   maxConcurrentRuns: "SWAMP_MAX_CONCURRENT_RUNS",
   maxRunsPerPrincipal: "SWAMP_MAX_RUNS_PER_PRINCIPAL",
   maxRunDuration: "SWAMP_MAX_RUN_DURATION",
-  tokenGcInterval: "SWAMP_TOKEN_GC_INTERVAL",
-  tokenGcGracePeriod: "SWAMP_TOKEN_GC_GRACE_PERIOD",
 };
 
 // ── Webhook Config Types ──────────────────────────────────────────────
@@ -101,8 +99,6 @@ export interface ServeConfigFile {
   "max-runs-per-principal"?: number;
   "max-run-duration"?: string;
   "hydration-timeout"?: string;
-  "token-gc-interval"?: string;
-  "token-gc-grace-period"?: string;
 }
 
 // ── Known Keys ────────────────────────────────────────────────────────
@@ -131,8 +127,6 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
   "max-runs-per-principal",
   "max-run-duration",
   "hydration-timeout",
-  "token-gc-interval",
-  "token-gc-grace-period",
 ]);
 
 const KNOWN_AUTH_KEYS = new Set([
@@ -537,8 +531,6 @@ export interface MergedServeOptions {
   maxRunsPerPrincipal?: number;
   maxRunDuration?: string;
   hydrationTimeout?: string;
-  tokenGcInterval?: string;
-  tokenGcGracePeriod?: string;
 }
 
 export function mergeServeOptions(
@@ -861,20 +853,6 @@ export function mergeServeOptions(
     undefined,
   );
 
-  const tokenGcInterval = resolveString(
-    "token-gc-interval",
-    cliOptions.tokenGcInterval as string | undefined,
-    config?.["token-gc-interval"],
-    undefined,
-  );
-
-  const tokenGcGracePeriod = resolveString(
-    "token-gc-grace-period",
-    cliOptions.tokenGcGracePeriod as string | undefined,
-    config?.["token-gc-grace-period"],
-    undefined,
-  );
-
   // Webhooks: CLI --webhook flags replace config file webhooks entirely
   let webhook: string[] | undefined;
   let webhookEndpoints: WebhookEndpoint[] | undefined;
@@ -920,7 +898,5 @@ export function mergeServeOptions(
     maxRunsPerPrincipal,
     maxRunDuration,
     hydrationTimeout,
-    tokenGcInterval,
-    tokenGcGracePeriod,
   };
 }

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -46,6 +46,8 @@ export const SERVE_ENV_MAP: Readonly<Record<string, string>> = {
   maxConcurrentRuns: "SWAMP_MAX_CONCURRENT_RUNS",
   maxRunsPerPrincipal: "SWAMP_MAX_RUNS_PER_PRINCIPAL",
   maxRunDuration: "SWAMP_MAX_RUN_DURATION",
+  tokenGcInterval: "SWAMP_TOKEN_GC_INTERVAL",
+  tokenGcGracePeriod: "SWAMP_TOKEN_GC_GRACE_PERIOD",
 };
 
 // ── Webhook Config Types ──────────────────────────────────────────────
@@ -99,6 +101,8 @@ export interface ServeConfigFile {
   "max-runs-per-principal"?: number;
   "max-run-duration"?: string;
   "hydration-timeout"?: string;
+  "token-gc-interval"?: string;
+  "token-gc-grace-period"?: string;
 }
 
 // ── Known Keys ────────────────────────────────────────────────────────
@@ -127,6 +131,8 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
   "max-runs-per-principal",
   "max-run-duration",
   "hydration-timeout",
+  "token-gc-interval",
+  "token-gc-grace-period",
 ]);
 
 const KNOWN_AUTH_KEYS = new Set([
@@ -531,6 +537,8 @@ export interface MergedServeOptions {
   maxRunsPerPrincipal?: number;
   maxRunDuration?: string;
   hydrationTimeout?: string;
+  tokenGcInterval?: string;
+  tokenGcGracePeriod?: string;
 }
 
 export function mergeServeOptions(
@@ -853,6 +861,20 @@ export function mergeServeOptions(
     undefined,
   );
 
+  const tokenGcInterval = resolveString(
+    "token-gc-interval",
+    cliOptions.tokenGcInterval as string | undefined,
+    config?.["token-gc-interval"],
+    undefined,
+  );
+
+  const tokenGcGracePeriod = resolveString(
+    "token-gc-grace-period",
+    cliOptions.tokenGcGracePeriod as string | undefined,
+    config?.["token-gc-grace-period"],
+    undefined,
+  );
+
   // Webhooks: CLI --webhook flags replace config file webhooks entirely
   let webhook: string[] | undefined;
   let webhookEndpoints: WebhookEndpoint[] | undefined;
@@ -898,5 +920,7 @@ export function mergeServeOptions(
     maxRunsPerPrincipal,
     maxRunDuration,
     hydrationTimeout,
+    tokenGcInterval,
+    tokenGcGracePeriod,
   };
 }

--- a/src/serve/server_token_gc_service.ts
+++ b/src/serve/server_token_gc_service.ts
@@ -89,6 +89,7 @@ export class ServerTokenGcService {
     this.#timer = setTimeout(() => {
       void this.#tick();
     }, this.#deps.intervalMs);
+    Deno.unrefTimer(this.#timer);
   }
 
   async #tick(): Promise<void> {

--- a/src/serve/server_token_gc_service.ts
+++ b/src/serve/server_token_gc_service.ts
@@ -1,0 +1,182 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+
+const logger = getSwampLogger(["serve", "token-gc"]);
+
+export const DEFAULT_TOKEN_GC_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+export const DEFAULT_TOKEN_GC_GRACE_PERIOD_MS = 60 * 60 * 1000; // 1 hour
+
+export interface TokenGcInfo {
+  readonly name: string;
+  readonly definitionId: string;
+  readonly state: "active" | "expired" | "revoked";
+  readonly expiresAt: string;
+  readonly revokedAt?: string;
+}
+
+export interface ServerTokenGcDeps {
+  readonly intervalMs: number;
+  readonly gracePeriodMs: number;
+
+  listTokens(): Promise<TokenGcInfo[]>;
+
+  deleteTokenSecret(tokenName: string): Promise<void>;
+
+  deleteOAuthAccessToken(tokenName: string): Promise<void>;
+
+  deleteTokenData(definitionId: string, tokenName: string): Promise<void>;
+
+  deleteDefinition(definitionId: string): Promise<void>;
+}
+
+export class ServerTokenGcService {
+  readonly #deps: ServerTokenGcDeps;
+  #timer: ReturnType<typeof setTimeout> | null = null;
+  #running = false;
+  #disposed = false;
+
+  constructor(deps: ServerTokenGcDeps) {
+    this.#deps = deps;
+  }
+
+  start(): void {
+    if (this.#disposed) return;
+    logger.info(
+      "Starting server token GC service (interval: {interval}ms, grace period: {grace}ms)",
+      {
+        interval: this.#deps.intervalMs,
+        grace: this.#deps.gracePeriodMs,
+      },
+    );
+    this.#scheduleNext();
+  }
+
+  async dispose(): Promise<void> {
+    this.#disposed = true;
+    if (this.#timer !== null) {
+      clearTimeout(this.#timer);
+      this.#timer = null;
+    }
+    while (this.#running) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+  }
+
+  async runOnce(): Promise<number> {
+    return await this.#sweep();
+  }
+
+  #scheduleNext(): void {
+    if (this.#disposed) return;
+    this.#timer = setTimeout(() => {
+      void this.#tick();
+    }, this.#deps.intervalMs);
+  }
+
+  async #tick(): Promise<void> {
+    if (this.#disposed) return;
+    this.#running = true;
+    try {
+      await this.#sweep();
+    } catch (err) {
+      logger.error`Server token GC cycle failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`;
+    } finally {
+      this.#running = false;
+      this.#scheduleNext();
+    }
+  }
+
+  async #sweep(): Promise<number> {
+    const tokens = await this.#deps.listTokens();
+    const now = Date.now();
+    let gcCount = 0;
+
+    for (const token of tokens) {
+      if (this.#disposed) break;
+
+      if (!this.#isGcEligible(token, now)) continue;
+
+      try {
+        await this.#gcToken(token);
+        gcCount++;
+      } catch (err) {
+        logger.warn(
+          "Failed to GC server token {name}, will retry next cycle: {error}",
+          {
+            name: token.name,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        );
+      }
+    }
+
+    if (gcCount > 0) {
+      logger.info("GC'd {count} expired/revoked server token(s)", {
+        count: gcCount,
+      });
+    }
+
+    return gcCount;
+  }
+
+  #isGcEligible(token: TokenGcInfo, nowMs: number): boolean {
+    if (token.state === "revoked") return true;
+
+    const expiresAtMs = Date.parse(token.expiresAt);
+    const effectivelyExpired = token.state === "expired" ||
+      expiresAtMs <= nowMs;
+
+    if (!effectivelyExpired) return false;
+
+    return (nowMs - expiresAtMs) >= this.#deps.gracePeriodMs;
+  }
+
+  async #gcToken(token: TokenGcInfo): Promise<void> {
+    try {
+      await this.#deps.deleteTokenSecret(token.name);
+    } catch (err) {
+      logger.warn(
+        "Failed to delete token secret for {name}: {error}",
+        {
+          name: token.name,
+          error: err instanceof Error ? err.message : String(err),
+        },
+      );
+    }
+
+    try {
+      await this.#deps.deleteOAuthAccessToken(token.name);
+    } catch (err) {
+      logger.warn(
+        "Failed to delete OAuth access token for {name}: {error}",
+        {
+          name: token.name,
+          error: err instanceof Error ? err.message : String(err),
+        },
+      );
+    }
+
+    await this.#deps.deleteTokenData(token.definitionId, token.name);
+    await this.#deps.deleteDefinition(token.definitionId);
+  }
+}

--- a/src/serve/server_token_gc_service_test.ts
+++ b/src/serve/server_token_gc_service_test.ts
@@ -1,0 +1,278 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  type ServerTokenGcDeps,
+  ServerTokenGcService,
+  type TokenGcInfo,
+} from "./server_token_gc_service.ts";
+
+const ONE_HOUR = 60 * 60 * 1000;
+const THIRTY_DAYS = 30 * 24 * ONE_HOUR;
+
+function makeToken(
+  overrides: Partial<TokenGcInfo> & { name: string },
+): TokenGcInfo {
+  return {
+    definitionId: `def-${overrides.name}`,
+    state: "active",
+    expiresAt: new Date(Date.now() + THIRTY_DAYS).toISOString(),
+    ...overrides,
+  };
+}
+
+function makeMockDeps(
+  tokens: TokenGcInfo[] = [],
+  overrides: Partial<ServerTokenGcDeps> = {},
+): ServerTokenGcDeps & {
+  deletedSecrets: string[];
+  deletedOAuthTokens: string[];
+  deletedData: Array<{ definitionId: string; tokenName: string }>;
+  deletedDefinitions: string[];
+} {
+  const deletedSecrets: string[] = [];
+  const deletedOAuthTokens: string[] = [];
+  const deletedData: Array<{ definitionId: string; tokenName: string }> = [];
+  const deletedDefinitions: string[] = [];
+
+  return {
+    intervalMs: 100,
+    gracePeriodMs: ONE_HOUR,
+    listTokens: () => Promise.resolve(tokens),
+    deleteTokenSecret: (name) => {
+      deletedSecrets.push(name);
+      return Promise.resolve();
+    },
+    deleteOAuthAccessToken: (name) => {
+      deletedOAuthTokens.push(name);
+      return Promise.resolve();
+    },
+    deleteTokenData: (definitionId, tokenName) => {
+      deletedData.push({ definitionId, tokenName });
+      return Promise.resolve();
+    },
+    deleteDefinition: (definitionId) => {
+      deletedDefinitions.push(definitionId);
+      return Promise.resolve();
+    },
+    deletedSecrets,
+    deletedOAuthTokens,
+    deletedData,
+    deletedDefinitions,
+    ...overrides,
+  };
+}
+
+Deno.test("runOnce: skips active tokens that have not expired", async () => {
+  const token = makeToken({ name: "oauth-active1" });
+  const deps = makeMockDeps([token]);
+  const service = new ServerTokenGcService(deps);
+
+  const count = await service.runOnce();
+
+  assertEquals(count, 0);
+  assertEquals(deps.deletedSecrets.length, 0);
+  assertEquals(deps.deletedDefinitions.length, 0);
+});
+
+Deno.test("runOnce: skips expired tokens within the grace period", async () => {
+  const token = makeToken({
+    name: "oauth-recent",
+    state: "expired",
+    expiresAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(), // 30 min ago
+  });
+  const deps = makeMockDeps([token]);
+  const service = new ServerTokenGcService(deps);
+
+  const count = await service.runOnce();
+
+  assertEquals(count, 0);
+  assertEquals(deps.deletedSecrets.length, 0);
+});
+
+Deno.test("runOnce: deletes expired tokens past the grace period across all 4 layers", async () => {
+  const token = makeToken({
+    name: "oauth-old",
+    state: "expired",
+    expiresAt: new Date(Date.now() - 2 * ONE_HOUR).toISOString(), // 2 hours ago
+  });
+  const deps = makeMockDeps([token]);
+  const service = new ServerTokenGcService(deps);
+
+  const count = await service.runOnce();
+
+  assertEquals(count, 1);
+  assertEquals(deps.deletedSecrets, ["oauth-old"]);
+  assertEquals(deps.deletedOAuthTokens, ["oauth-old"]);
+  assertEquals(deps.deletedData, [
+    { definitionId: "def-oauth-old", tokenName: "oauth-old" },
+  ]);
+  assertEquals(deps.deletedDefinitions, ["def-oauth-old"]);
+});
+
+Deno.test("runOnce: deletes revoked tokens immediately without grace period", async () => {
+  const token = makeToken({
+    name: "oauth-revoked",
+    state: "revoked",
+    expiresAt: new Date(Date.now() + THIRTY_DAYS).toISOString(), // not yet expired
+    revokedAt: new Date().toISOString(),
+  });
+  const deps = makeMockDeps([token]);
+  const service = new ServerTokenGcService(deps);
+
+  const count = await service.runOnce();
+
+  assertEquals(count, 1);
+  assertEquals(deps.deletedSecrets, ["oauth-revoked"]);
+  assertEquals(deps.deletedOAuthTokens, ["oauth-revoked"]);
+  assertEquals(deps.deletedData, [
+    { definitionId: "def-oauth-revoked", tokenName: "oauth-revoked" },
+  ]);
+  assertEquals(deps.deletedDefinitions, ["def-oauth-revoked"]);
+});
+
+Deno.test("runOnce: GC's active tokens that are past expiresAt plus grace period", async () => {
+  const token = makeToken({
+    name: "oauth-stale",
+    state: "active",
+    expiresAt: new Date(Date.now() - 2 * ONE_HOUR).toISOString(),
+  });
+  const deps = makeMockDeps([token]);
+  const service = new ServerTokenGcService(deps);
+
+  const count = await service.runOnce();
+
+  assertEquals(count, 1);
+  assertEquals(deps.deletedSecrets, ["oauth-stale"]);
+});
+
+Deno.test("runOnce: partial deletion failure logs warning and continues", async () => {
+  const token1 = makeToken({
+    name: "oauth-fail",
+    state: "revoked",
+  });
+  const token2 = makeToken({
+    name: "oauth-ok",
+    state: "revoked",
+  });
+  let callCount = 0;
+  const deps = makeMockDeps([token1, token2], {
+    deleteTokenData: (_defId, _name) => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.reject(new Error("data store unavailable"));
+      }
+      return Promise.resolve();
+    },
+  });
+  const service = new ServerTokenGcService(deps);
+
+  const count = await service.runOnce();
+
+  // First token fails at deleteTokenData (after secrets succeed), second succeeds fully
+  assertEquals(count, 1);
+  assertEquals(deps.deletedSecrets, ["oauth-fail", "oauth-ok"]);
+  assertEquals(deps.deletedOAuthTokens, ["oauth-fail", "oauth-ok"]);
+});
+
+Deno.test("dispose: prevents further ticks from running", async () => {
+  const token = makeToken({
+    name: "oauth-disposed",
+    state: "revoked",
+  });
+  let listCalls = 0;
+  const deps = makeMockDeps([], {
+    listTokens: () => {
+      listCalls++;
+      return Promise.resolve([token]);
+    },
+  });
+  const service = new ServerTokenGcService(deps);
+  service.start();
+
+  await service.dispose();
+
+  const callsAtDispose = listCalls;
+  await new Promise((r) => setTimeout(r, 250));
+  assertEquals(listCalls, callsAtDispose);
+});
+
+Deno.test("runOnce: returns zero and does not log when no tokens are eligible", async () => {
+  const deps = makeMockDeps([]);
+  const service = new ServerTokenGcService(deps);
+
+  const count = await service.runOnce();
+
+  assertEquals(count, 0);
+  assertEquals(deps.deletedSecrets.length, 0);
+  assertEquals(deps.deletedOAuthTokens.length, 0);
+  assertEquals(deps.deletedData.length, 0);
+  assertEquals(deps.deletedDefinitions.length, 0);
+});
+
+Deno.test("runOnce: handles mix of eligible and ineligible tokens", async () => {
+  const active = makeToken({ name: "oauth-active" });
+  const recentExpired = makeToken({
+    name: "oauth-recent",
+    state: "expired",
+    expiresAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(), // 10 min ago
+  });
+  const oldExpired = makeToken({
+    name: "oauth-old",
+    state: "expired",
+    expiresAt: new Date(Date.now() - 2 * ONE_HOUR).toISOString(),
+  });
+  const revoked = makeToken({
+    name: "oauth-revoked",
+    state: "revoked",
+  });
+
+  const deps = makeMockDeps([active, recentExpired, oldExpired, revoked]);
+  const service = new ServerTokenGcService(deps);
+
+  const count = await service.runOnce();
+
+  assertEquals(count, 2);
+  assertEquals(deps.deletedSecrets, ["oauth-old", "oauth-revoked"]);
+  assertEquals(deps.deletedDefinitions, [
+    "def-oauth-old",
+    "def-oauth-revoked",
+  ]);
+});
+
+Deno.test("runOnce: secret deletion failure does not prevent data and definition cleanup", async () => {
+  const token = makeToken({
+    name: "oauth-nosecret",
+    state: "revoked",
+  });
+  const deps = makeMockDeps([token], {
+    deleteTokenSecret: () => Promise.reject(new Error("secret already gone")),
+  });
+  const service = new ServerTokenGcService(deps);
+
+  const count = await service.runOnce();
+
+  assertEquals(count, 1);
+  assertEquals(deps.deletedOAuthTokens, ["oauth-nosecret"]);
+  assertEquals(deps.deletedData, [
+    { definitionId: "def-oauth-nosecret", tokenName: "oauth-nosecret" },
+  ]);
+  assertEquals(deps.deletedDefinitions, ["def-oauth-nosecret"]);
+});

--- a/src/serve/server_token_gc_service_test.ts
+++ b/src/serve/server_token_gc_service_test.ts
@@ -23,6 +23,10 @@ import {
   ServerTokenGcService,
   type TokenGcInfo,
 } from "./server_token_gc_service.ts";
+import type { ControlPlaneStore } from "../domain/datastore/control_plane_store.ts";
+import { ControlPlaneVaultProvider } from "../domain/vaults/control_plane_vault_provider.ts";
+import { serverTokenSecretKey } from "../domain/models/access/server_token_model.ts";
+import { oauthAccessTokenKey } from "./device_auth_handler.ts";
 
 const ONE_HOUR = 60 * 60 * 1000;
 const THIRTY_DAYS = 30 * 24 * ONE_HOUR;
@@ -275,4 +279,71 @@ Deno.test("runOnce: secret deletion failure does not prevent data and definition
     { definitionId: "def-oauth-nosecret", tokenName: "oauth-nosecret" },
   ]);
   assertEquals(deps.deletedDefinitions, ["def-oauth-nosecret"]);
+});
+
+function createInMemoryControlPlaneStore(): ControlPlaneStore & {
+  data: Map<string, Uint8Array>;
+} {
+  const data = new Map<string, Uint8Array>();
+  return {
+    data,
+    put: (key: string, value: Uint8Array) => {
+      data.set(key, value);
+      return Promise.resolve();
+    },
+    get: (key: string) => Promise.resolve(data.get(key) ?? null),
+    delete: (key: string) => {
+      data.delete(key);
+      return Promise.resolve();
+    },
+    list: (prefix: string) =>
+      Promise.resolve([...data.keys()].filter((k) => k.startsWith(prefix))),
+  };
+}
+
+Deno.test("runOnce: deletes control plane vault entries for token secrets and OAuth access tokens", async () => {
+  const store = createInMemoryControlPlaneStore();
+  const provider = new ControlPlaneVaultProvider(store);
+  await provider.initialize();
+
+  const tokenName = "oauth-test123";
+  await provider.put(serverTokenSecretKey(tokenName), "secret-value");
+  await provider.put(oauthAccessTokenKey(tokenName), "oauth-token-value");
+
+  const secretsBefore = await provider.list();
+  assertEquals(secretsBefore.length, 2);
+
+  const token = makeToken({
+    name: tokenName,
+    state: "revoked",
+  });
+  const deletedData: Array<{ definitionId: string; tokenName: string }> = [];
+  const deletedDefinitions: string[] = [];
+
+  const service = new ServerTokenGcService({
+    intervalMs: 100,
+    gracePeriodMs: ONE_HOUR,
+    listTokens: () => Promise.resolve([token]),
+    deleteTokenSecret: async (name) => {
+      await provider.delete(serverTokenSecretKey(name));
+    },
+    deleteOAuthAccessToken: async (name) => {
+      await provider.delete(oauthAccessTokenKey(name));
+    },
+    deleteTokenData: (definitionId, name) => {
+      deletedData.push({ definitionId, tokenName: name });
+      return Promise.resolve();
+    },
+    deleteDefinition: (definitionId) => {
+      deletedDefinitions.push(definitionId);
+      return Promise.resolve();
+    },
+  });
+
+  const count = await service.runOnce();
+
+  assertEquals(count, 1);
+  const secretsAfter = await provider.list();
+  assertEquals(secretsAfter.length, 0);
+  assertEquals(store.data.size, 1); // only the encryption key remains
 });


### PR DESCRIPTION
## Summary

- Add `ServerTokenGcService` to `swamp serve` that periodically sweeps and deletes expired/revoked server tokens across all four storage layers (token secret, OAuth access token, data record, definition YAML)
- Tokens are GC-eligible when revoked (immediately) or expired past a configurable grace period (default 1 hour after the 30-day token expiry)
- New CLI flags `--token-gc-interval` (default `1h`, `0` to disable) and `--token-gc-grace-period` (default `1h`) with config file and env var support
- Runs once at startup after token secret migration, then periodically; logs count of GC'd tokens at info level

## Test Plan

- [x] 10 unit tests covering: skip active tokens, skip tokens in grace period, delete across all 4 layers, revoked tokens GC'd immediately, active-but-past-expiry tokens, partial failure handling, dispose prevents ticks, empty sweep, mixed eligibility, secret deletion failure tolerance
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] Existing `serve_config_test.ts` tests (61) pass with new config additions

Closes #1614

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bha5ZVySmQunEtu5iGCxsw