### PR TITLE
fix(serve): key WebSocket auth rate limiter by token name, not IP

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -49,6 +49,12 @@ import {
   authenticateServerToken,
   extractWebSocketToken,
 } from "../../serve/token_auth.ts";
+import {
+  checkIpBurst,
+  checkRateLimit,
+  clearRateLimit,
+  rateLimitKey,
+} from "../../serve/rate_limiter.ts";
 import { parsePrincipal } from "../../domain/access/principal.ts";
 import { executeWorkflowWithLocks } from "../../serve/deps.ts";
 import { DaemonTelemetryFlushService } from "../../serve/telemetry_flush.ts";
@@ -187,49 +193,6 @@ type AnyOptions = any;
 const logger = getSwampLogger(["serve"]);
 
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
-
-const authAttempts = new Map<string, { count: number; resetAt: number }>();
-const MAX_AUTH_ATTEMPTS = 5;
-const AUTH_WINDOW_MS = 60_000;
-const MAX_RATE_LIMIT_ENTRIES = 10_000;
-
-function sweepExpiredEntries(): void {
-  const now = Date.now();
-  for (const [ip, entry] of authAttempts) {
-    if (now > entry.resetAt) authAttempts.delete(ip);
-  }
-}
-
-function checkRateLimit(
-  ip: string,
-): { allowed: true } | { allowed: false; retryAfterSeconds: number } {
-  const now = Date.now();
-  const entry = authAttempts.get(ip);
-  if (!entry || now > entry.resetAt) {
-    if (authAttempts.size >= MAX_RATE_LIMIT_ENTRIES) sweepExpiredEntries();
-    if (authAttempts.size >= MAX_RATE_LIMIT_ENTRIES) {
-      const oldest = authAttempts.keys().next().value!;
-      authAttempts.delete(oldest);
-    }
-    authAttempts.set(ip, { count: 1, resetAt: now + AUTH_WINDOW_MS });
-    return { allowed: true };
-  }
-  entry.count++;
-  if (entry.count <= MAX_AUTH_ATTEMPTS) {
-    return { allowed: true };
-  }
-  return {
-    allowed: false,
-    retryAfterSeconds: Math.ceil((entry.resetAt - now) / 1000),
-  };
-}
-
-function clearRateLimit(ip: string): void {
-  const entry = authAttempts.get(ip);
-  if (entry) {
-    entry.count = 0;
-  }
-}
 
 export function assertOffLoopbackSecurity(
   host: string,
@@ -2832,15 +2795,15 @@ export const serveCommand = new Command()
           }
 
           if (authConfig.mode !== "none") {
-            const rateCheck = checkRateLimit(remoteAddr);
-            if (!rateCheck.allowed) {
-              logger.warn("WebSocket auth rate-limited from {ip}", {
+            const ipBurst = checkIpBurst(remoteAddr);
+            if (!ipBurst.allowed) {
+              logger.warn("WebSocket IP burst rate-limited from {ip}", {
                 ip: remoteAddr,
               });
               return new Response("Too Many Requests", {
                 status: 429,
                 headers: {
-                  "Retry-After": String(rateCheck.retryAfterSeconds),
+                  "Retry-After": String(ipBurst.retryAfterSeconds),
                 },
               });
             }
@@ -2855,6 +2818,22 @@ export const serveCommand = new Command()
                 status: 401,
               });
             }
+
+            const rlKey = rateLimitKey(extracted.token, remoteAddr);
+            const rateCheck = checkRateLimit(rlKey);
+            if (!rateCheck.allowed) {
+              logger.warn(
+                "WebSocket auth rate-limited for {key} from {ip}",
+                { key: rlKey, ip: remoteAddr },
+              );
+              return new Response("Too Many Requests", {
+                status: 429,
+                headers: {
+                  "Retry-After": String(rateCheck.retryAfterSeconds),
+                },
+              });
+            }
+
             logger.debug(
               "WebSocket token received via {transport} from {ip}",
               { transport: extracted.transport, ip: remoteAddr },
@@ -2866,12 +2845,12 @@ export const serveCommand = new Command()
             );
             if (!result.ok) {
               logger.warn(
-                "WebSocket auth rejected from {ip}: {error}",
-                { ip: remoteAddr, error: result.error },
+                "WebSocket auth rejected for {key} from {ip}: {error}",
+                { key: rlKey, ip: remoteAddr, error: result.error },
               );
               return new Response("Unauthorized", { status: 401 });
             }
-            clearRateLimit(remoteAddr);
+            clearRateLimit(rlKey);
             const principal = parsePrincipal(result.principalId);
             const upgradeOpts = extracted.transport === "subprotocol"
               ? {
@@ -2925,12 +2904,12 @@ export const serveCommand = new Command()
                   ?.split(",")[0]?.trim() ??
                   info.remoteAddr.hostname)
                 : info.remoteAddr.hostname;
-              const cancelRateCheck = checkRateLimit(cancelRemoteAddr);
-              if (!cancelRateCheck.allowed) {
+              const cancelIpBurst = checkIpBurst(cancelRemoteAddr);
+              if (!cancelIpBurst.allowed) {
                 return new Response("Too Many Requests", {
                   status: 429,
                   headers: {
-                    "Retry-After": String(cancelRateCheck.retryAfterSeconds),
+                    "Retry-After": String(cancelIpBurst.retryAfterSeconds),
                   },
                 });
               }
@@ -2943,6 +2922,16 @@ export const serveCommand = new Command()
                   status: 401,
                 });
               }
