### PR TITLE
fix(serve): await control-plane put before delete in pending-run hooks

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -2388,13 +2388,15 @@ export const serveCommand = new Command()
             { triggerSource: "schedule" },
           ),
         pendingRunHook: {
-          enqueue: (entry) => {
+          enqueue: async (entry) => {
             runTracker.enqueuePendingRun(entry);
             if (controlPlaneStore) {
-              controlPlaneStore.put(
-                `pending-runs/${entry.id}`,
-                new TextEncoder().encode(JSON.stringify(entry)),
-              ).catch((err: unknown) => {
+              try {
+                await controlPlaneStore.put(
+                  `pending-runs/${entry.id}`,
+                  new TextEncoder().encode(JSON.stringify(entry)),
+                );
+              } catch (err: unknown) {
                 logger.warn(
                   "Control-plane dual-write failed for cron pending run {id}: {error}",
                   {
@@ -2402,15 +2404,17 @@ export const serveCommand = new Command()
                     error: err instanceof Error ? err.message : String(err),
                   },
                 );
-              });
+              }
             }
           },
-          delete: (id) => {
+          delete: async (id) => {
             runTracker.deletePendingRun(id);
             if (controlPlaneStore) {
-              controlPlaneStore.delete(
-                `pending-runs/${id}`,
-              ).catch((err: unknown) => {
+              try {
+                await controlPlaneStore.delete(
+                  `pending-runs/${id}`,
+                );
+              } catch (err: unknown) {
                 logger.warn(
                   "Control-plane delete failed for cron pending run {id}: {error}",
                   {
@@ -2418,7 +2422,7 @@ export const serveCommand = new Command()
                     error: err instanceof Error ? err.message : String(err),
                   },
                 );
-              });
+              }
             }
           },
         },

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -111,8 +111,8 @@ export interface PendingRunHook {
     source: "cron";
     workflowIdOrName: string;
     createdAt: string;
-  }): void;
-  delete(id: string): void;
+  }): Promise<void>;
+  delete(id: string): Promise<void>;
 }
 
 export interface ActiveRunHook {
@@ -150,6 +150,7 @@ export class ScheduledExecutionService {
   private readonly workflowNames = new Map<WorkflowId, string>();
   private readonly runQueue: Array<{
     pendingRunId?: string;
+    enqueuePromise?: Promise<void>;
     workflowId: WorkflowId;
     workflowName: string;
   }> = [];
@@ -390,16 +391,22 @@ export class ScheduledExecutionService {
     // contention. Before scheduling, each workflow ran as a separate
     // process via systemd timers; serializing preserves that behavior.
     let pendingRunId: string | undefined;
+    let enqueuePromise: Promise<void> | undefined;
     if (this.deps.pendingRunHook) {
       pendingRunId = crypto.randomUUID();
-      this.deps.pendingRunHook.enqueue({
+      enqueuePromise = this.deps.pendingRunHook.enqueue({
         id: pendingRunId,
         source: "cron",
         workflowIdOrName: workflowName,
         createdAt: new Date().toISOString(),
       });
     }
-    this.runQueue.push({ pendingRunId, workflowId, workflowName });
+    this.runQueue.push({
+      pendingRunId,
+      enqueuePromise,
+      workflowId,
+      workflowName,
+    });
     if (!this.processing) {
       this.processingPromise = this.processQueue();
     }
@@ -411,10 +418,11 @@ export class ScheduledExecutionService {
 
     try {
       while (this.runQueue.length > 0) {
-        const { pendingRunId, workflowId, workflowName } = this.runQueue
-          .shift()!;
+        const { pendingRunId, enqueuePromise, workflowId, workflowName } = this
+          .runQueue.shift()!;
         if (pendingRunId && this.deps.pendingRunHook) {
-          this.deps.pendingRunHook.delete(pendingRunId);
+          if (enqueuePromise) await enqueuePromise;
+          await this.deps.pendingRunHook.delete(pendingRunId);
         }
         await this.executeWorkflow(workflowId, workflowName);
       }

--- a/src/libswamp/workflows/scheduled_execution_test.ts
+++ b/src/libswamp/workflows/scheduled_execution_test.ts
@@ -367,8 +367,9 @@ Deno.test("ScheduledExecutionService: pendingRunHook delete awaits enqueue befor
       await new Promise<void>((r) => setTimeout(r, 50));
       ops.push("enqueue-done");
     },
-    delete: async (_id) => {
+    delete: (_id) => {
       ops.push("delete");
+      return Promise.resolve();
     },
   };
 

--- a/src/libswamp/workflows/scheduled_execution_test.ts
+++ b/src/libswamp/workflows/scheduled_execution_test.ts
@@ -17,9 +17,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertGreater } from "@std/assert";
 import {
   normalizeFireTime,
+  type PendingRunHook,
   type ScheduledExecutionEvent,
   ScheduledExecutionService,
 } from "./scheduled_execution.ts";
@@ -354,6 +355,55 @@ Deno.test("ScheduledExecutionService: cronFireDedup error falls through to execu
     (e as { dedupSkip?: boolean }).dedupSkip === true
   );
   assertEquals(skipped.length, 0);
+});
+
+Deno.test("ScheduledExecutionService: pendingRunHook delete awaits enqueue before running", async () => {
+  const wf = createTestWorkflow("hook-order-wf", "* * * * * *");
+  const ops: string[] = [];
+  let resolveEnqueue: (() => void) | undefined;
+
+  const hook: PendingRunHook = {
+    enqueue: (_entry) => {
+      ops.push("enqueue-start");
+      return new Promise<void>((resolve) => {
+        resolveEnqueue = () => {
+          ops.push("enqueue-done");
+          resolve();
+        };
+      });
+    },
+    delete: (_id) => {
+      ops.push("delete");
+      return Promise.resolve();
+    },
+  };
+
+  const mockRepo = createMockWorkflowRepo([wf]);
+  const service = new ScheduledExecutionService({
+    workflowRepo: mockRepo,
+    repoDir: "/tmp/nonexistent-test-repo",
+    executeWorkflow: () => Promise.resolve(),
+    pendingRunHook: hook,
+  });
+
+  await service.start();
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+
+  // Enqueue should have started but delete should be blocked until we resolve
+  assertEquals(ops[0], "enqueue-start");
+  const deleteBeforeResolve = ops.indexOf("delete");
+  assertEquals(deleteBeforeResolve, -1);
+
+  // Now resolve the enqueue promise
+  resolveEnqueue!();
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  await service.stop();
+
+  assertGreater(ops.length, 2);
+  const enqueueDoneIdx = ops.indexOf("enqueue-done");
+  const deleteIdx = ops.indexOf("delete");
+  assertGreater(deleteIdx, enqueueDoneIdx);
 });
 
 Deno.test("normalizeFireTime: truncates milliseconds and replaces colons for Windows compat", () => {

--- a/src/libswamp/workflows/scheduled_execution_test.ts
+++ b/src/libswamp/workflows/scheduled_execution_test.ts
@@ -360,21 +360,15 @@ Deno.test("ScheduledExecutionService: cronFireDedup error falls through to execu
 Deno.test("ScheduledExecutionService: pendingRunHook delete awaits enqueue before running", async () => {
   const wf = createTestWorkflow("hook-order-wf", "* * * * * *");
   const ops: string[] = [];
-  let resolveEnqueue: (() => void) | undefined;
 
   const hook: PendingRunHook = {
-    enqueue: (_entry) => {
+    enqueue: async (_entry) => {
       ops.push("enqueue-start");
-      return new Promise<void>((resolve) => {
-        resolveEnqueue = () => {
-          ops.push("enqueue-done");
-          resolve();
-        };
-      });
+      await new Promise<void>((r) => setTimeout(r, 50));
+      ops.push("enqueue-done");
     },
-    delete: (_id) => {
+    delete: async (_id) => {
       ops.push("delete");
-      return Promise.resolve();
     },
   };
 
@@ -388,22 +382,15 @@ Deno.test("ScheduledExecutionService: pendingRunHook delete awaits enqueue befor
 
   await service.start();
   await new Promise((resolve) => setTimeout(resolve, 1500));
-
-  // Enqueue should have started but delete should be blocked until we resolve
-  assertEquals(ops[0], "enqueue-start");
-  const deleteBeforeResolve = ops.indexOf("delete");
-  assertEquals(deleteBeforeResolve, -1);
-
-  // Now resolve the enqueue promise
-  resolveEnqueue!();
-  await new Promise((resolve) => setTimeout(resolve, 100));
-
   await service.stop();
 
   assertGreater(ops.length, 2);
-  const enqueueDoneIdx = ops.indexOf("enqueue-done");
-  const deleteIdx = ops.indexOf("delete");
-  assertGreater(deleteIdx, enqueueDoneIdx);
+  for (let i = 0; i < ops.length; i++) {
+    if (ops[i] === "delete") {
+      assertGreater(i, 0);
+      assertEquals(ops[i - 1], "enqueue-done");
+    }
+  }
 });
 
 Deno.test("normalizeFireTime: truncates milliseconds and replaces colons for Windows compat", () => {

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -345,6 +345,7 @@ export interface WebhookEndpointInfo {
 export class WebhookService {
   private readonly runQueue: Array<{
     pendingRunId?: string;
+    putPromise?: Promise<void>;
     workflowIdOrName: string;
     route: string;
     payload: WebhookPayload;
@@ -462,6 +463,7 @@ export class WebhookService {
     );
 
     let pendingRunId: string | undefined;
+    let putPromise: Promise<void> | undefined;
     if (this.deps.runTracker) {
       pendingRunId = crypto.randomUUID();
       const pendingEntry = {
@@ -476,7 +478,7 @@ export class WebhookService {
       };
       this.deps.runTracker.enqueuePendingRun(pendingEntry);
       if (this.deps.controlPlaneStore) {
-        this.deps.controlPlaneStore.put(
+        putPromise = this.deps.controlPlaneStore.put(
           `pending-runs/${pendingRunId}`,
           new TextEncoder().encode(JSON.stringify(pendingEntry)),
         ).catch((err: unknown) => {
@@ -493,6 +495,7 @@ export class WebhookService {
 
     this.runQueue.push({
       pendingRunId,
+      putPromise,
       workflowIdOrName: endpoint.workflowIdOrName,
       route: endpoint.route,
       payload: webhookPayload,
@@ -567,6 +570,7 @@ export class WebhookService {
       while (this.runQueue.length > 0) {
         const {
           pendingRunId,
+          putPromise,
           workflowIdOrName,
           route,
           payload,
@@ -576,7 +580,8 @@ export class WebhookService {
         if (pendingRunId && this.deps.runTracker) {
           this.deps.runTracker.deletePendingRun(pendingRunId);
           if (this.deps.controlPlaneStore) {
-            this.deps.controlPlaneStore.delete(
+            if (putPromise) await putPromise;
+            await this.deps.controlPlaneStore.delete(
               `pending-runs/${pendingRunId}`,
             ).catch((err: unknown) => {
               logger.warn(


### PR DESCRIPTION
## Summary

Fixes swamp-club#1627. Every cron tick wrote a durable intent record to
`_control/pending-runs/` via `controlPlaneStore.put()` and immediately
called `controlPlaneStore.delete()` — both as fire-and-forget promises.
The delete won the race (1 async I/O op vs 2+ for put), got `NotFound`,
and silently returned. The put then completed, leaving an orphan file
that replayed on every restart.

- Make `PendingRunHook` interface async (`Promise<void>` instead of `void`)
- Capture the enqueue promise on the queue entry and await it in
  `processQueue()` before calling delete
- Apply the same fix to the webhook path (identical race)
- Update `serve.ts` hook callbacks to `async`/`try-catch` instead of
  fire-and-forget `.catch()`

Also filed swamp-club#1628 for the related stale `active-runs/` empty
directory cleanup issue.

## Test Plan

- Added unit test verifying `processQueue` awaits enqueue before calling
  delete (delayed-promise mock proves ordering)
- Reproduced the bug in a scratch repo: 4 cron ticks → 4 leaked files,
  all 4 replayed on restart
- Verified the fix with the compiled binary: 4 cron ticks → 0 leaked
  files, clean restart
- All existing tests pass; `deno check`, `deno lint`, `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQhHs5cAADFfjmR8NwDZ9A