### PR TITLE
feat(cli): add workflow trigger set/get/remove commands

### DIFF
--- a/design/workflow.md
+++ b/design/workflow.md
@@ -473,7 +473,23 @@ future daemon, or programmatic use) can use the same scheduling infrastructure.
 
 Extension-bundled workflows are read-only — users cannot modify their YAML to
 add or change a trigger. The `triggers` section in `.swamp/serve.yaml` provides
-per-workflow overrides that survive extension updates:
+per-workflow overrides that survive extension updates.
+
+Overrides can be managed via the CLI or by editing `serve.yaml` directly:
+
+```bash
+# Set a trigger override (replace semantics — writes the full entry)
+swamp workflow trigger set @swamp/cve/researcher/scan --schedule "0 3 * * *" --input channel=#security
+swamp workflow trigger set daily-report --schedule "0 8 * * 1-5"
+
+# Show the effective trigger (built-in merged with override)
+swamp workflow trigger get @swamp/cve/researcher/scan
+
+# Remove a trigger override
+swamp workflow trigger remove daily-report
+```
+
+The equivalent `serve.yaml` representation:
 
 ```yaml
 # .swamp/serve.yaml

--- a/integration/workflow_trigger_cli_test.ts
+++ b/integration/workflow_trigger_cli_test.ts
@@ -1,0 +1,142 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../src/infrastructure/logging/logger.ts";
+import {
+  readServeConfigFile,
+  writeServeConfigFile,
+} from "../src/serve/serve_config.ts";
+
+await initializeLogging({});
+
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    await fn(dir);
+  } finally {
+    try {
+      await Deno.remove(dir, { recursive: true });
+    } catch { /* Windows EBUSY */ }
+  }
+}
+
+Deno.test("trigger CLI round trip: set → read → remove", async () => {
+  await withTempDir(async (dir) => {
+    await writeServeConfigFile(dir, {
+      triggers: {
+        "scan-cves": { schedule: "0 3 * * *", inputs: { channel: "#ops" } },
+      },
+    });
+
+    const afterSet = await readServeConfigFile(dir);
+    assertEquals(afterSet?.triggers?.["scan-cves"]?.schedule, "0 3 * * *");
+    assertEquals(afterSet?.triggers?.["scan-cves"]?.inputs?.channel, "#ops");
+
+    delete afterSet!.triggers!["scan-cves"];
+    if (Object.keys(afterSet!.triggers!).length === 0) {
+      delete afterSet!.triggers;
+    }
+    await writeServeConfigFile(dir, afterSet!);
+
+    const afterRemove = await readServeConfigFile(dir);
+    assertEquals(afterRemove?.triggers, undefined);
+  });
+});
+
+Deno.test("trigger CLI: replace semantics — set replaces entire entry", async () => {
+  await withTempDir(async (dir) => {
+    await writeServeConfigFile(dir, {
+      triggers: {
+        "my-workflow": {
+          schedule: "0 3 * * *",
+          inputs: { channel: "#security" },
+        },
+      },
+    });
+
+    const config = await readServeConfigFile(dir);
+    config!.triggers!["my-workflow"] = { schedule: "0 6 * * *" };
+    await writeServeConfigFile(dir, config!);
+
+    const result = await readServeConfigFile(dir);
+    assertEquals(result?.triggers?.["my-workflow"]?.schedule, "0 6 * * *");
+    assertEquals(result?.triggers?.["my-workflow"]?.inputs, undefined);
+  });
+});
+
+Deno.test("trigger CLI: preserves other config sections", async () => {
+  await withTempDir(async (dir) => {
+    await writeServeConfigFile(dir, {
+      port: 9090,
+      host: "0.0.0.0",
+      schedule: true,
+    });
+
+    const config = await readServeConfigFile(dir);
+    const triggers = config!.triggers ?? {};
+    triggers["new-workflow"] = { schedule: "0 8 * * 1-5" };
+    config!.triggers = triggers;
+    await writeServeConfigFile(dir, config!);
+
+    const result = await readServeConfigFile(dir);
+    assertEquals(result?.port, 9090);
+    assertEquals(result?.host, "0.0.0.0");
+    assertEquals(result?.schedule, true);
+    assertEquals(
+      result?.triggers?.["new-workflow"]?.schedule,
+      "0 8 * * 1-5",
+    );
+  });
+});
+
+Deno.test("trigger CLI: multiple triggers coexist", async () => {
+  await withTempDir(async (dir) => {
+    await writeServeConfigFile(dir, {
+      triggers: {
+        "workflow-a": { schedule: "0 1 * * *" },
+        "workflow-b": { schedule: "0 2 * * *" },
+      },
+    });
+
+    const config = await readServeConfigFile(dir);
+    delete config!.triggers!["workflow-a"];
+    await writeServeConfigFile(dir, config!);
+
+    const result = await readServeConfigFile(dir);
+    assertEquals(result?.triggers?.["workflow-a"], undefined);
+    assertEquals(result?.triggers?.["workflow-b"]?.schedule, "0 2 * * *");
+  });
+});
+
+Deno.test("trigger CLI: creates serve.yaml from scratch", async () => {
+  await withTempDir(async (dir) => {
+    const before = await readServeConfigFile(dir);
+    assertEquals(before, null);
+
+    await writeServeConfigFile(dir, {
+      triggers: { "my-workflow": { schedule: "0 0 * * *" } },
+    });
+
+    const after = await readServeConfigFile(dir);
+    assertEquals(after?.triggers?.["my-workflow"]?.schedule, "0 0 * * *");
+  });
+});

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -37,6 +37,7 @@ import { workflowRejectCommand } from "./workflow_reject.ts";
 import { workflowResumeCommand } from "./workflow_resume.ts";
 import { workflowApprovalsCommand } from "./workflow_approvals.ts";
 import { workflowCancelCommand } from "./workflow_cancel.ts";
+import { workflowTriggerCommand } from "./workflow_trigger.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
 
 export const workflowCommand = new Command()
@@ -59,6 +60,7 @@ export const workflowCommand = new Command()
   .command("resume", workflowResumeCommand)
   .command("approvals", workflowApprovalsCommand)
   .command("schema", workflowSchemaCommand)
+  .command("trigger", workflowTriggerCommand)
   .command(
     "list",
     new Command()

--- a/src/cli/commands/workflow_trigger.ts
+++ b/src/cli/commands/workflow_trigger.ts
@@ -1,0 +1,34 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { groupCommandAction } from "../group_action.ts";
+import { workflowTriggerSetCommand } from "./workflow_trigger_set.ts";
+import { workflowTriggerGetCommand } from "./workflow_trigger_get.ts";
+import { workflowTriggerRemoveCommand } from "./workflow_trigger_remove.ts";
+import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
+
+export const workflowTriggerCommand = new Command()
+  .name("trigger")
+  .description("Manage workflow trigger overrides in serve.yaml")
+  .error(unknownCommandErrorHandler)
+  .action(groupCommandAction)
+  .command("set", workflowTriggerSetCommand)
+  .command("get", workflowTriggerGetCommand)
+  .command("remove", workflowTriggerRemoveCommand);

--- a/src/cli/commands/workflow_trigger_get.ts
+++ b/src/cli/commands/workflow_trigger_get.ts
@@ -35,19 +35,10 @@ import {
   resolveServeUrl,
   withRemoteOptions,
 } from "../remote_run.ts";
-import type { WorkflowTriggerGetResponse } from "../../serve/protocol.ts";
-
-export interface EffectiveTrigger {
-  readonly schedule: string | null;
-  readonly inputs: Record<string, unknown>;
-}
-
-export interface WorkflowTriggerGetResult {
-  readonly workflowName: string;
-  readonly builtIn: EffectiveTrigger | null;
-  readonly override: TriggerOverrideEntry | null;
-  readonly effective: EffectiveTrigger;
-}
+import type {
+  EffectiveTrigger,
+  WorkflowTriggerGetResponse,
+} from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -89,7 +80,7 @@ export const workflowTriggerGetCommand = withRemoteOptions(
     );
     renderWorkflowTriggerGet(
       cliCtx.outputMode,
-      response.data as unknown as WorkflowTriggerGetResult,
+      response.data,
     );
     return;
   }
@@ -129,17 +120,6 @@ export const workflowTriggerGetCommand = withRemoteOptions(
       ...(override?.inputs ?? {}),
     },
   };
-
-  if (!builtIn && !override) {
-    cliCtx.logger.info`No trigger found for workflow ${workflowName}`;
-    renderWorkflowTriggerGet(cliCtx.outputMode, {
-      workflowName,
-      builtIn: null,
-      override: null,
-      effective: { schedule: null, inputs: {} },
-    });
-    return;
-  }
 
   renderWorkflowTriggerGet(cliCtx.outputMode, {
     workflowName,

--- a/src/cli/commands/workflow_trigger_get.ts
+++ b/src/cli/commands/workflow_trigger_get.ts
@@ -1,0 +1,152 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  readServeConfigFile,
+  type TriggerOverrideEntry,
+} from "../../serve/serve_config.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepoReadOnly } from "../repo_context.ts";
+import { renderWorkflowTriggerGet } from "../../presentation/renderers/workflow_trigger_get.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { WorkflowTriggerGetResponse } from "../../serve/protocol.ts";
+
+export interface EffectiveTrigger {
+  readonly schedule: string | null;
+  readonly inputs: Record<string, unknown>;
+}
+
+export interface WorkflowTriggerGetResult {
+  readonly workflowName: string;
+  readonly builtIn: EffectiveTrigger | null;
+  readonly override: TriggerOverrideEntry | null;
+  readonly effective: EffectiveTrigger;
+}
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const workflowTriggerGetCommand = withRemoteOptions(
+  new Command()
+    .name("get")
+    .description(
+      "Show the effective trigger for a workflow (built-in + override)",
+    )
+    .example(
+      "Show effective trigger",
+      "swamp workflow trigger get scan-cves",
+    )
+    .arguments("<workflow_name:string>")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    ),
+).action(async function (options: AnyOptions, workflowName: string) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "workflow",
+    "trigger",
+    "get",
+  ]);
+
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
+    );
+    const response = await requestServerResponse<WorkflowTriggerGetResponse>(
+      { server, token },
+      {
+        type: "workflow.trigger.get",
+        payload: { workflowName },
+      },
+    );
+    renderWorkflowTriggerGet(
+      cliCtx.outputMode,
+      response.data as unknown as WorkflowTriggerGetResult,
+    );
+    return;
+  }
+
+  const repoDir = resolveRepoDir(options.repoDir);
+
+  cliCtx.logger.debug`Getting trigger for workflow ${workflowName}`;
+
+  const config = await readServeConfigFile(repoDir);
+  const override: TriggerOverrideEntry | null =
+    config?.triggers?.[workflowName] ?? null;
+
+  let builtIn: EffectiveTrigger | null = null;
+  try {
+    const { repoContext } = await requireInitializedRepoReadOnly({
+      repoDir,
+      outputMode: cliCtx.outputMode,
+    });
+
+    const workflow = await repoContext.workflowRepo.findByName(workflowName);
+    if (workflow) {
+      builtIn = {
+        schedule: workflow.schedule ?? null,
+        inputs: workflow.triggerInputs ?? {},
+      };
+    }
+  } catch {
+    cliCtx.logger.debug(
+      "Could not initialize repo for built-in trigger lookup — showing override only",
+    );
+  }
+
+  const effective: EffectiveTrigger = {
+    schedule: override?.schedule ?? builtIn?.schedule ?? null,
+    inputs: {
+      ...(builtIn?.inputs ?? {}),
+      ...(override?.inputs ?? {}),
+    },
+  };
+
+  if (!builtIn && !override) {
+    cliCtx.logger.info`No trigger found for workflow ${workflowName}`;
+    renderWorkflowTriggerGet(cliCtx.outputMode, {
+      workflowName,
+      builtIn: null,
+      override: null,
+      effective: { schedule: null, inputs: {} },
+    });
+    return;
+  }
+
+  renderWorkflowTriggerGet(cliCtx.outputMode, {
+    workflowName,
+    builtIn,
+    override,
+    effective,
+  });
+
+  cliCtx.logger.debug("Workflow trigger get command completed");
+});

--- a/src/cli/commands/workflow_trigger_get_test.ts
+++ b/src/cli/commands/workflow_trigger_get_test.ts
@@ -1,0 +1,41 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+import "../../domain/models/models.ts";
+
+await initializeLogging({});
+
+Deno.test("workflowTriggerGetCommand: has correct name", async () => {
+  const { workflowTriggerGetCommand } = await import(
+    "./workflow_trigger_get.ts"
+  );
+  assertEquals(workflowTriggerGetCommand.getName(), "get");
+});
+
+Deno.test("workflowTriggerGetCommand: has repo-dir option", async () => {
+  const { workflowTriggerGetCommand } = await import(
+    "./workflow_trigger_get.ts"
+  );
+  const options = workflowTriggerGetCommand.getOptions();
+  const repoDirOpt = options.find((o) => o.name === "repo-dir");
+  assertEquals(repoDirOpt !== undefined, true);
+});

--- a/src/cli/commands/workflow_trigger_remove.ts
+++ b/src/cli/commands/workflow_trigger_remove.ts
@@ -1,0 +1,103 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  readServeConfigFile,
+  writeServeConfigFile,
+} from "../../serve/serve_config.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { renderWorkflowTriggerRemove } from "../../presentation/renderers/workflow_trigger_remove.ts";
+import { UserError } from "../../domain/errors.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { WorkflowTriggerRemoveResponse } from "../../serve/protocol.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const workflowTriggerRemoveCommand = withRemoteOptions(
+  new Command()
+    .name("remove")
+    .description("Remove a trigger override for a workflow from serve.yaml")
+    .example(
+      "Remove trigger override",
+      "swamp workflow trigger remove scan-cves",
+    )
+    .arguments("<workflow_name:string>")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    ),
+).action(async function (options: AnyOptions, workflowName: string) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "workflow",
+    "trigger",
+    "remove",
+  ]);
+
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
+    );
+    const _response = await requestServerResponse<
+      WorkflowTriggerRemoveResponse
+    >(
+      { server, token },
+      {
+        type: "workflow.trigger.remove",
+        payload: { workflowName },
+      },
+    );
+    renderWorkflowTriggerRemove(cliCtx.outputMode, { workflowName });
+    return;
+  }
+
+  const repoDir = resolveRepoDir(options.repoDir);
+
+  cliCtx.logger.debug`Removing trigger override for workflow ${workflowName}`;
+
+  const config = await readServeConfigFile(repoDir);
+  if (!config?.triggers?.[workflowName]) {
+    throw new UserError(
+      `No trigger override found for workflow '${workflowName}' in serve.yaml`,
+    );
+  }
+
+  delete config.triggers[workflowName];
+  if (Object.keys(config.triggers).length === 0) {
+    delete config.triggers;
+  }
+
+  await writeServeConfigFile(repoDir, config);
+
+  renderWorkflowTriggerRemove(cliCtx.outputMode, { workflowName });
+
+  cliCtx.logger.debug("Workflow trigger remove command completed");
+});

--- a/src/cli/commands/workflow_trigger_remove_test.ts
+++ b/src/cli/commands/workflow_trigger_remove_test.ts
@@ -1,0 +1,57 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+import "../../domain/models/models.ts";
+
+await initializeLogging({});
+
+Deno.test("workflowTriggerRemoveCommand: has correct name", async () => {
+  const { workflowTriggerRemoveCommand } = await import(
+    "./workflow_trigger_remove.ts"
+  );
+  assertEquals(workflowTriggerRemoveCommand.getName(), "remove");
+});
+
+Deno.test("workflowTriggerRemoveCommand: has repo-dir option", async () => {
+  const { workflowTriggerRemoveCommand } = await import(
+    "./workflow_trigger_remove.ts"
+  );
+  const options = workflowTriggerRemoveCommand.getOptions();
+  const repoDirOpt = options.find((o) => o.name === "repo-dir");
+  assertEquals(repoDirOpt !== undefined, true);
+});
+
+Deno.test("workflowTriggerCommand: has all subcommands", async () => {
+  const { workflowTriggerCommand } = await import("./workflow_trigger.ts");
+  const commands = workflowTriggerCommand.getCommands();
+  const names = commands.map((c) => c.getName());
+  assertEquals(names.includes("set"), true);
+  assertEquals(names.includes("get"), true);
+  assertEquals(names.includes("remove"), true);
+});
+
+Deno.test("workflowCommand: has trigger subcommand", async () => {
+  const { workflowCommand } = await import("./workflow.ts");
+  const commands = workflowCommand.getCommands();
+  const trigger = commands.find((c) => c.getName() === "trigger");
+  assertEquals(trigger !== undefined, true);
+});

--- a/src/cli/commands/workflow_trigger_set.ts
+++ b/src/cli/commands/workflow_trigger_set.ts
@@ -1,0 +1,156 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  readServeConfigFile,
+  type TriggerOverrideEntry,
+  validateTriggerOverrideEntry,
+  writeServeConfigFile,
+} from "../../serve/serve_config.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { renderWorkflowTriggerSet } from "../../presentation/renderers/workflow_trigger_set.ts";
+import { UserError } from "../../domain/errors.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { WorkflowTriggerSetResponse } from "../../serve/protocol.ts";
+
+export function parseInputFlag(
+  input: string,
+): { key: string; value: string } {
+  const equalsIndex = input.indexOf("=");
+  if (equalsIndex === -1 || equalsIndex === 0) {
+    throw new UserError(
+      `Invalid --input format: '${input}'. Expected key=value.`,
+    );
+  }
+  return {
+    key: input.substring(0, equalsIndex),
+    value: input.substring(equalsIndex + 1),
+  };
+}
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const workflowTriggerSetCommand = withRemoteOptions(
+  new Command()
+    .name("set")
+    .description("Set a trigger override for a workflow in serve.yaml")
+    .example(
+      "Override schedule",
+      'swamp workflow trigger set scan-cves --schedule "0 3 * * *"',
+    )
+    .example(
+      "Override schedule with inputs",
+      'swamp workflow trigger set @swamp/cve/researcher/scan --schedule "0 12 * * 1" --input channel=#security',
+    )
+    .arguments("<workflow_name:string>")
+    .option(
+      "--schedule <cron:string>",
+      "Cron expression for the trigger schedule",
+      { required: true },
+    )
+    .option("--input <value:string>", "Input values (key=value, repeatable)", {
+      collect: true,
+    })
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    ),
+).action(async function (options: AnyOptions, workflowName: string) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "workflow",
+    "trigger",
+    "set",
+  ]);
+
+  const inputs: Record<string, unknown> = {};
+  if (options.input) {
+    for (const raw of options.input as string[]) {
+      const { key, value } = parseInputFlag(raw);
+      inputs[key] = value;
+    }
+  }
+
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
+    );
+    const response = await requestServerResponse<WorkflowTriggerSetResponse>(
+      { server, token },
+      {
+        type: "workflow.trigger.set",
+        payload: {
+          workflowName,
+          schedule: options.schedule as string,
+          ...(Object.keys(inputs).length > 0 ? { inputs } : {}),
+        },
+      },
+    );
+    const data = response.data as unknown as {
+      workflowName: string;
+      entry: TriggerOverrideEntry;
+    };
+    renderWorkflowTriggerSet(cliCtx.outputMode, {
+      workflowName: data.workflowName,
+      entry: data.entry,
+    });
+    return;
+  }
+
+  const repoDir = resolveRepoDir(options.repoDir);
+
+  const entry: TriggerOverrideEntry = {
+    schedule: options.schedule as string,
+  };
+
+  const entryWithInputs: TriggerOverrideEntry = Object.keys(inputs).length > 0
+    ? { ...entry, inputs }
+    : entry;
+
+  const configPath = `${repoDir}/.swamp/serve.yaml`;
+  validateTriggerOverrideEntry(entryWithInputs, configPath, workflowName);
+
+  cliCtx.logger.debug`Setting trigger override for workflow ${workflowName}`;
+
+  const config = await readServeConfigFile(repoDir) ?? {};
+  const triggers = config.triggers ?? {};
+  triggers[workflowName] = entryWithInputs;
+  config.triggers = triggers;
+
+  await writeServeConfigFile(repoDir, config);
+
+  renderWorkflowTriggerSet(cliCtx.outputMode, {
+    workflowName,
+    entry: entryWithInputs,
+  });
+
+  cliCtx.logger.debug("Workflow trigger set command completed");
+});

--- a/src/cli/commands/workflow_trigger_set.ts
+++ b/src/cli/commands/workflow_trigger_set.ts
@@ -18,8 +18,10 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
+import { join } from "@std/path";
 import {
   readServeConfigFile,
+  SERVE_CONFIG_PATH,
   type TriggerOverrideEntry,
   validateTriggerOverrideEntry,
   writeServeConfigFile,
@@ -75,9 +77,13 @@ export const workflowTriggerSetCommand = withRemoteOptions(
       "Cron expression for the trigger schedule",
       { required: true },
     )
-    .option("--input <value:string>", "Input values (key=value, repeatable)", {
-      collect: true,
-    })
+    .option(
+      "--input <value:string>",
+      "Input values (key=value, repeatable; JSON syntax not supported)",
+      {
+        collect: true,
+      },
+    )
     .option(
       "--repo-dir <dir:string>",
       "Repository directory (env: SWAMP_REPO_DIR)",
@@ -114,13 +120,9 @@ export const workflowTriggerSetCommand = withRemoteOptions(
         },
       },
     );
-    const data = response.data as unknown as {
-      workflowName: string;
-      entry: TriggerOverrideEntry;
-    };
     renderWorkflowTriggerSet(cliCtx.outputMode, {
-      workflowName: data.workflowName,
-      entry: data.entry,
+      workflowName: response.data.workflowName,
+      entry: response.data.entry,
     });
     return;
   }
@@ -135,7 +137,7 @@ export const workflowTriggerSetCommand = withRemoteOptions(
     ? { ...entry, inputs }
     : entry;
 
-  const configPath = `${repoDir}/.swamp/serve.yaml`;
+  const configPath = join(repoDir, SERVE_CONFIG_PATH);
   validateTriggerOverrideEntry(entryWithInputs, configPath, workflowName);
 
   cliCtx.logger.debug`Setting trigger override for workflow ${workflowName}`;

--- a/src/cli/commands/workflow_trigger_set_test.ts
+++ b/src/cli/commands/workflow_trigger_set_test.ts
@@ -1,0 +1,69 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+import "../../domain/models/models.ts";
+
+await initializeLogging({});
+
+Deno.test("parseInputFlag: parses key=value", async () => {
+  const { parseInputFlag } = await import("./workflow_trigger_set.ts");
+  const result = parseInputFlag("channel=#security");
+  assertEquals(result, { key: "channel", value: "#security" });
+});
+
+Deno.test("parseInputFlag: handles values with equals signs", async () => {
+  const { parseInputFlag } = await import("./workflow_trigger_set.ts");
+  const result = parseInputFlag("expr=a=b=c");
+  assertEquals(result, { key: "expr", value: "a=b=c" });
+});
+
+Deno.test("parseInputFlag: throws on missing equals", async () => {
+  const { parseInputFlag } = await import("./workflow_trigger_set.ts");
+  assertThrows(
+    () => parseInputFlag("no-equals"),
+    Error,
+    "Invalid --input format",
+  );
+});
+
+Deno.test("parseInputFlag: throws on empty key", async () => {
+  const { parseInputFlag } = await import("./workflow_trigger_set.ts");
+  assertThrows(
+    () => parseInputFlag("=value"),
+    Error,
+    "Invalid --input format",
+  );
+});
+
+Deno.test("workflowTriggerSetCommand: has correct name and options", async () => {
+  const { workflowTriggerSetCommand } = await import(
+    "./workflow_trigger_set.ts"
+  );
+  assertEquals(workflowTriggerSetCommand.getName(), "set");
+
+  const options = workflowTriggerSetCommand.getOptions();
+  const scheduleOpt = options.find((o) => o.name === "schedule");
+  assertEquals(scheduleOpt !== undefined, true);
+
+  const inputOpt = options.find((o) => o.name === "input");
+  assertEquals(inputOpt !== undefined, true);
+});

--- a/src/presentation/renderers/workflow_trigger_get.ts
+++ b/src/presentation/renderers/workflow_trigger_get.ts
@@ -1,0 +1,77 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { WorkflowTriggerGetResult } from "../../cli/commands/workflow_trigger_get.ts";
+import type { OutputMode } from "../output/output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+
+export function renderWorkflowTriggerGet(
+  mode: OutputMode,
+  data: WorkflowTriggerGetResult,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  const logger = getSwampLogger(["workflow", "trigger", "get"]);
+
+  logger.info`Trigger for ${data.workflowName}:`;
+
+  if (data.builtIn) {
+    logger.info`  built-in:`;
+    if (data.builtIn.schedule) {
+      logger.info`    schedule: ${data.builtIn.schedule}`;
+    }
+    if (Object.keys(data.builtIn.inputs).length > 0) {
+      for (const [key, value] of Object.entries(data.builtIn.inputs)) {
+        logger.info`    input ${key}: ${value}`;
+      }
+    }
+  }
+
+  if (data.override) {
+    logger.info`  override (serve.yaml):`;
+    if (data.override.schedule) {
+      logger.info`    schedule: ${data.override.schedule}`;
+    }
+    if (data.override.inputs && Object.keys(data.override.inputs).length > 0) {
+      for (const [key, value] of Object.entries(data.override.inputs)) {
+        logger.info`    input ${key}: ${value}`;
+      }
+    }
+  }
+
+  logger.info`  effective:`;
+  if (data.effective.schedule) {
+    logger.info`    schedule: ${data.effective.schedule}${
+      data.override?.schedule ? " (from override)" : " (built-in)"
+    }`;
+  } else {
+    logger.info`    schedule: (none)`;
+  }
+  if (Object.keys(data.effective.inputs).length > 0) {
+    for (const [key, value] of Object.entries(data.effective.inputs)) {
+      const source = data.override?.inputs?.[key] !== undefined
+        ? "override"
+        : "built-in";
+      logger.info`    input ${key}: ${value} (${source})`;
+    }
+  }
+}

--- a/src/presentation/renderers/workflow_trigger_get.ts
+++ b/src/presentation/renderers/workflow_trigger_get.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { WorkflowTriggerGetResult } from "../../cli/commands/workflow_trigger_get.ts";
+import type { WorkflowTriggerGetResult } from "../../serve/protocol.ts";
 import type { OutputMode } from "../output/output.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 
@@ -32,10 +32,15 @@ export function renderWorkflowTriggerGet(
 
   const logger = getSwampLogger(["workflow", "trigger", "get"]);
 
+  if (!data.builtIn && !data.override) {
+    logger.info`No trigger configured for workflow ${data.workflowName}`;
+    return;
+  }
+
   logger.info`Trigger for ${data.workflowName}:`;
 
   if (data.builtIn) {
-    logger.info`  built-in:`;
+    logger.info("  built-in:");
     if (data.builtIn.schedule) {
       logger.info`    schedule: ${data.builtIn.schedule}`;
     }
@@ -47,7 +52,7 @@ export function renderWorkflowTriggerGet(
   }
 
   if (data.override) {
-    logger.info`  override (serve.yaml):`;
+    logger.info("  override (serve.yaml):");
     if (data.override.schedule) {
       logger.info`    schedule: ${data.override.schedule}`;
     }
@@ -58,13 +63,12 @@ export function renderWorkflowTriggerGet(
     }
   }
 
-  logger.info`  effective:`;
+  logger.info("  effective:");
   if (data.effective.schedule) {
-    logger.info`    schedule: ${data.effective.schedule}${
-      data.override?.schedule ? " (from override)" : " (built-in)"
-    }`;
+    const source = data.override?.schedule ? "override" : "built-in";
+    logger.info`    schedule: ${data.effective.schedule} (${source})`;
   } else {
-    logger.info`    schedule: (none)`;
+    logger.info("    schedule: (none)");
   }
   if (Object.keys(data.effective.inputs).length > 0) {
     for (const [key, value] of Object.entries(data.effective.inputs)) {

--- a/src/presentation/renderers/workflow_trigger_get_test.ts
+++ b/src/presentation/renderers/workflow_trigger_get_test.ts
@@ -1,0 +1,65 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import { renderWorkflowTriggerGet } from "./workflow_trigger_get.ts";
+
+await initializeLogging({});
+
+Deno.test("renderWorkflowTriggerGet: json mode outputs complete data", () => {
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => output.push(msg);
+  try {
+    renderWorkflowTriggerGet("json", {
+      workflowName: "scan-cves",
+      builtIn: { schedule: "0 6 * * *", inputs: {} },
+      override: { schedule: "0 3 * * *" },
+      effective: { schedule: "0 3 * * *", inputs: {} },
+    });
+  } finally {
+    console.log = origLog;
+  }
+  const parsed = JSON.parse(output[0]);
+  assertEquals(parsed.workflowName, "scan-cves");
+  assertEquals(parsed.builtIn.schedule, "0 6 * * *");
+  assertEquals(parsed.override.schedule, "0 3 * * *");
+  assertEquals(parsed.effective.schedule, "0 3 * * *");
+});
+
+Deno.test("renderWorkflowTriggerGet: json mode with no trigger", () => {
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => output.push(msg);
+  try {
+    renderWorkflowTriggerGet("json", {
+      workflowName: "nonexistent",
+      builtIn: null,
+      override: null,
+      effective: { schedule: null, inputs: {} },
+    });
+  } finally {
+    console.log = origLog;
+  }
+  const parsed = JSON.parse(output[0]);
+  assertEquals(parsed.workflowName, "nonexistent");
+  assertEquals(parsed.builtIn, null);
+  assertEquals(parsed.override, null);
+});

--- a/src/presentation/renderers/workflow_trigger_remove.ts
+++ b/src/presentation/renderers/workflow_trigger_remove.ts
@@ -1,0 +1,37 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { OutputMode } from "../output/output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+
+export interface WorkflowTriggerRemoveData {
+  readonly workflowName: string;
+}
+
+export function renderWorkflowTriggerRemove(
+  mode: OutputMode,
+  data: WorkflowTriggerRemoveData,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    const logger = getSwampLogger(["workflow", "trigger", "remove"]);
+    logger.info`Removed trigger override for ${data.workflowName}`;
+  }
+}

--- a/src/presentation/renderers/workflow_trigger_remove_test.ts
+++ b/src/presentation/renderers/workflow_trigger_remove_test.ts
@@ -1,0 +1,37 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import { renderWorkflowTriggerRemove } from "./workflow_trigger_remove.ts";
+
+await initializeLogging({});
+
+Deno.test("renderWorkflowTriggerRemove: json mode outputs workflow name", () => {
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => output.push(msg);
+  try {
+    renderWorkflowTriggerRemove("json", { workflowName: "scan-cves" });
+  } finally {
+    console.log = origLog;
+  }
+  const parsed = JSON.parse(output[0]);
+  assertEquals(parsed.workflowName, "scan-cves");
+});

--- a/src/presentation/renderers/workflow_trigger_set.ts
+++ b/src/presentation/renderers/workflow_trigger_set.ts
@@ -1,0 +1,47 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { TriggerOverrideEntry } from "../../serve/serve_config.ts";
+import type { OutputMode } from "../output/output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+
+export interface WorkflowTriggerSetData {
+  readonly workflowName: string;
+  readonly entry: TriggerOverrideEntry;
+}
+
+export function renderWorkflowTriggerSet(
+  mode: OutputMode,
+  data: WorkflowTriggerSetData,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    const logger = getSwampLogger(["workflow", "trigger", "set"]);
+    logger
+      .info`Set trigger override for ${data.workflowName}: schedule ${data.entry.schedule}`;
+    if (data.entry.inputs && Object.keys(data.entry.inputs).length > 0) {
+      logger.info`  inputs: ${
+        Object.entries(data.entry.inputs).map(([k, v]) => `${k}=${v}`).join(
+          ", ",
+        )
+      }`;
+    }
+  }
+}

--- a/src/presentation/renderers/workflow_trigger_set_test.ts
+++ b/src/presentation/renderers/workflow_trigger_set_test.ts
@@ -1,0 +1,59 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import { renderWorkflowTriggerSet } from "./workflow_trigger_set.ts";
+
+await initializeLogging({});
+
+Deno.test("renderWorkflowTriggerSet: json mode outputs valid JSON", () => {
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => output.push(msg);
+  try {
+    renderWorkflowTriggerSet("json", {
+      workflowName: "scan-cves",
+      entry: { schedule: "0 3 * * *", inputs: { channel: "#ops" } },
+    });
+  } finally {
+    console.log = origLog;
+  }
+  const parsed = JSON.parse(output[0]);
+  assertEquals(parsed.workflowName, "scan-cves");
+  assertEquals(parsed.entry.schedule, "0 3 * * *");
+  assertEquals(parsed.entry.inputs.channel, "#ops");
+});
+
+Deno.test("renderWorkflowTriggerSet: json mode without inputs", () => {
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => output.push(msg);
+  try {
+    renderWorkflowTriggerSet("json", {
+      workflowName: "daily-report",
+      entry: { schedule: "0 8 * * 1-5" },
+    });
+  } finally {
+    console.log = origLog;
+  }
+  const parsed = JSON.parse(output[0]);
+  assertEquals(parsed.workflowName, "daily-report");
+  assertEquals(parsed.entry.inputs, undefined);
+});

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -80,6 +80,9 @@ import {
   handleWorkflowRunSearch,
   handleWorkflowSchema,
   handleWorkflowSearch,
+  handleWorkflowTriggerGet,
+  handleWorkflowTriggerRemove,
+  handleWorkflowTriggerSet,
   handleWorkflowValidate,
 } from "./handlers/workflow_handlers.ts";
 import {
@@ -992,6 +995,32 @@ const WorkflowEvaluateRequestSchema = z.object({
   }).optional(),
 });
 
+const WorkflowTriggerSetRequestSchema = z.object({
+  type: z.literal("workflow.trigger.set"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    workflowName: z.string().min(1),
+    schedule: z.string().min(1),
+    inputs: z.record(z.string(), z.unknown()).optional(),
+  }),
+});
+
+const WorkflowTriggerGetRequestSchema = z.object({
+  type: z.literal("workflow.trigger.get"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    workflowName: z.string().min(1),
+  }),
+});
+
+const WorkflowTriggerRemoveRequestSchema = z.object({
+  type: z.literal("workflow.trigger.remove"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    workflowName: z.string().min(1),
+  }),
+});
+
 const VaultCreateRequestSchema = z.object({
   type: z.literal("vault.create"),
   id: z.string().min(1).max(256),
@@ -1199,6 +1228,9 @@ const ServerRequestSchema = z.discriminatedUnion("type", [
   WorkflowEditRequestSchema,
   WorkflowValidateRequestSchema,
   WorkflowEvaluateRequestSchema,
+  WorkflowTriggerSetRequestSchema,
+  WorkflowTriggerGetRequestSchema,
+  WorkflowTriggerRemoveRequestSchema,
   VaultCreateRequestSchema,
   VaultEditRequestSchema,
   VaultAuditTrailRequestSchema,
@@ -2217,6 +2249,36 @@ export function handleMessage(
       break;
     case "workflow.evaluate":
       task = handleWorkflowEvaluate(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "workflow.trigger.set":
+      task = handleWorkflowTriggerSet(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "workflow.trigger.get":
+      task = handleWorkflowTriggerGet(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "workflow.trigger.remove":
+      task = handleWorkflowTriggerRemove(
         socket,
         ctx,
         request.id,

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -123,6 +123,14 @@ import {
   subscribeUntilDetach,
 } from "./shared.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { join } from "@std/path";
+import {
+  readServeConfigFile,
+  SERVE_CONFIG_PATH,
+  type TriggerOverrideEntry,
+  validateTriggerOverrideEntry,
+  writeServeConfigFile,
+} from "../serve_config.ts";
 
 const logger = getSwampLogger(["serve", "connection"]);
 const DEFAULT_BUFFER_CAPACITY = 10_000;
@@ -1570,13 +1578,6 @@ export async function handleWorkflowEvaluate(
 
 // ── Workflow trigger override handlers ──────────────────────────────
 
-import {
-  readServeConfigFile,
-  type TriggerOverrideEntry,
-  validateTriggerOverrideEntry,
-  writeServeConfigFile,
-} from "../serve_config.ts";
-
 export async function handleWorkflowTriggerSet(
   socket: WebSocket,
   ctx: ConnectionContext,
@@ -1601,7 +1602,7 @@ export async function handleWorkflowTriggerSet(
         : {}),
     };
 
-    const configPath = `${ctx.repoDir}/.swamp/serve.yaml`;
+    const configPath = join(ctx.repoDir, SERVE_CONFIG_PATH);
     validateTriggerOverrideEntry(entry, configPath, payload.workflowName);
 
     const config = await readServeConfigFile(ctx.repoDir) ?? {};

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -76,6 +76,9 @@ import type {
   WorkflowRunSearchPayload,
   WorkflowSchemaPayload,
   WorkflowSearchPayload,
+  WorkflowTriggerGetPayload,
+  WorkflowTriggerRemovePayload,
+  WorkflowTriggerSetPayload,
   WorkflowValidatePayload,
 } from "../protocol.ts";
 import { acquireModelLocks } from "../../cli/repo_context.ts";
@@ -1562,5 +1565,167 @@ export async function handleWorkflowEvaluate(
   } catch (error) {
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "workflow_evaluate_failed", message);
+  }
+}
+
+// ── Workflow trigger override handlers ──────────────────────────────
+
+import {
+  readServeConfigFile,
+  type TriggerOverrideEntry,
+  validateTriggerOverrideEntry,
+  writeServeConfigFile,
+} from "../serve_config.ts";
+
+export async function handleWorkflowTriggerSet(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: WorkflowTriggerSetPayload,
+  _controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "write", {
+      kind: "workflow",
+      name: payload.workflowName,
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const entry: TriggerOverrideEntry = {
+      schedule: payload.schedule,
+      ...(payload.inputs && Object.keys(payload.inputs).length > 0
+        ? { inputs: payload.inputs }
+        : {}),
+    };
+
+    const configPath = `${ctx.repoDir}/.swamp/serve.yaml`;
+    validateTriggerOverrideEntry(entry, configPath, payload.workflowName);
+
+    const config = await readServeConfigFile(ctx.repoDir) ?? {};
+    const triggers = config.triggers ?? {};
+    triggers[payload.workflowName] = entry;
+    config.triggers = triggers;
+    await writeServeConfigFile(ctx.repoDir, config);
+
+    send(socket, {
+      type: "workflow.trigger.set",
+      id: requestId,
+      payload: {
+        data: { workflowName: payload.workflowName, entry },
+      },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "workflow_trigger_set_failed", message);
+  }
+}
+
+export async function handleWorkflowTriggerGet(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: WorkflowTriggerGetPayload,
+  _controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "read", {
+      kind: "workflow",
+      name: payload.workflowName,
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const config = await readServeConfigFile(ctx.repoDir);
+    const override: TriggerOverrideEntry | null =
+      config?.triggers?.[payload.workflowName] ?? null;
+
+    let builtIn:
+      | { schedule: string | null; inputs: Record<string, unknown> }
+      | null = null;
+    const workflow = await ctx.repoContext.workflowRepo.findByName(
+      payload.workflowName,
+    );
+    if (workflow) {
+      builtIn = {
+        schedule: workflow.schedule ?? null,
+        inputs: workflow.triggerInputs ?? {},
+      };
+    }
+
+    const effective = {
+      schedule: override?.schedule ?? builtIn?.schedule ?? null,
+      inputs: {
+        ...(builtIn?.inputs ?? {}),
+        ...(override?.inputs ?? {}),
+      },
+    };
+
+    send(socket, {
+      type: "workflow.trigger.get",
+      id: requestId,
+      payload: {
+        data: {
+          workflowName: payload.workflowName,
+          builtIn,
+          override,
+          effective,
+        },
+      },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "workflow_trigger_get_failed", message);
+  }
+}
+
+export async function handleWorkflowTriggerRemove(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: WorkflowTriggerRemovePayload,
+  _controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "write", {
+      kind: "workflow",
+      name: payload.workflowName,
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const config = await readServeConfigFile(ctx.repoDir);
+    if (!config?.triggers?.[payload.workflowName]) {
+      sendError(
+        socket,
+        requestId,
+        "not_found",
+        `No trigger override found for workflow '${payload.workflowName}' in serve.yaml`,
+      );
+      return;
+    }
+
+    delete config.triggers[payload.workflowName];
+    if (Object.keys(config.triggers).length === 0) {
+      delete config.triggers;
+    }
+    await writeServeConfigFile(ctx.repoDir, config);
+
+    send(socket, {
+      type: "workflow.trigger.remove",
+      id: requestId,
+      payload: {
+        data: { workflowName: payload.workflowName },
+      },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "workflow_trigger_remove_failed", message);
   }
 }

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -508,6 +508,21 @@ export interface WorkflowTriggerRemovePayload {
   workflowName: string;
 }
 
+export interface EffectiveTrigger {
+  readonly schedule: string | null;
+  readonly inputs: Record<string, unknown>;
+}
+
+export interface WorkflowTriggerGetResult {
+  readonly workflowName: string;
+  readonly builtIn: EffectiveTrigger | null;
+  readonly override: {
+    readonly schedule?: string;
+    readonly inputs?: Record<string, unknown>;
+  } | null;
+  readonly effective: EffectiveTrigger;
+}
+
 // ── Vault CRUD / audit operations ───────────────────────────────────
 
 export interface VaultCreatePayload {
@@ -1266,15 +1281,18 @@ export interface WorkflowEvaluateResponse {
 }
 
 export interface WorkflowTriggerSetResponse {
-  data: Record<string, unknown>;
+  data: {
+    workflowName: string;
+    entry: { schedule?: string; inputs?: Record<string, unknown> };
+  };
 }
 
 export interface WorkflowTriggerGetResponse {
-  data: Record<string, unknown>;
+  data: WorkflowTriggerGetResult;
 }
 
 export interface WorkflowTriggerRemoveResponse {
-  data: Record<string, unknown>;
+  data: { workflowName: string };
 }
 
 export interface VaultCreateResponse {

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -492,6 +492,22 @@ export interface WorkflowEvaluatePayload {
   inputs?: Record<string, unknown>;
 }
 
+// ── Workflow trigger override operations ────────────────────────────
+
+export interface WorkflowTriggerSetPayload {
+  workflowName: string;
+  schedule: string;
+  inputs?: Record<string, unknown>;
+}
+
+export interface WorkflowTriggerGetPayload {
+  workflowName: string;
+}
+
+export interface WorkflowTriggerRemovePayload {
+  workflowName: string;
+}
+
 // ── Vault CRUD / audit operations ───────────────────────────────────
 
 export interface VaultCreatePayload {
@@ -786,6 +802,21 @@ export type ServerRequest =
   | { type: "workflow.create"; id: string; payload: WorkflowCreatePayload }
   | { type: "workflow.delete"; id: string; payload: WorkflowDeletePayload }
   | { type: "workflow.edit"; id: string; payload: WorkflowEditPayload }
+  | {
+    type: "workflow.trigger.set";
+    id: string;
+    payload: WorkflowTriggerSetPayload;
+  }
+  | {
+    type: "workflow.trigger.get";
+    id: string;
+    payload: WorkflowTriggerGetPayload;
+  }
+  | {
+    type: "workflow.trigger.remove";
+    id: string;
+    payload: WorkflowTriggerRemovePayload;
+  }
   | {
     type: "workflow.validate";
     id: string;
@@ -1234,6 +1265,18 @@ export interface WorkflowEvaluateResponse {
   data: Record<string, unknown>;
 }
 
+export interface WorkflowTriggerSetResponse {
+  data: Record<string, unknown>;
+}
+
+export interface WorkflowTriggerGetResponse {
+  data: Record<string, unknown>;
+}
+
+export interface WorkflowTriggerRemoveResponse {
+  data: Record<string, unknown>;
+}
+
 export interface VaultCreateResponse {
   data: Record<string, unknown>;
 }
@@ -1525,6 +1568,21 @@ export type ServerMessage =
   | { type: "workflow.create"; id: string; payload: WorkflowCreateResponse }
   | { type: "workflow.delete"; id: string; payload: WorkflowDeleteResponse }
   | { type: "workflow.edit"; id: string; payload: WorkflowEditResponse }
+  | {
+    type: "workflow.trigger.set";
+    id: string;
+    payload: WorkflowTriggerSetResponse;
+  }
+  | {
+    type: "workflow.trigger.get";
+    id: string;
+    payload: WorkflowTriggerGetResponse;
+  }
+  | {
+    type: "workflow.trigger.remove";
+    id: string;
+    payload: WorkflowTriggerRemoveResponse;
+  }
   | {
     type: "workflow.validate";
     id: string;

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -17,9 +17,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { parse as parseYaml } from "@std/yaml";
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { join } from "@std/path";
 import { Cron } from "croner";
+import { atomicWriteTextFile } from "../infrastructure/persistence/atomic_write.ts";
 import { UserError } from "../domain/errors.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 import { resolveSecret, type WebhookEndpoint } from "./webhook.ts";
@@ -467,7 +468,7 @@ function validateWebhookEntry(
 
 const KNOWN_TRIGGER_OVERRIDE_KEYS = new Set(["schedule", "inputs"]);
 
-function validateTriggerOverrideEntry(
+export function validateTriggerOverrideEntry(
   entry: unknown,
   path: string,
   workflowName: string,
@@ -998,4 +999,63 @@ export function mergeServeOptions(
     hydrationTimeout,
     enableInternalApi,
   };
+}
+
+// ── Serve Config Write ──────────────────────────────────────────────
+
+export const SERVE_CONFIG_PATH = DEFAULT_CONFIG_PATH;
+
+export async function readServeConfigFile(
+  repoDir: string,
+): Promise<ServeConfigFile | null> {
+  const path = join(repoDir, DEFAULT_CONFIG_PATH);
+  let content: string;
+  try {
+    content = await Deno.readTextFile(path);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return null;
+    }
+    throw new UserError(`Failed to read serve config file ${path}: ${error}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(content);
+  } catch (cause) {
+    throw new UserError(
+      `Invalid YAML in serve config file ${path}: ${cause}`,
+    );
+  }
+
+  if (parsed === null || parsed === undefined) {
+    return null;
+  }
+
+  if (typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new UserError(
+      `Serve config file ${path} must be a YAML mapping, got ${
+        Array.isArray(parsed) ? "array" : typeof parsed
+      }`,
+    );
+  }
+
+  return parsed as ServeConfigFile;
+}
+
+export async function writeServeConfigFile(
+  repoDir: string,
+  config: ServeConfigFile,
+): Promise<void> {
+  const path = join(repoDir, DEFAULT_CONFIG_PATH);
+  const dir = join(repoDir, ".swamp");
+  try {
+    await Deno.mkdir(dir, { recursive: true });
+  } catch {
+    // Directory already exists
+  }
+  const content = stringifyYaml(
+    config as unknown as Record<string, unknown>,
+  );
+  await atomicWriteTextFile(path, content);
 }

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -1049,11 +1049,7 @@ export async function writeServeConfigFile(
 ): Promise<void> {
   const path = join(repoDir, DEFAULT_CONFIG_PATH);
   const dir = join(repoDir, ".swamp");
-  try {
-    await Deno.mkdir(dir, { recursive: true });
-  } catch {
-    // Directory already exists
-  }
+  await Deno.mkdir(dir, { recursive: true });
   const content = stringifyYaml(
     config as unknown as Record<string, unknown>,
   );

--- a/src/serve/serve_config_test.ts
+++ b/src/serve/serve_config_test.ts
@@ -26,9 +26,11 @@ import {
   mergeServeOptions,
   parseExplicitFlags,
   parseWebhookConfig,
+  readServeConfigFile,
   type ServeConfigFile,
   type TriggerOverrideEntry,
   type WebhookConfigEntry,
+  writeServeConfigFile,
 } from "./serve_config.ts";
 
 await initializeLogging({});
@@ -1002,4 +1004,75 @@ Deno.test("mergeServeOptions: triggerOverrides undefined when empty", () => {
     () => undefined,
   );
   assertEquals(merged.triggerOverrides, undefined);
+});
+
+// ── readServeConfigFile / writeServeConfigFile ──────────────────────
+
+Deno.test("writeServeConfigFile: creates file when it does not exist", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await writeServeConfigFile(dir, {
+      triggers: { "my-workflow": { schedule: "0 3 * * *" } },
+    });
+    const result = await readServeConfigFile(dir);
+    assertEquals(result?.triggers?.["my-workflow"]?.schedule, "0 3 * * *");
+  } finally {
+    try {
+      await Deno.remove(dir, { recursive: true });
+    } catch { /* Windows EBUSY */ }
+  }
+});
+
+Deno.test("writeServeConfigFile: preserves other config sections", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await writeServeConfigFile(dir, {
+      port: 9090,
+      host: "0.0.0.0",
+      triggers: { "scan-cves": { schedule: "0 3 * * *" } },
+    });
+    const result = await readServeConfigFile(dir);
+    assertEquals(result?.port, 9090);
+    assertEquals(result?.host, "0.0.0.0");
+    assertEquals(result?.triggers?.["scan-cves"]?.schedule, "0 3 * * *");
+  } finally {
+    try {
+      await Deno.remove(dir, { recursive: true });
+    } catch { /* Windows EBUSY */ }
+  }
+});
+
+Deno.test("writeServeConfigFile: replace semantics for trigger entries", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await writeServeConfigFile(dir, {
+      triggers: {
+        "my-workflow": { schedule: "0 3 * * *", inputs: { channel: "#ops" } },
+      },
+    });
+
+    const config = await readServeConfigFile(dir);
+    config!.triggers!["my-workflow"] = { schedule: "0 6 * * *" };
+    await writeServeConfigFile(dir, config!);
+
+    const result = await readServeConfigFile(dir);
+    assertEquals(result?.triggers?.["my-workflow"]?.schedule, "0 6 * * *");
+    assertEquals(result?.triggers?.["my-workflow"]?.inputs, undefined);
+  } finally {
+    try {
+      await Deno.remove(dir, { recursive: true });
+    } catch { /* Windows EBUSY */ }
+  }
+});
+
+Deno.test("readServeConfigFile: returns null when file does not exist", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const result = await readServeConfigFile(dir);
+    assertEquals(result, null);
+  } finally {
+    try {
+      await Deno.remove(dir, { recursive: true });
+    } catch { /* Windows EBUSY */ }
+  }
 });


