### PR TITLE
fix(workflows): update stale placement comments and add orphaned queueTimeout test

### DIFF
--- a/src/domain/workflows/job.ts
+++ b/src/domain/workflows/job.ts
@@ -75,8 +75,7 @@ const JobObjectSchema = z.object({
 /**
  * Zod schema for Job entity. Rejects the removed `driver`/`driverConfig`
  * fields with an actionable error (see design/remote-execution.md), and
- * rejects unknown keys — Zod's silent stripping would otherwise discard
- * misplaced placement blocks like a job-level `labels:` (swamp-club#1240).
+ * rejects unknown keys with did-you-mean suggestions (swamp-club#1240).
  */
 export const JobSchema = z.preprocess(
   rejectRemovedDriverFields,

--- a/src/domain/workflows/unknown_keys.ts
+++ b/src/domain/workflows/unknown_keys.ts
@@ -22,12 +22,10 @@
  * and step objects.
  *
  * Zod strips unknown keys silently by default, which turns authoring
- * mistakes into fail-open behavior: a `labels:` block placed on a job
- * instead of a step passes validation and the placement intent is
- * discarded, so the work runs on the orchestrator (swamp-club#1240).
- * Like removed_driver_fields.ts, this hook runs in a `z.preprocess`
- * wrapper so the raw keys are seen before unknown-key stripping drops
- * them.
+ * mistakes into fail-open behavior — a typo'd key passes validation and
+ * the intended field is silently ignored (swamp-club#1240). Like
+ * removed_driver_fields.ts, this hook runs in a `z.preprocess` wrapper
+ * so the raw keys are seen before unknown-key stripping drops them.
  */
 
 import { findClosestMatch } from "../string_distance.ts";

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -1754,6 +1754,33 @@ Deno.test("validate: no warning when queueTimeout is inherited from workflow wit
   assertEquals(warning, undefined);
 });
 
+Deno.test("validate: warns when job clears inherited placement but queueTimeout is still inherited", async () => {
+  const workflow = Workflow.create({
+    name: "orphaned-queue-timeout",
+    labels: { pool: "gke" },
+    queueTimeout: 30,
+    jobs: [
+      Job.create({
+        name: "main",
+        labels: {},
+        steps: [
+          Step.create({
+            name: "orphaned",
+            task: StepTask.model("test-model", "run"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const warning = results.find((r) =>
+    r.name.includes("queueTimeout without placement")
+  );
+  assertEquals(warning?.passed, true);
+  assertEquals(warning?.warning, true);
+});
+
 // --- Assert expr interpolation validation tests ---
 
 Deno.test("validate: fails when assert expr is wrapped in interpolation syntax", async () => {


### PR DESCRIPTION
## Summary

- Updates stale comments in `unknown_keys.ts` and `job.ts` that still referenced the old behavior where placement keys were rejected on non-step entities (pre-#2168)
- Adds a validation test for the edge case where workflow-level `labels` + `queueTimeout` are set, a job clears labels with `labels: {}`, and the orphaned `queueTimeout` correctly triggers a warning

Addresses code review suggestions from #2168.

## Test Plan

- `deno run test src/domain/workflows/validation_service_test.ts` — 58 passed, 0 failed
- New test verifies the orphaned queueTimeout warning fires when inherited placement is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)