### PR TITLE
feat(serve): register serve instances with swamp-club and send hourly heartbeats

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -2142,6 +2142,7 @@ export const serveCommand = new Command()
     const clubApiKey = Deno.env.get("SWAMP_API_KEY") ?? null;
     if (
       authConfig.mode === "oauth" &&
+      authConfig.oauthClientId &&
       authConfig.allowedCollectives.length > 0 &&
       clubApiKey
     ) {
@@ -2150,7 +2151,7 @@ export const serveCommand = new Command()
           authConfig.oauthProvider,
           clubApiKey,
           {
-            oauthClientId: authConfig.oauthClientId!,
+            oauthClientId: authConfig.oauthClientId,
             instanceId,
             collectiveSlugs: [...authConfig.allowedCollectives],
             hostname: Deno.hostname(),

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -116,6 +116,15 @@ import {
   resolveServeUrl,
 } from "../remote_run.ts";
 import { validateServerRepoExclusivity } from "./access_helpers.ts";
+import { VERSION } from "./version.ts";
+import {
+  registerInstance,
+  sendInstanceHeartbeat,
+} from "../../serve/oauth_client.ts";
+import {
+  ClubHeartbeatService,
+  DEFAULT_CLUB_HEARTBEAT_INTERVAL_MS,
+} from "../../serve/club_heartbeat_service.ts";
 import type { ServeReloadResponse } from "../../serve/protocol.ts";
 import { createServeReloadRenderer } from "../../presentation/renderers/serve_reload.ts";
 import {
@@ -2130,6 +2139,38 @@ export const serveCommand = new Command()
 
     const instanceId = crypto.randomUUID();
 
+    const clubApiKey = Deno.env.get("SWAMP_API_KEY") ?? null;
+    if (
+      authConfig.mode === "oauth" &&
+      authConfig.allowedCollectives.length > 0 &&
+      clubApiKey
+    ) {
+      try {
+        await registerInstance(
+          authConfig.oauthProvider,
+          clubApiKey,
+          {
+            oauthClientId: authConfig.oauthClientId!,
+            instanceId,
+            collectiveSlugs: [...authConfig.allowedCollectives],
+            hostname: Deno.hostname(),
+            version: VERSION,
+            deploymentMode: deploymentMode.mode,
+          },
+          AbortSignal.timeout(30_000),
+        );
+        logger.info(
+          "Registered serve instance with swamp-club (clientId: {clientId})",
+          { clientId: authConfig.oauthClientId },
+        );
+      } catch (err) {
+        logger.warn(
+          "Failed to register serve instance with swamp-club: {error}",
+          { error: err instanceof Error ? err.message : String(err) },
+        );
+      }
+    }
+
     // Migrate existing vault-backed token secrets to the encrypted
     // control-plane store. Runs before auth middleware accepts tokens.
     if (authConfig.mode === "oauth") {
@@ -2653,6 +2694,22 @@ export const serveCommand = new Command()
         closeConnectionsForPrincipal,
       });
       collectiveRefreshService.start();
+    }
+
+    let clubHeartbeatService: ClubHeartbeatService | null = null;
+    if (
+      authConfig.mode === "oauth" && authConfig.oauthClientId &&
+      authConfig.allowedCollectives.length > 0 &&
+      clubApiKey
+    ) {
+      clubHeartbeatService = new ClubHeartbeatService({
+        providerUrl: authConfig.oauthProvider,
+        oauthClientId: authConfig.oauthClientId,
+        intervalMs: DEFAULT_CLUB_HEARTBEAT_INTERVAL_MS,
+        getAccessToken: () => Promise.resolve(clubApiKey),
+        sendHeartbeat: sendInstanceHeartbeat,
+      });
+      clubHeartbeatService.start();
     }
 
     // Parse and initialize webhook endpoints
@@ -3280,6 +3337,9 @@ export const serveCommand = new Command()
       }
       if (collectiveRefreshService) {
         await collectiveRefreshService.dispose();
+      }
+      if (clubHeartbeatService) {
+        clubHeartbeatService.stop();
       }
       if (grantsDirectoryPoller) {
         await grantsDirectoryPoller.stop();

--- a/src/serve/club_heartbeat_service.ts
+++ b/src/serve/club_heartbeat_service.ts
@@ -1,0 +1,100 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+
+const logger = getSwampLogger(["serve", "club-heartbeat"]);
+
+export const DEFAULT_CLUB_HEARTBEAT_INTERVAL_MS = 60 * 60 * 1000;
+
+export interface ClubHeartbeatDeps {
+  readonly providerUrl: string;
+  readonly oauthClientId: string;
+  readonly intervalMs: number;
+
+  getAccessToken(): Promise<string | null>;
+
+  sendHeartbeat(
+    providerUrl: string,
+    accessToken: string,
+    oauthClientId: string,
+    signal: AbortSignal,
+  ): Promise<{ heartbeatCount: number }>;
+}
+
+export class ClubHeartbeatService {
+  readonly #deps: ClubHeartbeatDeps;
+  #timer: ReturnType<typeof setInterval> | null = null;
+  #disposed = false;
+
+  constructor(deps: ClubHeartbeatDeps) {
+    this.#deps = deps;
+  }
+
+  start(): void {
+    if (this.#disposed || this.#timer !== null) return;
+    logger.info(
+      "Starting swamp-club heartbeat (interval: {interval}ms, clientId: {clientId})",
+      {
+        interval: this.#deps.intervalMs,
+        clientId: this.#deps.oauthClientId,
+      },
+    );
+    this.#timer = setInterval(() => {
+      this.#beat().catch((err) => {
+        logger.warn("Club heartbeat failed: {error}", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }, this.#deps.intervalMs);
+    Deno.unrefTimer(this.#timer);
+  }
+
+  stop(): void {
+    if (this.#timer !== null) {
+      clearInterval(this.#timer);
+      this.#timer = null;
+    }
+    this.#disposed = true;
+  }
+
+  async #beat(): Promise<void> {
+    if (this.#disposed) return;
+
+    const accessToken = await this.#deps.getAccessToken();
+    if (!accessToken) {
+      logger.warn(
+        "No access token available for club heartbeat — skipping",
+      );
+      return;
+    }
+
+    const signal = AbortSignal.timeout(30_000);
+    const result = await this.#deps.sendHeartbeat(
+      this.#deps.providerUrl,
+      accessToken,
+      this.#deps.oauthClientId,
+      signal,
+    );
+    logger.info(
+      "Club heartbeat recorded (heartbeatCount: {count})",
+      { count: result.heartbeatCount },
+    );
+  }
+}

--- a/src/serve/club_heartbeat_service_test.ts
+++ b/src/serve/club_heartbeat_service_test.ts
@@ -62,3 +62,61 @@ Deno.test("ClubHeartbeatService: double start is idempotent", () => {
   service.start();
   service.stop();
 });
+
+Deno.test("ClubHeartbeatService: calls sendHeartbeat with correct arguments on tick", async () => {
+  const calls: { providerUrl: string; token: string; clientId: string }[] = [];
+  const service = new ClubHeartbeatService({
+    providerUrl: "https://club.example.com",
+    oauthClientId: "clt-test-456",
+    intervalMs: 50,
+    getAccessToken: () => Promise.resolve("my-secret-key"),
+    sendHeartbeat: (providerUrl, token, clientId) => {
+      calls.push({ providerUrl, token, clientId });
+      return Promise.resolve({ heartbeatCount: calls.length });
+    },
+  });
+  service.start();
+  await new Promise((r) => setTimeout(r, 120));
+  service.stop();
+  assertEquals(calls.length >= 1, true);
+  assertEquals(calls[0].providerUrl, "https://club.example.com");
+  assertEquals(calls[0].token, "my-secret-key");
+  assertEquals(calls[0].clientId, "clt-test-456");
+});
+
+Deno.test("ClubHeartbeatService: skips beat when getAccessToken returns null", async () => {
+  let heartbeatCalled = false;
+  const service = new ClubHeartbeatService({
+    providerUrl: "https://example.com",
+    oauthClientId: "clt-test",
+    intervalMs: 50,
+    getAccessToken: () => Promise.resolve(null),
+    sendHeartbeat: () => {
+      heartbeatCalled = true;
+      return Promise.resolve({ heartbeatCount: 1 });
+    },
+  });
+  service.start();
+  await new Promise((r) => setTimeout(r, 120));
+  service.stop();
+  assertEquals(heartbeatCalled, false);
+});
+
+Deno.test("ClubHeartbeatService: sendHeartbeat failure does not stop the service", async () => {
+  let callCount = 0;
+  const service = new ClubHeartbeatService({
+    providerUrl: "https://example.com",
+    oauthClientId: "clt-test",
+    intervalMs: 50,
+    getAccessToken: () => Promise.resolve("tok"),
+    sendHeartbeat: () => {
+      callCount++;
+      if (callCount === 1) throw new Error("network error");
+      return Promise.resolve({ heartbeatCount: callCount });
+    },
+  });
+  service.start();
+  await new Promise((r) => setTimeout(r, 180));
+  service.stop();
+  assertEquals(callCount >= 2, true);
+});

--- a/src/serve/club_heartbeat_service_test.ts
+++ b/src/serve/club_heartbeat_service_test.ts
@@ -1,0 +1,64 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  ClubHeartbeatService,
+  DEFAULT_CLUB_HEARTBEAT_INTERVAL_MS,
+} from "./club_heartbeat_service.ts";
+
+Deno.test("DEFAULT_CLUB_HEARTBEAT_INTERVAL_MS: is 1 hour", () => {
+  assertEquals(DEFAULT_CLUB_HEARTBEAT_INTERVAL_MS, 60 * 60 * 1000);
+});
+
+Deno.test("ClubHeartbeatService: stop is safe to call before start", () => {
+  const service = new ClubHeartbeatService({
+    providerUrl: "https://example.com",
+    oauthClientId: "test-client",
+    intervalMs: 1000,
+    getAccessToken: () => Promise.resolve("token"),
+    sendHeartbeat: () => Promise.resolve({ heartbeatCount: 1 }),
+  });
+  service.stop();
+});
+
+Deno.test("ClubHeartbeatService: start then stop does not leak timers", () => {
+  const service = new ClubHeartbeatService({
+    providerUrl: "https://example.com",
+    oauthClientId: "test-client",
+    intervalMs: 60_000,
+    getAccessToken: () => Promise.resolve("token"),
+    sendHeartbeat: () => Promise.resolve({ heartbeatCount: 1 }),
+  });
+  service.start();
+  service.stop();
+});
+
+Deno.test("ClubHeartbeatService: double start is idempotent", () => {
+  const service = new ClubHeartbeatService({
+    providerUrl: "https://example.com",
+    oauthClientId: "test-client",
+    intervalMs: 60_000,
+    getAccessToken: () => Promise.resolve("token"),
+    sendHeartbeat: () => Promise.resolve({ heartbeatCount: 1 }),
+  });
+  service.start();
+  service.start();
+  service.stop();
+});

--- a/src/serve/oauth_client.ts
+++ b/src/serve/oauth_client.ts
@@ -190,6 +190,84 @@ export async function getUserInfo(
   };
 }
 
+export interface RegisterInstanceRequest {
+  readonly oauthClientId: string;
+  readonly instanceId: string;
+  readonly collectiveSlugs: string[];
+  readonly hostname: string;
+  readonly version: string;
+  readonly deploymentMode: string;
+  readonly tags?: Record<string, string>;
+}
+
+export interface RegisterInstanceResponse {
+  readonly oauthClientId: string;
+  readonly instanceId: string;
+  readonly registeredAt: string;
+  readonly startedAt: string;
+}
+
+export async function registerInstance(
+  providerUrl: string,
+  accessToken: string,
+  request: RegisterInstanceRequest,
+  signal: AbortSignal,
+): Promise<RegisterInstanceResponse> {
+  const resp = await fetch(`${providerUrl}/api/v1/serve/instances`, {
+    method: "PUT",
+    headers: {
+      "content-type": "application/json",
+      "authorization": `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(request),
+    signal,
+  });
+  if (!resp.ok) {
+    const data = await resp.json().catch(() => ({}));
+    throw new Error(
+      `Instance registration failed: ${resp.status} ${resp.statusText}${
+        data.error ? ` — ${data.error}` : ""
+      }`,
+    );
+  }
+  return await resp.json() as RegisterInstanceResponse;
+}
+
+export interface HeartbeatResponse {
+  readonly oauthClientId: string;
+  readonly lastHeartbeatAt: string;
+  readonly heartbeatCount: number;
+}
+
+export async function sendInstanceHeartbeat(
+  providerUrl: string,
+  accessToken: string,
+  oauthClientId: string,
+  signal: AbortSignal,
+): Promise<HeartbeatResponse> {
+  const resp = await fetch(
+    `${providerUrl}/api/v1/serve/instances/${
+      encodeURIComponent(oauthClientId)
+    }/heartbeat`,
+    {
+      method: "PUT",
+      headers: {
+        "authorization": `Bearer ${accessToken}`,
+      },
+      signal,
+    },
+  );
+  if (!resp.ok) {
+    const data = await resp.json().catch(() => ({}));
+    throw new Error(
+      `Instance heartbeat failed: ${resp.status} ${resp.statusText}${
+        data.error ? ` — ${data.error}` : ""
+      }`,
+    );
+  }
+  return await resp.json() as HeartbeatResponse;
+}
+
 export async function resolveUsername(
   providerUrl: string,
   username: string,

--- a/src/serve/oauth_client_test.ts
+++ b/src/serve/oauth_client_test.ts
@@ -18,11 +18,14 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertRejects } from "@std/assert";
+import { assertStringIncludes } from "@std/assert";
 import {
   DeviceGrantPollError,
   getUserInfo,
   pollForToken,
+  registerInstance,
   resolveUsername,
+  sendInstanceHeartbeat,
   startDeviceGrant,
 } from "./oauth_client.ts";
 
@@ -616,6 +619,208 @@ Deno.test("resolveUsername: sends Bearer auth header", async () => {
       AbortSignal.timeout(5000),
     );
     assertEquals(receivedAuth, "Bearer my-secret-token");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+// ── registerInstance ───────────────────────────────────────────────────
+
+Deno.test("registerInstance: sends correct URL, headers, and body", async () => {
+  let receivedPath = "";
+  let receivedMethod = "";
+  let receivedAuth = "";
+  let receivedContentType = "";
+  let receivedBody: Record<string, unknown> = {};
+  const mock = startMockServer(async (req) => {
+    receivedPath = new URL(req.url).pathname;
+    receivedMethod = req.method;
+    receivedAuth = req.headers.get("authorization") ?? "";
+    receivedContentType = req.headers.get("content-type") ?? "";
+    receivedBody = await req.json();
+    return Response.json({
+      oauthClientId: "clt-abc",
+      instanceId: "inst-123",
+      registeredAt: "2026-08-13T10:00:00.000Z",
+      startedAt: "2026-08-13T14:00:00.000Z",
+    });
+  });
+  try {
+    const result = await registerInstance(
+      `http://localhost:${mock.port}`,
+      "my-api-key",
+      {
+        oauthClientId: "clt-abc",
+        instanceId: "inst-123",
+        collectiveSlugs: ["acme-corp"],
+        hostname: "prod-01",
+        version: "20260813.0",
+        deploymentMode: "durable",
+        tags: { env: "production" },
+      },
+      AbortSignal.timeout(5000),
+    );
+    assertEquals(receivedPath, "/api/v1/serve/instances");
+    assertEquals(receivedMethod, "PUT");
+    assertEquals(receivedAuth, "Bearer my-api-key");
+    assertEquals(receivedContentType, "application/json");
+    assertEquals(receivedBody.oauthClientId, "clt-abc");
+    assertEquals(receivedBody.instanceId, "inst-123");
+    assertEquals(receivedBody.collectiveSlugs, ["acme-corp"]);
+    assertEquals(receivedBody.hostname, "prod-01");
+    assertEquals(receivedBody.version, "20260813.0");
+    assertEquals(receivedBody.deploymentMode, "durable");
+    assertEquals(
+      receivedBody.tags as Record<string, string>,
+      { env: "production" },
+    );
+    assertEquals(result.oauthClientId, "clt-abc");
+    assertEquals(result.instanceId, "inst-123");
+    assertEquals(result.registeredAt, "2026-08-13T10:00:00.000Z");
+    assertEquals(result.startedAt, "2026-08-13T14:00:00.000Z");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("registerInstance: throws with JSON error body on HTTP error", async () => {
+  const mock = startMockServer(() =>
+    Response.json(
+      { error: "OAuth client not found" },
+      { status: 422 },
+    )
+  );
+  try {
+    const err = await assertRejects(
+      () =>
+        registerInstance(
+          `http://localhost:${mock.port}`,
+          "tok",
+          {
+            oauthClientId: "bad-client",
+            instanceId: "i",
+            collectiveSlugs: ["org"],
+            hostname: "h",
+            version: "v",
+            deploymentMode: "local",
+          },
+          AbortSignal.timeout(5000),
+        ),
+      Error,
+    );
+    assertStringIncludes(err.message, "422");
+    assertStringIncludes(err.message, "OAuth client not found");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("registerInstance: throws with status text on non-JSON error body", async () => {
+  const mock = startMockServer(() =>
+    new Response("Internal Server Error", { status: 500 })
+  );
+  try {
+    const err = await assertRejects(
+      () =>
+        registerInstance(
+          `http://localhost:${mock.port}`,
+          "tok",
+          {
+            oauthClientId: "c",
+            instanceId: "i",
+            collectiveSlugs: ["org"],
+            hostname: "h",
+            version: "v",
+            deploymentMode: "local",
+          },
+          AbortSignal.timeout(5000),
+        ),
+      Error,
+    );
+    assertStringIncludes(err.message, "500");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+// ── sendInstanceHeartbeat ─────────────────────────────────────────────
+
+Deno.test("sendInstanceHeartbeat: sends correct URL with encoded oauthClientId and auth header", async () => {
+  let receivedPath = "";
+  let receivedMethod = "";
+  let receivedAuth = "";
+  const mock = startMockServer((req) => {
+    receivedPath = new URL(req.url).pathname;
+    receivedMethod = req.method;
+    receivedAuth = req.headers.get("authorization") ?? "";
+    return Response.json({
+      oauthClientId: "clt/special",
+      lastHeartbeatAt: "2026-08-13T15:00:00.000Z",
+      heartbeatCount: 5,
+    });
+  });
+  try {
+    const result = await sendInstanceHeartbeat(
+      `http://localhost:${mock.port}`,
+      "my-token",
+      "clt/special",
+      AbortSignal.timeout(5000),
+    );
+    assertEquals(
+      receivedPath,
+      "/api/v1/serve/instances/clt%2Fspecial/heartbeat",
+    );
+    assertEquals(receivedMethod, "PUT");
+    assertEquals(receivedAuth, "Bearer my-token");
+    assertEquals(result.oauthClientId, "clt/special");
+    assertEquals(result.lastHeartbeatAt, "2026-08-13T15:00:00.000Z");
+    assertEquals(result.heartbeatCount, 5);
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("sendInstanceHeartbeat: throws with JSON error body on HTTP error", async () => {
+  const mock = startMockServer(() =>
+    Response.json(
+      { error: "No registration found for this oauthClientId" },
+      { status: 404 },
+    )
+  );
+  try {
+    const err = await assertRejects(
+      () =>
+        sendInstanceHeartbeat(
+          `http://localhost:${mock.port}`,
+          "tok",
+          "missing-client",
+          AbortSignal.timeout(5000),
+        ),
+      Error,
+    );
+    assertStringIncludes(err.message, "404");
+    assertStringIncludes(err.message, "No registration found");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("sendInstanceHeartbeat: throws with status text on non-JSON error body", async () => {
+  const mock = startMockServer(() =>
+    new Response("Bad Gateway", { status: 502 })
+  );
+  try {
+    const err = await assertRejects(
+      () =>
+        sendInstanceHeartbeat(
+          `http://localhost:${mock.port}`,
+          "tok",
+          "client-id",
+          AbortSignal.timeout(5000),
+        ),
+      Error,
+    );
+    assertStringIncludes(err.message, "502");
   } finally {
     await mock.shutdown();
   }


### PR DESCRIPTION
## Summary

- On startup (when `SWAMP_API_KEY` is set with a `serve:*` collective token and `--auth-mode oauth` + `--allowed-collectives` are configured), serve registers itself with swamp-club via `PUT /api/v1/serve/instances`
- A new `ClubHeartbeatService` sends an hourly `PUT /api/v1/serve/instances/:oauthClientId/heartbeat` so swamp-club can track instance liveness (stale after ~3h without a heartbeat)
- Both calls are non-blocking — failures log a warning and do not prevent serve from starting or running
- Adds `registerInstance()` and `sendInstanceHeartbeat()` to `oauth_client.ts` for the two PUT calls
- Companion to swamp-club/swamp-club#1066

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] `deno run test` passes (10253 passed, 0 failed)
- [x] Manual test: `SWAMP_API_KEY=<collective-token> swamp serve --auth-mode oauth --admins stack72 --allowed-collectives swamp-internal` — registration succeeds, server starts, heartbeat service armed
- [x] Manual test: serve starts cleanly without `SWAMP_API_KEY` (registration and heartbeat skipped, no error)
- [x] Manual test: serve starts cleanly when registration fails (403 logged as warning, startup completes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)