### PR TITLE
feat(serve): reload trigger overrides on serve reload

### DIFF
--- a/design/workflow.md
+++ b/design/workflow.md
@@ -516,8 +516,9 @@ override.
 - The `handleScheduleChange` callback also consults the override map, so
   live-reloaded workflows respect overrides
 - Overrides for unknown workflow names are logged as warnings and skipped
-- Overrides are read once at startup — editing `serve.yaml` while serve is
-  running requires a restart (consistent with other serve config fields)
+- Overrides are read at startup and re-read on `swamp serve reload` (SIGHUP or
+  WebSocket `serve.reload`) — changes to `serve.yaml` take effect without a
+  full restart
 - Works with both extension and local workflows — but the primary use case is
   extension workflows that cannot be edited directly
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -974,7 +974,8 @@ export const serveCommand = new Command()
   )
   .option(
     "--hot-reload",
-    "Enable SIGHUP-based hot-reload for pulled extension bundles. " +
+    "Enable SIGHUP-based hot-reload for pulled extension bundles and " +
+      "trigger overrides from serve.yaml. " +
       "Writes a PID file to .swamp/serve.pid; use 'swamp serve reload' to trigger a reload",
   )
   .option(

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -2564,6 +2564,7 @@ export const serveCommand = new Command()
           }
         }
       });
+      connectionCtx.scheduledExecution = scheduledExecution;
     }
 
     // Parse group refresh interval and construct service
@@ -3440,10 +3441,30 @@ export const serveCommand = new Command()
           return;
         }
         logger.info("SIGHUP received, reloading pulled extensions...");
