### PR TITLE
fix(datastore): count symlink bytes in migration bytesCopied (swamp-club#1670)

### DIFF
--- a/src/domain/datastore/datastore_migration_service.ts
+++ b/src/domain/datastore/datastore_migration_service.ts
@@ -134,6 +134,7 @@ async function copyDirectory(
           await Deno.symlink(target, destPath, { type: linkType });
         }
         result.filesCopied++;
+        result.bytesCopied += target.length;
       } catch (error) {
         result.errors.push(
           `Failed to migrate symlink ${entry.name}: ${

--- a/src/domain/datastore/datastore_migration_service_test.ts
+++ b/src/domain/datastore/datastore_migration_service_test.ts
@@ -103,6 +103,47 @@ Deno.test("migrateDatastore: does not migrate secrets directory", async () => {
   });
 });
 
+Deno.test("migrateDatastore: counts bytesCopied for symlinks and regular files", async () => {
+  await withTempDir(async (tmpDir) => {
+    const sourceDir = join(tmpDir, "source");
+    const destDir = join(tmpDir, "dest");
+
+    await Deno.mkdir(join(sourceDir, "data", "model"), { recursive: true });
+    await Deno.mkdir(destDir, { recursive: true });
+
+    const fileContent = '{"key": "value"}';
+    await Deno.writeTextFile(
+      join(sourceDir, "data", "model", "output.json"),
+      fileContent,
+    );
+
+    // Numeric symlink (converted to text file during migration)
+    await Deno.symlink(
+      "3",
+      join(sourceDir, "data", "model", "latest"),
+      { type: "file" },
+    );
+
+    const config: FilesystemDatastoreConfig = {
+      type: "filesystem",
+      path: destDir,
+    };
+
+    const result = await migrateDatastore(sourceDir, destDir, config);
+
+    assertEquals(
+      result.filesCopied,
+      2,
+      "should count both regular file and symlink",
+    );
+    assertEquals(
+      result.bytesCopied,
+      fileContent.length + "3".length,
+      "bytesCopied should include regular file size and symlink target length",
+    );
+  });
+});
+
 Deno.test("migrateDatastore: secrets survives full migration-then-cleanup cycle", async () => {
   await withTempDir(async (tmpDir) => {
     const sourceDir = join(tmpDir, "source");


### PR DESCRIPTION
## Summary

- Fix `bytesCopied` never being incremented in the symlink branch of `copyDirectory` in `datastore_migration_service.ts`, which caused `swamp datastore setup` to report `(0B)` even when thousands of files were successfully migrated
- Add test coverage for `bytesCopied` tracking across both regular files and symlinks

Fixes swamp-club#1670

## Test Plan

- [x] New unit test `migrateDatastore: counts bytesCopied for symlinks and regular files` verifies both regular file and numeric symlink byte counting
- [x] All existing migration tests pass
- [x] `deno check`, `deno lint`, `deno fmt` pass