### PR TITLE
fix(serve): distinguish rate-limited (429) from auth-failed (401) WebSocket errors

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -200,7 +200,9 @@ function sweepExpiredEntries(): void {
   }
 }
 
-function checkRateLimit(ip: string): boolean {
+function checkRateLimit(
+  ip: string,
+): { allowed: true } | { allowed: false; retryAfterSeconds: number } {
   const now = Date.now();
   const entry = authAttempts.get(ip);
   if (!entry || now > entry.resetAt) {
@@ -210,10 +212,16 @@ function checkRateLimit(ip: string): boolean {
       authAttempts.delete(oldest);
     }
     authAttempts.set(ip, { count: 1, resetAt: now + AUTH_WINDOW_MS });
-    return true;
+    return { allowed: true };
   }
   entry.count++;
-  return entry.count <= MAX_AUTH_ATTEMPTS;
+  if (entry.count <= MAX_AUTH_ATTEMPTS) {
+    return { allowed: true };
+  }
+  return {
+    allowed: false,
+    retryAfterSeconds: Math.ceil((entry.resetAt - now) / 1000),
+  };
 }
 
 function clearRateLimit(ip: string): void {
@@ -2824,11 +2832,17 @@ export const serveCommand = new Command()
           }
 
           if (authConfig.mode !== "none") {
-            if (!checkRateLimit(remoteAddr)) {
+            const rateCheck = checkRateLimit(remoteAddr);
+            if (!rateCheck.allowed) {
               logger.warn("WebSocket auth rate-limited from {ip}", {
                 ip: remoteAddr,
               });
-              return new Response("Too Many Requests", { status: 429 });
+              return new Response("Too Many Requests", {
+                status: 429,
+                headers: {
+                  "Retry-After": String(rateCheck.retryAfterSeconds),
+                },
+              });
             }
 
             const extracted = extractWebSocketToken(req);
@@ -2911,8 +2925,14 @@ export const serveCommand = new Command()
                   ?.split(",")[0]?.trim() ??
                   info.remoteAddr.hostname)
                 : info.remoteAddr.hostname;
-              if (!checkRateLimit(cancelRemoteAddr)) {
-                return new Response("Too Many Requests", { status: 429 });
+              const cancelRateCheck = checkRateLimit(cancelRemoteAddr);
+              if (!cancelRateCheck.allowed) {
+                return new Response("Too Many Requests", {
+                  status: 429,
+                  headers: {
+                    "Retry-After": String(cancelRateCheck.retryAfterSeconds),
+                  },
+                });
               }
               const authHeader = req.headers.get("authorization");
               const token = authHeader?.startsWith("Bearer ")
@@ -3028,12 +3048,16 @@ export const serveCommand = new Command()
                 ?.split(",")[0]?.trim() ??
                 info.remoteAddr.hostname)
               : info.remoteAddr.hostname;
-            if (!checkRateLimit(deviceRemoteAddr)) {
+            const deviceRateCheck = checkRateLimit(deviceRemoteAddr);
+            if (!deviceRateCheck.allowed) {
               return new Response(
                 JSON.stringify({ error: "Too Many Requests" }),
                 {
                   status: 429,
-                  headers: { "content-type": "application/json" },
+                  headers: {
+                    "content-type": "application/json",
+                    "Retry-After": String(deviceRateCheck.retryAfterSeconds),
+                  },
                 },
               );
             }

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -368,6 +368,16 @@ async function classifyConnectionError(
   wsUrl: string,
   originalMessage: string,
 ): Promise<string> {
+  const statusMatch = originalMessage.match(/Invalid status code: (\d+)/);
+  if (statusMatch) {
+    const statusCode = parseInt(statusMatch[1], 10);
+    if (statusCode === 429) {
+      return "Rate-limited by server — try again later";
+    }
+    if (statusCode === 401 || statusCode === 403) {
+      return `Authentication failed — run: swamp auth server-login --server ${wsUrl}`;
+    }
+  }
   if (await probeServerHealth(wsUrl)) {
     return `Authentication failed — run: swamp auth server-login --server ${wsUrl}`;
   }

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -764,6 +764,105 @@ Deno.test({
   },
 });
 
+// ── rate-limit error classification tests ────────────────────────────
+
+function rateLimitingServer(): {
+  url: string;
+  shutdown: () => Promise<void>;
+} {
+  const server = Deno.serve(
+    { port: 0, hostname: "127.0.0.1", onListen: () => {} },
+    (req) => {
+      if (req.headers.get("upgrade") === "websocket") {
+        return new Response("Too Many Requests", { status: 429 });
+      }
+      const url = new URL(req.url);
+      if (url.pathname === "/health") {
+        return Response.json({ status: "ok" });
+      }
+      return new Response("Not found", { status: 404 });
+    },
+  );
+  return {
+    url: `ws://127.0.0.1:${server.addr.port}`,
+    shutdown: () => server.shutdown(),
+  };
+}
+
+Deno.test({
+  name:
+    "remote run: rate-limited WebSocket upgrade shows rate-limit error, not auth failure",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = rateLimitingServer();
+    try {
+      const error = await assertRejects(async () => {
+        for await (
+          const _ of runWorkflowOverServer({
+            server: server.url,
+            payload: { workflowIdOrName: "wf" },
+          })
+          // deno-lint-ignore no-empty
+        ) {}
+      }, UserError);
+      assertStringIncludes(error.message, "Rate-limited");
+      assertEquals(error.message.includes("Authentication failed"), false);
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "requestServerResponse: rate-limited WebSocket upgrade shows rate-limit error, not auth failure",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = rateLimitingServer();
+    try {
+      const error = await assertRejects(
+        () =>
+          requestServerResponse(
+            { server: server.url },
+            { type: "test.request" },
+          ),
+        UserError,
+      );
+      assertStringIncludes(error.message, "Rate-limited");
+      assertEquals(error.message.includes("Authentication failed"), false);
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "remote run: auth rejection still shows authentication error (not rate-limit)",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = authRejectingServer();
+    try {
+      const error = await assertRejects(async () => {
+        for await (
+          const _ of runWorkflowOverServer({
+            server: server.url,
+            payload: { workflowIdOrName: "wf" },
+          })
+          // deno-lint-ignore no-empty
+        ) {}
+      }, UserError);
+      assertStringIncludes(error.message, "Authentication failed");
+      assertEquals(error.message.includes("Rate-limited"), false);
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
 // ── cross-instance reconnection tests ─────────────────────────────────
 
 Deno.test({


### PR DESCRIPTION
## Summary

Fixes swamp-club#1618 — when the server returns HTTP 429 (rate-limited) on a WebSocket upgrade, the client incorrectly shows "Authentication failed — run: swamp auth server-login", sending the user on a pointless re-login chase.

- **Client**: `classifyConnectionError` now parses the HTTP status code from Deno's WebSocket error message (`"Invalid status code: NNN"`). Maps 429 → "Rate-limited by server — try again later", 401/403 → existing auth message, unrecognized → falls back to the health-probe heuristic (graceful degradation if Deno changes the error format).
- **Server**: `checkRateLimit` returns `retryAfterSeconds` on rejection. All three 429 response sites (WebSocket upgrade, cancel endpoint, device auth) now include a `Retry-After` header.

## Test Plan

- [x] `deno run test src/cli/remote_run_test.ts` — 37 passed (3 new: 429→rate-limit via stream, 429→rate-limit via request-response, 401→auth preserved)
- [x] `deno run test` — 10,221 passed, 0 failed
- [x] `deno check` — clean
- [x] `deno lint` — clean
- [x] `deno fmt --check` — clean
- [x] Compiled binary verified against fake 429 server: shows "Rate-limited by server — try again later"
- [x] Compiled binary verified against fake 401 server: shows "Authentication failed — run: swamp auth server-login"

🤖 Generated with [Claude Code](https://claude.com/claude-code)