### PR TITLE
fix(extensions): surface local source indexing failure instead of misleading collective_not_trusted

### DIFF
--- a/integration/auto_resolver_local_source_failed_test.ts
+++ b/integration/auto_resolver_local_source_failed_test.ts
@@ -1,0 +1,318 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import {
+  createAutoResolveInstallerAdapter,
+  createAutoResolveOutputAdapter,
+} from "../src/cli/auto_resolver_adapters.ts";
+import { ExtensionAutoResolver } from "../src/domain/extensions/extension_auto_resolver.ts";
+import { ExtensionCatalogStore } from "../src/infrastructure/persistence/extension_catalog_store.ts";
+import { ExtensionRepository } from "../src/infrastructure/persistence/extension_repository.ts";
+import { LockfileRepository } from "../src/infrastructure/persistence/lockfile_repository.ts";
+import type { DenoRuntime } from "../src/domain/runtime/deno_runtime.ts";
+
+// Regression guard for swamp-club issue 1672: when a local source
+// extension fails to index (BundleBuildFailed or ValidationFailed),
+// the auto-resolver must emit "local_source_failed" — not the
+// misleading "collective_not_trusted" — when the type matches the
+// failed source's content.
+
+const stubDenoRuntime: DenoRuntime = {
+  ensureDeno: () => Promise.resolve("/usr/bin/false"),
+  getDenoEnv: () => Deno.env.toObject(),
+};
+
+Deno.test("integration: auto-resolver emits localSourceFailed when failed local source contains the type", async () => {
+  const tmpDir = await Deno.makeTempDir({
+    prefix: "swamp_issue_1672_match_",
+  });
+  try {
+    const repoDir = tmpDir;
+    await ensureDir(join(repoDir, ".swamp"));
+    await ensureDir(join(repoDir, "extensions", "models"));
+
+    const sourceFile = join(
+      repoDir,
+      "extensions",
+      "models",
+      "broken_model.ts",
+    );
+    await Deno.writeTextFile(
+      sourceFile,
+      `export const model = { type: "@repro/broken-model" };`,
+    );
+
+    const catalogPath = join(repoDir, ".swamp", "_extension_catalog.db");
+    const catalog = new ExtensionCatalogStore(catalogPath);
+    catalog.upsertWithIdentity({
+      source_path: sourceFile,
+      type_normalized: "",
+      kind: "model",
+      bundle_path: "",
+      version: "0.0.0",
+      description: "",
+      extends_type: "",
+      source_mtime: "",
+      source_fingerprint: "",
+      state: "BundleBuildFailed",
+      last_error: "deno bundle failed: npm dep not found",
+      extension_name: "@local/test-repo",
+      extension_version: "0.0.0",
+    });
+    catalog.markPopulated("model");
+
+    const lockfilePath = join(repoDir, "upstream_extensions.json");
+    await Deno.writeTextFile(lockfilePath, "{}");
+    const lockfileRepository = await LockfileRepository.create(lockfilePath);
+    const repository = new ExtensionRepository({
+      catalog,
+      lockfileRepository,
+      repoRoot: repoDir,
+    });
+
+    const outputCalls: string[] = [];
+    const output = createAutoResolveOutputAdapter("json");
+    const wrappedOutput = {
+      ...output,
+      localSourceFailed(type: string) {
+        outputCalls.push(`localSourceFailed:${type}`);
+        output.localSourceFailed(type);
+      },
+      collectiveNotTrusted(collective: string, type: string) {
+        outputCalls.push(`collectiveNotTrusted:${collective}:${type}`);
+        output.collectiveNotTrusted(collective, type);
+      },
+    };
+
+    const installer = createAutoResolveInstallerAdapter({
+      getExtension: () => Promise.resolve(null),
+      downloadArchive: () => Promise.reject(new Error("unreachable")),
+      getChecksum: () => Promise.resolve(null),
+      lockfilePath,
+      repoDir,
+      denoRuntime: stubDenoRuntime,
+      repository,
+    });
+
+    const resolver = new ExtensionAutoResolver({
+      allowedCollectives: [],
+      extensionLookup: {
+        getExtension: () => Promise.resolve(null),
+        searchExtensions: () => Promise.resolve({ extensions: [] }),
+      },
+      extensionInstaller: installer,
+      output: wrappedOutput,
+    });
+
+    const result = await resolver.resolve("@repro/broken-model");
+    assertEquals(result, false);
+    assertEquals(outputCalls, [
+      "localSourceFailed:@repro/broken-model",
+    ]);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("integration: auto-resolver emits collectiveNotTrusted when failed local source does NOT contain the type", async () => {
+  const tmpDir = await Deno.makeTempDir({
+    prefix: "swamp_issue_1672_nomatch_",
+  });
+  try {
+    const repoDir = tmpDir;
+    await ensureDir(join(repoDir, ".swamp"));
+    await ensureDir(join(repoDir, "extensions", "models"));
+
+    const sourceFile = join(
+      repoDir,
+      "extensions",
+      "models",
+      "other_model.ts",
+    );
+    await Deno.writeTextFile(
+      sourceFile,
+      `export const model = { type: "@other/something-else" };`,
+    );
+
+    const catalogPath = join(repoDir, ".swamp", "_extension_catalog.db");
+    const catalog = new ExtensionCatalogStore(catalogPath);
+    catalog.upsertWithIdentity({
+      source_path: sourceFile,
+      type_normalized: "",
+      kind: "model",
+      bundle_path: "",
+      version: "0.0.0",
+      description: "",
+      extends_type: "",
+      source_mtime: "",
+      source_fingerprint: "",
+      state: "BundleBuildFailed",
+      last_error: "deno bundle failed: npm dep not found",
+      extension_name: "@local/test-repo",
+      extension_version: "0.0.0",
+    });
+    catalog.markPopulated("model");
+
+    const lockfilePath = join(repoDir, "upstream_extensions.json");
+    await Deno.writeTextFile(lockfilePath, "{}");
+    const lockfileRepository = await LockfileRepository.create(lockfilePath);
+    const repository = new ExtensionRepository({
+      catalog,
+      lockfileRepository,
+      repoRoot: repoDir,
+    });
+
+    const outputCalls: string[] = [];
+    const output = createAutoResolveOutputAdapter("json");
+    const wrappedOutput = {
+      ...output,
+      localSourceFailed(type: string) {
+        outputCalls.push(`localSourceFailed:${type}`);
+        output.localSourceFailed(type);
+      },
+      collectiveNotTrusted(collective: string, type: string) {
+        outputCalls.push(`collectiveNotTrusted:${collective}:${type}`);
+        output.collectiveNotTrusted(collective, type);
+      },
+    };
+
+    const installer = createAutoResolveInstallerAdapter({
+      getExtension: () => Promise.resolve(null),
+      downloadArchive: () => Promise.reject(new Error("unreachable")),
+      getChecksum: () => Promise.resolve(null),
+      lockfilePath,
+      repoDir,
+      denoRuntime: stubDenoRuntime,
+      repository,
+    });
+
+    const resolver = new ExtensionAutoResolver({
+      allowedCollectives: [],
+      extensionLookup: {
+        getExtension: () => Promise.resolve(null),
+        searchExtensions: () => Promise.resolve({ extensions: [] }),
+      },
+      extensionInstaller: installer,
+      output: wrappedOutput,
+    });
+
+    const result = await resolver.resolve("@unrelated/widget");
+    assertEquals(result, false);
+    assertEquals(outputCalls, [
+      "collectiveNotTrusted:unrelated:@unrelated/widget",
+    ]);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("integration: auto-resolver emits localSourceFailed for ValidationFailed state too", async () => {
+  const tmpDir = await Deno.makeTempDir({
+    prefix: "swamp_issue_1672_valfail_",
+  });
+  try {
+    const repoDir = tmpDir;
+    await ensureDir(join(repoDir, ".swamp"));
+    await ensureDir(join(repoDir, "extensions", "models"));
+
+    const sourceFile = join(
+      repoDir,
+      "extensions",
+      "models",
+      "bad_schema.ts",
+    );
+    await Deno.writeTextFile(
+      sourceFile,
+      `export const model = { type: "@myns/bad-schema" };`,
+    );
+
+    const catalogPath = join(repoDir, ".swamp", "_extension_catalog.db");
+    const catalog = new ExtensionCatalogStore(catalogPath);
+    catalog.upsertWithIdentity({
+      source_path: sourceFile,
+      type_normalized: "",
+      kind: "model",
+      bundle_path: "/some/bundle.js",
+      version: "0.0.0",
+      description: "",
+      extends_type: "",
+      source_mtime: "",
+      source_fingerprint: "",
+      state: "ValidationFailed",
+      last_error: "missing required export",
+      extension_name: "@local/test-repo",
+      extension_version: "0.0.0",
+    });
+    catalog.markPopulated("model");
+
+    const lockfilePath = join(repoDir, "upstream_extensions.json");
+    await Deno.writeTextFile(lockfilePath, "{}");
+    const lockfileRepository = await LockfileRepository.create(lockfilePath);
+    const repository = new ExtensionRepository({
+      catalog,
+      lockfileRepository,
+      repoRoot: repoDir,
+    });
+
+    const outputCalls: string[] = [];
+    const output = createAutoResolveOutputAdapter("json");
+    const wrappedOutput = {
+      ...output,
+      localSourceFailed(type: string) {
+        outputCalls.push(`localSourceFailed:${type}`);
+        output.localSourceFailed(type);
+      },
+      collectiveNotTrusted(collective: string, type: string) {
+        outputCalls.push(`collectiveNotTrusted:${collective}:${type}`);
+        output.collectiveNotTrusted(collective, type);
+      },
+    };
+
+    const installer = createAutoResolveInstallerAdapter({
+      getExtension: () => Promise.resolve(null),
+      downloadArchive: () => Promise.reject(new Error("unreachable")),
+      getChecksum: () => Promise.resolve(null),
+      lockfilePath,
+      repoDir,
+      denoRuntime: stubDenoRuntime,
+      repository,
+    });
+
+    const resolver = new ExtensionAutoResolver({
+      allowedCollectives: [],
+      extensionLookup: {
+        getExtension: () => Promise.resolve(null),
+        searchExtensions: () => Promise.resolve({ extensions: [] }),
+      },
+      extensionInstaller: installer,
+      output: wrappedOutput,
+    });
+
+    const result = await resolver.resolve("@myns/bad-schema");
+    assertEquals(result, false);
+    assertEquals(outputCalls, [
+      "localSourceFailed:@myns/bad-schema",
+    ]);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});

--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -50,6 +50,7 @@ import {
   renderAutoResolveCollectiveNotTrusted,
   renderAutoResolveInstalled,
   renderAutoResolveInstalling,
+  renderAutoResolveLocalSourceFailed,
   renderAutoResolveNetworkError,
   renderAutoResolveNoStableVersion,
   renderAutoResolveNotFound,
@@ -342,6 +343,20 @@ export function createAutoResolveInstallerAdapter(
         additionalDirs: rest,
       });
     },
+
+    failedLocalSourceMatchesType(typeNormalized: string): boolean {
+      if (!repository) return false;
+      const paths = repository.getCatalogStore().getFailedLocalSourcePaths();
+      for (const sourcePath of paths) {
+        try {
+          const source = Deno.readTextFileSync(sourcePath);
+          if (source.includes(typeNormalized)) return true;
+        } catch {
+          // Source unreadable — skip this file
+        }
+      }
+      return false;
+    },
   };
 }
 
@@ -384,6 +399,9 @@ export function createAutoResolveOutputAdapter(
     },
     collectiveNotTrusted(collective: string, type: string) {
       renderAutoResolveCollectiveNotTrusted(collective, type, mode);
+    },
+    localSourceFailed(type: string) {
+      renderAutoResolveLocalSourceFailed(type, mode);
     },
     noStableVersion(extension: string) {
       renderAutoResolveNoStableVersion(extension, mode);

--- a/src/domain/extensions/extension_auto_resolver.ts
+++ b/src/domain/extensions/extension_auto_resolver.ts
@@ -106,6 +106,7 @@ export interface ExtensionInstallerPort {
   hotLoadModels(): Promise<number>;
   hotLoadVaults(): Promise<void>;
   hotLoadDatastores(): Promise<void>;
+  failedLocalSourceMatchesType(typeNormalized: string): boolean;
 }
 
 /**
@@ -150,6 +151,7 @@ export interface AutoResolveOutputPort {
    * caller fail with an opaque "unknown type" error.
    */
   collectiveNotTrusted(collective: string, type: string): void;
+  localSourceFailed(type: string): void;
   noStableVersion(extension: string): void;
 }
 
@@ -211,18 +213,20 @@ export class ExtensionAutoResolver {
     if (!this.config.allowedCollectives.includes(collective)) {
       logger
         .debug`Collective '${collective}' not in trusted list, skipping auto-resolution`;
-      // Surface an actionable trust hint for `@collective/*` references so the
-      // caller doesn't dead-end on an opaque "unknown type" error. Restricted
-      // to user-namespace (`@`) types to avoid false positives on local or
-      // built-in `a/b` type names, and emitted once per collective per process
-      // so multiple types from the same collective don't repeat it
-      // (swamp-club#465).
       if (
         ModelType.isUserNamespace(normalizedType) &&
         !this.warnedUntrusted.has(collective)
       ) {
         this.warnedUntrusted.add(collective);
-        this.config.output.collectiveNotTrusted(collective, normalizedType);
+        if (
+          this.config.extensionInstaller.failedLocalSourceMatchesType(
+            normalizedType,
+          )
+        ) {
+          this.config.output.localSourceFailed(normalizedType);
+        } else {
+          this.config.output.collectiveNotTrusted(collective, normalizedType);
+        }
       }
       return false;
     }

--- a/src/domain/extensions/extension_auto_resolver.ts
+++ b/src/domain/extensions/extension_auto_resolver.ts
@@ -106,6 +106,13 @@ export interface ExtensionInstallerPort {
   hotLoadModels(): Promise<number>;
   hotLoadVaults(): Promise<void>;
   hotLoadDatastores(): Promise<void>;
+  /**
+   * Checks whether any local source extension that failed to index
+   * (`BundleBuildFailed` or `ValidationFailed`) contains the given
+   * type string in its source file. Used by the auto-resolver to
+   * distinguish a local indexing failure from a genuinely untrusted
+   * registry collective (swamp-club#1672).
+   */
   failedLocalSourceMatchesType(typeNormalized: string): boolean;
 }
 
@@ -151,6 +158,13 @@ export interface AutoResolveOutputPort {
    * caller fail with an opaque "unknown type" error.
    */
   collectiveNotTrusted(collective: string, type: string): void;
+  /**
+   * Emitted when a type cannot be resolved and a local source extension
+   * that provides it failed to index. Surfaces the real cause (bundling
+   * or validation failure) with actionable `swamp doctor extensions`
+   * guidance instead of the misleading `collectiveNotTrusted` hint
+   * (swamp-club#1672).
+   */
   localSourceFailed(type: string): void;
   noStableVersion(extension: string): void;
 }

--- a/src/domain/extensions/extension_auto_resolver_test.ts
+++ b/src/domain/extensions/extension_auto_resolver_test.ts
@@ -65,6 +65,9 @@ function createMockOutput(): AutoResolveOutputPort & { calls: string[] } {
     collectiveNotTrusted(collective: string, type: string) {
       calls.push(`collectiveNotTrusted:${collective}:${type}`);
     },
+    localSourceFailed(type: string) {
+      calls.push(`localSourceFailed:${type}`);
+    },
     noStableVersion(extension: string) {
       calls.push(`noStableVersion:${extension}`);
     },
@@ -102,6 +105,7 @@ function createMockInstaller(
   shouldSucceed = true,
   version = "2026.03.16.1",
   inspection: InstallationInspection = { state: "missing" },
+  failedLocalSourceTypes: string[] = [],
 ): ExtensionInstallerPort & {
   installCalls: string[];
   inspectCalls: string[];
@@ -128,6 +132,11 @@ function createMockInstaller(
     },
     hotLoadDatastores() {
       return Promise.resolve();
+    },
+    failedLocalSourceMatchesType(typeNormalized: string) {
+      return failedLocalSourceTypes.some((t) =>
+        typeNormalized.includes(t) || t.includes(typeNormalized)
+      );
     },
   };
 }
@@ -683,6 +692,70 @@ Deno.test("ExtensionAutoResolver - untrusted collective hint is emitted once per
   await resolver.resolve("@myorg/utils/helper");
 
   // One hint for the whole collective, not one per referenced type.
+  assertEquals(output.calls, [
+    "collectiveNotTrusted:myorg:@myorg/tools/widget",
+  ]);
+});
+
+Deno.test("ExtensionAutoResolver - untrusted collective with matching failed local source emits localSourceFailed", async () => {
+  const output = createMockOutput();
+  const installer = createMockInstaller(
+    true,
+    "2026.03.16.1",
+    { state: "missing" },
+    ["myorg/tools"],
+  );
+  const resolver = new ExtensionAutoResolver({
+    allowedCollectives: ["swamp"],
+    extensionLookup: createMockLookup(),
+    extensionInstaller: installer,
+    output,
+  });
+
+  const result = await resolver.resolve("@myorg/tools/widget");
+  assertEquals(result, false);
+  assertEquals(output.calls, ["localSourceFailed:@myorg/tools/widget"]);
+});
+
+Deno.test("ExtensionAutoResolver - untrusted collective with non-matching failed local source emits collectiveNotTrusted", async () => {
+  const output = createMockOutput();
+  const installer = createMockInstaller(
+    true,
+    "2026.03.16.1",
+    { state: "missing" },
+    ["other/unrelated"],
+  );
+  const resolver = new ExtensionAutoResolver({
+    allowedCollectives: ["swamp"],
+    extensionLookup: createMockLookup(),
+    extensionInstaller: installer,
+    output,
+  });
+
+  const result = await resolver.resolve("@myorg/tools/widget");
+  assertEquals(result, false);
+  assertEquals(output.calls, [
+    "collectiveNotTrusted:myorg:@myorg/tools/widget",
+  ]);
+});
+
+Deno.test("ExtensionAutoResolver - untrusted collective without any failed local sources emits collectiveNotTrusted", async () => {
+  const output = createMockOutput();
+  const installer = createMockInstaller(
+    true,
+    "2026.03.16.1",
+    { state: "missing" },
+    [],
+  );
+  const resolver = new ExtensionAutoResolver({
+    allowedCollectives: ["swamp"],
+    extensionLookup: createMockLookup(),
+    extensionInstaller: installer,
+    output,
+  });
+
+  const result = await resolver.resolve("@myorg/tools/widget");
+  assertEquals(result, false);
   assertEquals(output.calls, [
     "collectiveNotTrusted:myorg:@myorg/tools/widget",
   ]);

--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -513,7 +513,7 @@ export class DefaultWorkflowValidationService
           WorkflowValidationResult.fail(
             checkName,
             `Model type '${resolution.modelType}' could not be resolved — ` +
-              `ensure the extension is pulled and available so its step ` +
+              `ensure the extension is available so its step ` +
               `inputs can be validated`,
           ),
         ];

--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -1375,13 +1375,6 @@ export class ExtensionCatalogStore {
     stmt.run(sourcePath);
   }
 
-  /**
-   * Returns every row in `bundle_types`, ordered by source_path so the
-   * output is stable across runs. Used by ExtensionRepository.loadAll
-   * (which groups by extension identity) and by I-Repo-1 verification
-   * (which scans the post-save state for cross-aggregate (kind, type)
-   * collisions).
-   */
   getFailedLocalSourcePaths(): string[] {
     const stmt = this.db.prepare(
       "SELECT source_path FROM bundle_types WHERE state IN ('BundleBuildFailed', 'ValidationFailed') AND extension_name LIKE '@local/%'",
@@ -1389,6 +1382,13 @@ export class ExtensionCatalogStore {
     return (stmt.all() as { source_path: string }[]).map((r) => r.source_path);
   }
 
+  /**
+   * Returns every row in `bundle_types`, ordered by source_path so the
+   * output is stable across runs. Used by ExtensionRepository.loadAll
+   * (which groups by extension identity) and by I-Repo-1 verification
+   * (which scans the post-save state for cross-aggregate (kind, type)
+   * collisions).
+   */
   findAll(): ExtensionTypeRow[] {
     const stmt = this.db.prepare(
       "SELECT * FROM bundle_types ORDER BY source_path",

--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -1382,6 +1382,13 @@ export class ExtensionCatalogStore {
    * (which scans the post-save state for cross-aggregate (kind, type)
    * collisions).
    */
+  getFailedLocalSourcePaths(): string[] {
+    const stmt = this.db.prepare(
+      "SELECT source_path FROM bundle_types WHERE state IN ('BundleBuildFailed', 'ValidationFailed') AND extension_name LIKE '@local/%'",
+    );
+    return (stmt.all() as { source_path: string }[]).map((r) => r.source_path);
+  }
+
   findAll(): ExtensionTypeRow[] {
     const stmt = this.db.prepare(
       "SELECT * FROM bundle_types ORDER BY source_path",

--- a/src/presentation/renderers/extension_auto_resolve.ts
+++ b/src/presentation/renderers/extension_auto_resolve.ts
@@ -219,6 +219,33 @@ export function renderAutoResolveCollectiveNotTrusted(
   }
 }
 
+export function renderAutoResolveLocalSourceFailed(
+  type: string,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(
+      JSON.stringify({
+        event: "auto_resolve",
+        status: "failed",
+        type,
+        reason: "local_source_failed",
+      }),
+    );
+  } else {
+    writeOutput(
+      gutterLine(
+        "Error",
+        STATUS_COLORS.error,
+        `${type} could not be loaded — a local source extension failed to index`,
+      ),
+    );
+    writeContentLine(
+      `Run: swamp doctor extensions — to diagnose and re-index`,
+    );
+  }
+}
+
 export function renderAutoResolveNetworkError(
   type: string,
   error: string,

--- a/src/presentation/renderers/extension_auto_resolve_test.ts
+++ b/src/presentation/renderers/extension_auto_resolve_test.ts
@@ -24,6 +24,7 @@ import {
   renderAutoResolveCollectiveNotTrusted,
   renderAutoResolveInstalled,
   renderAutoResolveInstalling,
+  renderAutoResolveLocalSourceFailed,
   renderAutoResolveNetworkError,
   renderAutoResolveNoStableVersion,
   renderAutoResolveNotFound,
@@ -211,6 +212,34 @@ Deno.test("renderAutoResolveTruncated: json mode emits failed status", () => {
     const parsed = JSON.parse(logs[0]);
     assertEquals(parsed.status, "failed");
     assertEquals(parsed.reason, "truncated");
+  } finally {
+    console.log = origLog;
+  }
+});
+
+// --- renderAutoResolveLocalSourceFailed ---
+
+Deno.test("renderAutoResolveLocalSourceFailed: log mode shows Error with doctor suggestion", () => {
+  const lines = captureOutput(() => {
+    renderAutoResolveLocalSourceFailed("@acme/widget", "log");
+  });
+  const output = lines.join("\n");
+  assertStringIncludes(output, "Error");
+  assertStringIncludes(output, "local source extension failed to index");
+  assertStringIncludes(output, "swamp doctor extensions");
+});
+
+Deno.test("renderAutoResolveLocalSourceFailed: json mode emits local_source_failed reason", () => {
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+  try {
+    renderAutoResolveLocalSourceFailed("@acme/widget", "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.status, "failed");
+    assertEquals(parsed.reason, "local_source_failed");
+    assertEquals(parsed.type, "@acme/widget");
   } finally {
     console.log = origLog;
   }


### PR DESCRIPTION
## Summary

Fixes swamp-club#1672.

When a local source extension transiently fails to index (`BundleBuildFailed` or `ValidationFailed`), `workflow validate` was emitting a misleading `collective_not_trusted` auto-resolve error telling the user to trust a collective or pull an extension — neither applies to local source extensions.

- Added `failedLocalSourceMatchesType()` to the auto-resolver's `ExtensionInstallerPort` — reads source files of failed local catalog rows and checks if they contain the type being resolved
- When a match is found, the resolver emits a new `local_source_failed` event with actionable guidance (`swamp doctor extensions`) instead of the misleading `collective_not_trusted`
- Covers both `BundleBuildFailed` and `ValidationFailed` states
- Fixed the validation service's "ensure the extension is pulled" message to be origin-agnostic ("ensure the extension is available")

## Test Plan

- 3 new unit tests for the auto-resolver (matching type, non-matching type, no failed sources)
- 2 new renderer tests for `renderAutoResolveLocalSourceFailed` (log + json modes)
- 3 new integration tests wiring real `ExtensionCatalogStore` + `ExtensionRepository` + `ExtensionAutoResolver`:
  - Matching failed source → emits `localSourceFailed`
  - Non-matching failed source → emits `collectiveNotTrusted` (no false positive)
  - `ValidationFailed` state → also emits `localSourceFailed`
- Verified against manual reproduction at `/tmp/swamp-repro-issue-1672/`
- Full test suite passes (10,385 tests)