### PR TITLE
fix(extensions): mark repository-verified as provisional in local quality score

### DIFF
--- a/integration/extension_quality_test.ts
+++ b/integration/extension_quality_test.ts
@@ -201,15 +201,25 @@ Deno.test(
       const parsed = parseFirstJson(stdout);
       assertEquals(parsed.status, "passed");
       assertEquals(parsed.rubricVersion, 3);
-      assertEquals(parsed.earnedPoints, 14);
+      assertEquals(parsed.earnedPoints, 12);
       assertEquals(parsed.maxEarnablePoints, 14);
+      assertEquals(parsed.maxClientEarnablePoints, 12);
+      assertEquals(parsed.provisionalPoints, 2);
       assertEquals(parsed.percentage, 100);
       assertEquals(parsed.allPassed, true);
 
-      // Every factor must be "earned" — catches any regression where a
-      // specific factor's pass logic drifts from the server.
+      // Every factor must be "earned" or "provisional" — catches any
+      // regression where a factor's pass logic drifts from the server.
       for (const f of parsed.factors) {
-        assertEquals(f.status, "earned", `factor ${f.id} not earned`);
+        if (f.id === "repository-verified") {
+          assertEquals(
+            f.status,
+            "provisional",
+            `factor ${f.id} not provisional`,
+          );
+        } else {
+          assertEquals(f.status, "earned", `factor ${f.id} not earned`);
+        }
       }
     } finally {
       await Deno.remove(tmpDir, { recursive: true });

--- a/src/domain/extensions/extension_rubric_scorer.ts
+++ b/src/domain/extensions/extension_rubric_scorer.ts
@@ -23,11 +23,13 @@ import type { ExtensionManifest } from "./extension_manifest.ts";
 /**
  * Client-side scorer for the Swamp Club extension quality rubric.
  *
- * Mirrors swamp-club's server-side scorecard pipeline byte-for-byte
+ * Client-side counterpart to swamp-club's server-side scorecard pipeline
  * (`lib/domain/scorecard/analysis-factors.ts` and
- * `lib/domain/scorecard/score.ts` in the swamp-club repo) so local
- * `swamp extension quality` results match the score the registry will
- * compute after publish.
+ * `lib/domain/scorecard/score.ts` in the swamp-club repo). Factors the
+ * CLI can fully evaluate use the same logic as the server. The
+ * `repository-verified` factor is marked "provisional" locally because
+ * only the server can HTTP-HEAD the URL — its points are excluded from
+ * the client-side total and tracked separately as `provisionalPoints`.
  *
  * Distinct from `extension_quality_checker.ts` in this directory —
  * that module runs `deno fmt` / `deno lint` / dynamic-import checks as
@@ -255,7 +257,7 @@ export function computeAnalysisFactors(input: {
 // ── Score composition (mirror score.ts) ────────────────────────────────
 
 /** Status of one scorecard row. */
-export type FactorStatus = "earned" | "partial" | "missing";
+export type FactorStatus = "earned" | "partial" | "missing" | "provisional";
 
 /** One row of the scorecard. */
 export interface RubricFactor {
@@ -275,6 +277,8 @@ export interface RubricScore {
   maxEarnablePoints: number;
   percentage: number;
   allPassed: boolean;
+  provisionalPoints: number;
+  maxClientEarnablePoints: number;
 }
 
 /**
@@ -370,17 +374,7 @@ export function composeScore(
           "(manifest beside LICENSE), opt in with `paths.base: manifest`.",
       },
     ),
-    boolRow(
-      "repository-verified",
-      "Verified public repository (server confirms on publish)",
-      2,
-      repositoryLikelyVerifiable(manifest.repository),
-      {
-        remediation:
-          "Set `repository:` to a public HTTPS URL on github.com, gitlab.com, " +
-          "codeberg.org, or bitbucket.org. Server will verify it resolves publicly.",
-      },
-    ),
+    repositoryVerifiedRow(manifest.repository),
     dependencyTrustRow(
       factors.dependencyTrustPassed,
       factors.dependencyTrustBlockerCount,
@@ -389,7 +383,13 @@ export function composeScore(
 
   const earned = rows.reduce((s, r) => s + r.earnedPoints, 0);
   const max = rows.reduce((s, r) => s + r.maxPoints, 0);
-  const percentage = max === 0 ? 0 : Math.floor((earned * 100) / max);
+  const provisional = rows
+    .filter((r) => r.status === "provisional")
+    .reduce((s, r) => s + r.maxPoints, 0);
+  const clientMax = max - provisional;
+  const percentage = clientMax === 0
+    ? 0
+    : Math.floor((earned * 100) / clientMax);
 
   return {
     rubricVersion: RUBRIC_VERSION,
@@ -397,7 +397,11 @@ export function composeScore(
     earnedPoints: earned,
     maxEarnablePoints: max,
     percentage,
-    allPassed: rows.every((r) => r.status === "earned"),
+    allPassed: rows.every((r) =>
+      r.status === "earned" || r.status === "provisional"
+    ),
+    provisionalPoints: provisional,
+    maxClientEarnablePoints: clientMax,
   };
 }
 
@@ -415,6 +419,31 @@ function boolRow(
     maxPoints,
     status: earned ? "earned" : "missing",
     remediation: earned ? undefined : extra.remediation,
+  };
+}
+
+function repositoryVerifiedRow(
+  repository: string | undefined,
+): RubricFactor {
+  const verifiable = repositoryLikelyVerifiable(repository);
+  if (verifiable) {
+    return {
+      id: "repository-verified",
+      label: "Verified public repository (server confirms on publish)",
+      earnedPoints: 0,
+      maxPoints: 2,
+      status: "provisional",
+    };
+  }
+  return {
+    id: "repository-verified",
+    label: "Verified public repository (server confirms on publish)",
+    earnedPoints: 0,
+    maxPoints: 2,
+    status: "missing",
+    remediation:
+      "Set `repository:` to a public HTTPS URL on github.com, gitlab.com, " +
+      "codeberg.org, or bitbucket.org. Server will verify it resolves publicly.",
   };
 }
 

--- a/src/domain/extensions/extension_rubric_scorer_test.ts
+++ b/src/domain/extensions/extension_rubric_scorer_test.ts
@@ -389,10 +389,12 @@ function factorsAllEarned(): Parameters<typeof composeScore>[0] {
   };
 }
 
-Deno.test("composeScore: perfect extension earns 14/14 (100%)", () => {
+Deno.test("composeScore: perfect extension earns 12/12 client-confirmed (100%)", () => {
   const score = composeScore(factorsAllEarned(), makeManifest());
-  assertEquals(score.earnedPoints, 14);
+  assertEquals(score.earnedPoints, 12);
   assertEquals(score.maxEarnablePoints, 14);
+  assertEquals(score.maxClientEarnablePoints, 12);
+  assertEquals(score.provisionalPoints, 2);
   assertEquals(score.percentage, 100);
   assertEquals(score.allPassed, true);
 });
@@ -403,10 +405,23 @@ Deno.test("composeScore: has-readme is worth 2 points", () => {
   assertEquals(factor.maxPoints, 2);
 });
 
-Deno.test("composeScore: repository-verified is worth 2 points", () => {
+Deno.test("composeScore: repository-verified is provisional when URL is verifiable", () => {
   const score = composeScore(factorsAllEarned(), makeManifest());
   const factor = score.factors.find((f) => f.id === "repository-verified")!;
   assertEquals(factor.maxPoints, 2);
+  assertEquals(factor.earnedPoints, 0);
+  assertEquals(factor.status, "provisional");
+});
+
+Deno.test("composeScore: repository-verified is missing when URL is not verifiable", () => {
+  const score = composeScore(
+    factorsAllEarned(),
+    makeManifest({ repository: "http://bad/x" }),
+  );
+  const factor = score.factors.find((f) => f.id === "repository-verified")!;
+  assertEquals(factor.maxPoints, 2);
+  assertEquals(factor.earnedPoints, 0);
+  assertEquals(factor.status, "missing");
 });
 
 Deno.test("composeScore: bad manifest fails several factors", () => {
@@ -420,7 +435,7 @@ Deno.test("composeScore: bad manifest fails several factors", () => {
   );
   assertEquals(score.allPassed, false);
   const failed = score.factors
-    .filter((f) => f.status !== "earned")
+    .filter((f) => f.status !== "earned" && f.status !== "provisional")
     .map((f) => f.id);
   assert(failed.includes("description"));
   assert(failed.includes("repository-verified"));
@@ -536,13 +551,13 @@ Deno.test("composeScore: factor IDs and order match server", () => {
 });
 
 Deno.test("composeScore: percentage floors (not rounds)", () => {
-  // 13/14 = 92.86 → floor = 92
+  // 11/12 client-earnable = 91.67 → floor = 91
   const score = composeScore(
     { ...factorsAllEarned(), hasLicenseFile: false },
     makeManifest(),
   );
-  assertEquals(score.earnedPoints, 13);
-  assertEquals(score.percentage, 92);
+  assertEquals(score.earnedPoints, 11);
+  assertEquals(score.percentage, 91);
 });
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -861,21 +876,23 @@ Deno.test("[parity] composeScore: empty everything earns universal-platform only
   assertEquals(byId.get("entrypoints-docs"), undefined);
 });
 
-Deno.test("[parity] composeScore: perfect score hits 100% without any verification badge", () => {
+Deno.test("[parity] composeScore: perfect score hits 100% with repository-verified provisional", () => {
   const score = composeScore(factorsAllEarned(), makeManifest());
-  // 14/14
-  assertEquals(score.earnedPoints, 14);
+  // 12/12 client-earnable (repo-verified is provisional, excluded from total)
+  assertEquals(score.earnedPoints, 12);
+  assertEquals(score.maxClientEarnablePoints, 12);
+  assertEquals(score.provisionalPoints, 2);
   assertEquals(score.percentage, 100);
   assertEquals(score.allPassed, true);
 });
 
-Deno.test("[parity] composeScore: percentage floors (13/14 → 92)", () => {
+Deno.test("[parity] composeScore: percentage floors (11/12 → 91)", () => {
   const score = composeScore(
     { ...factorsAllEarned(), hasLicenseFile: false },
     makeManifest(),
   );
-  assertEquals(score.earnedPoints, 13);
-  assertEquals(score.percentage, 92);
+  assertEquals(score.earnedPoints, 11);
+  assertEquals(score.percentage, 91);
 });
 
 Deno.test("[parity] composeScore: platforms factor earns 2 for any count", () => {

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -852,6 +852,7 @@ export {
   type PackageCacheHashInput,
 } from "../domain/extensions/extension_package_cache.ts";
 export {
+  type FactorStatus,
   RUBRIC_VERSION,
   type RubricFactor,
   type RubricScore,

--- a/src/presentation/renderers/extension_quality.ts
+++ b/src/presentation/renderers/extension_quality.ts
@@ -20,6 +20,7 @@
 import type {
   EventHandlers,
   ExtensionQualityEvent,
+  FactorStatus,
 } from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
@@ -30,6 +31,18 @@ function formatDownloads(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return String(n);
+}
+
+function factorMark(status: FactorStatus): string {
+  switch (status) {
+    case "earned":
+      return "✓";
+    case "provisional":
+      return "~";
+    case "partial":
+    case "missing":
+      return "✗";
+  }
 }
 
 /** Renderer interface that also reports pass/fail to the CLI. */
@@ -67,19 +80,27 @@ class LogExtensionQualityRenderer implements ExtensionQualityRenderer {
       },
       completed: (e) => {
         const { score, archiveSize } = e.data;
-        logger
-          .info`Rubric v${score.rubricVersion} — ${score.earnedPoints}/${score.maxEarnablePoints} points (${score.percentage}%, ${
-          score.allPassed ? "all factors earned" : "some factors missing"
-        })`;
+        const provisional = score.provisionalPoints > 0
+          ? ` (+${score.provisionalPoints} pending server verification)`
+          : "";
+        const passStatus = score.allPassed
+          ? "all factors earned"
+          : "some factors missing";
+        logger.info(
+          `Rubric v${score.rubricVersion} — ${score.earnedPoints}/${score.maxClientEarnablePoints} points (${score.percentage}%${provisional}, ${passStatus})`,
+        );
         for (const factor of score.factors) {
-          const mark = factor.status === "earned" ? "✓" : "✗";
+          const mark = factorMark(factor.status);
           const pts = `${factor.earnedPoints}/${factor.maxPoints}`;
           logger.info`  ${mark} ${factor.id} [${pts}] — ${factor.label}`;
           if (factor.id === "fast-check") {
             logger
               .info`      ℹ This factor is deprecated and will be removed in a future release.`;
           }
-          if (factor.status !== "earned" && factor.remediation) {
+          if (
+            factor.status !== "earned" && factor.status !== "provisional" &&
+            factor.remediation
+          ) {
             logger.info`      → ${factor.remediation}`;
           }
         }
@@ -115,12 +136,6 @@ class LogExtensionQualityRenderer implements ExtensionQualityRenderer {
             logger.warn`  ${w.dependency}: ${w.message}`;
           }
         }
-        // `repository-verified` is a structural check on our side — the
-        // server does the final HTTP HEAD to confirm the repo is public.
-        // Surface that caveat so users know why their local "earned"
-        // could still come back "missing" from the registry.
-        logger
-          .info`Note: \`repository-verified\` earns here when the URL is well-formed on an allowlisted host; the registry does the final public-reachable check on publish.`;
         logger.info`Packaged archive: ${archiveSize} bytes`;
       },
       error: (e) => {
@@ -161,6 +176,8 @@ class JsonExtensionQualityRenderer implements ExtensionQualityRenderer {
             rubricVersion: score.rubricVersion,
             earnedPoints: score.earnedPoints,
             maxEarnablePoints: score.maxEarnablePoints,
+            maxClientEarnablePoints: score.maxClientEarnablePoints,
+            provisionalPoints: score.provisionalPoints,
             percentage: score.percentage,
             allPassed: score.allPassed,
             factors: score.factors,

--- a/src/presentation/renderers/extension_quality_test.ts
+++ b/src/presentation/renderers/extension_quality_test.ts
@@ -49,7 +49,9 @@ function makeScore(overrides: Partial<RubricScore> = {}): RubricScore {
     ],
     earnedPoints: 12,
     maxEarnablePoints: 14,
-    percentage: 85,
+    maxClientEarnablePoints: 12,
+    provisionalPoints: 2,
+    percentage: 100,
     allPassed: false,
     ...overrides,
   };


### PR DESCRIPTION
Closes swamp-club#1636

## Summary

- Add `"provisional"` to `FactorStatus` for factors only the server can fully verify
- `repository-verified` now earns 0 points locally with status `"provisional"` — its max points are excluded from the client-side percentage denominator
- New `RubricScore` fields: `provisionalPoints` and `maxClientEarnablePoints` let callers distinguish confirmed from pending points
- Log renderer shows `~` marker for provisional factors and appends `(+N pending server verification)` to the summary line
- JSON output includes the new fields for programmatic consumers
- A perfect extension now reports `12/12 (100% (+2 pending server verification))` instead of the misleading `14/14 (100%)`

## Test Plan

- Updated 72 unit tests in `extension_rubric_scorer_test.ts` — all pass
- Updated renderer tests in `extension_quality_test.ts` — all pass
- Updated integration test in `integration/extension_quality_test.ts` — all pass
- Full test suite: 10,250 passed, 0 failed
- Manual verification: compiled binary, scored an extension pointing at a nonexistent GitHub repo — confirmed `repository-verified` is `"provisional"` with `earnedPoints: 0`
- `deno check`, `deno lint`, `deno fmt` all clean