### PR TITLE
feat(serve): support @vault= for webhook secrets

### DIFF
--- a/integration/webhook_signature_schemes_test.ts
+++ b/integration/webhook_signature_schemes_test.ts
@@ -107,7 +107,7 @@ async function withService(
       repoDir: resolvedRepoDir,
       repoContext,
       datastoreConfig,
-      endpoints: [parseWebhookFlag(flag)],
+      endpoints: [await parseWebhookFlag(flag)],
       syncService,
     });
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -98,6 +98,7 @@ import {
   loadServeConfig,
   mergeServeOptions,
   parseExplicitFlags,
+  parseWebhookConfig,
 } from "../../serve/serve_config.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
@@ -2762,11 +2763,28 @@ export const serveCommand = new Command()
       clubHeartbeatService.start();
     }
 
-    // Parse and initialize webhook endpoints
+    // Parse and initialize webhook endpoints — resolve secrets (including
+    // @vault= references) now that the vault type registry is loaded.
     let webhookService: WebhookService | null = null;
-    const webhookEndpoints = webhookFlags.length > 0
-      ? webhookFlags.map(parseWebhookFlag)
-      : merged.webhookEndpoints ?? [];
+    const hasWebhooks = webhookFlags.length > 0 ||
+      (merged.webhookConfigs && merged.webhookConfigs.length > 0);
+    let webhookEndpoints: import("../../serve/webhook.ts").WebhookEndpoint[] =
+      [];
+    if (hasWebhooks) {
+      const vaultService = await VaultService.fromRepository(
+        resolvedRepoDir,
+        { defaultVaultName: repoMarker?.defaultVault },
+      );
+      webhookEndpoints = webhookFlags.length > 0
+        ? await Promise.all(
+          webhookFlags.map((f) => parseWebhookFlag(f, vaultService)),
+        )
+        : await Promise.all(
+          merged.webhookConfigs!.map((e) =>
+            parseWebhookConfig(e, vaultService)
+          ),
+        );
+    }
     if (webhookEndpoints.length > 0) {
       const endpoints = webhookEndpoints;
       webhookService = new WebhookService({

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -92,6 +92,7 @@ import {
 import {
   isSensitiveHeader,
   parseWebhookFlag,
+  type WebhookEndpoint,
   WebhookService,
 } from "../../serve/webhook.ts";
 import {
@@ -529,8 +530,9 @@ const daemonEnableCommand = new Command()
   .option(
     "--webhook <spec:string>",
     "Register a webhook endpoint: <route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]. " +
-      "Secret may use @env=VAR to read from an environment variable or " +
-      "@file=/path to read from a file (avoids secrets in argv)",
+      "Secret may use @env=VAR to read from an environment variable, " +
+      "@file=/path to read from a file, or @vault=<vault>:<key> to read " +
+      "from a configured vault (avoids secrets in argv)",
     { collect: true },
   )
   .option(
@@ -859,8 +861,9 @@ export const serveCommand = new Command()
     "Register a webhook endpoint: <route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]. " +
       "scheme is one of github (default), linear, stripe, slack, generic; " +
       "generic requires a header name and accepts an optional value prefix. " +
-      "Secret may use @env=VAR to read from an environment variable or " +
-      "@file=/path to read from a file (avoids secrets in argv)",
+      "Secret may use @env=VAR to read from an environment variable, " +
+      "@file=/path to read from a file, or @vault=<vault>:<key> to read " +
+      "from a configured vault (avoids secrets in argv)",
     { collect: true },
   )
   .option(
@@ -1006,6 +1009,10 @@ export const serveCommand = new Command()
   .example(
     "Webhook (secret from file)",
     "swamp serve --webhook '/hooks/github:my-workflow:@file=/run/secrets/webhook'",
+  )
+  .example(
+    "Webhook (secret from vault)",
+    "swamp serve --webhook '/hooks/github:my-workflow:@vault=production:webhook-secret'",
   )
   .example(
     "Webhook with a provider scheme",
@@ -2768,8 +2775,7 @@ export const serveCommand = new Command()
     let webhookService: WebhookService | null = null;
     const hasWebhooks = webhookFlags.length > 0 ||
       (merged.webhookConfigs && merged.webhookConfigs.length > 0);
-    let webhookEndpoints: import("../../serve/webhook.ts").WebhookEndpoint[] =
-      [];
+    let webhookEndpoints: WebhookEndpoint[] = [];
     if (hasWebhooks) {
       const vaultService = await VaultService.fromRepository(
         resolvedRepoDir,

--- a/src/serve/mod.ts
+++ b/src/serve/mod.ts
@@ -34,6 +34,7 @@ export {
 } from "./deps.ts";
 export {
   parseWebhookFlag,
+  type VaultSecretResolver,
   type WebhookEndpoint,
   type WebhookEndpointInfo,
   type WebhookEvent,

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -596,7 +596,6 @@ export interface MergedServeOptions {
   grantsDir?: string;
   grantReload: string;
   webhook?: string[];
-  webhookEndpoints?: WebhookEndpoint[];
   webhookConfigs?: WebhookConfigEntry[];
   authMode: string;
   admins?: string;

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -23,7 +23,11 @@ import { Cron } from "croner";
 import { atomicWriteTextFile } from "../infrastructure/persistence/atomic_write.ts";
 import { UserError } from "../domain/errors.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
-import { resolveSecret, type WebhookEndpoint } from "./webhook.ts";
+import {
+  resolveSecret,
+  type VaultSecretResolver,
+  type WebhookEndpoint,
+} from "./webhook.ts";
 import { WEBHOOK_SCHEMES, type WebhookScheme } from "./webhook_verifiers.ts";
 import type { VerifierConfig } from "./webhook_verifiers.ts";
 
@@ -522,8 +526,11 @@ export function validateTriggerOverrideEntry(
 
 // ── Webhook Config to WebhookEndpoint ─────────────────────────────────
 
-export function parseWebhookConfig(entry: WebhookConfigEntry): WebhookEndpoint {
-  const secret = resolveSecret(entry.secret);
+export async function parseWebhookConfig(
+  entry: WebhookConfigEntry,
+  vault?: VaultSecretResolver,
+): Promise<WebhookEndpoint> {
+  const secret = await resolveSecret(entry.secret, vault);
   const scheme = (entry.scheme ?? "github") as WebhookScheme;
 
   let verifier: VerifierConfig;
@@ -590,6 +597,7 @@ export interface MergedServeOptions {
   grantReload: string;
   webhook?: string[];
   webhookEndpoints?: WebhookEndpoint[];
+  webhookConfigs?: WebhookConfigEntry[];
   authMode: string;
   admins?: string;
   allowedCollectives?: string;
@@ -945,14 +953,16 @@ export function mergeServeOptions(
     false,
   );
 
-  // Webhooks: CLI --webhook flags replace config file webhooks entirely
+  // Webhooks: CLI --webhook flags replace config file webhooks entirely.
+  // Config-file webhooks are passed as raw entries — secret resolution
+  // (which may need async vault access) happens later at startup.
   let webhook: string[] | undefined;
-  let webhookEndpoints: WebhookEndpoint[] | undefined;
+  let webhookConfigs: WebhookConfigEntry[] | undefined;
 
   if (explicitFlags.has("webhook")) {
     webhook = cliOptions.webhook as string[] | undefined;
   } else if (config?.webhooks && config.webhooks.length > 0) {
-    webhookEndpoints = config.webhooks.map(parseWebhookConfig);
+    webhookConfigs = config.webhooks;
   }
 
   // Trigger overrides: serve.yaml only (no CLI flag or env var in v1)
@@ -971,7 +981,7 @@ export function mergeServeOptions(
     grantsDir,
     grantReload,
     webhook,
-    webhookEndpoints,
+    webhookConfigs,
     authMode,
     admins,
     allowedCollectives,

--- a/src/serve/serve_config_test.ts
+++ b/src/serve/serve_config_test.ts
@@ -307,31 +307,31 @@ Deno.test("loadServeConfig: empty file returns null", () => {
   });
 });
 
-Deno.test("parseWebhookConfig: parses github scheme webhook", () => {
+Deno.test("parseWebhookConfig: parses github scheme webhook", async () => {
   const entry: WebhookConfigEntry = {
     route: "/hooks/ci",
     workflow: "deploy-pipeline",
     secret: "my-secret",
   };
-  const endpoint = parseWebhookConfig(entry);
+  const endpoint = await parseWebhookConfig(entry);
   assertEquals(endpoint.route, "/hooks/ci");
   assertEquals(endpoint.workflowIdOrName, "deploy-pipeline");
   assertEquals(endpoint.secret, "my-secret");
   assertEquals(endpoint.verifier, { scheme: "github" });
 });
 
-Deno.test("parseWebhookConfig: parses linear scheme webhook", () => {
+Deno.test("parseWebhookConfig: parses linear scheme webhook", async () => {
   const entry: WebhookConfigEntry = {
     route: "/hooks/linear",
     workflow: "triage",
     secret: "linear-secret",
     scheme: "linear",
   };
-  const endpoint = parseWebhookConfig(entry);
+  const endpoint = await parseWebhookConfig(entry);
   assertEquals(endpoint.verifier, { scheme: "linear" });
 });
 
-Deno.test("parseWebhookConfig: parses generic scheme with header and prefix", () => {
+Deno.test("parseWebhookConfig: parses generic scheme with header and prefix", async () => {
   const entry: WebhookConfigEntry = {
     route: "/hooks/custom",
     workflow: "process",
@@ -340,7 +340,7 @@ Deno.test("parseWebhookConfig: parses generic scheme with header and prefix", ()
     header: "X-Signature",
     prefix: "sha256=",
   };
-  const endpoint = parseWebhookConfig(entry);
+  const endpoint = await parseWebhookConfig(entry);
   assertEquals(endpoint.verifier, {
     scheme: "generic",
     header: "X-Signature",
@@ -486,10 +486,10 @@ Deno.test("mergeServeOptions: CLI webhooks replace config webhooks", () => {
     envLookup,
   );
   assertEquals(merged.webhook, ["/hooks/cli:cli-wf:cli-secret"]);
-  assertEquals(merged.webhookEndpoints, undefined);
+  assertEquals(merged.webhookConfigs, undefined);
 });
 
-Deno.test("mergeServeOptions: config webhooks used when no CLI webhooks", () => {
+Deno.test("mergeServeOptions: config webhooks passed as raw entries for deferred resolution", () => {
   const config: ServeConfigFile = {
     webhooks: [{
       route: "/hooks/config",
@@ -508,10 +508,10 @@ Deno.test("mergeServeOptions: config webhooks used when no CLI webhooks", () => 
     envLookup,
   );
   assertEquals(merged.webhook, undefined);
-  assertNotEquals(merged.webhookEndpoints, undefined);
-  assertEquals(merged.webhookEndpoints!.length, 1);
-  assertEquals(merged.webhookEndpoints![0].route, "/hooks/config");
-  assertEquals(merged.webhookEndpoints![0].workflowIdOrName, "config-wf");
+  assertNotEquals(merged.webhookConfigs, undefined);
+  assertEquals(merged.webhookConfigs!.length, 1);
+  assertEquals(merged.webhookConfigs![0].route, "/hooks/config");
+  assertEquals(merged.webhookConfigs![0].workflow, "config-wf");
 });
 
 Deno.test("mergeServeOptions: env var fallback works with no config file (backwards compat)", () => {

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -172,7 +172,8 @@ export async function resolveSecret(
     if (!vault) {
       throw new UserError(
         `Webhook secret references vault '${vaultName}' ` +
-          `(via ${VAULT_PREFIX}), but no vault service is available`,
+          `(via ${VAULT_PREFIX}), but no vault service is available. ` +
+          `Ensure a vault is configured in your repo (see 'swamp vault create')`,
       );
     }
     try {

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -110,8 +110,16 @@ export function buildWebhookPayload(
 
 const ENV_PREFIX = "@env=";
 const FILE_PREFIX = "@file=";
+const VAULT_PREFIX = "@vault=";
 
-export function resolveSecret(raw: string): string {
+export interface VaultSecretResolver {
+  get(vaultName: string, secretKey: string): Promise<string>;
+}
+
+export async function resolveSecret(
+  raw: string,
+  vault?: VaultSecretResolver,
+): Promise<string> {
   if (raw.startsWith(ENV_PREFIX)) {
     const varName = raw.slice(ENV_PREFIX.length);
     const value = Deno.env.get(varName);
@@ -142,6 +150,46 @@ export function resolveSecret(raw: string): string {
       );
     }
     return content;
+  }
+
+  if (raw.startsWith(VAULT_PREFIX)) {
+    const ref = raw.slice(VAULT_PREFIX.length);
+    const colonIdx = ref.indexOf(":");
+    if (colonIdx < 1) {
+      throw new UserError(
+        `Webhook secret uses ${VAULT_PREFIX} but the format is invalid: ` +
+          `expected '@vault=<vault-name>:<key>', got '${raw}'`,
+      );
+    }
+    const vaultName = ref.slice(0, colonIdx);
+    const secretKey = ref.slice(colonIdx + 1);
+    if (!secretKey) {
+      throw new UserError(
+        `Webhook secret uses ${VAULT_PREFIX} but the key is empty: ` +
+          `expected '@vault=<vault-name>:<key>', got '${raw}'`,
+      );
+    }
+    if (!vault) {
+      throw new UserError(
+        `Webhook secret references vault '${vaultName}' ` +
+          `(via ${VAULT_PREFIX}), but no vault service is available`,
+      );
+    }
+    try {
+      const value = await vault.get(vaultName, secretKey);
+      if (!value) {
+        throw new UserError(
+          `Vault '${vaultName}' returned an empty value for key '${secretKey}'`,
+        );
+      }
+      return value;
+    } catch (cause) {
+      if (cause instanceof UserError) throw cause;
+      throw new UserError(
+        `Webhook secret could not be resolved from vault '${vaultName}', ` +
+          `key '${secretKey}' (via ${VAULT_PREFIX}): ${cause}`,
+      );
+    }
   }
 
   return raw;
@@ -175,7 +223,10 @@ export interface WebhookEndpoint {
  * given, the remaining fields are positional: `generic` requires a header name
  * (fifth field) and accepts an optional value prefix (sixth field).
  */
-export function parseWebhookFlag(flag: string): WebhookEndpoint {
+export async function parseWebhookFlag(
+  flag: string,
+  vault?: VaultSecretResolver,
+): Promise<WebhookEndpoint> {
   const fields = flag.split(":");
   const usage =
     "expected '<route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]' " +
@@ -217,7 +268,7 @@ export function parseWebhookFlag(flag: string): WebhookEndpoint {
     verifier = { scheme: "github" };
   }
 
-  secret = resolveSecret(secret);
+  secret = await resolveSecret(secret, vault);
 
   if (!route || !workflowIdOrName || !secret) {
     throw new UserError(

--- a/src/serve/webhook_test.ts
+++ b/src/serve/webhook_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import {
   buildWebhookPayload,
   isSensitiveHeader,
@@ -25,6 +25,7 @@ import {
   resolveSecret,
   WebhookService,
 } from "./webhook.ts";
+import type { VaultSecretResolver } from "./webhook.ts";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 
 await initializeLogging({});
@@ -90,8 +91,8 @@ Deno.test("buildWebhookPayload: drops the scheme-specific signature header", () 
 
 // ── parseWebhookFlag ───────────────────────────────────────────────────
 
-Deno.test("parseWebhookFlag: parses valid flag", () => {
-  const result = parseWebhookFlag("/hooks/github:my-workflow:mysecret");
+Deno.test("parseWebhookFlag: parses valid flag", async () => {
+  const result = await parseWebhookFlag("/hooks/github:my-workflow:mysecret");
   assertEquals(result, {
     route: "/hooks/github",
     workflowIdOrName: "my-workflow",
@@ -100,13 +101,13 @@ Deno.test("parseWebhookFlag: parses valid flag", () => {
   });
 });
 
-Deno.test("parseWebhookFlag: three-field form defaults to github", () => {
-  const result = parseWebhookFlag("/hooks/gh:deploy:mysecret");
+Deno.test("parseWebhookFlag: three-field form defaults to github", async () => {
+  const result = await parseWebhookFlag("/hooks/gh:deploy:mysecret");
   assertEquals(result.verifier, { scheme: "github" });
 });
 
-Deno.test("parseWebhookFlag: secret can contain colons (legacy 3-field form)", () => {
-  const result = parseWebhookFlag(
+Deno.test("parseWebhookFlag: secret can contain colons (legacy 3-field form)", async () => {
+  const result = await parseWebhookFlag(
     "/hooks/gh:deploy:secret:with:colons",
   );
   assertEquals(result.route, "/hooks/gh");
@@ -115,25 +116,25 @@ Deno.test("parseWebhookFlag: secret can contain colons (legacy 3-field form)", (
   assertEquals(result.verifier, { scheme: "github" });
 });
 
-Deno.test("parseWebhookFlag: parses an explicit linear scheme", () => {
-  const result = parseWebhookFlag("/hooks/linear:wf:mysecret:linear");
+Deno.test("parseWebhookFlag: parses an explicit linear scheme", async () => {
+  const result = await parseWebhookFlag("/hooks/linear:wf:mysecret:linear");
   assertEquals(result.secret, "mysecret");
   assertEquals(result.verifier, { scheme: "linear" });
 });
 
-Deno.test("parseWebhookFlag: parses stripe and slack schemes", () => {
+Deno.test("parseWebhookFlag: parses stripe and slack schemes", async () => {
   assertEquals(
-    parseWebhookFlag("/hooks/s:wf:sec:stripe").verifier,
+    (await parseWebhookFlag("/hooks/s:wf:sec:stripe")).verifier,
     { scheme: "stripe" },
   );
   assertEquals(
-    parseWebhookFlag("/hooks/s:wf:sec:slack").verifier,
+    (await parseWebhookFlag("/hooks/s:wf:sec:slack")).verifier,
     { scheme: "slack" },
   );
 });
 
-Deno.test("parseWebhookFlag: parses generic scheme with header and prefix", () => {
-  const result = parseWebhookFlag(
+Deno.test("parseWebhookFlag: parses generic scheme with header and prefix", async () => {
+  const result = await parseWebhookFlag(
     "/hooks/x:wf:sec:generic:X-Signature:sha256=",
   );
   assertEquals(result.verifier, {
@@ -143,8 +144,8 @@ Deno.test("parseWebhookFlag: parses generic scheme with header and prefix", () =
   });
 });
 
-Deno.test("parseWebhookFlag: generic prefix defaults to empty", () => {
-  const result = parseWebhookFlag("/hooks/x:wf:sec:generic:X-Signature");
+Deno.test("parseWebhookFlag: generic prefix defaults to empty", async () => {
+  const result = await parseWebhookFlag("/hooks/x:wf:sec:generic:X-Signature");
   assertEquals(result.verifier, {
     scheme: "generic",
     header: "X-Signature",
@@ -152,64 +153,64 @@ Deno.test("parseWebhookFlag: generic prefix defaults to empty", () => {
   });
 });
 
-Deno.test("parseWebhookFlag: a non-scheme 4th field stays part of a colon-secret", () => {
+Deno.test("parseWebhookFlag: a non-scheme 4th field stays part of a colon-secret", async () => {
   // 'nope' is not a known scheme, so the legacy interpretation wins: the secret
   // is everything after the 2nd colon and the scheme defaults to github.
-  const result = parseWebhookFlag("/hooks/x:wf:sec:nope");
+  const result = await parseWebhookFlag("/hooks/x:wf:sec:nope");
   assertEquals(result.secret, "sec:nope");
   assertEquals(result.verifier, { scheme: "github" });
 });
 
-Deno.test("parseWebhookFlag: rejects generic without a header", () => {
-  assertThrows(
+Deno.test("parseWebhookFlag: rejects generic without a header", async () => {
+  await assertRejects(
     () => parseWebhookFlag("/hooks/x:wf:sec:generic"),
     Error,
     "'generic' scheme requires a header",
   );
 });
 
-Deno.test("parseWebhookFlag: rejects missing first colon", () => {
-  assertThrows(
+Deno.test("parseWebhookFlag: rejects missing first colon", async () => {
+  await assertRejects(
     () => parseWebhookFlag("/hooks/github"),
     Error,
     "Invalid --webhook format",
   );
 });
 
-Deno.test("parseWebhookFlag: rejects missing second colon", () => {
-  assertThrows(
+Deno.test("parseWebhookFlag: rejects missing second colon", async () => {
+  await assertRejects(
     () => parseWebhookFlag("/hooks/github:my-workflow"),
     Error,
     "Invalid --webhook format",
   );
 });
 
-Deno.test("parseWebhookFlag: rejects empty route", () => {
-  assertThrows(
+Deno.test("parseWebhookFlag: rejects empty route", async () => {
+  await assertRejects(
     () => parseWebhookFlag(":my-workflow:secret"),
     Error,
     "must all be non-empty",
   );
 });
 
-Deno.test("parseWebhookFlag: rejects empty workflow", () => {
-  assertThrows(
+Deno.test("parseWebhookFlag: rejects empty workflow", async () => {
+  await assertRejects(
     () => parseWebhookFlag("/hooks/github::secret"),
     Error,
     "must all be non-empty",
   );
 });
 
-Deno.test("parseWebhookFlag: rejects empty secret", () => {
-  assertThrows(
+Deno.test("parseWebhookFlag: rejects empty secret", async () => {
+  await assertRejects(
     () => parseWebhookFlag("/hooks/github:my-workflow:"),
     Error,
     "must all be non-empty",
   );
 });
 
-Deno.test("parseWebhookFlag: rejects route without leading slash", () => {
-  assertThrows(
+Deno.test("parseWebhookFlag: rejects route without leading slash", async () => {
+  await assertRejects(
     () => parseWebhookFlag("hooks/github:my-workflow:secret"),
     Error,
     "must start with '/'",
@@ -218,15 +219,15 @@ Deno.test("parseWebhookFlag: rejects route without leading slash", () => {
 
 // ── resolveSecret ─────────────────────────────────────────────────────
 
-Deno.test("resolveSecret: returns a literal string unchanged", () => {
-  assertEquals(resolveSecret("mysecretvalue"), "mysecretvalue");
+Deno.test("resolveSecret: returns a literal string unchanged", async () => {
+  assertEquals(await resolveSecret("mysecretvalue"), "mysecretvalue");
 });
 
-Deno.test("resolveSecret: reads from an environment variable via @env=", () => {
+Deno.test("resolveSecret: reads from an environment variable via @env=", async () => {
   Deno.env.set("TEST_WEBHOOK_SECRET_758", "env-secret-value");
   try {
     assertEquals(
-      resolveSecret("@env=TEST_WEBHOOK_SECRET_758"),
+      await resolveSecret("@env=TEST_WEBHOOK_SECRET_758"),
       "env-secret-value",
     );
   } finally {
@@ -234,19 +235,19 @@ Deno.test("resolveSecret: reads from an environment variable via @env=", () => {
   }
 });
 
-Deno.test("resolveSecret: throws for an unset environment variable", () => {
+Deno.test("resolveSecret: throws for an unset environment variable", async () => {
   Deno.env.delete("NONEXISTENT_WEBHOOK_VAR_758");
-  assertThrows(
+  await assertRejects(
     () => resolveSecret("@env=NONEXISTENT_WEBHOOK_VAR_758"),
     Error,
     "not set or is empty",
   );
 });
 
-Deno.test("resolveSecret: throws for an empty environment variable", () => {
+Deno.test("resolveSecret: throws for an empty environment variable", async () => {
   Deno.env.set("EMPTY_WEBHOOK_VAR_758", "");
   try {
-    assertThrows(
+    await assertRejects(
       () => resolveSecret("@env=EMPTY_WEBHOOK_VAR_758"),
       Error,
       "not set or is empty",
@@ -256,39 +257,39 @@ Deno.test("resolveSecret: throws for an empty environment variable", () => {
   }
 });
 
-Deno.test("resolveSecret: reads from a file via @file=", () => {
+Deno.test("resolveSecret: reads from a file via @file=", async () => {
   const tmpFile = Deno.makeTempFileSync();
   try {
     Deno.writeTextFileSync(tmpFile, "file-secret-value\n");
-    assertEquals(resolveSecret(`@file=${tmpFile}`), "file-secret-value");
+    assertEquals(await resolveSecret(`@file=${tmpFile}`), "file-secret-value");
   } finally {
     Deno.removeSync(tmpFile);
   }
 });
 
-Deno.test("resolveSecret: trims trailing CRLF from file", () => {
+Deno.test("resolveSecret: trims trailing CRLF from file", async () => {
   const tmpFile = Deno.makeTempFileSync();
   try {
     Deno.writeTextFileSync(tmpFile, "file-secret\r\n");
-    assertEquals(resolveSecret(`@file=${tmpFile}`), "file-secret");
+    assertEquals(await resolveSecret(`@file=${tmpFile}`), "file-secret");
   } finally {
     Deno.removeSync(tmpFile);
   }
 });
 
-Deno.test("resolveSecret: throws for a missing file", () => {
-  assertThrows(
+Deno.test("resolveSecret: throws for a missing file", async () => {
+  await assertRejects(
     () => resolveSecret("@file=/tmp/nonexistent-webhook-secret-758"),
     Error,
     "could not be read",
   );
 });
 
-Deno.test("resolveSecret: throws for an empty file", () => {
+Deno.test("resolveSecret: throws for an empty file", async () => {
   const tmpFile = Deno.makeTempFileSync();
   try {
     Deno.writeTextFileSync(tmpFile, "");
-    assertThrows(
+    await assertRejects(
       () => resolveSecret(`@file=${tmpFile}`),
       Error,
       "is empty",
@@ -298,11 +299,11 @@ Deno.test("resolveSecret: throws for an empty file", () => {
   }
 });
 
-Deno.test("resolveSecret: throws for a file containing only a newline", () => {
+Deno.test("resolveSecret: throws for a file containing only a newline", async () => {
   const tmpFile = Deno.makeTempFileSync();
   try {
     Deno.writeTextFileSync(tmpFile, "\n");
-    assertThrows(
+    await assertRejects(
       () => resolveSecret(`@file=${tmpFile}`),
       Error,
       "is empty",
@@ -310,14 +311,81 @@ Deno.test("resolveSecret: throws for a file containing only a newline", () => {
   } finally {
     Deno.removeSync(tmpFile);
   }
+});
+
+// ── resolveSecret: @vault= ──────────────────────────────────────────
+
+function createMockVault(
+  secrets: Record<string, Record<string, string>>,
+): VaultSecretResolver {
+  return {
+    get(vaultName: string, secretKey: string): Promise<string> {
+      const vault = secrets[vaultName];
+      if (!vault) {
+        return Promise.reject(new Error(`Vault '${vaultName}' not found`));
+      }
+      const value = vault[secretKey];
+      if (value === undefined) {
+        return Promise.reject(
+          new Error(`Key '${secretKey}' not found in vault '${vaultName}'`),
+        );
+      }
+      return Promise.resolve(value);
+    },
+  };
+}
+
+Deno.test("resolveSecret: resolves @vault= from vault service", async () => {
+  const vault = createMockVault({
+    forgejo: { "webhook-secret": "vault-value" },
+  });
+  assertEquals(
+    await resolveSecret("@vault=forgejo:webhook-secret", vault),
+    "vault-value",
+  );
+});
+
+Deno.test("resolveSecret: throws for @vault= with no vault service", async () => {
+  await assertRejects(
+    () => resolveSecret("@vault=forgejo:webhook-secret"),
+    Error,
+    "no vault service is available",
+  );
+});
+
+Deno.test("resolveSecret: throws for @vault= with missing colon separator", async () => {
+  const vault = createMockVault({});
+  await assertRejects(
+    () => resolveSecret("@vault=forgejo", vault),
+    Error,
+    "expected '@vault=<vault-name>:<key>'",
+  );
+});
+
+Deno.test("resolveSecret: throws for @vault= with empty key", async () => {
+  const vault = createMockVault({});
+  await assertRejects(
+    () => resolveSecret("@vault=forgejo:", vault),
+    Error,
+    "key is empty",
+  );
+});
+
+Deno.test("resolveSecret: throws for @vault= when vault get fails", async () => {
+  const vault = createMockVault({});
+  await assertRejects(
+    () => resolveSecret("@vault=nonexistent:key", vault),
+    Error,
+    "could not be resolved from vault",
+  );
 });
 
 // ── parseWebhookFlag with secret indirection ──────────────────────────
 
-Deno.test("parseWebhookFlag: resolves @env= secret in legacy form", () => {
+Deno.test("parseWebhookFlag: resolves @env= secret in legacy form", async () => {
   Deno.env.set("TEST_WH_SECRET_LEGACY_758", "resolved-secret");
   try {
-    const result = parseWebhookFlag(
+    const result = await parseWebhookFlag(
       "/hooks/gh:wf:@env=TEST_WH_SECRET_LEGACY_758",
     );
     assertEquals(result.secret, "resolved-secret");
@@ -327,10 +395,10 @@ Deno.test("parseWebhookFlag: resolves @env= secret in legacy form", () => {
   }
 });
 
-Deno.test("parseWebhookFlag: resolves @env= secret in scheme-qualified form", () => {
+Deno.test("parseWebhookFlag: resolves @env= secret in scheme-qualified form", async () => {
   Deno.env.set("TEST_WH_SECRET_SCHEME_758", "resolved-secret");
   try {
-    const result = parseWebhookFlag(
+    const result = await parseWebhookFlag(
       "/hooks/linear:wf:@env=TEST_WH_SECRET_SCHEME_758:linear",
     );
     assertEquals(result.secret, "resolved-secret");
@@ -340,11 +408,11 @@ Deno.test("parseWebhookFlag: resolves @env= secret in scheme-qualified form", ()
   }
 });
 
-Deno.test("parseWebhookFlag: resolves @file= secret", () => {
+Deno.test("parseWebhookFlag: resolves @file= secret", async () => {
   const tmpFile = Deno.makeTempFileSync();
   try {
     Deno.writeTextFileSync(tmpFile, "file-resolved\n");
-    const result = parseWebhookFlag(`/hooks/gh:wf:@file=${tmpFile}`);
+    const result = await parseWebhookFlag(`/hooks/gh:wf:@file=${tmpFile}`);
     assertEquals(result.secret, "file-resolved");
   } finally {
     Deno.removeSync(tmpFile);
@@ -353,18 +421,18 @@ Deno.test("parseWebhookFlag: resolves @file= secret", () => {
 
 // ── listEndpoints ─────────────────────────────────────────────────────
 
-Deno.test("listEndpoints: includes scheme from each endpoint verifier", () => {
+Deno.test("listEndpoints: includes scheme from each endpoint verifier", async () => {
   const service = new WebhookService({
     repoDir: "/tmp/fake",
     // deno-lint-ignore no-explicit-any
     repoContext: {} as any,
     // deno-lint-ignore no-explicit-any
     datastoreConfig: {} as any,
-    endpoints: [
+    endpoints: await Promise.all([
       parseWebhookFlag("/hooks/gh:deploy:secret"),
       parseWebhookFlag("/hooks/stripe:billing:secret:stripe"),
       parseWebhookFlag("/hooks/custom:wf:secret:generic:X-Sig:sha256="),
-    ],
+    ]),
   });
 
   const infos = service.listEndpoints();

--- a/src/serve/webhook_test.ts
+++ b/src/serve/webhook_test.ts
@@ -349,7 +349,7 @@ Deno.test("resolveSecret: throws for @vault= with no vault service", async () =>
   await assertRejects(
     () => resolveSecret("@vault=forgejo:webhook-secret"),
     Error,
-    "no vault service is available",
+    "no vault service is available. Ensure a vault is configured",
   );
 });
 


### PR DESCRIPTION
## Summary

- Adds `@vault=<vault-name>:<key>` support to webhook secret resolution, alongside the existing `@env=` and `@file=` prefixes
- Makes `resolveSecret` async and introduces a `VaultSecretResolver` interface so vault-managed secrets are resolved at serve startup
- Defers webhook config resolution from `mergeServeOptions` to the serve command's webhook initialization, where `VaultService` is available
- Any configured vault backend (local encryption, AWS Secrets Manager, etc.) works transparently

Closes swamp-club#1632

## Test Plan

- 5 new unit tests for `@vault=` resolution: happy path, no vault service, missing colon separator, empty key, vault get failure
- All 49 webhook tests pass (existing tests updated for async signatures)
- All 74 serve_config tests pass
- Full suite: 10,382 tests pass, 0 failures
- End-to-end verified in scratch repo with `local_encryption` vault — correct HMAC accepted, wrong HMAC rejected
- End-to-end verified with `@swamp/aws-sm` vault backed by ministack (AWS SM emulator) — secret resolved from remote store, HMAC verification works