### PR TITLE
fix(docs): correct trigger inputs override semantics in design doc

### DIFF
--- a/design/workflow.md
+++ b/design/workflow.md
@@ -507,11 +507,12 @@ override.
 
 **Precedence for schedule:** `serve.yaml override > workflow YAML trigger`
 
-**Precedence for trigger inputs:** override inputs replace the original
-`trigger.inputs` entirely (shallow-merge at the trigger level, not deep-merge
-at the inputs level). The existing `caller > trigger.inputs > schema defaults`
-layering remains unchanged — the override simply changes which `trigger.inputs`
-is used as the baseline.
+**Precedence for trigger inputs:** override inputs are merged on top of the
+workflow's built-in `trigger.inputs` — override keys win, but built-in keys
+not present in the override fall through. The existing
+`caller inputs > trigger.inputs > schema defaults` layering remains unchanged;
+override inputs occupy the caller inputs slot, layered above built-in
+`trigger.inputs`.
 
 #### Trigger Inputs
 


### PR DESCRIPTION
## Summary

Fixes the design doc to match the actual implementation of trigger input overrides (#2144).

The doc incorrectly stated override inputs "replace entirely" the built-in `trigger.inputs`. The actual behavior is overlay — override keys win, but built-in keys not present in the override fall through. This is the more useful behavior (noted by the adversarial review on #2144).

## Test Plan

- Doc-only change, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)