### PR TITLE
feat(workflows): support labels/target/platform at job and workflow level

### DIFF
--- a/.claude/skills/swamp/references/workflow/references/remote-execution.md
+++ b/.claude/skills/swamp/references/workflow/references/remote-execution.md
@@ -36,8 +36,40 @@ inspect the pool with `swamp worker list`.
 
 ## Placing steps on workers
 
-A step declaring any placement field dispatches to a matching worker instead of
-running locally; steps without placement are unaffected:
+Placement fields (`target`, `labels`, `platform`, `queueTimeout`) can be set at
+the **workflow**, **job**, or **step** level. Steps without any effective
+placement run locally; steps with placement dispatch to a matching worker.
+
+Inheritance: workflow-level placement applies to all steps as a default,
+job-level overrides workflow, step-level overrides job. An explicit empty value
+(e.g., `labels: {}`) clears inherited placement for that field.
+
+```yaml
+name: deploy-pipeline
+labels:
+  pool: gke
+  fleet: platform-fleet-v3
+
+jobs:
+  - name: build
+    steps:
+      - name: compile
+        task: ... # inherits workflow labels
+      - name: test
+        task: ... # inherits workflow labels
+  - name: report
+    labels: {} # override: run all steps locally
+    steps:
+      - name: summarize
+        task: ... # no placement — runs locally
+  - name: gpu-work
+    steps:
+      - name: train
+        target: gpu-box-1 # step overrides: pin to specific worker
+        task: ...
+```
+
+Step-level placement:
 
 ```yaml
 steps:
@@ -56,11 +88,6 @@ Matching order: `target` → `labels` → `platform`; idle eligible workers win,
 all-busy queues the step, and no eligible worker fails the step fast. `forEach`
 is the fan-out construct — expand a step over a list and the instances spread
 across matching workers (each worker runs one dispatch at a time).
-
-Placement fields are step properties only. Placing them on a job or at the
-workflow top level fails schema validation with an error naming the misplaced
-key and showing the step-level form — as does any other unknown key (with a
-did-you-mean suggestion).
 
 ## Running workflows through the orchestrator
 

--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -887,9 +887,13 @@ dispatches at the **step** granularity, which is what yields fan-out *across*
 workers; shipping a whole workflow to one worker is just the degenerate
 single-worker case.
 
-A step declares its requirements in workflow YAML with three new fields —
+A step declares its requirements in workflow YAML with three placement fields —
 `target:` (worker name or `instanceUuid`), `labels:` (selector map), and
-`platform:` — alongside the existing step fields; none of these exist today.
+`platform:`. These fields can be set at the **workflow**, **job**, or **step**
+level with inheritance: workflow-level placement applies to all steps as a
+default, job-level overrides workflow, and step-level overrides job. An explicit
+empty value (e.g., `labels: {}`) at any level clears the inherited value,
+causing the step to run locally. Omitting a field inherits from the parent.
 **`forEach` is the fan-out construct**: it already expands one step template
 into N parallel instances (`ForEachExpansionService`), so `forEach` over a list
 plus a label selector *is* "fan out across the fleet," with the existing

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -369,11 +369,11 @@ actionable error (swamp-club#1240). Zod's default unknown-key stripping is
 disabled by a `rejectUnknownKeys` preprocess hook (chained after the
 removed-driver-fields guard, which keeps its specific migration message):
 
-- A step-level placement property (`labels`, `target`, `platform`,
-  `queueTimeout`) found on a job or workflow names the misplaced key and shows
-  the step-level form. Silent stripping here failed open: the placement intent
-  was discarded and the work ran on the orchestrator.
-- Any other unknown key gets a did-you-mean suggestion (Levenshtein) plus the
+- Placement properties (`labels`, `target`, `platform`, `queueTimeout`) are
+  valid at the workflow, job, and step level (swamp-club#1685). Workflow-level
+  placement applies to all steps as a default, job-level overrides workflow,
+  and step-level overrides job.
+- Any unknown key gets a did-you-mean suggestion (Levenshtein) plus the
   list of valid keys for that entity.
 
 Because a schema-rejected file is invisible to the repository loader (it is

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -20,6 +20,7 @@
 import type { Workflow } from "./workflow.ts";
 import type { Job } from "./job.ts";
 import { Step } from "./step.ts";
+import { mergePlacementFields, resolvePlacement } from "./placement.ts";
 import { StepTask } from "./step_task.ts";
 import type { AssertSeverity } from "./step_task.ts";
 import { severityAtOrAbove } from "./assert_severity.ts";
@@ -297,6 +298,10 @@ export interface StepExecutionContext {
   workflowRunRepo?: WorkflowRunRepository;
   workflowGateService?:
     import("../models/workflow_gate_service.ts").WorkflowGateService;
+  /** Workflow-level placement defaults (inherited by all steps unless overridden) */
+  workflowPlacement?: import("./placement.ts").PlacementFields;
+  /** Job-level placement defaults (inherited by steps in this job unless overridden) */
+  jobPlacement?: import("./placement.ts").PlacementFields;
 }
 
 /**
@@ -560,13 +565,23 @@ export class DefaultStepExecutor implements StepExecutor {
       executionService.workflowGateService = ctx.workflowGateService;
     }
 
+    // Compute effective placement by merging workflow → job → step defaults.
+    // Each level inherits from its parent; explicit values (including {})
+    // override inherited ones. The merge happens here — after forEach
+    // expansion but before expression resolution — so inherited fields are
+    // available for expression resolution.
+    const effectiveFields = mergePlacementFields(
+      mergePlacementFields(ctx.workflowPlacement, ctx.jobPlacement),
+      ctx.step?.placementFields,
+    );
+    let resolvedPlacement = resolvePlacement(effectiveFields);
+
     // Resolve every available expression (self.* from the forEach variable,
     // run.*, etc.) anywhere in the task and placement fields before model
     // lookup. The expression context has self populated with the forEach
     // variable by runStep(). resolveAvailableExpressions defers vault/env and
     // step-output kinds to their dedicated stages — see
     // available_expression_resolver.ts.
-    let resolvedPlacement = ctx.step?.placement;
     if (ctx.expressionContext) {
       const celEvaluator = new CelEvaluator();
       const evaluate = (expr: string, context: Record<string, unknown>) =>
@@ -3013,6 +3028,8 @@ export class WorkflowExecutionService {
           workflowRepo: this.workflowRepo,
           workflowRunRepo: this.runRepo,
           workflowGateService: this.workflowGateService,
+          workflowPlacement: workflow.placementFields,
+          jobPlacement: job.placementFields,
         };
         return this.executor.execute(step, ctx);
       });

--- a/src/domain/workflows/job.ts
+++ b/src/domain/workflows/job.ts
@@ -26,6 +26,7 @@ import {
 import { Step, type StepData, StepSchema } from "./step.ts";
 import { rejectRemovedDriverFields } from "../removed_driver_fields.ts";
 import { rejectUnknownKeys } from "./unknown_keys.ts";
+import { type PlacementFields, PlacementFieldsSchema } from "./placement.ts";
 
 /**
  * Schema for job dependency with condition.
@@ -68,6 +69,7 @@ const JobObjectSchema = z.object({
   dependsOn: JobDependencyFieldSchema,
   weight: z.number().default(0),
   concurrency: z.number().int().nonnegative().optional(),
+  ...PlacementFieldsSchema.shape,
 });
 
 /**
@@ -112,6 +114,10 @@ export interface CreateJobProps {
   dependsOn?: JobDependency[];
   weight?: number;
   concurrency?: number;
+  target?: string;
+  labels?: Record<string, string>;
+  platform?: string;
+  queueTimeout?: number;
 }
 
 /**
@@ -132,6 +138,10 @@ export class Job {
     private _dependsOn: JobDependency[],
     readonly weight: number,
     readonly concurrency: number | undefined,
+    readonly target: string | undefined,
+    readonly labels: Record<string, string> | undefined,
+    readonly platform: string | undefined,
+    readonly queueTimeout: number | undefined,
   ) {}
 
   /**
@@ -152,6 +162,10 @@ export class Job {
       })),
       weight: props.weight ?? 0,
       concurrency: props.concurrency,
+      target: props.target,
+      labels: props.labels,
+      platform: props.platform,
+      queueTimeout: props.queueTimeout,
     });
 
     return Job.fromData(data);
@@ -175,6 +189,10 @@ export class Job {
       dependsOn,
       validated.weight,
       validated.concurrency,
+      validated.target,
+      validated.labels,
+      validated.platform,
+      validated.queueTimeout,
     );
   }
 
@@ -206,6 +224,15 @@ export class Job {
     return this._steps.find((s) => s.name === name);
   }
 
+  get placementFields(): PlacementFields {
+    return {
+      target: this.target,
+      labels: this.labels,
+      platform: this.platform,
+      queueTimeout: this.queueTimeout,
+    };
+  }
+
   /**
    * Converts to plain data for persistence.
    */
@@ -220,6 +247,10 @@ export class Job {
       })),
       weight: this.weight,
       concurrency: this.concurrency,
+      target: this.target,
+      labels: this.labels,
+      platform: this.platform,
+      queueTimeout: this.queueTimeout,
     };
   }
 }

--- a/src/domain/workflows/job_test.ts
+++ b/src/domain/workflows/job_test.ts
@@ -238,31 +238,99 @@ Deno.test("Job.fromData and toData roundtrip correctly", () => {
   assertEquals(restored.weight, original.weight);
 });
 
-// Unknown-key rejection tests (swamp-club#1240)
+// Placement inheritance tests (swamp-club#1685)
 
-Deno.test("JobSchema rejects job-level labels with step-property message", () => {
-  // Exact shape from swamp-club#1240 variant A: the labels block sits on
-  // the job, which previously passed and was silently dropped.
-  const error = assertThrows(
-    () =>
-      JobSchema.parse({
-        name: "placed",
-        labels: { fb28: "probe" },
-        steps: [{
-          name: "echo",
-          task: {
-            type: "model_method",
-            modelIdOrName: "fb28-probe",
-            methodName: "execute",
-            inputs: { run: 'echo "hello"' },
-          },
-        }],
-      }),
-    Error,
-  );
-  assertStringIncludes(error.message, "'labels' is a step property");
-  assertStringIncludes(error.message, "job 'placed'");
-  assertStringIncludes(error.message, "Move it onto the step");
+Deno.test("JobSchema accepts job-level placement fields", () => {
+  const data = JobSchema.parse({
+    name: "placed",
+    labels: { pool: "gke", fleet: "v3" },
+    target: "worker-1",
+    platform: "linux/amd64",
+    queueTimeout: 30,
+    steps: [{
+      name: "echo",
+      task: {
+        type: "model_method",
+        modelIdOrName: "my-model",
+        methodName: "run",
+      },
+    }],
+  });
+  assertEquals(data.labels, { pool: "gke", fleet: "v3" });
+  assertEquals(data.target, "worker-1");
+  assertEquals(data.platform, "linux/amd64");
+  assertEquals(data.queueTimeout, 30);
+});
+
+Deno.test("Job placement: round-trips through toData/fromData", () => {
+  const job = Job.fromData({
+    name: "remote-job",
+    labels: { env: "prod", region: "us-east" },
+    platform: "linux",
+    steps: [{
+      name: "step1",
+      task: {
+        type: "model_method" as const,
+        modelIdOrName: "my-model",
+        methodName: "run",
+      },
+    }],
+  });
+  assertEquals(job.labels, { env: "prod", region: "us-east" });
+  assertEquals(job.platform, "linux");
+  assertEquals(job.target, undefined);
+
+  const data = job.toData();
+  assertEquals(data.labels, { env: "prod", region: "us-east" });
+  assertEquals(data.platform, "linux");
+
+  const restored = Job.fromData(data);
+  assertEquals(restored.labels, job.labels);
+  assertEquals(restored.platform, job.platform);
+});
+
+Deno.test("Job placementFields: returns all placement fields", () => {
+  const job = Job.fromData({
+    name: "placed",
+    target: "w1",
+    labels: { env: "prod" },
+    platform: "linux",
+    queueTimeout: 60,
+    steps: [{
+      name: "step1",
+      task: {
+        type: "model_method" as const,
+        modelIdOrName: "my-model",
+        methodName: "run",
+      },
+    }],
+  });
+  assertEquals(job.placementFields, {
+    target: "w1",
+    labels: { env: "prod" },
+    platform: "linux",
+    queueTimeout: 60,
+  });
+});
+
+Deno.test("Job placement: undefined when not set", () => {
+  const job = Job.fromData({
+    name: "local-job",
+    steps: [{
+      name: "step1",
+      task: {
+        type: "model_method" as const,
+        modelIdOrName: "my-model",
+        methodName: "run",
+      },
+    }],
+  });
+  assertEquals(job.placementFields, {
+    target: undefined,
+    labels: undefined,
+    platform: undefined,
+    queueTimeout: undefined,
+  });
 });
 
 Deno.test("JobSchema rejects unknown key with did-you-mean suggestion", () => {

--- a/src/domain/workflows/placement.ts
+++ b/src/domain/workflows/placement.ts
@@ -1,0 +1,83 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+
+export const PlacementFieldsSchema = z.object({
+  target: z.string().optional(),
+  labels: z.record(z.string(), z.string()).optional(),
+  platform: z.string().optional(),
+  queueTimeout: z.number().nonnegative().optional(),
+});
+
+export type PlacementFields = z.infer<typeof PlacementFieldsSchema>;
+
+export interface ResolvedPlacement {
+  target?: string;
+  labels?: Record<string, string>;
+  platform?: string;
+  queueTimeoutMs?: number;
+}
+
+/**
+ * Merges placement layers with child-wins semantics: for each field,
+ * if the child's value is undefined (omitted), inherit from parent;
+ * if the child's value is anything else (including explicit {} for labels),
+ * use the child's value.
+ */
+export function mergePlacementFields(
+  parent: PlacementFields | undefined,
+  child: PlacementFields | undefined,
+): PlacementFields | undefined {
+  if (parent === undefined && child === undefined) return undefined;
+  if (parent === undefined) return child;
+  if (child === undefined) return parent;
+  return {
+    target: child.target !== undefined ? child.target : parent.target,
+    labels: child.labels !== undefined ? child.labels : parent.labels,
+    platform: child.platform !== undefined ? child.platform : parent.platform,
+    queueTimeout: child.queueTimeout !== undefined
+      ? child.queueTimeout
+      : parent.queueTimeout,
+  };
+}
+
+/**
+ * Resolves merged placement fields into the dispatching form, or undefined
+ * when no placement is active (step runs on the loopback executor).
+ */
+export function resolvePlacement(
+  fields: PlacementFields | undefined,
+): ResolvedPlacement | undefined {
+  if (fields === undefined) return undefined;
+  if (
+    fields.target === undefined && fields.platform === undefined &&
+    (fields.labels === undefined || Object.keys(fields.labels).length === 0)
+  ) {
+    return undefined;
+  }
+  return {
+    target: fields.target,
+    labels: fields.labels,
+    platform: fields.platform,
+    queueTimeoutMs: fields.queueTimeout !== undefined
+      ? fields.queueTimeout * 1000
+      : undefined,
+  };
+}

--- a/src/domain/workflows/placement_test.ts
+++ b/src/domain/workflows/placement_test.ts
@@ -1,0 +1,138 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { mergePlacementFields, resolvePlacement } from "./placement.ts";
+
+Deno.test("mergePlacementFields: both undefined returns undefined", () => {
+  assertEquals(mergePlacementFields(undefined, undefined), undefined);
+});
+
+Deno.test("mergePlacementFields: parent only returns parent", () => {
+  const parent = { target: "w1", labels: { env: "prod" } };
+  assertEquals(mergePlacementFields(parent, undefined), parent);
+});
+
+Deno.test("mergePlacementFields: child only returns child", () => {
+  const child = { target: "w2", platform: "linux" };
+  assertEquals(mergePlacementFields(undefined, child), child);
+});
+
+Deno.test("mergePlacementFields: child overrides parent per-field", () => {
+  const parent = {
+    target: "w1",
+    labels: { env: "prod", region: "us-east" },
+    platform: "linux",
+    queueTimeout: 60,
+  };
+  const child = { labels: { env: "staging" } };
+  const merged = mergePlacementFields(parent, child);
+  assertEquals(merged, {
+    target: "w1",
+    labels: { env: "staging" },
+    platform: "linux",
+    queueTimeout: 60,
+  });
+});
+
+Deno.test("mergePlacementFields: child undefined fields inherit from parent", () => {
+  const parent = { target: "w1", labels: { env: "prod" } };
+  const child = { platform: "darwin" };
+  const merged = mergePlacementFields(parent, child);
+  assertEquals(merged, {
+    target: "w1",
+    labels: { env: "prod" },
+    platform: "darwin",
+    queueTimeout: undefined,
+  });
+});
+
+Deno.test("mergePlacementFields: explicit empty labels clears inherited labels", () => {
+  const parent = { labels: { env: "prod", region: "us-east" } };
+  const child = { labels: {} };
+  const merged = mergePlacementFields(parent, child);
+  assertEquals(merged?.labels, {});
+});
+
+Deno.test("mergePlacementFields: three-level merge (workflow → job → step)", () => {
+  const workflow = { labels: { pool: "gke", fleet: "v3" }, platform: "linux" };
+  const job = { labels: { pool: "gke", fleet: "v4" } };
+  const step = { target: "special-worker" };
+
+  const jobEffective = mergePlacementFields(workflow, job);
+  const stepEffective = mergePlacementFields(jobEffective, step);
+
+  assertEquals(stepEffective, {
+    target: "special-worker",
+    labels: { pool: "gke", fleet: "v4" },
+    platform: "linux",
+    queueTimeout: undefined,
+  });
+});
+
+Deno.test("mergePlacementFields: job clears all placement with empty overrides", () => {
+  const workflow = {
+    target: "w1",
+    labels: { pool: "gke" },
+    platform: "linux",
+    queueTimeout: 30,
+  };
+  const job = { labels: {} };
+  const step = {};
+
+  const jobEffective = mergePlacementFields(workflow, job);
+  const stepEffective = mergePlacementFields(jobEffective, step);
+
+  assertEquals(stepEffective?.labels, {});
+  assertEquals(stepEffective?.target, "w1");
+});
+
+Deno.test("resolvePlacement: undefined fields returns undefined", () => {
+  assertEquals(resolvePlacement(undefined), undefined);
+});
+
+Deno.test("resolvePlacement: empty labels and no target/platform returns undefined", () => {
+  assertEquals(resolvePlacement({ labels: {} }), undefined);
+  assertEquals(resolvePlacement({}), undefined);
+});
+
+Deno.test("resolvePlacement: converts queueTimeout seconds to milliseconds", () => {
+  const result = resolvePlacement({ target: "w1", queueTimeout: 30 });
+  assertEquals(result?.queueTimeoutMs, 30_000);
+});
+
+Deno.test("resolvePlacement: target alone produces placement", () => {
+  const result = resolvePlacement({ target: "w1" });
+  assertEquals(result, {
+    target: "w1",
+    labels: undefined,
+    platform: undefined,
+    queueTimeoutMs: undefined,
+  });
+});
+
+Deno.test("resolvePlacement: labels alone produces placement", () => {
+  const result = resolvePlacement({ labels: { env: "prod" } });
+  assertEquals(result, {
+    target: undefined,
+    labels: { env: "prod" },
+    platform: undefined,
+    queueTimeoutMs: undefined,
+  });
+});

--- a/src/domain/workflows/step.ts
+++ b/src/domain/workflows/step.ts
@@ -28,6 +28,12 @@ import { DataOutputOverrideSchema } from "../models/data_output_override.ts";
 import type { DataOutputOverride } from "../models/data_output_override.ts";
 import { rejectRemovedDriverFields } from "../removed_driver_fields.ts";
 import { rejectUnknownKeys } from "./unknown_keys.ts";
+import {
+  type PlacementFields,
+  PlacementFieldsSchema,
+  type ResolvedPlacement,
+  resolvePlacement,
+} from "./placement.ts";
 
 /**
  * Schema for step dependency with condition.
@@ -86,13 +92,7 @@ const StepObjectSchema = z.object({
   concurrency: z.number().int().nonnegative().optional(),
   dataOutputOverrides: z.array(DataOutputOverrideSchema).optional(),
   allowFailure: z.boolean().default(false),
-  // Remote-execution placement (see design/remote-execution.md): a step
-  // declaring any of these dispatches to a matching worker instead of the
-  // loopback executor.
-  target: z.string().optional(),
-  labels: z.record(z.string(), z.string()).optional(),
-  platform: z.string().optional(),
-  queueTimeout: z.number().nonnegative().optional(),
+  ...PlacementFieldsSchema.shape,
   guard: z.string().optional(),
 });
 
@@ -320,31 +320,22 @@ export class Step {
     };
   }
 
-  /**
-   * The step's remote-execution placement, or undefined when it has none —
-   * placement-free steps run on the loopback executor.
-   */
-  get placement():
-    | {
-      target?: string;
-      labels?: Record<string, string>;
-      platform?: string;
-      queueTimeoutMs?: number;
-    }
-    | undefined {
-    if (
-      this.target === undefined && this.platform === undefined &&
-      (this.labels === undefined || Object.keys(this.labels).length === 0)
-    ) {
-      return undefined;
-    }
+  get placementFields(): PlacementFields {
     return {
       target: this.target,
       labels: this.labels,
       platform: this.platform,
-      queueTimeoutMs: this.queueTimeout !== undefined
-        ? this.queueTimeout * 1000
-        : undefined,
+      queueTimeout: this.queueTimeout,
     };
+  }
+
+  /**
+   * The step's own remote-execution placement, or undefined when it has none —
+   * placement-free steps run on the loopback executor. Does not include
+   * inherited placement from job or workflow; use resolvePlacement with
+   * mergePlacementFields for the effective placement.
+   */
+  get placement(): ResolvedPlacement | undefined {
+    return resolvePlacement(this.placementFields);
   }
 }

--- a/src/domain/workflows/unknown_keys.ts
+++ b/src/domain/workflows/unknown_keys.ts
@@ -36,38 +36,10 @@ import { findClosestMatch } from "../string_distance.ts";
 export type WorkflowEntity = "workflow" | "job" | "step";
 
 /**
- * Step-level remote-placement properties (see design/remote-execution.md).
- * Misplacing these on a job or workflow is the dangerous authoring mistake:
- * the placement intent is silently dropped and the step runs locally.
- */
-const STEP_PLACEMENT_KEYS = ["labels", "target", "platform", "queueTimeout"];
-
-/**
  * Fields owned by rejectRemovedDriverFields, which runs before this hook
  * and produces its own migration message.
  */
 const REMOVED_DRIVER_FIELDS = ["driver", "driverConfig"];
-
-/**
- * Builds the error message for a step placement property found on a
- * workflow or job.
- */
-export function misplacedPlacementKeyMessage(
-  field: string,
-  entity: WorkflowEntity,
-  entityName: string | undefined,
-): string {
-  const where = entityName ? `${entity} '${entityName}'` : `a ${entity}`;
-  return `'${field}' is a step property, not a ${entity} property — ` +
-    `remote placement is declared per step (see design/remote-execution.md). ` +
-    `The key was found on ${where}.\n\n` +
-    `Move it onto the step:\n` +
-    `  steps:\n` +
-    `    - name: <step-name>\n` +
-    `      ${field}: ...\n` +
-    `      task:\n` +
-    `        ...`;
-}
 
 /**
  * Builds the error message for an unknown key, with a did-you-mean
@@ -109,11 +81,6 @@ export function rejectUnknownKeys(
     for (const field of Object.keys(record)) {
       if (known.has(field) || REMOVED_DRIVER_FIELDS.includes(field)) {
         continue;
-      }
-      if (entity !== "step" && STEP_PLACEMENT_KEYS.includes(field)) {
-        throw new Error(
-          misplacedPlacementKeyMessage(field, entity, entityName),
-        );
       }
       throw new Error(unknownKeyMessage(field, entity, entityName, knownKeys));
     }

--- a/src/domain/workflows/unknown_keys_test.ts
+++ b/src/domain/workflows/unknown_keys_test.ts
@@ -27,6 +27,10 @@ const JOB_KEYS = [
   "dependsOn",
   "weight",
   "concurrency",
+  "target",
+  "labels",
+  "platform",
+  "queueTimeout",
 ];
 
 Deno.test("rejectUnknownKeys: passes through objects with only known keys", () => {
@@ -45,26 +49,32 @@ Deno.test("rejectUnknownKeys: passes through non-object values", () => {
   assertEquals(hook(arr), arr);
 });
 
-Deno.test("rejectUnknownKeys: rejects job-level labels as a misplaced step property", () => {
+Deno.test("rejectUnknownKeys: accepts placement keys on job", () => {
   const hook = rejectUnknownKeys("job", JOB_KEYS);
-  const error = assertThrows(
-    () => hook({ name: "placed", labels: { fb28: "probe" }, steps: [] }),
-    Error,
-  );
-  assertStringIncludes(error.message, "'labels' is a step property");
-  assertStringIncludes(error.message, "job 'placed'");
-  assertStringIncludes(error.message, "Move it onto the step");
+  const data = {
+    name: "placed",
+    labels: { fb28: "probe" },
+    target: "w1",
+    platform: "linux",
+    queueTimeout: 30,
+    steps: [],
+  };
+  assertEquals(hook(data), data);
 });
 
-Deno.test("rejectUnknownKeys: rejects all placement keys on non-step entities", () => {
-  const hook = rejectUnknownKeys("workflow", ["name", "jobs"]);
+Deno.test("rejectUnknownKeys: accepts placement keys on workflow", () => {
+  const WORKFLOW_KEYS = [
+    "name",
+    "jobs",
+    "target",
+    "labels",
+    "platform",
+    "queueTimeout",
+  ];
+  const hook = rejectUnknownKeys("workflow", WORKFLOW_KEYS);
   for (const key of ["labels", "target", "platform", "queueTimeout"]) {
-    const error = assertThrows(
-      () => hook({ name: "wf", jobs: [], [key]: "x" }),
-      Error,
-    );
-    assertStringIncludes(error.message, `'${key}' is a step property`);
-    assertStringIncludes(error.message, "workflow 'wf'");
+    const data = { name: "wf", jobs: [], [key]: "x" };
+    assertEquals(hook(data), data);
   }
 });
 
@@ -90,7 +100,7 @@ Deno.test("rejectUnknownKeys: unknown key without close match lists valid keys",
   assertStringIncludes(error.message, "Unknown key 'zzz_bogus_zzz'");
   assertStringIncludes(
     error.message,
-    "Valid job keys: name, description, steps, dependsOn, weight, concurrency",
+    "Valid job keys: name, description, steps, dependsOn, weight, concurrency, target, labels, platform, queueTimeout",
   );
 });
 
@@ -105,8 +115,8 @@ Deno.test("rejectUnknownKeys: leaves driver/driverConfig for the removed-fields 
 Deno.test("rejectUnknownKeys: omits entity name when data has no string name", () => {
   const hook = rejectUnknownKeys("job", JOB_KEYS);
   const error = assertThrows(
-    () => hook({ steps: [], labels: {} }),
+    () => hook({ steps: [], zzz_bogus: true }),
     Error,
   );
-  assertStringIncludes(error.message, "found on a job");
+  assertStringIncludes(error.message, "Unknown key 'zzz_bogus' on job");
 });

--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -20,6 +20,7 @@
 import type { Workflow } from "./workflow.ts";
 import { WorkflowSchema } from "./workflow.ts";
 import type { WorkflowRepository } from "./repositories.ts";
+import { mergePlacementFields, resolvePlacement } from "./placement.ts";
 import { createWorkflowId } from "./workflow_id.ts";
 import {
   CyclicDependencyError,
@@ -183,11 +184,23 @@ export class DefaultWorkflowValidationService
     const results: WorkflowValidationResult[] = [];
     for (const job of workflow.jobs) {
       for (const step of job.steps) {
-        if (step.queueTimeout !== undefined && step.placement === undefined) {
+        const effectiveFields = mergePlacementFields(
+          mergePlacementFields(
+            workflow.placementFields,
+            job.placementFields,
+          ),
+          step.placementFields,
+        );
+        const effectiveQueueTimeout = step.queueTimeout ??
+          job.queueTimeout ?? workflow.queueTimeout;
+        if (
+          effectiveQueueTimeout !== undefined &&
+          resolvePlacement(effectiveFields) === undefined
+        ) {
           results.push(
             WorkflowValidationResult.warning(
               `queueTimeout without placement in job '${job.name}' step '${step.name}'`,
-              `Step '${step.name}' sets queueTimeout but has no target, labels, or platform — ` +
+              `Step '${step.name}' has queueTimeout (directly or inherited) but no effective target, labels, or platform — ` +
                 `queueTimeout only applies to remote-execution steps with placement requirements`,
             ),
           );

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -1704,6 +1704,56 @@ Deno.test("validate: no warning when queueTimeout is set with placement", async 
   assertEquals(warning, undefined);
 });
 
+Deno.test("validate: no warning when queueTimeout is on step but placement is inherited from job", async () => {
+  const workflow = Workflow.create({
+    name: "queue-timeout-inherited",
+    jobs: [
+      Job.create({
+        name: "main",
+        labels: { pool: "gke" },
+        steps: [
+          Step.create({
+            name: "inherits",
+            task: StepTask.model("test-model", "run"),
+            queueTimeout: 30,
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const warning = results.find((r) =>
+    r.name.includes("queueTimeout without placement")
+  );
+  assertEquals(warning, undefined);
+});
+
+Deno.test("validate: no warning when queueTimeout is inherited from workflow with placement", async () => {
+  const workflow = Workflow.create({
+    name: "queue-timeout-workflow",
+    labels: { pool: "gke" },
+    queueTimeout: 30,
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "inherits",
+            task: StepTask.model("test-model", "run"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const warning = results.find((r) =>
+    r.name.includes("queueTimeout without placement")
+  );
+  assertEquals(warning, undefined);
+});
+
 // --- Assert expr interpolation validation tests ---
 
 Deno.test("validate: fails when assert expr is wrapped in interpolation syntax", async () => {

--- a/src/domain/workflows/workflow.ts
+++ b/src/domain/workflows/workflow.ts
@@ -32,6 +32,7 @@ import {
   ReportSelectionSchema,
 } from "../reports/report_selection.ts";
 import { Cron } from "croner";
+import { type PlacementFields, PlacementFieldsSchema } from "./placement.ts";
 
 const WORKFLOW_NAME_MAX_LENGTH = 64;
 const WORKFLOW_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
@@ -104,6 +105,7 @@ const WorkflowObjectSchema = z.object({
   version: z.number().int().positive().default(1),
   concurrency: z.number().int().nonnegative().optional(),
   reports: ReportSelectionSchema,
+  ...PlacementFieldsSchema.shape,
 });
 
 /**
@@ -145,6 +147,10 @@ export interface CreateWorkflowProps {
   version?: number;
   concurrency?: number;
   reports?: ReportSelection;
+  target?: string;
+  labels?: Record<string, string>;
+  platform?: string;
+  queueTimeout?: number;
 }
 
 /**
@@ -171,6 +177,10 @@ export class Workflow {
     readonly version: number,
     readonly concurrency: number | undefined,
     readonly reports: ReportSelection | undefined,
+    readonly target: string | undefined,
+    readonly labels: Record<string, string> | undefined,
+    readonly platform: string | undefined,
+    readonly queueTimeout: number | undefined,
   ) {}
 
   /**
@@ -194,6 +204,10 @@ export class Workflow {
       version,
       concurrency: props.concurrency,
       reports: props.reports,
+      target: props.target,
+      labels: props.labels,
+      platform: props.platform,
+      queueTimeout: props.queueTimeout,
     };
 
     // Scoped @collective/name is validated by workflowNameBase (in the schema);
@@ -220,6 +234,10 @@ export class Workflow {
       data.version,
       data.concurrency,
       data.reports,
+      data.target,
+      data.labels,
+      data.platform,
+      data.queueTimeout,
     );
   }
 
@@ -241,6 +259,10 @@ export class Workflow {
       validated.version,
       validated.concurrency,
       validated.reports,
+      validated.target,
+      validated.labels,
+      validated.platform,
+      validated.queueTimeout,
     );
   }
 
@@ -313,6 +335,15 @@ export class Workflow {
     this._jobs.push(job);
   }
 
+  get placementFields(): PlacementFields {
+    return {
+      target: this.target,
+      labels: this.labels,
+      platform: this.platform,
+      queueTimeout: this.queueTimeout,
+    };
+  }
+
   /**
    * Converts to plain data for persistence.
    */
@@ -328,6 +359,10 @@ export class Workflow {
       version: this.version,
       concurrency: this.concurrency,
       reports: this.reports,
+      target: this.target,
+      labels: this.labels,
+      platform: this.platform,
+      queueTimeout: this.queueTimeout,
     };
   }
 }

--- a/src/domain/workflows/workflow_test.ts
+++ b/src/domain/workflows/workflow_test.ts
@@ -647,21 +647,52 @@ Deno.test("WorkflowSchema rejects removed driverConfig field with actionable err
   );
 });
 
-// Unknown-key rejection tests (swamp-club#1240)
+// Placement inheritance tests (swamp-club#1685)
 
-Deno.test("WorkflowSchema rejects workflow-level labels with step-property message", () => {
-  const error = assertThrows(
-    () =>
-      Workflow.fromData({
-        id: "550e8400-e29b-41d4-a716-446655440000",
-        name: "test-workflow",
-        labels: { env: "prod" },
-        jobs: [createTestJob("job1").toData()],
-      } as unknown as WorkflowInput),
-    Error,
-  );
-  assertStringIncludes(error.message, "'labels' is a step property");
-  assertStringIncludes(error.message, "workflow 'test-workflow'");
+Deno.test("WorkflowSchema accepts workflow-level placement fields", () => {
+  const workflow = Workflow.fromData({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "test-workflow",
+    labels: { env: "prod" },
+    target: "worker-1",
+    platform: "linux/amd64",
+    queueTimeout: 30,
+    jobs: [createTestJob("job1").toData()],
+  } as unknown as WorkflowInput);
+  assertEquals(workflow.labels, { env: "prod" });
+  assertEquals(workflow.target, "worker-1");
+  assertEquals(workflow.platform, "linux/amd64");
+  assertEquals(workflow.queueTimeout, 30);
+});
+
+Deno.test("Workflow placement: round-trips through toData", () => {
+  const workflow = Workflow.fromData({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "test-workflow",
+    labels: { pool: "gke", fleet: "v3" },
+    platform: "linux",
+    jobs: [createTestJob("job1").toData()],
+  } as unknown as WorkflowInput);
+  const data = workflow.toData();
+  assertEquals(data.labels, { pool: "gke", fleet: "v3" });
+  assertEquals(data.platform, "linux");
+  const restored = Workflow.fromData(data);
+  assertEquals(restored.labels, workflow.labels);
+  assertEquals(restored.platform, workflow.platform);
+});
+
+Deno.test("Workflow placement: undefined when not set", () => {
+  const workflow = Workflow.fromData({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "test-workflow",
+    jobs: [createTestJob("job1").toData()],
+  } as unknown as WorkflowInput);
+  assertEquals(workflow.placementFields, {
+    target: undefined,
+    labels: undefined,
+    platform: undefined,
+    queueTimeout: undefined,
+  });
 });
 
 Deno.test("WorkflowSchema rejects unknown top-level key with did-you-mean suggestion", () => {
@@ -679,9 +710,8 @@ Deno.test("WorkflowSchema rejects unknown top-level key with did-you-mean sugges
   assertStringIncludes(error.message, "Did you mean 'version'?");
 });
 
-Deno.test("Workflow YAML with job-level labels fails to parse naming the key", () => {
-  // swamp-club#1240 variant A verbatim: previously passed validation and
-  // silently ran locally, discarding the placement intent.
+Deno.test("Workflow YAML with job-level labels parses and preserves placement", () => {
+  // swamp-club#1685: job-level placement is now supported with inheritance.
   const yaml = `
 id: 550e8400-e29b-41d4-a716-446655440000
 name: variant-a-job-labels
