### PR TITLE
feat(serve): headless OAuth client bootstrap via SWAMP_API_KEY

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -209,8 +209,8 @@ management is through `swamp access token mint/list/revoke`.
 When `--auth-mode oauth` is active, users authenticate via the OAuth device
 grant flow (RFC 8628) against swamp-club. The server acts as an OAuth client
 relay — it holds client credentials (auto-registered on first start or
-supplied via `--oauth-client-id`) and proxies the device authorization flow.
-The flow:
+supplied via `--oauth-client-id` or via headless API key bootstrap) and
+proxies the device authorization flow. The flow:
 
 1. User runs `swamp auth login --server <url>`
 2. CLI calls `GET /auth/info` on the serve instance to discover auth mode
@@ -238,13 +238,22 @@ token record (via a per-connection WeakMap set at upgrade time), enabling
 `idp-group:` grants to match for OAuth-authenticated users.
 
 Auto-registration: on first start with `--auth-mode oauth`, if no client
-credentials are stored, the serve instance reads the admin's swamp-club API
-key from `~/.config/swamp/auth.json`, calls
-`POST /api/auth/oauth2/register`, and stores the returned `client_id` and
+credentials are stored, the serve instance registers an OAuth client via
+`POST /api/auth/oauth2/register` and stores the returned `client_id` and
 `client_secret` in the vault (keys: `oauth-client-id`,
-`oauth-client-secret`). Subsequent starts read from the vault. If the admin
-hasn't run `swamp auth login`, the server refuses to start. If no vault is
-initialized, the server refuses to start.
+`oauth-client-secret`). Subsequent starts read from the vault. Two
+registration paths exist:
+
+- **Headless (SWAMP_API_KEY)**: when the `SWAMP_API_KEY` env var is set
+  (a collective API token with `oauth:manage` scope), the server validates
+  the key against `/api/whoami`, uses it as a bearer token for client
+  registration and admin/allowed-user username resolution. The API key
+  is never persisted in the vault — it is read fresh from the environment
+  on each boot, so key rotation is transparent.
+- **Interactive (device grant)**: when `SWAMP_API_KEY` is not set, the
+  server initiates a device grant flow (RFC 8628) and waits for the
+  admin to approve in a browser. The device grant access token is
+  stored in the vault for subsequent admin resolution.
 
 Collectives are snapshotted at login time and become stale if the user's
 collective membership changes in swamp-club. Refresh is a later phase.

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1587,6 +1587,8 @@ export const serveCommand = new Command()
       knownUndecryptable: new Set(healthResult.undecryptable),
     });
 
