### PR TITLE
feat(serve): use system pipe format for all serve console output

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -69,7 +69,10 @@ import { DispatchRegistry } from "../../serve/dispatch_registry.ts";
 import { BundleRegistry } from "../../serve/bundle_registry.ts";
 import { DataPlane } from "../../serve/data_plane.ts";
 import { setRemoteStepDispatcher } from "../../domain/remote/remote_dispatch.ts";
-import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import {
+  enableServeOutput,
+  getSwampLogger,
+} from "../../infrastructure/logging/logger.ts";
 import {
   createServiceScheduler,
   resolveServiceMode,
@@ -1016,6 +1019,9 @@ export const serveCommand = new Command()
     const ctx = createContext(options as GlobalOptions, ["serve"]);
     const repoDir = resolveRepoDir(options.repoDir as string | undefined);
     const isJson = ctx.outputMode === "json";
+    if (!isJson) {
+      enableServeOutput();
+    }
 
     // Load config file and merge with CLI flags (four-level priority:
     // CLI flag > env var > config file > default)

--- a/src/infrastructure/logging/log_format.ts
+++ b/src/infrastructure/logging/log_format.ts
@@ -45,3 +45,24 @@ export const TIMESTAMP_FORMAT = "rfc3339" as const;
 export function textFormatter(): TextFormatter {
   return getTextFormatter({ timestamp: TIMESTAMP_FORMAT });
 }
+
+/**
+ * Serve-mode formatter: renders log records as `" system │ message"`,
+ * matching the pipe-prefix style used by workflow and model-method runs.
+ * No timestamp, level, or category — just the message with a fixed
+ * "system" prefix padded to the current pipe width.
+ *
+ * Accepts a width getter so the caller (logger.ts) owns the mutable
+ * width state and this module stays a leaf.
+ */
+export function serveTextFormatter(
+  getWidth: () => number,
+): TextFormatter {
+  return getTextFormatter({
+    timestamp: "none",
+    format: (values) => {
+      const padded = "system".padStart(getWidth() + 1);
+      return `${padded} │ ${values.message}`;
+    },
+  });
+}

--- a/src/infrastructure/logging/log_format_test.ts
+++ b/src/infrastructure/logging/log_format_test.ts
@@ -19,7 +19,11 @@
 
 import { assertEquals, assertMatch, assertNotMatch } from "@std/assert";
 import type { LogRecord } from "@logtape/logtape";
-import { textFormatter, TIMESTAMP_FORMAT } from "./log_format.ts";
+import {
+  serveTextFormatter,
+  textFormatter,
+  TIMESTAMP_FORMAT,
+} from "./log_format.ts";
 
 // A fixed instant so timestamp assertions are deterministic:
 // 2026-07-15T10:18:15.912Z.
@@ -63,4 +67,33 @@ Deno.test("textFormatter: emits no ANSI escape codes", () => {
     makeRecord(["model", "method", "run"], "acquiring lock", "warning"),
   );
   assertNotMatch(line, ANSI);
+});
+
+Deno.test("serveTextFormatter: renders system pipe prefix with message only", () => {
+  const fmt = serveTextFormatter(() => 6);
+  const line = fmt(makeRecord(["serve"], "Listening on https://0.0.0.0:9090"))
+    .trimEnd();
+  assertEquals(line, " system │ Listening on https://0.0.0.0:9090");
+});
+
+Deno.test("serveTextFormatter: omits timestamp, level, and category", () => {
+  const fmt = serveTextFormatter(() => 6);
+  const line = fmt(
+    makeRecord(["serve", "token-auth"], "authenticated", "debug"),
+  )
+    .trimEnd();
+  assertNotMatch(line, RFC3339);
+  assertNotMatch(line, /\[DBG\]/);
+  assertNotMatch(line, /token-auth/);
+  assertEquals(line, " system │ authenticated");
+});
+
+Deno.test("serveTextFormatter: respects dynamic pipe width", () => {
+  let width = 8;
+  const fmt = serveTextFormatter(() => width);
+  const line1 = fmt(makeRecord(["serve"], "msg")).trimEnd();
+  assertEquals(line1, "   system │ msg");
+  width = 6;
+  const line2 = fmt(makeRecord(["serve"], "msg")).trimEnd();
+  assertEquals(line2, " system │ msg");
 });