@@ -699,12 +729,9 @@ jobs:
             run: echo "hello"
 `;
   const data = parseYaml(yaml);
-  const error = assertThrows(
-    () => Workflow.fromData(data as WorkflowInput),
-    Error,
-  );
-  assertStringIncludes(error.message, "'labels' is a step property");
-  assertStringIncludes(error.message, "job 'placed'");
+  const workflow = Workflow.fromData(data as WorkflowInput);
+  const job = workflow.getJob("placed");
+  assertEquals(job?.labels, { fb28: "probe" });
 });
 
 // Reports field tests

--- a/src/libswamp/workflows/broken_workflow_test.ts
+++ b/src/libswamp/workflows/broken_workflow_test.ts
@@ -53,13 +53,12 @@ jobs:
           methodName: run
 `;
 
-const JOB_LABELS_WORKFLOW = `
+const BROKEN_UNKNOWN_KEY_WORKFLOW = `
 id: 74ae52ba-5f3f-4937-a4fd-c1de950572e7
-name: variant-a-job-labels
+name: broken-unknown-key
 jobs:
   - name: placed
-    labels:
-      fb28: probe
+    environmnet: prod
     steps:
       - name: echo
         task:
@@ -89,7 +88,7 @@ Deno.test("listBrokenWorkflows: skips valid files and reports schema-rejected on
     );
     await Deno.writeTextFile(
       join(dir, "workflow-74ae52ba-5f3f-4937-a4fd-c1de950572e7.yaml"),
-      JOB_LABELS_WORKFLOW,
+      BROKEN_UNKNOWN_KEY_WORKFLOW,
     );
     // Files without the workflow- prefix are not loaded by the repository
     // and must not be scanned.
