### PR TITLE
fix(extensions): sort files[] in upstream_extensions.json for deterministic output (swamp-club#1688)

### DIFF
--- a/src/infrastructure/persistence/lockfile_repository.ts
+++ b/src/infrastructure/persistence/lockfile_repository.ts
@@ -141,7 +141,7 @@ export class LockfileRepository {
       current[name] = {
         version,
         pulledAt: options?.pulledAt ?? new Date().toISOString(),
-        files,
+        files: [...files].sort(),
         ...(options?.include && options.include.length > 0
           ? { include: options.include }
           : {}),

--- a/src/infrastructure/persistence/lockfile_repository_test.ts
+++ b/src/infrastructure/persistence/lockfile_repository_test.ts
@@ -120,6 +120,34 @@ Deno.test("LockfileRepository.writeEntry: creates file and updates own cache", a
   });
 });
 
+Deno.test("LockfileRepository.writeEntry: sorts files[] for deterministic output", async () => {
+  await withTempDir(async (dir) => {
+    const path = join(dir, "upstream_extensions.json");
+    const repo = await LockfileRepository.create(path);
+
+    const unsorted = [
+      "models/z.ts",
+      ".swamp/bundles/abc/x.js",
+      "models/a.ts",
+      ".claude/skills/my-skill",
+      "models/_lib/b.ts",
+    ];
+    await repo.writeEntry("@scope/foo", "1.0.0", unsorted);
+
+    const sorted = [
+      ".claude/skills/my-skill",
+      ".swamp/bundles/abc/x.js",
+      "models/_lib/b.ts",
+      "models/a.ts",
+      "models/z.ts",
+    ];
+    assertEquals(repo.getEntry("@scope/foo")?.files, sorted);
+
+    const onDisk = JSON.parse(await Deno.readTextFile(path));
+    assertEquals(onDisk["@scope/foo"].files, sorted);
+  });
+});
+
 Deno.test("LockfileRepository.writeEntry: omits empty/undefined optional fields", async () => {
   await withTempDir(async (dir) => {
     const path = join(dir, "upstream_extensions.json");


### PR DESCRIPTION
## Summary

- Sort `files[]` array in `LockfileRepository.writeEntry()` before serializing to JSON, eliminating lockfile churn caused by filesystem-dependent enumeration order from `Deno.readDir()`
- On deploy targets this churn made the tracked lockfile permanently dirty, blocking `git pull` and silently preventing deploys

## Test Plan

- Added unit test verifying unsorted input produces sorted output in both cache and on-disk JSON
- All 15 existing `lockfile_repository_test.ts` tests continue to pass
- Verified against reproduction: sorted lockfile, deleted extension sources, ran `extension install` — lockfile remained sorted (no diff)
- `deno check`, `deno lint`, `deno fmt`, `deno run test` all pass

Closes swamp-club#1688