### PR TITLE
fix(access): use canonical model type for grant/group data storage (swamp-club#1682)

### DIFF
--- a/src/cli/commands/access_grant.ts
+++ b/src/cli/commands/access_grant.ts
@@ -76,9 +76,13 @@ export async function queryGrants(
     `modelType == "${GRANT_MODEL_TYPE.normalized}"`,
     { loadAttributes: true },
   );
+  const orphanedRecords = await repoContext.dataQueryService.query(
+    `modelType == "@${GRANT_MODEL_TYPE.normalized}"`,
+    { loadAttributes: true },
+  );
 
   const results: { grant: Grant; instanceName: string }[] = [];
-  for (const record of records) {
+  for (const record of [...records, ...orphanedRecords]) {
     const dataRecord = record as DataRecord;
     const parsed = GrantSchema.safeParse(dataRecord.attributes);
     if (parsed.success) {

--- a/src/cli/commands/access_group.ts
+++ b/src/cli/commands/access_group.ts
@@ -80,9 +80,13 @@ async function queryGroups(
     `modelType == "${GROUP_MODEL_TYPE.normalized}"`,
     { loadAttributes: true },
   );
+  const orphanedRecords = await repoContext.dataQueryService.query(
+    `modelType == "@${GROUP_MODEL_TYPE.normalized}"`,
+    { loadAttributes: true },
+  );
 
   const results: { group: Group; instanceName: string }[] = [];
-  for (const record of records) {
+  for (const record of [...records, ...orphanedRecords]) {
     const dataRecord = record as DataRecord;
     const parsed = GroupSchema.safeParse(dataRecord.attributes);
     if (parsed.success) {

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -359,6 +359,7 @@ export const workflowResumeCommand = withRemoteOptions(
       if (!modelDef) {
         throw new Error(`Unknown model type: ${resolvedType.normalized}`);
       }
+      resolvedType = modelDef.type;
       const autoDefRepo = new YamlDefinitionRepository(
         repoDir,
         undefined,

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -375,6 +375,7 @@ export const workflowRunCommand = new Command()
                 `Unknown model type: ${resolvedType.normalized}`,
               );
             }
+            resolvedType = modelDef.type;
             const autoDefRepo = new YamlDefinitionRepository(
               dir,
               undefined,

--- a/src/domain/access/admin_materializer.ts
+++ b/src/domain/access/admin_materializer.ts
@@ -32,7 +32,7 @@ import type { AuthMode } from "./serve_auth_config.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
 import { Definition } from "../definitions/definition.ts";
 import type { UnifiedDataRepository } from "../data/repositories.ts";
-import type { ModelType } from "../models/model_type.ts";
+import { ModelType } from "../models/model_type.ts";
 import { createResourceWriter } from "../models/data_writer.ts";
 
 const logger = getLogger(["swamp", "admin-materializer"]);
@@ -94,7 +94,13 @@ export function createAdminGrantStore(
 ): AdminGrantStore {
   return {
     async queryConfigGrants() {
-      const grantDataItems = await dataRepo.findAllForType(GRANT_MODEL_TYPE);
+      const [canonical, orphaned] = await Promise.all([
+        dataRepo.findAllForType(GRANT_MODEL_TYPE),
+        dataRepo.findAllForType(
+          ModelType.create(`@${GRANT_MODEL_TYPE.normalized}`),
+        ).catch(() => []),
+      ]);
+      const grantDataItems = [...canonical, ...orphaned];
 
       const configGrants = new Map<
         string,

--- a/src/domain/access/grant_file_reconciler.ts
+++ b/src/domain/access/grant_file_reconciler.ts
@@ -32,6 +32,7 @@ import type { MaterializeResult } from "./admin_materializer.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
 import { Definition } from "../definitions/definition.ts";
 import type { UnifiedDataRepository } from "../data/repositories.ts";
+import { ModelType } from "../models/model_type.ts";
 import { createResourceWriter } from "../models/data_writer.ts";
 
 const logger = getLogger(["swamp", "grant-file-reconciler"]);
@@ -247,7 +248,13 @@ export function createFileGrantStore(
 ): FileGrantStore {
   return {
     async queryFileGrants() {
-      const grantDataItems = await dataRepo.findAllForType(GRANT_MODEL_TYPE);
+      const [canonical, orphaned] = await Promise.all([
+        dataRepo.findAllForType(GRANT_MODEL_TYPE),
+        dataRepo.findAllForType(
+          ModelType.create(`@${GRANT_MODEL_TYPE.normalized}`),
+        ).catch(() => []),
+      ]);
+      const grantDataItems = [...canonical, ...orphaned];
 
       const fileGrants = new Map<
         string,

--- a/src/domain/access/policy_snapshot_loader.ts
+++ b/src/domain/access/policy_snapshot_loader.ts
@@ -38,7 +38,8 @@ import {
   GROUP_MODEL_TYPE,
   GroupSchema,
 } from "../models/access/group_model.ts";
-import type { ModelType } from "../models/model_type.ts";
+import { ModelType } from "../models/model_type.ts";
+import type { Data } from "../data/data.ts";
 import type { PrincipalContext } from "./principal_context.ts";
 import type { ConditionEvaluator } from "./policy_snapshot.ts";
 import { PolicySnapshot } from "./policy_snapshot.ts";
@@ -210,8 +211,8 @@ export class PolicySnapshotLoader {
     groupCount: number;
   }> {
     const [grantDataItems, groupDataItems] = await Promise.all([
-      this.#dataRepo.findAllForType(GRANT_MODEL_TYPE),
-      this.#dataRepo.findAllForType(GROUP_MODEL_TYPE),
+      this.#findAllIncludingOrphaned(GRANT_MODEL_TYPE),
+      this.#findAllIncludingOrphaned(GROUP_MODEL_TYPE),
     ]);
 
     const grants: Grant[] = [];
@@ -264,6 +265,20 @@ export class PolicySnapshotLoader {
         .warn`Skipping ${modelType.normalized}/${modelId}/${dataName}: failed to parse JSON content: ${error}`;
       return null;
     }
+  }
+
+  async #findAllIncludingOrphaned(
+    type: ModelType,
+  ): Promise<Array<{ data: Data; modelType: ModelType; modelId: string }>> {
+    const canonical = await this.#dataRepo.findAllForType(type);
+    const orphanedType = ModelType.create(`@${type.normalized}`);
+    let orphaned: Array<{ data: Data; modelType: ModelType; modelId: string }>;
+    try {
+      orphaned = await this.#dataRepo.findAllForType(orphanedType);
+    } catch {
+      orphaned = [];
+    }
+    return [...canonical, ...orphaned];
   }
 
   #scheduleRebuild(): void {

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -311,6 +311,13 @@ export async function* modelMethodRun(
             }
           }
 
+          // Use the model definition's canonical type so data is stored
+          // under the registered type path, not the caller's @-prefixed
+          // syntax marker (e.g. swamp/grant, not @swamp/grant).
+          if (resolvedModelDef) {
+            resolvedType = resolvedModelDef.type;
+          }
+
           if (!resolvedModelDef) {
             yield {
               kind: "error",

--- a/src/libswamp/models/run_test.ts
+++ b/src/libswamp/models/run_test.ts
@@ -671,6 +671,58 @@ Deno.test("modelMethodRun: direct execution resolves @-prefixed type from regist
   }
 });
 
+Deno.test("modelMethodRun: direct execution uses canonical type when getModelDef resolves @-prefixed internal type", async () => {
+  // Simulates the #1676 fix: getModelDef("@swamp/grant") returns the model def
+  // (because resolveModelType strips @ for internal types), but the model's
+  // canonical type is "swamp/grant" (without @). Data must be stored under
+  // the canonical type to be discoverable by findAllForType.
+  const canonicalType = ModelType.create("swamp/grant");
+  const modelDef: ModelDefinition = {
+    type: canonicalType,
+    version: "2026.06.17.1",
+    methods: {
+      create: {
+        description: "Create a grant",
+        arguments: z.object({}),
+        execute: (_args, _ctx) => Promise.resolve({ dataHandles: [] }),
+      },
+    },
+  };
+
+  const deps: ModelMethodRunDeps = {
+    ...createTestDeps(null, undefined),
+    getModelDef: (type) => {
+      const key = typeof type === "string"
+        ? ModelType.create(type).normalized
+        : type.normalized;
+      // Matches both "@swamp/grant" and "swamp/grant" — just like
+      // resolveModelType after the #1676 fix
+      if (key === "@swamp/grant" || key === "swamp/grant") return modelDef;
+      return undefined;
+    },
+    createAndSaveDefinition: async (_type, _def) => {},
+    getDefinitionPath: (_type, id) => `/tmp/auto/${id}.yaml`,
+  };
+
+  const ctx = createLibSwampContext();
+  const events = await collect(
+    modelMethodRun(ctx, deps, {
+      modelIdOrName: "@swamp/grant",
+      methodName: "create",
+      inputs: {},
+      lastEvaluated: false,
+      typeArg: "@swamp/grant",
+      definitionName: "grant-abc123",
+    }),
+  );
+
+  const autoCreated = events.find((e) => e.kind === "auto_created");
+  assertEquals(autoCreated !== undefined, true);
+  if (autoCreated && autoCreated.kind === "auto_created") {
+    assertEquals(autoCreated.modelType, "swamp/grant");
+  }
+});
+
 Deno.test("modelMethodRun: direct execution strips @ fallback for repo-local types", async () => {
   const localType = ModelType.create("sandbox/coder-server");
   const modelDef: ModelDefinition = {

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -142,6 +142,7 @@ export async function createWorkflowRunDeps(
         if (!modelDef) {
           throw new Error(`Unknown model type: ${resolvedType.normalized}`);
         }
+        resolvedType = modelDef.type;
         const autoDefRepo = new YamlDefinitionRepository(
           dir,
           repoContext.eventBus,

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -49,6 +49,7 @@ import {
   GRANT_MODEL_TYPE,
   GrantSchema,
 } from "../../domain/models/access/grant_model.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
 import {
   type Group,
   GROUP_MODEL_TYPE,
@@ -106,9 +107,13 @@ export async function handleAccessGrantList(
 
   try {
     await modelRegistry.ensureLoaded();
-    const dataItems = await ctx.repoContext.unifiedDataRepo.findAllForType(
-      GRANT_MODEL_TYPE,
-    );
+    const [canonicalItems, orphanedItems] = await Promise.all([
+      ctx.repoContext.unifiedDataRepo.findAllForType(GRANT_MODEL_TYPE),
+      ctx.repoContext.unifiedDataRepo.findAllForType(
+        ModelType.create(`@${GRANT_MODEL_TYPE.normalized}`),
+      ).catch(() => []),
+    ]);
+    const dataItems = [...canonicalItems, ...orphanedItems];
 
     let results: { grant: Grant; instanceName: string }[] = [];
     for (const { data, modelType, modelId } of dataItems) {
@@ -224,9 +229,13 @@ export async function handleAccessGroupList(
 
   try {
     await modelRegistry.ensureLoaded();
-    const dataItems = await ctx.repoContext.unifiedDataRepo.findAllForType(
-      GROUP_MODEL_TYPE,
-    );
+    const [canonicalGroupItems, orphanedGroupItems] = await Promise.all([
+      ctx.repoContext.unifiedDataRepo.findAllForType(GROUP_MODEL_TYPE),
+      ctx.repoContext.unifiedDataRepo.findAllForType(
+        ModelType.create(`@${GROUP_MODEL_TYPE.normalized}`),
+      ).catch(() => []),
+    ]);
+    const dataItems = [...canonicalGroupItems, ...orphanedGroupItems];
 
     let groups: Group[] = [];
     for (const { data, modelType, modelId } of dataItems) {


### PR DESCRIPTION
## Summary

- `modelMethodRun` now uses `resolvedModelDef.type` as the canonical model type
  instead of the caller's `@`-prefixed `typeArg`, fixing a regression from #2164
  where grant/group data was stored under `@swamp/grant` instead of `swamp/grant`
  — making it invisible to all readers and causing `--deny` grants to silently
  fail open
- Applied the same fix to all four direct-type-execution sites (`run.ts`,
  `serve/deps.ts`, `workflow_run.ts`, `workflow_resume.ts`)
- All grant and group data readers now also scan the `@`-prefixed path to recover
  data created during the regression window

## Root Cause

The #1676 fix (#2164) taught `resolveModelType` to handle `@`-prefixed internal
types, but `modelMethodRun` still used `ModelType.create(typeArg)` as
`resolvedType`. Since `resolveModelType` now succeeded with `@swamp/grant`, the
existing `@`-stripping fallback never fired, and data was written under the wrong
type directory.

## Test Plan

- [x] Added unit test reproducing the regression: `getModelDef` resolves both
  `@swamp/grant` and `swamp/grant` (simulating #1676 fix), asserts `auto_created`
  event emits the canonical `swamp/grant` type
- [x] All 10,408 existing tests pass
- [x] E2E verified with compiled binary against local `swamp serve`:
  - New grants stored under `swamp/grant/` (correct)
  - Orphaned grants under `@swamp/grant/` (from buggy build) found by recovery
    code
  - `access check` enforces both canonical and orphaned deny grants
  - `grant list` shows both canonical and orphaned grants
- [x] Verified #1676 fix is preserved (`resolveModelType` code untouched)

Fixes swamp-club#1682

🤖 Generated with [Claude Code](https://claude.com/claude-code)