### PR DESCRIPTION
## Summary

Adds `swamp workflow trigger set/get/remove` CLI commands to manage workflow trigger overrides in serve.yaml programmatically, replacing manual YAML editing. Supports both local and remote (`--server`) execution.

- `swamp workflow trigger set <name> --schedule <cron> [--input key=value ...]` — writes/updates a trigger override (replace semantics)
- `swamp workflow trigger get <name>` — shows built-in trigger, override, and effective (merged) trigger
- `swamp workflow trigger remove <name>` — removes a trigger override

### Implementation

- **serve_config.ts**: exported `validateTriggerOverrideEntry`, added `readServeConfigFile`/`writeServeConfigFile` using `stringifyYaml` + `atomicWriteTextFile`
- **Protocol**: added `workflow.trigger.set/get/remove` WebSocket message types and server-side handlers
- **Commands**: 4 new files (`workflow_trigger{,_set,_get,_remove}.ts`) with `withRemoteOptions` for `--server` support
- **Renderers**: log + JSON output modes for all three commands
- **design/workflow.md**: updated trigger overrides section to document CLI commands

### Follow-up issues

- swamp-club #1652 — documentation updates for reference/how-to pages
- swamp-uat #345 — UAT coverage for the new commands

## Test Plan

- Unit tests: `writeServeConfigFile` (create, update, preserve, replace semantics), `parseInputFlag`, command structure tests
- Integration test: `workflow_trigger_cli_test.ts` — set→get→remove round trip, replace semantics, preserving other config sections, multiple triggers, creating serve.yaml from scratch
- E2E (manual): compiled binary, initialized temp repo, pulled `@swamp/cve/researcher`, set trigger with `* * * * *`, started `swamp serve`, confirmed cron fired twice on schedule, then tested full `--server` round trip (set/get/remove via `ws://localhost:9292`)
- All 10,336 existing tests pass

Closes swamp-club#1644

🤖 Generated with [Claude Code](https://claude.com/claude-code)