### PR TITLE
fix(workflows): append to run log on resume instead of truncating (swamp-club#1639)

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -2114,7 +2114,8 @@ export class WorkflowExecutionService {
 
     const secretRedactor = new SecretRedactor();
 
-    // Re-register the log file sink so resume output is captured
+    // Re-register the log file sink so resume output is captured.
+    // Append to preserve records from earlier attempts.
     const workflowLogPath = existingRun.logFile ??
       join(
         swampPath(this.repoDir, SWAMP_SUBDIRS.workflowRuns),
@@ -2126,6 +2127,7 @@ export class WorkflowExecutionService {
       workflowLogPath,
       secretRedactor,
       swampPath(this.repoDir),
+      { append: true },
     );
 
     // Declared before the try so the finally at the end of this method can

--- a/src/infrastructure/logging/run_file_sink.ts
+++ b/src/infrastructure/logging/run_file_sink.ts
@@ -91,6 +91,7 @@ export class RunFileSink {
     filePath: string,
     redactor?: SecretRedactor,
     boundary?: string,
+    options?: { append?: boolean },
   ): Promise<string> {
     // Validate the file path stays within the expected boundary
     if (boundary) {
@@ -106,7 +107,7 @@ export class RunFileSink {
     const fd = await Deno.open(filePath, {
       write: true,
       create: true,
-      truncate: true,
+      ...(options?.append ? { append: true } : { truncate: true }),
     });
 
     // Only mutate the map once all fallible I/O has succeeded.

--- a/src/infrastructure/logging/run_file_sink_test.ts
+++ b/src/infrastructure/logging/run_file_sink_test.ts
@@ -420,6 +420,46 @@ Deno.test("RunFileSink.redactActive: applies the union of every active redactor"
   });
 });
 
+Deno.test("RunFileSink: register with append preserves existing file content", async () => {
+  await withTempDir(async (dir) => {
+    const sink = new RunFileSink();
+    const logPath = join(dir, "append.log");
+
+    const handle1 = await sink.register([], logPath);
+    sink.sink(makeRecord(["workflow", "run", "wf1"], "first attempt"));
+    sink.unregister(handle1);
+
+    const handle2 = await sink.register([], logPath, undefined, undefined, {
+      append: true,
+    });
+    sink.sink(makeRecord(["workflow", "run", "wf1"], "second attempt"));
+    sink.unregister(handle2);
+
+    const content = await Deno.readTextFile(logPath);
+    assertStringIncludes(content, "first attempt");
+    assertStringIncludes(content, "second attempt");
+  });
+});
+
+Deno.test("RunFileSink: register without append truncates existing file content", async () => {
+  await withTempDir(async (dir) => {
+    const sink = new RunFileSink();
+    const logPath = join(dir, "truncate.log");
+
+    const handle1 = await sink.register([], logPath);
+    sink.sink(makeRecord(["workflow", "run", "wf1"], "first attempt"));
+    sink.unregister(handle1);
+
+    const handle2 = await sink.register([], logPath);
+    sink.sink(makeRecord(["workflow", "run", "wf1"], "second attempt"));
+    sink.unregister(handle2);
+
+    const content = await Deno.readTextFile(logPath);
+    assertEquals(content.includes("first attempt"), false);
+    assertStringIncludes(content, "second attempt");
+  });
+});
+
 Deno.test("RunFileSink.redactActive: passes text through unchanged when no redactor is active", async () => {
   await withTempDir(async (dir) => {
     const sink = new RunFileSink();


### PR DESCRIPTION
## Summary

- `RunFileSink.register()` unconditionally opened log files with `truncate: true`, which destroyed earlier attempt records when `workflow resume` re-registered the sink on the same file
- Added an `append` option to `register()` (default `false` to preserve existing behavior) and set it to `true` from `WorkflowExecutionService.resume()`
- Reproduced and verified: after the fix, `workflow history logs` shows records from both the original run and the resumed attempt

Fixes swamp-club#1639

## Test Plan

- [x] New unit tests for `RunFileSink.register()` append mode (preserves existing content) and default truncate mode (unchanged behavior)
- [x] Existing `execution_service_test.ts` resume tests pass
- [x] Existing `workflow_resume_test.ts` CLI tests pass
- [x] Manual reproduction: `workflow run` → fail → `workflow resume --from` → log file contains records from both attempts
- [x] `deno check`, `deno lint`, `deno fmt`, `deno run test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)