### PR TITLE
feat(serve): use identifiable OAuth client_name instead of random UUID (swamp-club#1691)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -163,7 +163,7 @@ import {
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { GRANT_MODEL_TYPE } from "../../domain/models/access/grant_model.ts";
 import { cleanupEmptyParentDirs } from "../../infrastructure/persistence/directory_cleanup.ts";
-import { isAbsolute, join, resolve } from "@std/path";
+import { basename, isAbsolute, join, resolve } from "@std/path";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
 import {
   RepoMarkerRepository,
@@ -342,6 +342,9 @@ export function collectServeExtraArgs(options: AnyOptions): string[] {
   }
   if (options.oauthClientId) {
     args.push("--oauth-client-id", options.oauthClientId as string);
+  }
+  if (options.oauthClientName) {
+    args.push("--oauth-client-name", options.oauthClientName as string);
   }
   if (options.groupsField) {
     args.push("--groups-field", options.groupsField as string);
@@ -561,6 +564,11 @@ const daemonEnableCommand = new Command()
     "OAuth client ID — auto-registered on first start if omitted. " +
       "Set SWAMP_API_KEY (a collective API token with oauth:manage scope) " +
       "for headless registration without browser interaction.",
+  )
+  .option(
+    "--oauth-client-name <name:string>",
+    "OAuth client name used during registration (env: SWAMP_OAUTH_CLIENT_NAME). " +
+      "Defaults to swamp-serve-{repoName}-{hostname}.",
   )
   .option(
     "--groups-field <field:string>",
@@ -898,6 +906,11 @@ export const serveCommand = new Command()
     "OAuth client ID — auto-registered on first start if omitted. " +
       "Set SWAMP_API_KEY (a collective API token with oauth:manage scope) " +
       "for headless registration without browser interaction.",
+  )
+  .option(
+    "--oauth-client-name <name:string>",
+    "OAuth client name used during registration (env: SWAMP_OAUTH_CLIENT_NAME). " +
+      "Defaults to swamp-serve-{repoName}-{hostname}.",
   )
   .option(
     "--groups-field <field:string>",
@@ -1604,6 +1617,11 @@ export const serveCommand = new Command()
     });
 
     const clubApiKey = Deno.env.get("SWAMP_API_KEY") ?? null;
+    const oauthClientName = merged.oauthClientName ??
+      `swamp-serve-${basename(resolvedRepoDir)}-${Deno.hostname()}`.slice(
+        0,
+        128,
+      );
 
     let oauthClientSecret = "";
     const resolvedUserNames: Record<string, string> = {};
@@ -1652,6 +1670,7 @@ export const serveCommand = new Command()
                 const result = await registerClientWithApiKey(
                   providerUrl,
                   clubApiKey,
+                  oauthClientName,
                   signal,
                 );
                 return {
@@ -1733,9 +1752,7 @@ export const serveCommand = new Command()
                     "authorization": `Bearer ${tokenResponse.accessToken}`,
                   },
                   body: JSON.stringify({
-                    client_name: `swamp-serve-${
-                      crypto.randomUUID().slice(0, 8)
-                    }`,
+                    client_name: oauthClientName,
                     redirect_uris: ["http://localhost"],
                     grant_types: ["authorization_code"],
                     scope: "openid profile email collectives",

--- a/src/serve/oauth_registration.ts
+++ b/src/serve/oauth_registration.ts
@@ -147,6 +147,7 @@ export async function resolveOAuthClientCredentials(
 export async function registerClientWithApiKey(
   providerUrl: string,
   apiKey: string,
+  clientName: string,
   signal: AbortSignal,
 ): Promise<{ clientId: string; clientSecret: string }> {
   const verifyResp = await fetch(`${providerUrl}/api/whoami`, {
@@ -183,7 +184,7 @@ export async function registerClientWithApiKey(
       "authorization": `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      client_name: `swamp-serve-${crypto.randomUUID().slice(0, 8)}`,
+      client_name: clientName,
       redirect_uris: ["http://localhost"],
       grant_types: ["authorization_code"],
       scope: "openid profile email collectives",

--- a/src/serve/oauth_registration_test.ts
+++ b/src/serve/oauth_registration_test.ts
@@ -37,18 +37,23 @@ interface StubResponse {
 
 function stubFetch(
   responses: StubResponse[],
-): { [Symbol.dispose]: () => void } {
+): {
+  [Symbol.dispose]: () => void;
+  calls: { url: string; init?: RequestInit }[];
+} {
   const originalFetch = globalThis.fetch;
   let callIndex = 0;
+  const calls: { url: string; init?: RequestInit }[] = [];
   globalThis.fetch = (
     input: string | URL | Request,
-    _init?: RequestInit,
+    init?: RequestInit,
   ): Promise<Response> => {
     const url = typeof input === "string"
       ? input
       : input instanceof URL
       ? input.href
       : input.url;
+    calls.push({ url, init });
     const stub = responses[callIndex++];
     if (!stub) {
       throw new Error(`stubFetch: unexpected call #${callIndex} to ${url}`);
@@ -66,6 +71,7 @@ function stubFetch(
     );
   };
   return {
+    calls,
     [Symbol.dispose]: () => {
       globalThis.fetch = originalFetch;
     },
@@ -243,7 +249,7 @@ Deno.test("resolveOAuthClientCredentials: does not store null access token in va
 });
 
 Deno.test("registerClientWithApiKey: registers client and returns credentials without accessToken", async () => {
-  using _fetch = stubFetch([
+  using stub = stubFetch([
     {
       url: "https://swamp-club.com/api/whoami",
       status: 200,
@@ -261,11 +267,14 @@ Deno.test("registerClientWithApiKey: registers client and returns credentials wi
   const result = await registerClientWithApiKey(
     "https://swamp-club.com",
     "test-api-key",
+    "swamp-serve-myrepo-myhost",
     AbortSignal.timeout(5000),
   );
   assertEquals(result.clientId, "headless-client-id");
   assertEquals(result.clientSecret, "headless-client-secret");
   assertEquals("accessToken" in result, false);
+  const registerBody = JSON.parse(stub.calls[1].init?.body as string);
+  assertEquals(registerBody.client_name, "swamp-serve-myrepo-myhost");
 });
 
 Deno.test("registerClientWithApiKey: throws on invalid API key", async () => {
@@ -281,6 +290,7 @@ Deno.test("registerClientWithApiKey: throws on invalid API key", async () => {
       registerClientWithApiKey(
         "https://swamp-club.com",
         "bad-key",
+        "swamp-serve-myrepo-myhost",
         AbortSignal.timeout(5000),
       ),
     Error,
@@ -301,6 +311,7 @@ Deno.test("registerClientWithApiKey: throws when token is missing oauth:manage s
       registerClientWithApiKey(
         "https://swamp-club.com",
         "no-oauth-scope-key",
+        "swamp-serve-myrepo-myhost",
         AbortSignal.timeout(5000),
       ),
     Error,
@@ -326,6 +337,7 @@ Deno.test("registerClientWithApiKey: throws on registration failure", async () =
       registerClientWithApiKey(
         "https://swamp-club.com",
         "test-api-key",
+        "swamp-serve-myrepo-myhost",
         AbortSignal.timeout(5000),
       ),
     Error,

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -38,6 +38,7 @@ const logger = getSwampLogger(["serve", "config"]);
 export const SERVE_ENV_MAP: Readonly<Record<string, string>> = {
   certFile: "SWAMP_SERVE_CERT_FILE",
   keyFile: "SWAMP_SERVE_KEY_FILE",
+  oauthClientName: "SWAMP_OAUTH_CLIENT_NAME",
   grantsFile: "SWAMP_GRANTS_FILE",
   grantsDir: "SWAMP_GRANTS_DIR",
   wsIdleTimeout: "SWAMP_WS_IDLE_TIMEOUT",
@@ -85,6 +86,7 @@ export interface ServeConfigFile {
     "allowed-users"?: string[];
     "oauth-provider"?: string;
     "oauth-client-id"?: string;
+    "oauth-client-name"?: string;
     "groups-field"?: string;
     "restricted-model-types"?: string[];
     "restricted-commands"?: string[];
@@ -154,6 +156,7 @@ const KNOWN_AUTH_KEYS = new Set([
   "allowed-users",
   "oauth-provider",
   "oauth-client-id",
+  "oauth-client-name",
   "groups-field",
   "restricted-model-types",
   "restricted-commands",
@@ -355,6 +358,7 @@ function validateConfigValues(
       ["auth.mode", authObj.mode],
       ["auth.oauth-provider", authObj["oauth-provider"]],
       ["auth.oauth-client-id", authObj["oauth-client-id"]],
+      ["auth.oauth-client-name", authObj["oauth-client-name"]],
       ["auth.groups-field", authObj["groups-field"]],
       ["auth.group-refresh-interval", authObj["group-refresh-interval"]],
     ];
@@ -603,6 +607,7 @@ export interface MergedServeOptions {
   allowedUsers?: string;
   oauthProvider?: string;
   oauthClientId?: string;
+  oauthClientName?: string;
   groupsField?: string;
   restrictedModelTypes?: string;
   restrictedCommands?: string;
@@ -821,6 +826,13 @@ export function mergeServeOptions(
     undefined,
   );
 
+  const oauthClientName = resolveString(
+    "oauth-client-name",
+    cliOptions.oauthClientName as string | undefined,
+    config?.auth?.["oauth-client-name"],
+    undefined,
+  );
+
   const groupsField = resolveString(
     "groups-field",
     cliOptions.groupsField as string | undefined,
@@ -987,6 +999,7 @@ export function mergeServeOptions(
     allowedUsers,
     oauthProvider,
     oauthClientId,
+    oauthClientName,
     groupsField,
     restrictedModelTypes,
     restrictedCommands,


### PR DESCRIPTION
## Summary

- Default OAuth `client_name` to `swamp-serve-{repoName}-{hostname}` (truncated to 128 chars) instead of `swamp-serve-{randomUUID}`, so registrations are traceable to a specific deployment
- Add `--oauth-client-name` flag (env: `SWAMP_OAUTH_CLIENT_NAME`, config: `auth.oauth-client-name`) for explicit override — useful in k8s/container environments where hostname isn't meaningful
- Updated both registration paths: `registerClientWithApiKey` (headless) and the inline device-grant flow

## Test Plan

- [x] `deno check` — full type check passes
- [x] `deno lint` — no lint errors
- [x] `deno fmt --check` — formatting clean
- [x] `deno run test` — all 10,437 tests pass
- [x] `registerClientWithApiKey` tests updated to verify `clientName` parameter is threaded through to the HTTP request body
- [x] New flag added to serve command, daemon enable subcommand, and `collectServeExtraArgs`
- [x] `SERVE_ENV_MAP` updated with `SWAMP_OAUTH_CLIENT_NAME` for four-level priority merge

## Documentation

The `serve-flags.md` reference page in swamp-club needs updating with the new `--oauth-client-name` flag (swamp-club/swamp-club issues are disabled — noting here for tracking).

Closes swamp-club#1691