@@ -97,9 +96,9 @@ Deno.test("listBrokenWorkflows: skips valid files and reports schema-rejected on
 
     const broken = await listBrokenWorkflows(dir);
     assertEquals(broken.length, 1);
-    assertEquals(broken[0].name, "variant-a-job-labels");
+    assertEquals(broken[0].name, "broken-unknown-key");
     assertEquals(broken[0].id, "74ae52ba-5f3f-4937-a4fd-c1de950572e7");
-    assertStringIncludes(broken[0].error, "'labels' is a step property");
+    assertStringIncludes(broken[0].error, "Unknown key 'environmnet'");
   });
 });
 
@@ -119,11 +118,11 @@ Deno.test("findBrokenWorkflow: matches by raw name and by raw id", async () => {
   await withTempDir(async (dir) => {
     await Deno.writeTextFile(
       join(dir, "workflow-74ae52ba-5f3f-4937-a4fd-c1de950572e7.yaml"),
-      JOB_LABELS_WORKFLOW,
+      BROKEN_UNKNOWN_KEY_WORKFLOW,
     );
 
-    const byName = await findBrokenWorkflow(dir, "variant-a-job-labels");
-    assertEquals(byName?.name, "variant-a-job-labels");
+    const byName = await findBrokenWorkflow(dir, "broken-unknown-key");
+    assertEquals(byName?.name, "broken-unknown-key");
 
     const byId = await findBrokenWorkflow(
       dir,

--- a/src/libswamp/workflows/run_test.ts
+++ b/src/libswamp/workflows/run_test.ts
@@ -272,11 +272,10 @@ Deno.test("workflowRun surfaces the parse error for a schema-rejected workflow f
       ),
       `
 id: 74ae52ba-5f3f-4937-a4fd-c1de950572e7
-name: variant-a-job-labels
+name: broken-unknown-key
 jobs:
   - name: placed
-    labels:
-      fb28: probe
+    environmnet: prod
     steps:
       - name: echo
         task:
@@ -289,14 +288,14 @@ jobs:
     const deps = { ...createTestDeps(null, []), repoDir };
     const ctx = createLibSwampContext();
     const events = await collect(workflowRun(ctx, deps, {
-      workflowIdOrName: "variant-a-job-labels",
+      workflowIdOrName: "broken-unknown-key",
     }));
 
     const last = events[events.length - 1];
     assertEquals(last.kind, "error");
     if (last.kind === "error") {
       assertEquals(last.error.code, "workflow_load_failed");
-      assertStringIncludes(last.error.message, "'labels' is a step property");
+      assertStringIncludes(last.error.message, "Unknown key 'environmnet'");
     }
   } finally {
     await Deno.remove(repoDir, { recursive: true }).catch(() => {});


### PR DESCRIPTION
## Summary

- Adds `labels`, `target`, `platform`, and `queueTimeout` placement fields to the **workflow** and **job** level YAML schemas with inheritance: workflow-level applies to all steps as a default, job-level overrides workflow, step-level overrides job
- An explicit empty value (e.g. `labels: {}`) at any level clears the inherited value, causing the step to run locally
- Omitting a field inherits from the parent level
- Existing step-only workflows work identically — no migration needed

### Example

```yaml
name: deploy-pipeline
labels:
  pool: gke
  fleet: platform-fleet-v3

jobs:
  - name: build
    steps:
      - name: compile    # inherits workflow labels → remote
        task: ...
      - name: test       # inherits workflow labels → remote
        task: ...
  - name: report
    labels: {}           # override: clear inherited labels
    steps:
      - name: summarize  # no placement → runs locally
        task: ...
```

### Key changes

- **New**: `src/domain/workflows/placement.ts` — shared `PlacementFieldsSchema`, `mergePlacementFields()`, `resolvePlacement()`
- **Schema**: `WorkflowObjectSchema` and `JobObjectSchema` now include placement fields via `PlacementFieldsSchema.shape` spread
- **Execution**: `execution_service.ts` computes effective placement by merging workflow→job→step before expression resolution
- **Guard removed**: `STEP_PLACEMENT_KEYS` rejection in `unknown_keys.ts` removed — placement keys are now valid at all levels
- **Validation**: `validateQueueTimeoutPlacement` accounts for inherited placement

## Test Plan

- 13 new unit tests for `mergePlacementFields` and `resolvePlacement` (merge semantics, override/clear, three-level merge)
- Updated schema acceptance tests for workflow/job-level placement (previously asserted rejection)
- Updated broken-workflow and run tests to use truly-broken fixtures
- 2 new validation service tests for inherited placement with queueTimeout
- E2E verified with `swamp serve` + real worker node:
  - Workflow-level `labels` dispatched to remote worker (serial timing confirms remote)
  - Job-level `labels: {}` override ran locally (26ms vs 1.7s)
  - Step-level `target` overrides workflow-level `labels` (queued for nonexistent worker instead of matching label)
  - `forEach` with inherited `${{ inputs.* }}` expression in workflow-level labels resolved correctly and dispatched all expansions to remote worker
- Full test suite: 10,427 passed, 0 failed

Closes swamp-club#1685

🤖 Generated with [Claude Code](https://claude.com/claude-code)