### PR TITLE
feat(extensions): warn on push when version bumped without upgrade entry

### DIFF
--- a/.claude/skills/swamp/references/extension/reference.md
+++ b/.claude/skills/swamp/references/extension/reference.md
@@ -163,8 +163,13 @@ All extension types follow the same lifecycle:
 6. **Unit tests** — colocate `*_test.ts`; `~/.swamp/deno/deno test` passes.
 7. **Version + manifest** — `swamp extension version`,
    `swamp extension fmt manifest.yaml --check`.
-8. **Quality check** (optional) — `swamp extension quality manifest.yaml`.
-9. **Publish** — use the `swamp-extension-publish` skill.
+8. **Upgrade entry** (if bumping version) — add an `upgrades` entry for the new
+   version, even a no-op. Without one, existing instances stay at their old
+   `typeVersion` forever. See
+   [references/model/upgrades.md](references/model/upgrades.md). `push` warns
+   when it detects a version bump without an upgrade entry.
+9. **Quality check** (optional) — `swamp extension quality manifest.yaml`.
+10. **Publish** — use the `swamp-extension-publish` skill.
 
 ### Adversarial Review Gate
 

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -48,6 +48,7 @@ import {
 } from "../../presentation/renderers/extension_push.ts";
 import type { SafetyIssue } from "../../domain/extensions/extension_safety_analyzer.ts";
 import {
+  checkVersionBumpWithoutUpgrade,
   checkVersionConsistency,
   type PublishedExtensionState,
   type QualityIssue,
@@ -71,6 +72,7 @@ interface ExtensionPushOptions extends GlobalOptions {
   releaseNotes?: string;
   channel?: string;
   versionSuffix?: string;
+  skipUpgradeCheck?: boolean;
 }
 
 /**
@@ -198,6 +200,10 @@ export const extensionPushCommand = new Command()
   .option(
     "--version-suffix <type:string>",
     "Override version micro segment: 'epoch' uses Unix timestamp (e.g. 2026.06.18.1750263600)",
+  )
+  .option(
+    "--skip-upgrade-check",
+    "Suppress warning when version is bumped without upgrade entries",
   )
   .action(async function (options: ExtensionPushOptions, manifestPath: string) {
     if (
@@ -574,6 +580,24 @@ export const extensionPushCommand = new Command()
     );
     if (versionIssues.length > 0) {
       renderer.renderVersionDriftWarnings(versionIssues);
+    }
+
+    // 6e. Version-bump-without-upgrade check — warn when the extension
+    // version changed from the published baseline but model files lack
+    // an upgrades array. Skipped when --skip-upgrade-check is passed,
+    // when there is no published version, or when the version has not
+    // changed.
+    if (
+      !options.skipUpgradeCheck &&
+      published &&
+      published.manifestVersion !== prepared.manifest.version
+    ) {
+      const upgradeWarnings = await checkVersionBumpWithoutUpgrade(
+        allModelFiles,
+      );
+      if (upgradeWarnings.length > 0) {
+        renderer.renderVersionBumpUpgradeWarnings(upgradeWarnings);
+      }
     }
 
     // 7. Dry run — stop here

--- a/src/domain/extensions/extension_quality_checker.ts
+++ b/src/domain/extensions/extension_quality_checker.ts
@@ -25,7 +25,13 @@ import {
 
 /** A quality issue found during checking. */
 export interface QualityIssue {
-  check: "fmt" | "lint" | "dynamic-import" | "version-drift" | "upgrade-chain";
+  check:
+    | "fmt"
+    | "lint"
+    | "dynamic-import"
+    | "version-drift"
+    | "upgrade-chain"
+    | "version-bump-upgrade";
   output: string;
 }
 
@@ -41,6 +47,8 @@ export function qualityCheckLabel(check: QualityIssue["check"]): string {
       return "Version drift";
     case "upgrade-chain":
       return "Upgrade chain";
+    case "version-bump-upgrade":
+      return "Version bump upgrade";
   }
 }
 
@@ -448,6 +456,51 @@ export async function checkUpgradeChainConsistency(
           `or update the model version to match.`,
       });
     }
