### PR TITLE
fix(extensions): retry catalog upsert on SQLite lock contention (swamp-club#1638)

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -68,6 +68,7 @@ import {
   ModelTypeType,
   WorkflowNameType,
 } from "./completion_types.ts";
+import { isTransientError } from "../infrastructure/persistence/io_errors.ts";
 import { ExtensionCatalogStore } from "../infrastructure/persistence/extension_catalog_store.ts";
 import { ExtensionRepository } from "../infrastructure/persistence/extension_repository.ts";
 import { readLocalManifestIdentity } from "../infrastructure/persistence/local_manifest_reader.ts";
@@ -584,6 +585,26 @@ function isMissingHomeError(error: unknown): boolean {
   return error instanceof Error && error.message.includes("home directory");
 }
 
+function throwOnTransientLoadFailures(
+  failures: ReadonlyArray<
+    { file: string; error: string; originalError?: unknown }
+  >,
+  kind: string,
+): void {
+  const transient = failures.filter((f) =>
+    isTransientError(f.originalError ?? new Error(f.error))
+  );
+  if (transient.length === 0) return;
+  const details = transient
+    .map((f) => `${f.file}: ${f.error}`)
+    .join("; ");
+  throw new UserError(
+    `Failed to load ${transient.length} extension ${kind}(s): ${details}. ` +
+      "If another swamp process is writing the extension index, retry once it finishes.",
+    "lock_timeout",
+  );
+}
+
 /**
  * Load user models from configured directory.
  * Uses the bundle catalog for lazy per-bundle loading when available.
@@ -658,6 +679,8 @@ async function loadUserModels(
       },
     );
 
+    throwOnTransientLoadFailures(result.failed, "model");
+
     for (const failure of result.failed) {
       if (failure.error.startsWith("Cannot extend unregistered model type")) {
         logger
@@ -668,10 +691,20 @@ async function loadUserModels(
       }
     }
   } catch (error) {
+    if (error instanceof UserError) throw error;
     if (error instanceof Deno.errors.NotFound) return;
     // configureExtensionLoaders already emitted one actionable warning for
     // the missing-home case; suppress the misleading per-kind duplicate.
     if (isMissingHomeError(error)) return;
+    if (isTransientError(error)) {
+      throw new UserError(
+        `Failed to load extension models: ${
+          error instanceof Error ? error.message : String(error)
+        }. ` +
+          "If another swamp process is writing the extension index, retry once it finishes.",
+        "lock_timeout",
+      );
+    }
     logger
       .warn`Failed to load user model extensions: ${
       error instanceof Error ? error.message : String(error)
@@ -728,6 +761,8 @@ async function loadUserVaults(
         additionalDirs: [...sourceDirs, ...pulledDirs],
       });
 
+      throwOnTransientLoadFailures(result.failed, "vault");
+
       for (const failure of result.failed) {
         logger
           .warn`Failed to load user vault ${failure.file}: ${failure.error}`;
@@ -738,14 +773,26 @@ async function loadUserVaults(
         skipAlreadyRegistered: true,
       });
 
+      throwOnTransientLoadFailures(result.failed, "vault");
+
       for (const failure of result.failed) {
         logger
           .warn`Failed to load user vault ${failure.file}: ${failure.error}`;
       }
     }
   } catch (error) {
+    if (error instanceof UserError) throw error;
     if (error instanceof Deno.errors.NotFound) return;
     if (isMissingHomeError(error)) return;
+    if (isTransientError(error)) {
+      throw new UserError(
+        `Failed to load extension vaults: ${
+          error instanceof Error ? error.message : String(error)
+        }. ` +
+          "If another swamp process is writing the extension index, retry once it finishes.",
+        "lock_timeout",
+      );
+    }
     logger
       .warn`Failed to load user vault extensions: ${
       error instanceof Error ? error.message : String(error)
@@ -799,6 +846,8 @@ async function loadUserDatastores(
         },
       );
 
+      throwOnTransientLoadFailures(result.failed, "datastore");
+
       for (const failure of result.failed) {
         logger
           .warn`Failed to load user datastore ${failure.file}: ${failure.error}`;
@@ -809,14 +858,26 @@ async function loadUserDatastores(
         skipAlreadyRegistered: true,
       });
 
+      throwOnTransientLoadFailures(result.failed, "datastore");
+
       for (const failure of result.failed) {
         logger
           .warn`Failed to load user datastore ${failure.file}: ${failure.error}`;
       }
     }
   } catch (error) {
+    if (error instanceof UserError) throw error;
     if (error instanceof Deno.errors.NotFound) return;
     if (isMissingHomeError(error)) return;
+    if (isTransientError(error)) {
+      throw new UserError(
+        `Failed to load extension datastores: ${
+          error instanceof Error ? error.message : String(error)
+        }. ` +
+          "If another swamp process is writing the extension index, retry once it finishes.",
+        "lock_timeout",
+      );
+    }
     logger
       .warn`Failed to load user datastore extensions: ${
       error instanceof Error ? error.message : String(error)
@@ -869,6 +930,8 @@ async function loadUserReports(
         additionalDirs: [...sourceDirs, ...pulledDirs],
       });
 
+      throwOnTransientLoadFailures(result.failed, "report");
+
       for (const failure of result.failed) {
         logger
           .warn`Failed to load user report ${failure.file}: ${failure.error}`;
@@ -879,14 +942,26 @@ async function loadUserReports(
         skipAlreadyRegistered: true,
       });
 
+      throwOnTransientLoadFailures(result.failed, "report");
+
       for (const failure of result.failed) {
         logger
           .warn`Failed to load user report ${failure.file}: ${failure.error}`;
       }
     }
   } catch (error) {
+    if (error instanceof UserError) throw error;
     if (error instanceof Deno.errors.NotFound) return;
     if (isMissingHomeError(error)) return;
+    if (isTransientError(error)) {
+      throw new UserError(
+        `Failed to load extension reports: ${
+          error instanceof Error ? error.message : String(error)
+        }. ` +
+          "If another swamp process is writing the extension index, retry once it finishes.",
+        "lock_timeout",
+      );
+    }
     logger
       .warn`Failed to load user report extensions: ${
       error instanceof Error ? error.message : String(error)

--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -785,7 +785,7 @@ export class ExtensionCatalogStore {
       updateClauses.push("last_error         = excluded.last_error");
     }
 
-    const stmt = this.db.prepare(`
+    const sql = `
       INSERT INTO bundle_types (
         source_path, type_normalized, kind, bundle_path,
         version, description, extends_type, source_mtime,
@@ -793,8 +793,8 @@ export class ExtensionCatalogStore {
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(source_path) DO UPDATE SET
         ${updateClauses.join(",\n        ")}
-    `);
-    stmt.run(
+    `;
+    const params = [
       canonicalizePath(row.source_path),
       row.type_normalized,
       row.kind,
@@ -806,7 +806,31 @@ export class ExtensionCatalogStore {
       row.source_fingerprint ?? "",
       row.state ?? "Indexed",
       row.last_error ?? "",
-    );
+    ];
+
+    const MAX_RETRIES = 5;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const stmt = this.db.prepare(sql);
+        stmt.run(...params);
+        return;
+      } catch (error: unknown) {
+        const isLock = error instanceof Error &&
+          /database is (locked|busy)/i.test(error.message);
+        if (isLock && attempt < MAX_RETRIES) {
+          const delay = 100 * Math.pow(2, attempt) +
+            Math.floor(Math.random() * 50);
+          Atomics.wait(
+            new Int32Array(new SharedArrayBuffer(4)),
+            0,
+            0,
+            delay,
+          );
+          continue;
+        }
+        throw error;
+      }
+    }
   }
 
   /**

--- a/src/infrastructure/persistence/io_errors.ts
+++ b/src/infrastructure/persistence/io_errors.ts
@@ -50,3 +50,27 @@ export function isIoError(error: unknown): boolean {
 
   return false;
 }
+
+const SQLITE_TRANSIENT_RE = /database is (locked|busy)/i;
+
+/**
+ * Matches SQLite transient contention errors — "database is locked" or
+ * "database is busy" — that arise when another process holds a write lock
+ * past the busy_timeout.
+ */
+export function isSqliteTransientError(error: unknown): boolean {
+  if (error == null || typeof error !== "object") return false;
+  const e = error as Record<string, unknown>;
+  if (typeof e.message === "string" && SQLITE_TRANSIENT_RE.test(e.message)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Combined check for any transient error that should not be silently
+ * swallowed: I/O resource-exhaustion errors OR SQLite lock contention.
+ */
+export function isTransientError(error: unknown): boolean {
+  return isIoError(error) || isSqliteTransientError(error);
+}

--- a/src/infrastructure/persistence/io_errors_test.ts
+++ b/src/infrastructure/persistence/io_errors_test.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { isIoError } from "./io_errors.ts";
+import {
+  isIoError,
+  isSqliteTransientError,
+  isTransientError,
+} from "./io_errors.ts";
 
 Deno.test("isIoError: returns true for EMFILE error with code property", () => {
   const error = Object.assign(new Error("Too many open files"), {
@@ -109,4 +113,49 @@ Deno.test("isIoError: returns true for EROFS error with code property", () => {
     code: "EROFS",
   });
   assertEquals(isIoError(error), true);
+});
+
+Deno.test("isSqliteTransientError: returns true for 'database is locked'", () => {
+  assertEquals(isSqliteTransientError(new Error("database is locked")), true);
+});
+
+Deno.test("isSqliteTransientError: returns true for 'database is busy'", () => {
+  assertEquals(isSqliteTransientError(new Error("database is busy")), true);
+});
+
+Deno.test("isSqliteTransientError: case-insensitive match", () => {
+  assertEquals(
+    isSqliteTransientError(new Error("Error: Database Is Locked")),
+    true,
+  );
+});
+
+Deno.test("isSqliteTransientError: returns false for parse errors", () => {
+  assertEquals(
+    isSqliteTransientError(new SyntaxError("Unexpected token")),
+    false,
+  );
+});
+
+Deno.test("isSqliteTransientError: returns false for null", () => {
+  assertEquals(isSqliteTransientError(null), false);
+});
+
+Deno.test("isSqliteTransientError: returns false for non-object", () => {
+  assertEquals(isSqliteTransientError("database is locked"), false);
+});
+
+Deno.test("isTransientError: returns true for I/O errors", () => {
+  const error = Object.assign(new Error("Too many open files"), {
+    code: "EMFILE",
+  });
+  assertEquals(isTransientError(error), true);
+});
+
+Deno.test("isTransientError: returns true for SQLite transient errors", () => {
+  assertEquals(isTransientError(new Error("database is locked")), true);
+});
+
+Deno.test("isTransientError: returns false for parse errors", () => {
+  assertEquals(isTransientError(new SyntaxError("Unexpected token")), false);
 });


### PR DESCRIPTION
## Summary

- Add retry with exponential backoff (MAX_RETRIES=5) to `ExtensionCatalogStore.upsert()` for SQLite `database is locked/busy` errors, matching the existing `runInTransaction()` retry pattern
- Extend `io_errors.ts` with `isSqliteTransientError()` and `isTransientError()` to classify SQLite lock contention alongside existing I/O error detection
- Propagate persistent transient errors as `UserError` with code `lock_timeout` (exit code 75) from all four loader functions (`loadUserModels`, `loadUserVaults`, `loadUserDatastores`, `loadUserReports`) via shared `throwOnTransientLoadFailures()` helper, instead of silently swallowing them as warnings

**Before:** A concurrent swamp process holding the catalog write lock past the 5s busy_timeout caused a partial type registry, triggering the auto-resolve path which fabricated a "local edits" diagnosis and recommended destructive `--force` re-pull on a pristine, checksum-verified install.

**After:** Short contention is absorbed invisibly by retry. Persistent contention produces an honest error naming the real cause with exit code 75 (EX_TEMPFAIL), signaling the caller can retry.

Closes swamp-club#1638

## Test Plan

- 9 new unit tests for `isSqliteTransientError`, `isTransientError` in `io_errors_test.ts`
- All 70 existing `extension_catalog_store_test.ts` tests pass (including concurrency tests)
- Full test suite: 10,325 passed, 0 failed
- Manual end-to-end verification with reproduction scenario:
  - Short lock contention (10s EXCLUSIVE hold): retry absorbs it, type loads normally
  - Persistent lock contention (60s EXCLUSIVE hold): honest `UserError` with exit code 75, no fabricated cascade