### PR TITLE
fix(extensions): skip auto-resolution for internal model types (swamp-club#1676)

### DIFF
--- a/src/domain/extensions/extension_auto_resolver.ts
+++ b/src/domain/extensions/extension_auto_resolver.ts
@@ -488,11 +488,25 @@ export async function resolveModelType(
   await modelRegistry.ensureTypeLoaded(type);
   const def = modelRegistry.get(type);
   if (def) return def;
-  if (!resolver) return undefined;
 
+  // Internal types (swamp/grant, swamp/server-token, etc.) are registered
+  // without the @ prefix, but the CLI prefixes @ for direct type execution.
+  // Check the stripped form against the internal allow list before triggering
+  // auto-resolution — these types are compiled into the binary and must
+  // never cause a registry fetch.
   const normalized = typeof type === "string"
     ? ModelType.create(type).normalized
     : type.normalized;
+  if (normalized.startsWith("@")) {
+    const stripped = normalized.slice(1);
+    if (modelRegistry.isInternal(stripped)) {
+      await modelRegistry.ensureTypeLoaded(stripped);
+      const internalDef = modelRegistry.get(stripped);
+      if (internalDef) return internalDef;
+    }
+  }
+
+  if (!resolver) return undefined;
   const resolved = await resolver.resolve(normalized);
   if (resolved) return modelRegistry.get(type);
   return undefined;

--- a/src/domain/extensions/extension_auto_resolver_test.ts
+++ b/src/domain/extensions/extension_auto_resolver_test.ts
@@ -489,6 +489,48 @@ Deno.test("resolveModelType - returns undefined for unknown type without resolve
   assertEquals(result, undefined);
 });
 
+Deno.test("resolveModelType - finds internal type via @-prefixed lookup without auto-resolver", async () => {
+  const testType = ModelType.create("test-internal/grant-repro");
+  if (!modelRegistry.has(testType)) {
+    modelRegistry.register({
+      type: testType,
+      version: "2026.08.16.1",
+      methods: {
+        create: {
+          description: "test",
+          arguments: z.object({}),
+          execute: () => Promise.resolve({ dataHandles: [] }),
+        },
+      },
+    });
+  }
+  modelRegistry.markInternal("test-internal/grant-repro");
+
+  const result = await resolveModelType("@test-internal/grant-repro", null);
+  assertEquals(result !== undefined, true);
+  assertEquals(result?.type.normalized, "test-internal/grant-repro");
+});
+
+Deno.test("resolveModelType - does not strip @ for non-internal types", async () => {
+  const testType = ModelType.create("test-non-internal/widget");
+  if (!modelRegistry.has(testType)) {
+    modelRegistry.register({
+      type: testType,
+      version: "2026.08.16.1",
+      methods: {
+        run: {
+          description: "test",
+          arguments: z.object({}),
+          execute: () => Promise.resolve({ dataHandles: [] }),
+        },
+      },
+    });
+  }
+
+  const result = await resolveModelType("@test-non-internal/widget", null);
+  assertEquals(result, undefined);
+});
+
 Deno.test("resolveVaultType - returns true for existing vault type", async () => {
   // Register a test vault type if needed
   if (!vaultTypeRegistry.has("test-resolve-vault")) {


### PR DESCRIPTION
## Summary

- `resolveModelType` now checks `modelRegistry.isInternal()` for the `@`-stripped form before triggering auto-resolution, so built-in types like `swamp/grant` are found locally instead of hitting the extension registry
- Fixes `swamp access grant create` silently installing an unrelated extension (`@swamp/gcp/migrationcenter`) on every invocation

## Root Cause

The CLI prefixes `@` as a syntax marker for direct type execution (`@swamp/grant`), but internal types are registered without `@` (`swamp/grant`). The key mismatch caused `resolveModelType` to miss the built-in, fall through to the auto-resolver, search for `"grant"` in the registry, and install the first hit.

## Test Plan

- Added unit test: internal type registered without `@`, looked up with `@` prefix → found without auto-resolver
- Added unit test: non-internal type registered without `@`, looked up with `@` prefix → not found (auto-resolver would fire)
- Verified reproduction: `swamp access grant create` in a clean repo no longer installs extensions (compiled binary)
- All 10,385 tests pass

Fixes swamp-club#1676

🤖 Generated with [Claude Code](https://claude.com/claude-code)