+  }
+
+  return issues;
+}
+
+/**
+ * Checks for model files that have a version field but no upgrades array.
+ * This catches the case where a version was bumped but no upgrade entry
+ * was added — existing instances would be stranded at their old
+ * typeVersion. Only meaningful when the extension version is being bumped
+ * from a previously published baseline.
+ */
+export async function checkVersionBumpWithoutUpgrade(
+  modelFiles: string[],
+): Promise<QualityIssue[]> {
+  const issues: QualityIssue[] = [];
+
+  for (const file of modelFiles) {
+    let content: string;
+    try {
+      content = await Deno.readTextFile(file);
+    } catch (e) {
+      if (!(e instanceof Deno.errors.NotFound)) {
+        issues.push({
+          check: "version-bump-upgrade",
+          output: `${basename(file)}: could not read file: ${e}`,
+        });
+      }
+      continue;
+    }
+
+    const modelVersion = extractModelVersion(content);
+    if (!modelVersion) continue;
+
+    const lastToVersion = extractLastUpgradeToVersion(content);
+    if (lastToVersion !== null) continue;
+
+    issues.push({
+      check: "version-bump-upgrade",
+      output: `${basename(file)}: model has version "${modelVersion}" but no ` +
+        `upgrades array. Existing instances will not auto-migrate to this ` +
+        `version. Add an upgrades entry (even a no-op) — see ` +
+        `references/model/upgrades.md. If this model is new and has never ` +
+        `been published, pass --skip-upgrade-check to acknowledge.`,
+    });
   }
 
   return issues;

--- a/src/domain/extensions/extension_quality_checker_test.ts
+++ b/src/domain/extensions/extension_quality_checker_test.ts
@@ -22,6 +22,7 @@ import { join } from "@std/path";
 import {
   checkExtensionQuality,
   checkUpgradeChainConsistency,
+  checkVersionBumpWithoutUpgrade,
   checkVersionConsistency,
   type PublishedExtensionState,
   stripCommentsAndStrings,
@@ -700,4 +701,77 @@ Deno.test("checkUpgradeChainConsistency: file without model export is skipped", 
       assertEquals(issues, []);
     },
   );
+});
+
+// ── checkVersionBumpWithoutUpgrade tests ─────────────────────────────
+
+Deno.test("checkVersionBumpWithoutUpgrade: model with upgrades produces no issues", async () => {
+  await withTempFiles(
+    {
+      "model.ts": `export const model = {
+  type: "@test/greeter",
+  version: "2026.05.22.1",
+  methods: {},
+  upgrades: [
+    {
+      toVersion: "2026.05.22.1",
+      description: "Upgrade",
+      upgradeAttributes: (old) => old,
+    },
+  ],
+};
+`,
+    },
+    async (_dir, paths) => {
+      const issues = await checkVersionBumpWithoutUpgrade(paths);
+      assertEquals(issues, []);
+    },
+  );
+});
+
+Deno.test("checkVersionBumpWithoutUpgrade: model without upgrades reports issue", async () => {
+  await withTempFiles(
+    {
+      "model.ts": `export const model = {
+  type: "@test/greeter",
+  version: "2026.05.22.1",
+  methods: {},
+};
+`,
+    },
+    async (_dir, paths) => {
+      const issues = await checkVersionBumpWithoutUpgrade(paths);
+      assertEquals(issues.length, 1);
+      assertEquals(issues[0].check, "version-bump-upgrade");
+      assertStringIncludes(issues[0].output, "2026.05.22.1");
+      assertStringIncludes(issues[0].output, "no upgrades array");
+    },
+  );
+});
+
+Deno.test("checkVersionBumpWithoutUpgrade: file without model export is skipped", async () => {
+  await withTempFiles(
+    {
+      "helper.ts": `export function add(a: number, b: number): number {
+  return a + b;
+}
+`,
+    },
+    async (_dir, paths) => {
+      const issues = await checkVersionBumpWithoutUpgrade(paths);
+      assertEquals(issues, []);
+    },
+  );
+});
+
+Deno.test("checkVersionBumpWithoutUpgrade: empty file list produces no issues", async () => {
+  const issues = await checkVersionBumpWithoutUpgrade([]);
+  assertEquals(issues, []);
+});
+
+Deno.test("checkVersionBumpWithoutUpgrade: nonexistent files are skipped", async () => {
+  const issues = await checkVersionBumpWithoutUpgrade([
+    "/tmp/does-not-exist-12345.ts",
+  ]);
+  assertEquals(issues, []);
 });

--- a/src/presentation/renderers/extension_push.ts
+++ b/src/presentation/renderers/extension_push.ts
@@ -52,6 +52,7 @@ export interface ExtensionPushRenderer extends Renderer<ExtensionPushEvent> {
   renderQualityErrors(issues: QualityIssue[]): void;
   renderUpgradeChainErrors(issues: QualityIssue[]): void;
   renderVersionDriftWarnings(warnings: QualityIssue[]): void;
+  renderVersionBumpUpgradeWarnings(warnings: QualityIssue[]): void;
   renderCompilationErrors(errors: CompilationError[]): void;
   renderDryRun(data: {
     name: string;
@@ -258,6 +259,13 @@ class LogExtensionPushRenderer implements ExtensionPushRenderer {
     }
   }
 
+  renderVersionBumpUpgradeWarnings(warnings: QualityIssue[]): void {
+    this.logger.warn`Version bump without upgrade entry (non-blocking):`;
+    for (const w of warnings) {
+      this.logger.warn`  ${w.output}`;
+    }
+  }
+
   renderCompilationErrors(errors: CompilationError[]): void {
     this.logger.error`Bundle compilation failed:`;
     for (const r of errors) {
@@ -373,6 +381,12 @@ class JsonExtensionPushRenderer implements ExtensionPushRenderer {
   renderVersionDriftWarnings(warnings: QualityIssue[]): void {
     console.log(
       JSON.stringify({ versionDriftWarnings: warnings }, null, 2),
+    );
+  }
+
+  renderVersionBumpUpgradeWarnings(warnings: QualityIssue[]): void {
+    console.log(
+      JSON.stringify({ versionBumpUpgradeWarnings: warnings }, null, 2),
     );
   }
 


### PR DESCRIPTION
## Summary

- Add `checkVersionBumpWithoutUpgrade` domain function that detects model files with a `version` field but no `upgrades` array — the "agent bumped version but forgot to add upgrades" case
- Integrate the check into `swamp extension push` as a non-blocking warning when the extension version is bumped from its published baseline
- Add `--skip-upgrade-check` CLI flag to acknowledge intentional omissions (e.g. genuinely new models added in a version bump)
- Update extension guide's Shared Development Workflow with an explicit "Upgrade entry" step between versioning and quality check

Closes swamp-club#1641

## Test Plan

- [x] 5 new unit tests for `checkVersionBumpWithoutUpgrade` (model with upgrades, model without upgrades, file without model export, empty list, nonexistent files)
- [x] Full test suite passes (10,260 tests)
- [x] `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)