### PR TITLE
feat(workflows): include trigger in get and search JSON output

### DIFF
--- a/src/libswamp/workflows/get.ts
+++ b/src/libswamp/workflows/get.ts
@@ -51,6 +51,7 @@ export interface WorkflowGetData {
   description?: string;
   version: number;
   inputs?: InputsSchema;
+  trigger?: { schedule?: string; inputs?: Record<string, unknown> };
   tags: Record<string, string>;
   reports?: ReportSelection;
   jobs: {
@@ -127,6 +128,7 @@ export async function* workflowGet(
         description: workflow.description,
         version: workflow.version,
         inputs: workflow.inputs,
+        trigger: workflow.trigger,
         tags: workflow.tags,
         reports: workflow.reports,
         jobs: workflow.jobs.map((job) => ({

--- a/src/libswamp/workflows/get_test.ts
+++ b/src/libswamp/workflows/get_test.ts
@@ -38,6 +38,7 @@ const testWorkflow = {
     },
     required: [],
   },
+  trigger: { schedule: "0 3 * * *", inputs: { env: "prod" } },
   tags: { env: "staging" },
   reports: { require: ["junit"] },
   jobs: [{
@@ -96,6 +97,7 @@ Deno.test("workflowGet yields resolving -> completed with workflow data on succe
           },
           required: [],
         },
+        trigger: { schedule: "0 3 * * *", inputs: { env: "prod" } },
         tags: { env: "staging" },
         reports: { require: ["junit"] },
         jobs: [{

--- a/src/libswamp/workflows/search.ts
+++ b/src/libswamp/workflows/search.ts
@@ -30,6 +30,7 @@ export interface WorkflowSearchItem {
   description?: string;
   jobCount: number;
   hasInputs: boolean;
+  trigger?: { schedule?: string; inputs?: Record<string, unknown> };
 }
 
 /**
@@ -56,6 +57,7 @@ export interface WorkflowSearchDeps {
       description?: string;
       jobs: readonly unknown[];
       inputs?: { properties?: Record<string, unknown> };
+      trigger?: { schedule?: string; inputs?: Record<string, unknown> };
     }>
   >;
 }
@@ -91,6 +93,7 @@ export async function* workflowSearch(
         description: w.description,
         jobCount: w.jobs.length,
         hasInputs: Object.keys(w.inputs?.properties ?? {}).length > 0,
+        trigger: w.trigger,
       }));
 
       yield {

--- a/src/libswamp/workflows/search_test.ts
+++ b/src/libswamp/workflows/search_test.ts
@@ -42,6 +42,7 @@ function makeDeps(
               target: { type: "string", default: "prod" },
             },
           },
+          trigger: { schedule: "0 8 * * 1-5" },
         },
         {
           id: "wf-2",
@@ -73,11 +74,13 @@ Deno.test("workflowSearch: returns all workflows with no query", async () => {
   assertEquals(completed.data.results[0].description, "Deploy to production");
   assertEquals(completed.data.results[0].jobCount, 2);
   assertEquals(completed.data.results[0].hasInputs, true);
+  assertEquals(completed.data.results[0].trigger, { schedule: "0 8 * * 1-5" });
   assertEquals(completed.data.results[1].id, "wf-2");
   assertEquals(completed.data.results[1].name, "test");
   assertEquals(completed.data.results[1].description, undefined);
   assertEquals(completed.data.results[1].jobCount, 1);
   assertEquals(completed.data.results[1].hasInputs, false);
+  assertEquals(completed.data.results[1].trigger, undefined);
 });
 
 Deno.test("workflowSearch: passes query through in data", async () => {


### PR DESCRIPTION
## Summary

- Add `trigger` field (schedule + inputs) to `WorkflowGetData` and `WorkflowSearchItem` interfaces
- `workflow get --json` and `workflow search --json` now expose trigger/schedule info without requiring a separate `workflow trigger get` call per workflow

Closes swamp-club#1690

## Test Plan

- Updated unit tests in `get_test.ts` to include trigger in fixture and assert it appears in output
- Updated unit tests in `search_test.ts` to verify trigger for both scheduled (with trigger) and unscheduled (undefined) workflows
- `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)