### PR TITLE
fix(extensions): use /healthz endpoint for issue lifecycle health check

### DIFF
--- a/extensions/models/_lib/swamp_club.ts
+++ b/extensions/models/_lib/swamp_club.ts
@@ -399,7 +399,7 @@ export async function createSwampClubClient(
 
   // Reachability check — verify the swamp-club URL is accessible before proceeding
   try {
-    const healthUrl = `${url}/api/health`;
+    const healthUrl = `${url}/healthz`;
     const res = await fetch(healthUrl, {
       method: "GET",
       signal: AbortSignal.timeout(5_000),

--- a/extensions/models/issue_lifecycle.ts
+++ b/extensions/models/issue_lifecycle.ts
@@ -74,7 +74,7 @@ async function readState(
 
 export const model = {
   type: "@swamp/issue-lifecycle",
-  version: "2026.07.30.1",
+  version: "2026.08.16.1",
   globalArguments: GlobalArgsSchema,
 
   upgrades: [
@@ -172,6 +172,11 @@ export const model = {
         "Session summary — new summarizing phase between notify and done; " +
         "notify/skip_notify transition to summarizing, new summarize method " +
         "records problem/outcome before closing. No globalArguments changes.",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.08.16.1",
+      description: "Change Swamp Club API Health Endpoint",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
   ],

--- a/extensions/models/issue_lifecycle_test.ts
+++ b/extensions/models/issue_lifecycle_test.ts
@@ -319,8 +319,8 @@ Deno.test("model: exposes the new link_pr method definition", () => {
   );
 });
 
-Deno.test("model: version is 2026.07.30.1", () => {
-  assertEquals(model.version, "2026.07.30.1");
+Deno.test("model: version is 2026.08.16.1", () => {
+  assertEquals(model.version, "2026.08.16.1");
 });
 
 // ---------------------------------------------------------------------------
@@ -644,8 +644,8 @@ function happyRoutes(opts: {
 }): FetchStubRoute[] {
   return [
     {
-      urlIncludes: "/api/health",
-      response: { status: 200, body: { ok: true } },
+      urlIncludes: "/healthz",
+      response: { status: 200, body: "" },
     },
     {
       urlIncludes: `/api/v1/lab/issues/${opts.issueNumber}`,
@@ -856,8 +856,8 @@ Deno.test("start: persists author in context-main", async () => {
     authUsername: "alice",
     routes: [
       {
-        urlIncludes: "/api/health",
-        response: { status: 200, body: { ok: true } },
+        urlIncludes: "/healthz",
+        response: { status: 200, body: "" },
       },
       {
         urlIncludes: "/api/v1/lab/issues/99",


### PR DESCRIPTION
## Summary

- Switch the issue lifecycle reachability check from the removed `/api/health` endpoint to `/healthz`
- Bump model version to `2026.08.16.1` with a corresponding upgrade entry
- Update test stubs to match the new endpoint and response shape

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno run test extensions/models/issue_lifecycle_test.ts` — 55/55 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)