### PR TITLE
fix(serve): clean up empty parent directories after control-plane store delete

### DIFF
--- a/src/infrastructure/persistence/fs_control_plane_store.ts
+++ b/src/infrastructure/persistence/fs_control_plane_store.ts
@@ -20,6 +20,7 @@
 import { dirname, join } from "@std/path";
 import type { ControlPlaneStore } from "../../domain/datastore/control_plane_store.ts";
 import { atomicWriteFile } from "./atomic_write.ts";
+import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { assertContainedPath } from "./safe_path.ts";
 
 /**
@@ -81,14 +82,16 @@ export class FileSystemControlPlaneStore implements ControlPlaneStore {
   }
 
   async delete(key: string): Promise<void> {
+    const path = this.#keyToPath(key);
     try {
-      await Deno.remove(this.#keyToPath(key));
+      await Deno.remove(path);
     } catch (error) {
       if (error instanceof Deno.errors.NotFound) {
         return;
       }
       throw error;
     }
+    await cleanupEmptyParentDirs(path, this.#rootDir);
   }
 
   async list(prefix: string): Promise<string[]> {

--- a/src/infrastructure/persistence/fs_control_plane_store_test.ts
+++ b/src/infrastructure/persistence/fs_control_plane_store_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertRejects } from "@std/assert";
+import { join } from "@std/path";
 import { FileSystemControlPlaneStore } from "./fs_control_plane_store.ts";
 import { PathTraversalError } from "./safe_path.ts";
 
@@ -263,6 +264,41 @@ Deno.test("FileSystemControlPlaneStore: two rapid putIfAbsent calls — one wins
       true,
       `stored data should match the winner's payload, got: ${stored}`,
     );
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: delete cleans up empty parent directories", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    await store.put("active-runs/instance-1/run-abc", encoder.encode("data"));
+    await store.delete("active-runs/instance-1/run-abc");
+
+    const controlDir = join(dir, "_control");
+    const instanceDir = join(controlDir, "active-runs", "instance-1");
+    const activeRunsDir = join(controlDir, "active-runs");
+
+    const instanceExists = await Deno.stat(instanceDir).then(() => true).catch(
+      () => false,
+    );
+    const activeRunsExists = await Deno.stat(activeRunsDir).then(() => true)
+      .catch(() => false);
+
+    assertEquals(instanceExists, false, "instance dir should be removed");
+    assertEquals(activeRunsExists, false, "active-runs dir should be removed");
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: delete preserves non-empty parent directories", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    await store.put("active-runs/instance-1/run-a", encoder.encode("a"));
+    await store.put("active-runs/instance-1/run-b", encoder.encode("b"));
+    await store.delete("active-runs/instance-1/run-a");
+
+    const remaining = await store.get("active-runs/instance-1/run-b");
+    assertEquals(decoder.decode(remaining!), "b");
   });
 });
 


### PR DESCRIPTION
## Summary

- Wire the existing `cleanupEmptyParentDirs` utility into `FileSystemControlPlaneStore.delete()` so empty parent directories are pruned after file removal
- Fixes stale empty directory accumulation under `active-runs/` (and any other nested control-plane store path)

Closes swamp-club/swamp-club#1628

## Test Plan

- Added unit test verifying empty parent directories are removed after deleting the last key under a nested path
- Added unit test verifying non-empty parent directories are preserved when sibling keys still exist
- All 21 existing `FileSystemControlPlaneStore` tests continue to pass (including delete-then-put and putIfAbsent-after-delete scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)