--- a/src/infrastructure/logging/logger.ts
+++ b/src/infrastructure/logging/logger.ts
@@ -23,9 +23,14 @@ import {
   getLogger,
   type LogLevel,
   type Sink,
+  type TextFormatter,
 } from "@logtape/logtape";
 import { getPrettyFormatter } from "@logtape/pretty";
-import { textFormatter, TIMESTAMP_FORMAT } from "./log_format.ts";
+import {
+  serveTextFormatter,
+  textFormatter,
+  TIMESTAMP_FORMAT,
+} from "./log_format.ts";
 import { runFileSink } from "./run_file_sink.ts";
 import { initLogs, type InitLogsConfig } from "../tracing/mod.ts";
 import { createOtelLogRecordSink } from "./otel_log_sink.ts";
@@ -62,6 +67,7 @@ function createStderrSink(): Sink {
 
 let isInitialized = false;
 let systemPipeWidth = 6;
+let serveFormatEnabled = false;
 
 export function setSystemPipeWidth(width: number): void {
   systemPipeWidth = Math.max(width, 6);
@@ -69,6 +75,22 @@ export function setSystemPipeWidth(width: number): void {
 
 export function getSystemPipeWidth(): number {
   return systemPipeWidth;
+}
+
+/**
+ * Switch the console sink to the `" system │ message"` format used by
+ * workflow and model-method runs. Call once at serve startup (non-JSON
+ * mode) — all subsequent LogTape console output will use the new style.
+ */
+export function enableServeOutput(): void {
+  serveFormatEnabled = true;
+}
+
+function createDynamicFormatter(
+  normalFmt: TextFormatter,
+): TextFormatter {
+  const serveFmt = serveTextFormatter(() => systemPipeWidth);
+  return (record) => serveFormatEnabled ? serveFmt(record) : normalFmt(record);
 }
 
 export async function initializeLogging(
@@ -87,9 +109,14 @@ export async function initializeLogging(
   // non-interactive contexts (piped, redirected, `--no-color`, non-TTY stdin),
   // where ANSI escape codes would pollute the output. Colored output is the
   // pretty sink's job, selected only when stdin is a TTY.
+  //
+  // Both sinks use a dynamic formatter that switches to the serve-style
+  // " system │ message" format when enableServeOutput() is called.
   const consoleSink: Sink = options.stderrOnly
     ? createStderrSink()
-    : getConsoleSink({ formatter: textFormatter() });
+    : getConsoleSink({
+      formatter: createDynamicFormatter(textFormatter()),
+    });
 
   const sinks: Record<string, Sink | (Sink & Disposable)> = {
     console: consoleSink,
@@ -121,7 +148,9 @@ export async function initializeLogging(
       inspectOptions: { colors: useColors },
     });
 
-    sinks["pretty"] = getConsoleSink({ formatter: prettyFormat });
+    sinks["pretty"] = getConsoleSink({
+      formatter: createDynamicFormatter(prettyFormat),
+    });
   }
 
   // Initialize the OTel logs signal. When OTLP logs export is enabled (same


### PR DESCRIPTION
## Summary

- Switch serve's LogTape console output from the timestamped `[INF] category: message` format to the ` system │ message` pipe format already used by workflow and model-method runs
- Add `serveTextFormatter` to the logging infrastructure — uses LogTape's `getTextFormatter` with `timestamp: "none"` and a custom `format` callback
- Console and pretty sinks use a dynamic formatter that switches on `enableServeOutput()`, so log files, OTLP export, and JSON mode are unaffected

## Test Plan

- Added 3 unit tests for `serveTextFormatter`: prefix rendering, timestamp/level/category omission, dynamic pipe width
- Compiled binary and tested `swamp serve` in a fresh repo tmpdir:
  - `--no-color`: all lines render as ` system │ ...`
  - `--verbose`: debug lines also use the pipe format
  - `--json`: clean structured output, no bleed-through
- Full test suite passes (10,344 tests)