-        performServeReload(resolvedRepoDir, extensionLockfilePath)
+        const reloadOptions = scheduledExecution
+          ? {
+            triggerOverrideUpdater: (
+              overrides: ReadonlyMap<string, TriggerOverride>,
+            ) => scheduledExecution!.updateTriggerOverrides(overrides),
+          }
+          : undefined;
+        performServeReload(
+          resolvedRepoDir,
+          extensionLockfilePath,
+          reloadOptions,
+        )
           .then((result) => {
             if (result.success) {
               logger.info`Hot-reloaded ${result.reloadedCount} type(s)`;
+              if (
+                result.triggerOverridesChanged &&
+                result.triggerOverridesChanged > 0
+              ) {
+                logger.info(
+                  "Reloaded {count} trigger override(s) from serve.yaml",
+                  { count: result.triggerOverridesChanged },
+                );
+              }
               if (result.errors.length > 0) {
                 for (const err of result.errors) {
                   logger.warn`${err}`;

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -163,8 +163,10 @@ export class ScheduledExecutionService {
   private processing = false;
   private processingPromise: Promise<void> = Promise.resolve();
   private eventHandler: ScheduledExecutionEventHandler | null = null;
+  private triggerOverrides: ReadonlyMap<string, TriggerOverride>;
 
   constructor(private readonly deps: ScheduledExecutionDeps) {
+    this.triggerOverrides = deps.triggerOverrides ?? new Map();
     this.scheduler = new WorkflowScheduler();
     this.watcher = new WorkflowWatcher(
       workflowsDir(deps.repoDir),
@@ -311,7 +313,7 @@ export class ScheduledExecutionService {
     workflowName: string,
     builtInSchedule: string | null,
   ): string | null {
-    const override = this.deps.triggerOverrides?.get(workflowName);
+    const override = this.triggerOverrides.get(workflowName);
     if (override?.schedule !== undefined) {
       return override.schedule;
     }
@@ -334,7 +336,7 @@ export class ScheduledExecutionService {
         cronExpression: effective,
       });
       const isOverride =
-        this.deps.triggerOverrides?.get(workflowName)?.schedule !== undefined;
+        this.triggerOverrides.get(workflowName)?.schedule !== undefined;
       logger.info(
         isOverride
           ? "Registered schedule for workflow {name}: {schedule} (serve.yaml override)"
@@ -355,8 +357,8 @@ export class ScheduledExecutionService {
   }
 
   private async applyTriggerOverrides(): Promise<void> {
-    const overrides = this.deps.triggerOverrides;
-    if (!overrides || overrides.size === 0) return;
+    const overrides = this.triggerOverrides;
+    if (overrides.size === 0) return;
 
     const registeredNames = new Set(this.workflowNames.values());
 
@@ -384,6 +386,81 @@ export class ScheduledExecutionService {
 
       this.handleScheduleChange(workflow.id, null, workflow.name);
     }
+  }
+
+  async updateTriggerOverrides(
+    newOverrides: ReadonlyMap<string, TriggerOverride>,
+  ): Promise<number> {
+    const oldOverrides = this.triggerOverrides;
+    this.triggerOverrides = newOverrides;
+    let changed = 0;
+
+    // Removed overrides: fall back to built-in schedule
+    for (const [workflowName] of oldOverrides) {
+      if (newOverrides.has(workflowName)) continue;
+
+      const workflowId = this.findWorkflowIdByName(workflowName);
+      if (workflowId) {
+        const workflow = await this.deps.workflowRepo.findByName(workflowName);
+        this.handleScheduleChange(
+          workflowId,
+          workflow?.schedule ?? null,
+          workflowName,
+        );
+        changed++;
+      }
+    }
+
+    // Added or changed overrides
+    for (const [workflowName, newOverride] of newOverrides) {
+      const oldOverride = oldOverrides.get(workflowName);
+
+      if (
+        oldOverride?.schedule === newOverride.schedule &&
+        JSON.stringify(oldOverride?.inputs) ===
+          JSON.stringify(newOverride.inputs)
+      ) {
+        continue;
+      }
+
+      const workflowId = this.findWorkflowIdByName(workflowName);
+      if (workflowId) {
+        const workflow = await this.deps.workflowRepo.findByName(workflowName);
+        this.handleScheduleChange(
+          workflowId,
+          workflow?.schedule ?? null,
+          workflowName,
+        );
+        changed++;
+      } else if (newOverride.schedule) {
+        const workflow = await this.deps.workflowRepo.findByName(workflowName);
+        if (workflow) {
+          this.handleScheduleChange(workflow.id, null, workflow.name);
+          changed++;
+        } else {
+          logger.warn(
+            "Trigger override for unknown workflow {name} — skipping",
+            { name: workflowName },
+          );
+        }
+      }
+    }
+
+    if (changed > 0) {
+      logger.info(
+        "Updated trigger overrides: {changed} schedule(s) changed",
+        { changed },
+      );
+    }
+
+    return changed;
+  }
+
+  private findWorkflowIdByName(name: string): WorkflowId | undefined {
+    for (const [id, n] of this.workflowNames) {
+      if (n === name) return id;
+    }
+    return undefined;
   }
 
   private async handleFire(
@@ -505,7 +582,7 @@ export class ScheduledExecutionService {
       let completedRun: WorkflowRunView | undefined;
       let streamError: string | undefined;
 
-      const override = this.deps.triggerOverrides?.get(workflowName);
+      const override = this.triggerOverrides.get(workflowName);
 
       await withSpan(
         "swamp.scheduled.fire",

--- a/src/libswamp/workflows/scheduled_execution_test.ts
+++ b/src/libswamp/workflows/scheduled_execution_test.ts
@@ -539,6 +539,196 @@ Deno.test("ScheduledExecutionService: no trigger overrides works as before", asy
   await service.stop();
 });
 
+// ── updateTriggerOverrides ──────────────────────────────────────────
+
+Deno.test("updateTriggerOverrides: adding a new override registers the schedule", async () => {
+  const wf = createTestWorkflow("unscheduled-wf");
+  const events: ScheduledExecutionEvent[] = [];
+
+  const service = new ScheduledExecutionService({
+    workflowRepo: createMockWorkflowRepo([wf]),
+    repoDir: "/tmp/nonexistent-test-repo",
+    executeWorkflow: () => Promise.resolve(),
+  });
+
+  await service.start((e) => events.push(e));
+  assertEquals(service.listSchedules().length, 0);
+
+  const changed = await service.updateTriggerOverrides(
+    new Map([["unscheduled-wf", { schedule: "0 6 * * *" }]]),
+  );
+
+  assertEquals(changed, 1);
+  const schedules = service.listSchedules();
+  assertEquals(schedules.length, 1);
+  assertEquals(schedules[0].cronExpression, "0 6 * * *");
+
+  await service.stop();
+});
+
+Deno.test("updateTriggerOverrides: changing an override re-registers with new schedule", async () => {
+  const wf = createTestWorkflow("scheduled-wf", "0 12 * * *");
+  const events: ScheduledExecutionEvent[] = [];
+
+  const service = new ScheduledExecutionService({
+    workflowRepo: createMockWorkflowRepo([wf]),
+    repoDir: "/tmp/nonexistent-test-repo",
+    executeWorkflow: () => Promise.resolve(),
+    triggerOverrides: new Map([
+      ["scheduled-wf", { schedule: "0 3 * * *" }],
+    ]),
+  });
+
+  await service.start((e) => events.push(e));
+  assertEquals(service.listSchedules()[0].cronExpression, "0 3 * * *");
+
+  const changed = await service.updateTriggerOverrides(
+    new Map([["scheduled-wf", { schedule: "0 6 * * *" }]]),
+  );
+
+  assertEquals(changed, 1);
+  assertEquals(service.listSchedules()[0].cronExpression, "0 6 * * *");
+
+  await service.stop();
+});
+
+Deno.test("updateTriggerOverrides: removing an override falls back to built-in schedule", async () => {
+  const wf = createTestWorkflow("scheduled-wf", "0 12 * * *");
+
+  const service = new ScheduledExecutionService({
+    workflowRepo: createMockWorkflowRepo([wf]),
+    repoDir: "/tmp/nonexistent-test-repo",
+    executeWorkflow: () => Promise.resolve(),
+    triggerOverrides: new Map([
+      ["scheduled-wf", { schedule: "0 3 * * *" }],
+    ]),
+  });
+
+  await service.start();
+  assertEquals(service.listSchedules()[0].cronExpression, "0 3 * * *");
+
+  const changed = await service.updateTriggerOverrides(new Map());
+
+  assertEquals(changed, 1);
+  assertEquals(service.listSchedules()[0].cronExpression, "0 12 * * *");
+
+  await service.stop();
+});
+
+Deno.test("updateTriggerOverrides: removing override for override-only workflow unregisters it", async () => {
+  const wf = createTestWorkflow("unscheduled-wf");
+
+  const service = new ScheduledExecutionService({
+    workflowRepo: createMockWorkflowRepo([wf]),
+    repoDir: "/tmp/nonexistent-test-repo",
+    executeWorkflow: () => Promise.resolve(),
+    triggerOverrides: new Map([
+      ["unscheduled-wf", { schedule: "0 3 * * *" }],
+    ]),
+  });
+
+  await service.start();
+  assertEquals(service.listSchedules().length, 1);
+
+  const changed = await service.updateTriggerOverrides(new Map());
+
+  assertEquals(changed, 1);
+  assertEquals(service.listSchedules().length, 0);
+
+  await service.stop();
+});
+
+Deno.test("updateTriggerOverrides: no-op when overrides unchanged", async () => {
+  const wf = createTestWorkflow("scheduled-wf", "0 12 * * *");
+
+  const overrides = new Map([
+    ["scheduled-wf", { schedule: "0 3 * * *" }],
+  ]);
+
+  const service = new ScheduledExecutionService({
+    workflowRepo: createMockWorkflowRepo([wf]),
+    repoDir: "/tmp/nonexistent-test-repo",
+    executeWorkflow: () => Promise.resolve(),
+    triggerOverrides: overrides,
+  });
+
+  await service.start();
+
+  const changed = await service.updateTriggerOverrides(
+    new Map([["scheduled-wf", { schedule: "0 3 * * *" }]]),
+  );
+
+  assertEquals(changed, 0);
+
+  await service.stop();
+});
+
+Deno.test("updateTriggerOverrides: inputs-only change is detected", async () => {
+  const wf = createTestWorkflow("scheduled-wf", "* * * * * *");
+  const capturedInputs: WorkflowRunInput[] = [];
+
+  const service = new ScheduledExecutionService({
+    workflowRepo: createMockWorkflowRepo([wf]),
+    repoDir: "/tmp/nonexistent-test-repo",
+    executeWorkflow: (input, _signal, onEvent) => {
+      capturedInputs.push(input);
+      onEvent({
+        kind: "started",
+        runId: "run-1",
+        workflowName: wf.name,
+        jobs: [],
+      });
+      onEvent({
+        kind: "completed",
+        run: {
+          id: "run-1",
+          workflowId: wf.id,
+          workflowName: wf.name,
+          status: "succeeded",
+          jobs: [],
+        },
+      });
+      return Promise.resolve();
+    },
+    triggerOverrides: new Map([
+      ["scheduled-wf", { inputs: { channel: "#old" } }],
+    ]),
+  });
+
+  await service.start();
+
+  const changed = await service.updateTriggerOverrides(
+    new Map([["scheduled-wf", { inputs: { channel: "#new" } }]]),
+  );
+  assertEquals(changed, 1);
+
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  await service.stop();
+
+  assertGreater(capturedInputs.length, 0);
+  const lastInput = capturedInputs[capturedInputs.length - 1];
+  assertEquals(lastInput.inputs, { channel: "#new" });
+});
+
+Deno.test("updateTriggerOverrides: override for unknown workflow is skipped", async () => {
+  const service = new ScheduledExecutionService({
+    workflowRepo: createMockWorkflowRepo([]),
+    repoDir: "/tmp/nonexistent-test-repo",
+    executeWorkflow: () => Promise.resolve(),
+  });
+
+  await service.start();
+
+  const changed = await service.updateTriggerOverrides(
+    new Map([["nonexistent-wf", { schedule: "0 3 * * *" }]]),
+  );
+
+  assertEquals(changed, 0);
+  assertEquals(service.listSchedules().length, 0);
+
+  await service.stop();
+});
+
 Deno.test("normalizeFireTime: truncates milliseconds and replaces colons for Windows compat", () => {
   assertEquals(
     normalizeFireTime(new Date("2026-08-01T12:30:45.123Z")),

--- a/src/presentation/renderers/serve_reload.ts
+++ b/src/presentation/renderers/serve_reload.ts
@@ -40,6 +40,13 @@ class LogServeReloadRenderer implements ServeReloadRenderer {
 
     logger.info`Reloaded ${result.reloadedCount} extension type(s)`;
 
+    if (result.triggerOverridesChanged && result.triggerOverridesChanged > 0) {
+      logger.info(
+        "Reloaded {count} trigger override(s) from serve.yaml",
+        { count: result.triggerOverridesChanged },
+      );
+    }
+
     if (result.errors.length > 0) {
       for (const error of result.errors) {
         logger.warn`${error}`;

--- a/src/presentation/renderers/serve_reload_test.ts
+++ b/src/presentation/renderers/serve_reload_test.ts
@@ -75,3 +75,15 @@ Deno.test("serveReloadRenderer json: includes errors on failure", () => {
   assertEquals(parsed.success, false);
   assertStringIncludes(parsed.errors[0], "already in progress");
 });
+
+Deno.test("serveReloadRenderer json: includes triggerOverridesChanged in output", () => {
+  const result: ServeReloadResponse = {
+    success: true,
+    reloadedCount: 2,
+    triggerOverridesChanged: 3,
+    errors: [],
+  };
+  const output = captureRender("json", result);
+  const parsed = JSON.parse(output.join(""));
+  assertEquals(parsed.triggerOverridesChanged, 3);
+});

--- a/src/serve/extension_reload.ts
+++ b/src/serve/extension_reload.ts
@@ -46,6 +46,8 @@ import { AuthRepository } from "../infrastructure/persistence/auth_repository.ts
 import { resolveTrustedCollectives } from "../libswamp/mod.ts";
 import { resolveModelsDir } from "../cli/resolve_models_dir.ts";
 import type { ServeReloadResponse } from "./protocol.ts";
+import { readServeConfigFile } from "./serve_config.ts";
+import type { TriggerOverride } from "../libswamp/mod.ts";
 
 const logger = getSwampLogger(["serve", "reload"]);
 
@@ -230,9 +232,16 @@ export async function resolveLockfilePath(
   );
 }
 
+export interface ServeReloadOptions {
+  triggerOverrideUpdater?: (
+    overrides: ReadonlyMap<string, TriggerOverride>,
+  ) => Promise<number>;
+}
+
 export async function performServeReload(
   repoDir: string,
   lockfilePath: string,
+  options?: ServeReloadOptions,
 ): Promise<ServeReloadResponse> {
   if (reloading) {
     return {
@@ -245,6 +254,7 @@ export async function performServeReload(
   reloading = true;
   const errors: string[] = [];
   let reloadedCount = 0;
+  let triggerOverridesChanged = 0;
 
   try {
     reloadedCount = await reloadPulledExtensions(repoDir, lockfilePath);
@@ -258,7 +268,24 @@ export async function performServeReload(
       );
     }
 
-    return { success: true, reloadedCount, errors };
+    if (options?.triggerOverrideUpdater) {
+      try {
+        const config = await readServeConfigFile(repoDir);
+        const overrides = new Map<string, TriggerOverride>(
+          config?.triggers ? Object.entries(config.triggers) : [],
+        );
+        triggerOverridesChanged = await options.triggerOverrideUpdater(
+          overrides,
+        );
+      } catch (err) {
+        errors.push(
+          "Failed to reload trigger overrides: " +
+            (err instanceof Error ? err.message : String(err)),
+        );
+      }
+    }
+
+    return { success: true, reloadedCount, triggerOverridesChanged, errors };
   } catch (err) {
     return {
       success: false,

--- a/src/serve/extension_reload_test.ts
+++ b/src/serve/extension_reload_test.ts
@@ -87,3 +87,94 @@ Deno.test("performServeReload: resets isReloading flag after failure", async () 
     await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
+
+Deno.test("performServeReload: calls triggerOverrideUpdater with overrides from serve.yaml", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(join(tmpDir, ".swamp"), { recursive: true });
+    await Deno.writeTextFile(
+      join(tmpDir, ".swamp", "serve.yaml"),
+      `triggers:\n  my-workflow:\n    schedule: "0 3 * * *"\n`,
+    );
+
+    let receivedOverrides: ReadonlyMap<string, unknown> | undefined;
+    const result = await performServeReload(
+      tmpDir,
+      join(tmpDir, "nonexistent_lockfile.json"),
+      {
+        triggerOverrideUpdater: (overrides) => {
+          receivedOverrides = overrides;
+          return Promise.resolve(overrides.size);
+        },
+      },
+    );
+
+    assertEquals(result.success, true);
+    assertEquals(result.triggerOverridesChanged, 1);
+    assertEquals(receivedOverrides?.size, 1);
+    const entry = receivedOverrides?.get("my-workflow") as
+      | { schedule?: string }
+      | undefined;
+    assertEquals(entry?.schedule, "0 3 * * *");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("performServeReload: passes empty map when serve.yaml has no triggers", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(join(tmpDir, ".swamp"), { recursive: true });
+    await Deno.writeTextFile(
+      join(tmpDir, ".swamp", "serve.yaml"),
+      `port: 8080\n`,
+    );
+
+    let receivedOverrides: ReadonlyMap<string, unknown> | undefined;
+    const result = await performServeReload(
+      tmpDir,
+      join(tmpDir, "nonexistent_lockfile.json"),
+      {
+        triggerOverrideUpdater: (overrides) => {
+          receivedOverrides = overrides;
+          return Promise.resolve(overrides.size);
+        },
+      },
+    );
+
+    assertEquals(result.success, true);
+    assertEquals(result.triggerOverridesChanged, 0);
+    assertEquals(receivedOverrides?.size, 0);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("performServeReload: trigger override updater error is soft failure", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(join(tmpDir, ".swamp"), { recursive: true });
+    await Deno.writeTextFile(
+      join(tmpDir, ".swamp", "serve.yaml"),
+      `triggers:\n  my-wf:\n    schedule: "0 3 * * *"\n`,
+    );
+
+    const result = await performServeReload(
+      tmpDir,
+      join(tmpDir, "nonexistent_lockfile.json"),
+      {
+        triggerOverrideUpdater: () =>
+          Promise.reject(new Error("scheduler broke")),
+      },
+    );
+
+    assertEquals(result.success, true);
+    assertStringIncludes(
+      result.errors[0],
+      "Failed to reload trigger overrides",
+    );
+    assertStringIncludes(result.errors[0], "scheduler broke");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -72,6 +72,7 @@ import {
   ReconcileFromDiskService,
   type ReconcileTransition,
   resolveServerUrl,
+  type TriggerOverride,
   UpgradeExtensionService,
   validateExtensionName,
   vaultMigrate,
@@ -1743,11 +1744,31 @@ export async function handleServeReload(
 
   try {
     const lockfilePath = await resolveLockfilePath(ctx.repoDir);
-    const result = await performServeReload(ctx.repoDir, lockfilePath);
+    const reloadOptions = ctx.scheduledExecution
+      ? {
+        triggerOverrideUpdater: (
+          overrides: ReadonlyMap<string, TriggerOverride>,
+        ) => ctx.scheduledExecution!.updateTriggerOverrides(overrides),
+      }
+      : undefined;
+    const result = await performServeReload(
+      ctx.repoDir,
+      lockfilePath,
+      reloadOptions,
+    );
 
     if (result.success) {
       logger
         .info`Extension reload completed: ${result.reloadedCount} type(s) reloaded (requested by ${who})`;
+      if (
+        result.triggerOverridesChanged &&
+        result.triggerOverridesChanged > 0
+      ) {
+        logger.info(
+          "Reloaded {count} trigger override(s) from serve.yaml (requested by {who})",
+          { count: result.triggerOverridesChanged, who },
+        );
+      }
     }
 
     send(socket, {

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -42,6 +42,7 @@ import {
 } from "../../domain/access/principal.ts";
 import type { Action } from "../../domain/access/action.ts";
 import type { AccessResource } from "../../domain/access/access_decision_service.ts";
+import type { ScheduledExecutionService } from "../../libswamp/mod.ts";
 
 export const MAX_CLIENT_ERROR_LENGTH = 200;
 
@@ -109,6 +110,8 @@ export interface ConnectionContext {
   grantsDir?: string;
   /** Whether --hot-reload is enabled — gates serve.reload over WebSocket. */
   hotReload?: boolean;
+  /** Scheduled execution service — used by serve.reload to update trigger overrides. */
+  scheduledExecution?: ScheduledExecutionService;
   /** Inverted resolvedAdmins map: OAuth sub → username. Populated at startup in OAuth mode. */
   resolvedUserNames?: Record<string, string>;
 }

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -957,6 +957,7 @@ export interface AccessReloadResponse {
 export interface ServeReloadResponse {
   success: boolean;
   reloadedCount: number;
+  triggerOverridesChanged?: number;
   errors: string[];
 }
 


### PR DESCRIPTION
## Summary

- Adds `updateTriggerOverrides` method to `ScheduledExecutionService` that diffs old vs new overrides and registers/unregisters cron jobs accordingly — handles additions, removals (falling back to built-in schedules), schedule changes, and input-only changes
- Extends `performServeReload` with an optional `triggerOverrideUpdater` callback that re-reads `.swamp/serve.yaml` and passes the new trigger map to the service
- Wires the updater into both reload paths (SIGHUP handler and WebSocket `serve.reload`) via `ConnectionContext.scheduledExecution`

## Test Plan

- [x] 7 new unit tests for `updateTriggerOverrides` covering: add, change, remove (fallback to built-in), remove (override-only workflow), no-op, inputs-only change, unknown workflow
- [x] 3 new tests for `performServeReload` with trigger callback: with overrides, empty, updater error as soft failure
- [x] All 10,351 existing tests pass
- [x] `deno check`, `deno lint`, `deno fmt` clean

Closes #1659

🤖 Generated with [Claude Code](https://claude.com/claude-code)