+    const clubApiKey = Deno.env.get("SWAMP_API_KEY") ?? null;
+
     let oauthClientSecret = "";
     const resolvedUserNames: Record<string, string> = {};
     if (authConfig.mode === "oauth") {
@@ -1627,6 +1629,22 @@ export const serveCommand = new Command()
             putVaultSecret: (_v, k, val) =>
               oauthVaultService.put(TOKEN_SECRETS_VAULT_NAME, k, val),
             registerClient: async (providerUrl, signal) => {
+              if (clubApiKey) {
+                const { registerClientWithApiKey } = await import(
+                  "../../serve/oauth_registration.ts"
+                );
+                const result = await registerClientWithApiKey(
+                  providerUrl,
+                  clubApiKey,
+                  signal,
+                );
+                return {
+                  clientId: result.clientId,
+                  clientSecret: result.clientSecret,
+                  accessToken: null,
+                };
+              }
+
               const { startDeviceGrant, pollForToken } = await import(
                 "../../serve/oauth_client.ts"
               );
@@ -1763,77 +1781,91 @@ export const serveCommand = new Command()
         const missingAllowed = authConfig.allowedUsers
           .map((e) => e.startsWith("user:") ? e.slice(5) : e)
           .filter((u) => !cachedMap[`allowed:${u}`]);
-        logger.info(
-          "OAuth user config changed — device grant required to resolve: {admins}",
-          {
-            admins: [
-              ...missingAdmins,
-              ...missingAllowed.map((u) => `allowed:${u}`),
-            ].join(", "),
-          },
-        );
 
-        const { startDeviceGrant, pollForToken, DeviceGrantPollError } =
-          await import(
-            "../../serve/oauth_client.ts"
+        if (clubApiKey) {
+          logger.info(
+            "Using SWAMP_API_KEY to resolve admin/allowed-user usernames: {admins}",
+            {
+              admins: [
+                ...missingAdmins,
+                ...missingAllowed.map((u) => `allowed:${u}`),
+              ].join(", "),
+            },
           );
-        const { BOOTSTRAP_CLIENT_ID } = await import(
-          "../../serve/oauth_registration.ts"
-        );
-        const grantSignal = AbortSignal.timeout(300_000);
-        const grant = await startDeviceGrant(
-          authConfig.oauthProvider,
-          BOOTSTRAP_CLIENT_ID,
-          grantSignal,
-        );
+          accessToken = clubApiKey;
+        } else {
+          logger.info(
+            "OAuth user config changed — device grant required to resolve: {admins}",
+            {
+              admins: [
+                ...missingAdmins,
+                ...missingAllowed.map((u) => `allowed:${u}`),
+              ].join(", "),
+            },
+          );
 
-        const verifyUrl = grant.verificationUriComplete ||
-          grant.verificationUri;
-        logger.info(
-          "Visit {uri} and verify code: {code}",
-          { uri: verifyUrl, code: grant.userCode },
-        );
-
-        let currentIntervalMs = (grant.interval || 5) * 1000;
-        const deadline = Date.now() + grant.expiresIn * 1000;
-        let tokenResponse;
-        while (Date.now() < deadline) {
-          try {
-            tokenResponse = await pollForToken(
-              authConfig.oauthProvider,
-              BOOTSTRAP_CLIENT_ID,
-              "",
-              grant.deviceCode,
-              grantSignal,
+          const { startDeviceGrant, pollForToken, DeviceGrantPollError } =
+            await import(
+              "../../serve/oauth_client.ts"
             );
-            break;
-          } catch (err) {
-            if (err instanceof DeviceGrantPollError) {
-              if (err.code === "slow_down") {
-                currentIntervalMs += 5000;
-              }
-              if (
-                err.code === "authorization_pending" ||
-                err.code === "slow_down"
-              ) {
-                await new Promise((resolve) =>
-                  setTimeout(resolve, currentIntervalMs)
-                );
-                continue;
-              }
-              throw new UserError(
-                `OAuth re-registration failed: ${err.message}`,
-              );
-            }
-            throw err;
-          }
-        }
-        if (!tokenResponse) {
-          throw new UserError(
-            "OAuth re-registration failed: device grant timed out",
+          const { BOOTSTRAP_CLIENT_ID } = await import(
+            "../../serve/oauth_registration.ts"
           );
+          const grantSignal = AbortSignal.timeout(300_000);
+          const grant = await startDeviceGrant(
+            authConfig.oauthProvider,
+            BOOTSTRAP_CLIENT_ID,
+            grantSignal,
+          );
+
+          const verifyUrl = grant.verificationUriComplete ||
+            grant.verificationUri;
+          logger.info(
+            "Visit {uri} and verify code: {code}",
+            { uri: verifyUrl, code: grant.userCode },
+          );
+
+          let currentIntervalMs = (grant.interval || 5) * 1000;
+          const deadline = Date.now() + grant.expiresIn * 1000;
+          let tokenResponse;
+          while (Date.now() < deadline) {
+            try {
+              tokenResponse = await pollForToken(
+                authConfig.oauthProvider,
+                BOOTSTRAP_CLIENT_ID,
+                "",
+                grant.deviceCode,
+                grantSignal,
+              );
+              break;
+            } catch (err) {
+              if (err instanceof DeviceGrantPollError) {
+                if (err.code === "slow_down") {
+                  currentIntervalMs += 5000;
+                }
+                if (
+                  err.code === "authorization_pending" ||
+                  err.code === "slow_down"
+                ) {
+                  await new Promise((resolve) =>
+                    setTimeout(resolve, currentIntervalMs)
+                  );
+                  continue;
+                }
+                throw new UserError(
+                  `OAuth re-registration failed: ${err.message}`,
+                );
+              }
+              throw err;
+            }
+          }
+          if (!tokenResponse) {
+            throw new UserError(
+              "OAuth re-registration failed: device grant timed out",
+            );
+          }
+          accessToken = tokenResponse.accessToken;
         }
-        accessToken = tokenResponse.accessToken;
       }
 
       const resolvedMap: Record<string, string> = {};
@@ -2168,8 +2200,6 @@ export const serveCommand = new Command()
     }
 
     const instanceId = crypto.randomUUID();
-
-    const clubApiKey = Deno.env.get("SWAMP_API_KEY") ?? null;
     if (
       authConfig.mode === "oauth" &&
       authConfig.oauthClientId &&

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -555,7 +555,9 @@ const daemonEnableCommand = new Command()
   )
   .option(
     "--oauth-client-id <id:string>",
-    "OAuth client ID — auto-registered on first start if omitted",
+    "OAuth client ID — auto-registered on first start if omitted. " +
+      "Set SWAMP_API_KEY (a collective API token with oauth:manage scope) " +
+      "for headless registration without browser interaction.",
   )
   .option(
     "--groups-field <field:string>",
@@ -821,6 +823,10 @@ export const serveCommand = new Command()
     "Bind to all interfaces (TLS + auth required)",
     "swamp serve --host 0.0.0.0 --port 3000 --cert-file server.crt --key-file server.key --auth-mode token",
   )
+  .example(
+    "Headless OAuth (CI / container)",
+    "SWAMP_API_KEY=<token> swamp serve --auth-mode oauth --admins dmc --allowed-collectives my-org",
+  )
   .option(
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
@@ -885,7 +891,9 @@ export const serveCommand = new Command()
   )
   .option(
     "--oauth-client-id <id:string>",
-    "OAuth client ID — auto-registered on first start if omitted",
+    "OAuth client ID — auto-registered on first start if omitted. " +
+      "Set SWAMP_API_KEY (a collective API token with oauth:manage scope) " +
+      "for headless registration without browser interaction.",
   )
   .option(
     "--groups-field <field:string>",
@@ -1751,7 +1759,7 @@ export const serveCommand = new Command()
       } catch (err) {
         if (err instanceof UserError) throw err;
         throw new UserError(
-          `OAuth bootstrap failed: ${
+          `OAuth bootstrap: ${
             err instanceof Error ? err.message : String(err)
           }`,
         );

--- a/src/serve/oauth_registration.ts
+++ b/src/serve/oauth_registration.ts
@@ -198,14 +198,22 @@ export async function registerClientWithApiKey(
       }`,
     );
   }
-  const data = await resp.json();
+  const data = await resp.json() as Record<string, unknown>;
+  if (
+    typeof data.client_id !== "string" ||
+    typeof data.client_secret !== "string"
+  ) {
+    throw new Error(
+      "OAuth registration response missing client_id or client_secret",
+    );
+  }
   logger.info(
     "Registered OAuth client {clientId} via SWAMP_API_KEY (headless)",
     { clientId: data.client_id },
   );
   return {
-    clientId: data.client_id as string,
-    clientSecret: data.client_secret as string,
+    clientId: data.client_id,
+    clientSecret: data.client_secret,
   };
 }
 

--- a/src/serve/oauth_registration.ts
+++ b/src/serve/oauth_registration.ts
@@ -57,7 +57,7 @@ export interface OAuthRegistrationDeps {
   ) => Promise<{
     clientId: string;
     clientSecret: string;
-    accessToken: string;
+    accessToken: string | null;
   }>;
 }
 
@@ -123,11 +123,13 @@ export async function resolveOAuthClientCredentials(
     OAUTH_CLIENT_SECRET_KEY,
     result.clientSecret,
   );
-  await deps.putVaultSecret(
-    vaultName,
-    OAUTH_BOOTSTRAP_ACCESS_TOKEN_KEY,
-    result.accessToken,
-  );
+  if (result.accessToken) {
+    await deps.putVaultSecret(
+      vaultName,
+      OAUTH_BOOTSTRAP_ACCESS_TOKEN_KEY,
+      result.accessToken,
+    );
+  }
 
   logger.info(
     "Registered OAuth client {clientId} and stored credentials in vault",
@@ -139,6 +141,71 @@ export async function resolveOAuthClientCredentials(
     clientSecret: result.clientSecret,
     accessToken: result.accessToken,
     resolvedAdmins: null,
+  };
+}
+
+export async function registerClientWithApiKey(
+  providerUrl: string,
+  apiKey: string,
+  signal: AbortSignal,
+): Promise<{ clientId: string; clientSecret: string }> {
+  const verifyResp = await fetch(`${providerUrl}/api/whoami`, {
+    headers: { "authorization": `Bearer ${apiKey}` },
+    signal,
+  });
+  if (!verifyResp.ok) {
+    const body = await verifyResp.text().catch(() => "");
+    throw new Error(
+      `SWAMP_API_KEY validation failed: ${verifyResp.status} ${verifyResp.statusText}${
+        body ? ` — ${body}` : ""
+      }`,
+    );
+  }
+  const whoami = await verifyResp.json() as {
+    scopes?: string[];
+  };
+  const scopes = whoami.scopes ?? [];
+  if (!scopes.includes("oauth:manage")) {
+    throw new Error(
+      `SWAMP_API_KEY is missing the "oauth:manage" scope required for headless OAuth client registration. ` +
+        `Generate a new collective API token that includes "oauth:manage".`,
+    );
+  }
+
+  logger.info(
+    "SWAMP_API_KEY verified with oauth:manage scope — registering OAuth client (headless)",
+  );
+
+  const resp = await fetch(`${providerUrl}/api/auth/oauth2/register`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "authorization": `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      client_name: `swamp-serve-${crypto.randomUUID().slice(0, 8)}`,
+      redirect_uris: ["http://localhost"],
+      grant_types: ["authorization_code"],
+      scope: "openid profile email collectives",
+    }),
+    signal,
+  });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => "");
+    throw new Error(
+      `OAuth client registration via API key failed: ${resp.status} ${resp.statusText}${
+        body ? ` — ${body}` : ""
+      }`,
+    );
+  }
+  const data = await resp.json();
+  logger.info(
+    "Registered OAuth client {clientId} via SWAMP_API_KEY (headless)",
+    { clientId: data.client_id },
+  );
+  return {
+    clientId: data.client_id as string,
+    clientSecret: data.client_secret as string,
   };
 }
 

--- a/src/serve/oauth_registration_test.ts
+++ b/src/serve/oauth_registration_test.ts
@@ -17,16 +17,55 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import {
   OAUTH_BOOTSTRAP_ACCESS_TOKEN_KEY,
   OAUTH_CLIENT_ID_KEY,
   OAUTH_CLIENT_SECRET_KEY,
   OAUTH_RESOLVED_ADMINS_KEY,
   type OAuthRegistrationDeps,
+  registerClientWithApiKey,
   resolveOAuthClientCredentials,
   storeResolvedAdmins,
 } from "./oauth_registration.ts";
+
+interface StubResponse {
+  url: string;
+  status: number;
+  body: string;
+}
+
+function stubFetch(
+  responses: StubResponse[],
+): { [Symbol.dispose]: () => void } {
+  const originalFetch = globalThis.fetch;
+  let callIndex = 0;
+  globalThis.fetch = (
+    input: string | URL | Request,
+    _init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.href
+      : input.url;
+    const stub = responses[callIndex++];
+    if (!stub) {
+      throw new Error(`stubFetch: unexpected call #${callIndex} to ${url}`);
+    }
+    return Promise.resolve(
+      new Response(stub.body, {
+        status: stub.status,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  };
+  return {
+    [Symbol.dispose]: () => {
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
 
 function createMockDeps(
   overrides: Partial<OAuthRegistrationDeps> = {},
@@ -167,6 +206,126 @@ Deno.test("resolveOAuthClientCredentials: prefers cached resolutions over stored
   );
   assertEquals(result.accessToken, null);
   assertEquals(result.resolvedAdmins, { swampadmin: "6a4d-sub-id" });
+});
+
+Deno.test("resolveOAuthClientCredentials: does not store null access token in vault", async () => {
+  const storedSecrets = new Map<string, string>();
+  const deps = createMockDeps({
+    registerClient: () =>
+      Promise.resolve({
+        clientId: "api-key-client",
+        clientSecret: "api-key-secret",
+        accessToken: null,
+      }),
+    putVaultSecret: (_, key, value) => {
+      storedSecrets.set(key, value);
+      return Promise.resolve();
+    },
+  });
+  const result = await resolveOAuthClientCredentials(
+    deps,
+    "https://swamp-club.com",
+    "default",
+    undefined,
+    AbortSignal.timeout(5000),
+  );
+  assertEquals(result.clientId, "api-key-client");
+  assertEquals(result.clientSecret, "api-key-secret");
+  assertEquals(result.accessToken, null);
+  assertEquals(storedSecrets.get(OAUTH_CLIENT_ID_KEY), "api-key-client");
+  assertEquals(storedSecrets.get(OAUTH_CLIENT_SECRET_KEY), "api-key-secret");
+  assertEquals(storedSecrets.has(OAUTH_BOOTSTRAP_ACCESS_TOKEN_KEY), false);
+});
+
+Deno.test("registerClientWithApiKey: registers client and returns credentials without accessToken", async () => {
+  using _fetch = stubFetch([
+    {
+      url: "https://swamp-club.com/api/whoami",
+      status: 200,
+      body: JSON.stringify({ scopes: ["oauth:manage", "serve:*"] }),
+    },
+    {
+      url: "https://swamp-club.com/api/auth/oauth2/register",
+      status: 200,
+      body: JSON.stringify({
+        client_id: "headless-client-id",
+        client_secret: "headless-client-secret",
+      }),
+    },
+  ]);
+  const result = await registerClientWithApiKey(
+    "https://swamp-club.com",
+    "test-api-key",
+    AbortSignal.timeout(5000),
+  );
+  assertEquals(result.clientId, "headless-client-id");
+  assertEquals(result.clientSecret, "headless-client-secret");
+  assertEquals("accessToken" in result, false);
+});
+
+Deno.test("registerClientWithApiKey: throws on invalid API key", async () => {
+  using _fetch = stubFetch([
+    {
+      url: "https://swamp-club.com/api/whoami",
+      status: 401,
+      body: "Unauthorized",
+    },
+  ]);
+  await assertRejects(
+    () =>
+      registerClientWithApiKey(
+        "https://swamp-club.com",
+        "bad-key",
+        AbortSignal.timeout(5000),
+      ),
+    Error,
+    "SWAMP_API_KEY validation failed: 401",
+  );
+});
+
+Deno.test("registerClientWithApiKey: throws when token is missing oauth:manage scope", async () => {
+  using _fetch = stubFetch([
+    {
+      url: "https://swamp-club.com/api/whoami",
+      status: 200,
+      body: JSON.stringify({ scopes: ["serve:*", "extensions:*"] }),
+    },
+  ]);
+  await assertRejects(
+    () =>
+      registerClientWithApiKey(
+        "https://swamp-club.com",
+        "no-oauth-scope-key",
+        AbortSignal.timeout(5000),
+      ),
+    Error,
+    'SWAMP_API_KEY is missing the "oauth:manage" scope',
+  );
+});
+
+Deno.test("registerClientWithApiKey: throws on registration failure", async () => {
+  using _fetch = stubFetch([
+    {
+      url: "https://swamp-club.com/api/whoami",
+      status: 200,
+      body: JSON.stringify({ scopes: ["oauth:manage"] }),
+    },
+    {
+      url: "https://swamp-club.com/api/auth/oauth2/register",
+      status: 403,
+      body: "Forbidden — missing serve:* scope",
+    },
+  ]);
+  await assertRejects(
+    () =>
+      registerClientWithApiKey(
+        "https://swamp-club.com",
+        "test-api-key",
+        AbortSignal.timeout(5000),
+      ),
+    Error,
+    "OAuth client registration via API key failed: 403",
+  );
 });
 
 Deno.test("storeResolvedAdmins: stores admin mapping in vault", async () => {

--- a/src/serve/oauth_registration_test.ts
+++ b/src/serve/oauth_registration_test.ts
@@ -53,6 +53,11 @@ function stubFetch(
     if (!stub) {
       throw new Error(`stubFetch: unexpected call #${callIndex} to ${url}`);
     }
+    if (url !== stub.url) {
+      throw new Error(
+        `stubFetch: call #${callIndex} expected ${stub.url} but got ${url}`,
+      );
+    }
     return Promise.resolve(
       new Response(stub.body, {
         status: stub.status,


### PR DESCRIPTION
Closes swamp-club#1649

## Summary

- Add `registerClientWithApiKey()` in `src/serve/oauth_registration.ts` — validates the API key via `/api/whoami`, checks for `oauth:manage` scope, then calls `POST /api/auth/oauth2/register` with the key as bearer auth
- Wire `SWAMP_API_KEY` into the OAuth bootstrap decision tree in `serve.ts` — when set and no stored credentials exist, uses the API key path instead of the interactive device grant flow
- Wire `SWAMP_API_KEY` into admin/allowed-user username resolution — uses the key as bearer token for `resolveUsername()` instead of starting a second device grant
- API key is **never persisted in the vault** — read fresh from env on each boot so key rotation is transparent
- Update `design/remote-execution.md` to document headless vs interactive OAuth bootstrap paths

### Boot flow

```
SWAMP_API_KEY set?
├─ No  → existing device-grant flow (unchanged)
└─ Yes → stored OAuth client credentials?
         ├─ Yes → use stored credentials (unchanged)
         └─ No  → validate key via /api/whoami
                   → check oauth:manage scope
                   → POST /api/auth/oauth2/register
                   → store client_id + client_secret in vault
                   → resolve admin usernames via SWAMP_API_KEY
                   → register instance (already works)
                   → start heartbeats (already works)
                   → server ready, zero browser interaction
```

### Security

- API key validated against `/api/whoami` before any registration attempt
- `oauth:manage` scope required — clear error if missing (without leaking current scopes)
- API key never stored in vault (`accessToken: null` from registration path)
- Key read fresh from env each boot — rotation is transparent
- Defense in depth: server independently validates scope on registration endpoint

## Test Plan

- 11 unit tests pass (4 new: headless registration success, invalid API key, missing scope, registration failure; 1 new: null accessToken vault handling)
- Type checking, linting, formatting all pass
- Full test suite passes (10381 passed, 1 pre-existing flaky unrelated to this change)
- End-to-end verified: `SWAMP_API_KEY` with `oauth:manage` scope bootstraps serve headlessly, registers in swamp-club UI, resolves admin usernames — zero browser interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)