### PR TITLE
fix(serve): echo request id on WebSocket validation failure

### DIFF
--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -1262,6 +1262,23 @@ export function validateServerRequest(
   return `Invalid request: ${issues}`;
 }
 
+/**
+ * Best-effort extraction of the request `id` from a parsed message
+ * BEFORE schema validation. When validation fails, the validated
+ * request object is unavailable, but the client still needs the id
+ * echoed back so it can match the error to its pending request.
+ * Falls back to `"unknown"` when the id is absent or not a string.
+ */
+export function extractRequestId(data: unknown): string {
+  if (
+    typeof data === "object" && data !== null &&
+    "id" in data && typeof (data as Record<string, unknown>).id === "string"
+  ) {
+    return (data as Record<string, unknown>).id as string;
+  }
+  return "unknown";
+}
+
 const logger = getSwampLogger(["serve", "connection"]);
 
 export function handleConnection(
@@ -1332,9 +1349,11 @@ export function handleMessage(
     return;
   }
 
+  const requestId = extractRequestId(parsed);
+
   const validated = validateServerRequest(parsed);
   if (typeof validated === "string") {
-    sendError(socket, "unknown", "invalid_request", validated);
+    sendError(socket, requestId, "invalid_request", validated);
     return;
   }
 

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
+  extractRequestId,
   handleMessage,
   sanitizeErrorForClient,
   validateServerRequest,
@@ -127,6 +128,24 @@ Deno.test("validateServerRequest rejects missing methodName for model.method.run
   assertEquals(typeof result, "string");
 });
 
+// ── extractRequestId ────────────────────────────────────────────────────
+
+Deno.test("extractRequestId: returns id when present", () => {
+  assertEquals(extractRequestId({ type: "foo", id: "req-1" }), "req-1");
+});
+
+Deno.test("extractRequestId: returns 'unknown' when id is missing", () => {
+  assertEquals(extractRequestId({ type: "foo" }), "unknown");
+});
+
+Deno.test("extractRequestId: returns 'unknown' for non-string id", () => {
+  assertEquals(extractRequestId({ type: "foo", id: 123 }), "unknown");
+});
+
+Deno.test("extractRequestId: returns 'unknown' for null data", () => {
+  assertEquals(extractRequestId(null), "unknown");
+});
+
 // ── handleMessage: invalid JSON ─────────────────────────────────────────
 
 Deno.test("handleMessage sends error for invalid JSON", () => {
@@ -162,6 +181,63 @@ Deno.test("handleMessage sends error for invalid request shape", () => {
   assertEquals(mock.sent.length, 1);
   const msg = parseSent(mock);
   assertEquals(msg.type, "error");
+  assertEquals(msg.id, "x");
+  assertEquals((msg.error as Record<string, unknown>).code, "invalid_request");
+});
+
+Deno.test("handleMessage echoes request id on validation failure", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    stubCtx,
+    active,
+    makeEvent(JSON.stringify({ type: "bad", id: "req-42" })),
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals(msg.id, "req-42");
+});
+
+Deno.test("handleMessage uses 'unknown' id when id is missing", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    stubCtx,
+    active,
+    makeEvent(JSON.stringify({ type: "bad" })),
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals(msg.id, "unknown");
+});
+
+Deno.test("handleMessage echoes id for valid type with invalid payload", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    stubCtx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "workflow.trigger.set",
+      id: "client-uuid-123",
+      payload: { workflowName: "", schedule: "" },
+    })),
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals(msg.id, "client-uuid-123");
   assertEquals((msg.error as Record<string, unknown>).code, "invalid_request");
 });
 


### PR DESCRIPTION
## Summary

- When Zod schema validation fails for an incoming WebSocket request,
  the server was sending the error response with `id: "unknown"` instead
  of the client's actual request id
- `requestServerResponse` matches responses by id, so the client
  silently ignored these errors and timed out after 30s with a
  misleading "server may not support this operation" message
- Adds `extractRequestId()` to pull the request id from parsed JSON
  before validation, so error responses always echo the correct id

This fixes the scenario where a newer client sends a request type the
server doesn't recognize (e.g. `workflow.trigger.set` against an older
server binary) — the client now gets the actual validation error instead
of a 30s timeout.

## Test Plan

- 4 unit tests for `extractRequestId` (present, missing, non-string, null)
- 3 new `handleMessage` tests: id echoed on validation failure, unknown
  fallback when id is missing, id echoed for valid type with invalid
  payload (`workflow.trigger.set` with empty strings)
- Existing test updated to also assert the echoed id
- All 10,377 tests pass
- `deno check`, `deno lint`, `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)