+              const cancelRlKey = rateLimitKey(token, cancelRemoteAddr);
+              const cancelRateCheck = checkRateLimit(cancelRlKey);
+              if (!cancelRateCheck.allowed) {
+                return new Response("Too Many Requests", {
+                  status: 429,
+                  headers: {
+                    "Retry-After": String(cancelRateCheck.retryAfterSeconds),
+                  },
+                });
+              }
               const authResult = await authenticateServerToken(
                 token,
                 resolvedRepoDir,
@@ -2951,7 +2940,7 @@ export const serveCommand = new Command()
               if (!authResult.ok) {
                 return new Response("Unauthorized", { status: 401 });
               }
-              clearRateLimit(cancelRemoteAddr);
+              clearRateLimit(cancelRlKey);
 
               const cancelPrincipal = parsePrincipal(authResult.principalId);
               if (!policySnapshotLoader) {
@@ -3048,7 +3037,7 @@ export const serveCommand = new Command()
                 ?.split(",")[0]?.trim() ??
                 info.remoteAddr.hostname)
               : info.remoteAddr.hostname;
-            const deviceRateCheck = checkRateLimit(deviceRemoteAddr);
+            const deviceRateCheck = checkIpBurst(deviceRemoteAddr);
             if (!deviceRateCheck.allowed) {
               return new Response(
                 JSON.stringify({ error: "Too Many Requests" }),

--- a/src/serve/rate_limiter.ts
+++ b/src/serve/rate_limiter.ts
@@ -1,0 +1,112 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { splitServerToken } from "./token_auth.ts";
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+type RateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterSeconds: number };
+
+const MAX_PRINCIPAL_ATTEMPTS = 5;
+const PRINCIPAL_WINDOW_MS = 60_000;
+
+const MAX_IP_BURST = 50;
+const IP_BURST_WINDOW_MS = 60_000;
+
+const MAX_ENTRIES = 10_000;
+
+const principalBuckets = new Map<string, RateLimitEntry>();
+const ipBurstBuckets = new Map<string, RateLimitEntry>();
+
+function sweepExpired(buckets: Map<string, RateLimitEntry>): void {
+  const now = Date.now();
+  for (const [key, entry] of buckets) {
+    if (now > entry.resetAt) buckets.delete(key);
+  }
+}
+
+function checkBucket(
+  buckets: Map<string, RateLimitEntry>,
+  key: string,
+  maxAttempts: number,
+  windowMs: number,
+): RateLimitResult {
+  const now = Date.now();
+  const entry = buckets.get(key);
+  if (!entry || now > entry.resetAt) {
+    if (buckets.size >= MAX_ENTRIES) sweepExpired(buckets);
+    if (buckets.size >= MAX_ENTRIES) {
+      const oldest = buckets.keys().next().value!;
+      buckets.delete(oldest);
+    }
+    buckets.set(key, { count: 1, resetAt: now + windowMs });
+    return { allowed: true };
+  }
+  entry.count++;
+  if (entry.count <= maxAttempts) {
+    return { allowed: true };
+  }
+  return {
+    allowed: false,
+    retryAfterSeconds: Math.ceil((entry.resetAt - now) / 1000),
+  };
+}
+
+export function rateLimitKey(
+  token: string | null,
+  ip: string,
+): string {
+  if (token !== null) {
+    const split = splitServerToken(token);
+    if (split !== null) {
+      return `token:${split.name}`;
+    }
+  }
+  return `ip:${ip}`;
+}
+
+export function checkIpBurst(ip: string): RateLimitResult {
+  return checkBucket(ipBurstBuckets, ip, MAX_IP_BURST, IP_BURST_WINDOW_MS);
+}
+
+export function checkRateLimit(key: string): RateLimitResult {
+  return checkBucket(
+    principalBuckets,
+    key,
+    MAX_PRINCIPAL_ATTEMPTS,
+    PRINCIPAL_WINDOW_MS,
+  );
+}
+
+export function clearRateLimit(key: string): void {
+  const entry = principalBuckets.get(key);
+  if (entry) {
+    entry.count = 0;
+  }
+}
+
+export function resetRateLimitState(): void {
+  principalBuckets.clear();
+  ipBurstBuckets.clear();
+}

--- a/src/serve/rate_limiter_test.ts
+++ b/src/serve/rate_limiter_test.ts
@@ -1,0 +1,187 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  checkIpBurst,
+  checkRateLimit,
+  clearRateLimit,
+  rateLimitKey,
+  resetRateLimitState,
+} from "./rate_limiter.ts";
+
+// ── rateLimitKey ────────────────────────────────────────────────────────
+
+Deno.test("rateLimitKey: returns token-name key for valid token format", () => {
+  assertEquals(rateLimitKey("mytoken.secret123", "10.0.0.1"), "token:mytoken");
+});
+
+Deno.test("rateLimitKey: returns IP key for null token", () => {
+  assertEquals(rateLimitKey(null, "10.0.0.1"), "ip:10.0.0.1");
+});
+
+Deno.test("rateLimitKey: returns IP key for malformed token", () => {
+  assertEquals(rateLimitKey("no-dot-here", "10.0.0.1"), "ip:10.0.0.1");
+});
+
+Deno.test("rateLimitKey: returns IP key for empty token", () => {
+  assertEquals(rateLimitKey("", "10.0.0.1"), "ip:10.0.0.1");
+});
+
+Deno.test("rateLimitKey: returns IP key for token starting with dot", () => {
+  assertEquals(rateLimitKey(".secret", "10.0.0.1"), "ip:10.0.0.1");
+});
+
+Deno.test("rateLimitKey: returns IP key for token ending with dot", () => {
+  assertEquals(rateLimitKey("name.", "10.0.0.1"), "ip:10.0.0.1");
+});
+
+// ── checkRateLimit (per-principal) ──────────────────────────────────────
+
+Deno.test("checkRateLimit: allows up to 5 attempts for a key", () => {
+  resetRateLimitState();
+  const key = "token:test-allows-five";
+  for (let i = 0; i < 5; i++) {
+    const result = checkRateLimit(key);
+    assertEquals(result.allowed, true);
+  }
+});
+
+Deno.test("checkRateLimit: blocks on 6th attempt for same key", () => {
+  resetRateLimitState();
+  const key = "token:test-blocks-sixth";
+  for (let i = 0; i < 5; i++) {
+    checkRateLimit(key);
+  }
+  const result = checkRateLimit(key);
+  assertEquals(result.allowed, false);
+});
+
+Deno.test("checkRateLimit: different token names are independent", () => {
+  resetRateLimitState();
+  const keyA = "token:worker-a";
+  const keyB = "token:worker-b";
+
+  for (let i = 0; i < 5; i++) {
+    checkRateLimit(keyA);
+  }
+  // keyA is now exhausted
+  const resultA = checkRateLimit(keyA);
+  assertEquals(resultA.allowed, false);
+
+  // keyB should still be allowed
+  const resultB = checkRateLimit(keyB);
+  assertEquals(resultB.allowed, true);
+});
+
+Deno.test("checkRateLimit: rate-limited token does not block different token on same IP", () => {
+  resetRateLimitState();
+  const badToken = "token:bad-worker";
+  const goodToken = "token:good-user";
+
+  // Exhaust bad token's budget
+  for (let i = 0; i < 6; i++) {
+    checkRateLimit(badToken);
+  }
+
+  // Good token on same conceptual IP is unaffected
+  const result = checkRateLimit(goodToken);
+  assertEquals(result.allowed, true);
+});
+
+Deno.test("checkRateLimit: IP-keyed fallback works like token keys", () => {
+  resetRateLimitState();
+  const ipKey = "ip:192.168.1.1";
+  for (let i = 0; i < 5; i++) {
+    const result = checkRateLimit(ipKey);
+    assertEquals(result.allowed, true);
+  }
+  const result = checkRateLimit(ipKey);
+  assertEquals(result.allowed, false);
+});
+
+// ── clearRateLimit ──────────────────────────────────────────────────────
+
+Deno.test("clearRateLimit: resets count for token-name key", () => {
+  resetRateLimitState();
+  const key = "token:clear-test";
+  for (let i = 0; i < 5; i++) {
+    checkRateLimit(key);
+  }
+  // Now at limit
+  assertEquals(checkRateLimit(key).allowed, false);
+
+  clearRateLimit(key);
+
+  // Should be allowed again
+  assertEquals(checkRateLimit(key).allowed, true);
+});
+
+Deno.test("clearRateLimit: no-op for unknown key", () => {
+  resetRateLimitState();
+  clearRateLimit("token:nonexistent");
+});
+
+// ── checkIpBurst ────────────────────────────────────────────────────────
+
+Deno.test("checkIpBurst: allows up to 50 requests from one IP", () => {
+  resetRateLimitState();
+  const ip = "10.0.0.99";
+  for (let i = 0; i < 50; i++) {
+    const result = checkIpBurst(ip);
+    assertEquals(result.allowed, true);
+  }
+});
+
+Deno.test("checkIpBurst: blocks on 51st request from same IP", () => {
+  resetRateLimitState();
+  const ip = "10.0.0.100";
+  for (let i = 0; i < 50; i++) {
+    checkIpBurst(ip);
+  }
+  const result = checkIpBurst(ip);
+  assertEquals(result.allowed, false);
+});
+
+Deno.test("checkIpBurst: different IPs are independent", () => {
+  resetRateLimitState();
+  const ipA = "10.0.0.101";
+  const ipB = "10.0.0.102";
+
+  for (let i = 0; i < 50; i++) {
+    checkIpBurst(ipA);
+  }
+  // ipA is exhausted
+  assertEquals(checkIpBurst(ipA).allowed, false);
+
+  // ipB is unaffected
+  assertEquals(checkIpBurst(ipB).allowed, true);
+});
+
+Deno.test("checkIpBurst: prevents bypass via token name enumeration", () => {
+  resetRateLimitState();
+  const ip = "10.0.0.200";
+
+  // Simulate attacker sending 50 requests with different fake token names
+  // The IP burst limiter catches this regardless of token diversity
+  for (let i = 0; i < 50; i++) {
+    checkIpBurst(ip);
+  }
+  assertEquals(checkIpBurst(ip).allowed, false);
+});


### PR DESCRIPTION
## Summary

Fixes swamp-club#1615 — the WebSocket auth rate limiter was keyed by source IP address, which in Kubernetes environments blocks legitimate users when they share an IP with a failing client (e.g. a worker retrying with a stale token).

- **Extract rate limiter** from `serve.ts` into `src/serve/rate_limiter.ts` with two tiers:
  - **Per-token-name limiter** (5 req/60s): isolates principals sharing an IP — `bad-worker` failures don't block `good-user`
  - **Per-IP burst limiter** (50 req/60s): DoS backstop preventing bypass via fake token name enumeration
- **Token name derivation**: uses `splitServerToken` to extract the name from `<name>.<secret>` before auth; falls back to IP for no-token/malformed requests
- **Device auth** stays IP-only (no token presented at login initiation)
- **17 new tests** in `src/serve/rate_limiter_test.ts` covering per-token isolation, IP fallback, burst limiting, and bypass prevention

## Test Plan

- [x] `deno run test src/serve/rate_limiter_test.ts` — 17 passed
- [x] `deno run test src/cli/remote_run_test.ts` — 37 passed (existing 429 client-side tests)
- [x] `deno run test src/cli/commands/serve_test.ts` — 49 passed
- [x] `deno run test` — 10,238 passed, 0 failed
- [x] `deno check` — clean
- [x] `deno lint` — clean
- [x] `deno fmt --check` — clean
- [x] End-to-end verification: started `swamp serve --auth-mode token`, minted two tokens, exhausted `bad-worker` rate limit (6 attempts → 5×401, 1×429), confirmed `good-user` still gets 101 Switching Protocols, confirmed `bad-worker` stays at 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)