### PR TITLE
docs(skills): document workflow/job-level placement in workflow skill

### DIFF
--- a/.claude/skills/swamp/references/workflow/reference.md
+++ b/.claude/skills/swamp/references/workflow/reference.md
@@ -450,6 +450,43 @@ swamp workflow evaluate --all --json
 - Vault expressions (`${{ vault.get(...) }}`) remain raw for runtime resolution
 - Output saved to `.swamp/workflows-evaluated/` for `--last-evaluated` use
 
+## Placement (Remote Execution)
+
+Placement fields (`target`, `labels`, `platform`, `queueTimeout`) dispatch steps
+to remote workers. They can be set at the **workflow**, **job**, or **step**
+level with child-wins inheritance: workflow defaults apply to all steps, job
+overrides workflow, step overrides job. An explicit empty value (e.g.,
+`labels: {}`) clears inherited placement, causing the step to run locally.
+
+```yaml
+name: deploy-pipeline
+labels:
+  pool: gke
+  fleet: platform-fleet-v3
+
+jobs:
+  - name: build
+    steps:
+      - name: compile
+        task: ... # inherits workflow labels → remote
+      - name: test
+        task: ... # inherits workflow labels → remote
+  - name: report
+    labels: {} # override: clear inherited labels
+    steps:
+      - name: summarize
+        task: ... # no placement → runs locally
+  - name: gpu-work
+    steps:
+      - name: train
+        target: gpu-box-1 # step overrides workflow labels
+        task: ...
+```
+
+Placement requires running under `swamp serve`. See
+[references/remote-execution.md](references/remote-execution.md) for worker
+provisioning, matching semantics, and full examples.
+
 ## Concurrency Limits
 
 Add `concurrency: N` at the workflow, job, or step level to cap parallel

--- a/.claude/skills/swamp/references/workflow/references/execution-semantics.md
+++ b/.claude/skills/swamp/references/workflow/references/execution-semantics.md
@@ -65,7 +65,10 @@ follows this sequence:
    evaluated. A truthy result skips the step with reason `"guarded"` (already
    done). A falsy result proceeds to execution. A CEL error fails the step.
    Guards see writes made by earlier steps in the same run.
-4. **Task execution** — the step's task runs (model method, nested workflow,
+4. **Placement resolution** — effective placement is computed by merging
+   workflow → job → step placement fields (child wins). If placement is active,
+   the step dispatches to a matching worker; otherwise it runs locally.
+5. **Task execution** — the step's task runs (model method, nested workflow,
    manual approval, or assert).
 
 Guard evaluation happens after dependency checks but before task execution. This

--- a/.claude/skills/swamp/references/workflow/references/scenarios.md
+++ b/.claude/skills/swamp/references/workflow/references/scenarios.md
@@ -10,6 +10,7 @@ End-to-end scenarios showing how to build workflows for common use cases.
 - [Scenario 4: Conditional Cleanup](#scenario-4-conditional-cleanup)
 - [Scenario 5: Nested Workflows](#scenario-5-nested-workflows)
 - [Scenario 6: Idempotent Provisioning with Guards](#scenario-6-idempotent-provisioning-with-guards)
+- [Scenario 7: Remote Execution with Placement Inheritance](#scenario-7-remote-execution-with-placement-inheritance)
 
 ---
 
@@ -723,6 +724,116 @@ jobs:
           modelIdOrName: api-client
           methodName: fetch
 ```
+
+---
+
+## Scenario 7: Remote Execution with Placement Inheritance
+
+### User Request
+
+> "I want all my workflow steps to run on a remote worker pool, except the
+> reporting job which should run locally."
+
+### What You'll Build
+
+- 1 workflow with workflow-level `labels` for default remote placement
+- A job that clears labels to run locally
+- A step that overrides to target a specific worker
+
+### Decision Tree
+
+```
+All steps remote by default → Workflow-level labels
+One job runs locally → Job-level labels: {} override
+Pin one step to specific worker → Step-level target override
+```
+
+### Step-by-Step
+
+**1. Provision workers with labels**
+
+```bash
+swamp worker token create build-runner --duration 24h
+swamp worker connect ws://orchestrator:4000 \
+  --token <name>.<secret> \
+  --label pool=ci --label arch=x86_64
+```
+
+**2. Create the workflow with placement inheritance**
+
+```bash
+swamp workflow create build-test-report --json
+```
+
+```yaml
+id: d1e2f3a4-b5c6-4d7e-8f9a-0b1c2d3e4f5g
+name: build-test-report
+description: Build and test on remote workers, report locally
+version: 1
+labels:
+  pool: ci
+jobs:
+  - name: build
+    steps:
+      - name: compile
+        task:
+          type: model_method
+          modelIdOrName: builder
+          methodName: compile
+      - name: test
+        task:
+          type: model_method
+          modelIdOrName: builder
+          methodName: test
+
+  - name: gpu-test
+    steps:
+      - name: train-smoke
+        target: gpu-box-1
+        task:
+          type: model_method
+          modelIdOrName: ml-runner
+          methodName: smoke-test
+
+  - name: report
+    labels: {}
+    dependsOn:
+      - job: build
+        condition:
+          type: succeeded
+      - job: gpu-test
+        condition:
+          type: any_completed
+    steps:
+      - name: summarize
+        task:
+          type: model_method
+          modelIdOrName: reporter
+          methodName: summarize
+```
+
+**3. Run through the orchestrator**
+
+```bash
+swamp workflow run build-test-report --server ws://orchestrator:4000
+```
+
+### Placement Resolution
+
+| Step        | Effective Placement            | Runs On              |
+| ----------- | ------------------------------ | -------------------- |
+| compile     | `labels: {pool: ci}` (inherit) | Any `pool=ci` worker |
+| test        | `labels: {pool: ci}` (inherit) | Any `pool=ci` worker |
+| train-smoke | `target: gpu-box-1` (step)     | Specific GPU worker  |
+| summarize   | None (`labels: {}` clears)     | Local (orchestrator) |
+
+### Inheritance Rules
+
+- **Omitting** a placement field inherits from the parent level
+- **Setting** a field overrides the parent's value for that field
+- **Explicit empty** (`labels: {}`) clears the inherited value — the step runs
+  locally
+- Resolution order: step > job > workflow
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a **Placement (Remote Execution)** section to the workflow skill's `reference.md`, parallel to the existing Concurrency Limits section, documenting the workflow→job→step inheritance model with a compact example
- Adds **Scenario 7: Remote Execution with Placement Inheritance** to `scenarios.md` showing a full end-to-end example with a placement resolution table
- Adds a **Placement resolution** step to the Step Evaluation Order in `execution-semantics.md`

Follows up on #2168 which added placement fields at the workflow and job level — the code and `remote-execution.md` were updated in that PR, but the main workflow skill references were not.

## Test Plan

- Verified `deno fmt --check` passes on all changed files
- Docs-only change — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)