### PR TITLE
fix(expressions): flatten vault error newlines in model resolver wrapper (swamp-club#1671)

### DIFF
--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -1158,10 +1158,10 @@ export class ModelResolver {
 
         resolvedValue = resolvedValue.split(fullMatch).join(celReplacement);
       } catch (error) {
+        const msg = (error instanceof Error ? error.message : String(error))
+          .replace(/\n\s*/g, " — ");
         throw new Error(
-          `Failed to resolve vault expression ${fullMatch}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
+          `Failed to resolve vault expression ${fullMatch}: ${msg}`,
         );
       }
     }

--- a/src/domain/vaults/vault_expression_test.ts
+++ b/src/domain/vaults/vault_expression_test.ts
@@ -257,6 +257,19 @@ Deno.test("ModelResolver.resolveVaultExpressions", async (t) => {
     assertStringIncludes(error.message, "vault.get(missing-vault, key)");
   });
 
+  await t.step(
+    "resolveVaultExpressions: flattens multi-line vault errors into single line",
+    async () => {
+      const resolver = createResolverWithMockVault({});
+      const error = await assertRejects(
+        () => resolver.resolveVaultExpressions("vault.get(missing-vault, key)"),
+        Error,
+      );
+      assertEquals(error.message.includes("\n"), false);
+      assertStringIncludes(error.message, " — ");
+    },
+  );
+
   await t.step("should throw error for missing secret key", async () => {
     const resolver = createResolverWithMockVault({ "existing-key": "value" });
     const error = await assertRejects(


### PR DESCRIPTION
## Summary

- Flatten embedded newlines in vault error messages when wrapped by
  `model_resolver.ts`, replacing `\n` (and following whitespace) with ` — ` so
  the "Failed to resolve vault expression" error renders as a single clean line
- Add test verifying multi-line vault errors produce single-line wrapped output

Closes swamp-club#1671

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno run test src/domain/vaults/vault_expression_test.ts` — all 33 steps pass
- [x] Reproduced original bug in scratch repo at `/tmp/swamp-repro-issue-1671`
- [x] Verified fix: error now renders as single line with ` — ` separators

🤖 Generated with [Claude Code](https://claude.com/claude-code)