### PR TITLE
fix(workflows): persist resolved approval prompt per run (swamp-club#1705)

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -2772,7 +2772,7 @@ export class WorkflowExecutionService {
 
       // Handle manual approval tasks — suspend the workflow
       if (task.type === "manual_approval") {
-        stepRun.waitForApproval();
+        stepRun.waitForApproval(task.prompt);
         yield {
           kind: "approval_requested",
           runId: run.id,

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -70,6 +70,7 @@ export const StepRunSchema = z.object({
   dataArtifacts: z.array(DataArtifactRefSchema).optional(),
   allowedFailure: z.boolean().optional(),
   approvalDecision: ApprovalDecisionSchema.optional(),
+  approvalPrompt: z.string().optional(),
   assertResult: AssertResultSchema.optional(),
 });
 
@@ -159,6 +160,7 @@ export class StepRun {
     private _dataArtifacts: DataArtifactRef[] = [],
     private _allowedFailure: boolean = false,
     private _approvalDecision: ApprovalDecisionData | undefined = undefined,
+    private _approvalPrompt: string | undefined = undefined,
     private _assertResult: AssertResultData | undefined = undefined,
   ) {}
 
@@ -193,6 +195,7 @@ export class StepRun {
       validated.dataArtifacts ?? [],
       validated.allowedFailure ?? false,
       validated.approvalDecision,
+      validated.approvalPrompt,
       validated.assertResult,
     );
   }
@@ -235,6 +238,10 @@ export class StepRun {
     return this._approvalDecision;
   }
 
+  get approvalPrompt(): string | undefined {
+    return this._approvalPrompt;
+  }
+
   get assertResult(): AssertResultData | undefined {
     return this._assertResult;
   }
@@ -273,6 +280,7 @@ export class StepRun {
     this._dataArtifacts = [];
     this._allowedFailure = false;
     this._approvalDecision = undefined;
+    this._approvalPrompt = undefined;
     this._assertResult = undefined;
   }
 
@@ -287,8 +295,11 @@ export class StepRun {
   /**
    * Marks the step as waiting for manual approval.
    */
-  waitForApproval(): void {
+  waitForApproval(prompt?: string): void {
     this._status = "waiting_approval";
+    if (prompt !== undefined) {
+      this._approvalPrompt = prompt;
+    }
   }
 
   /**
@@ -339,6 +350,9 @@ export class StepRun {
     }
     if (this._approvalDecision) {
       data.approvalDecision = { ...this._approvalDecision };
+    }
+    if (this._approvalPrompt !== undefined) {
+      data.approvalPrompt = this._approvalPrompt;
     }
     if (this._assertResult) {
       data.assertResult = { ...this._assertResult };

--- a/src/libswamp/workflows/approvals.ts
+++ b/src/libswamp/workflows/approvals.ts
@@ -123,8 +123,8 @@ export async function* workflowApprovals(
             }
           }
 
-          let prompt: string | undefined;
-          if (evaluatedWorkflow) {
+          let prompt: string | undefined = step?.approvalPrompt;
+          if (!prompt && evaluatedWorkflow) {
             const evalTaskData = evaluatedWorkflow.jobs
               .find((j) => j.name === waiting.jobName)?.steps
               .find((s) => s.name === waiting.stepName)?.task.data;

--- a/src/libswamp/workflows/approvals_test.ts
+++ b/src/libswamp/workflows/approvals_test.ts
@@ -74,10 +74,12 @@ function makeRun(overrides?: {
   stepStatus?: string;
   startedAt?: Date;
   inputs?: Record<string, unknown>;
+  approvalPrompt?: string;
 }): WorkflowRun {
   const stepStatus = overrides?.stepStatus ?? "waiting_approval";
   const startedAt = overrides?.startedAt ?? new Date();
   const inputs = overrides?.inputs ?? {};
+  const approvalPrompt = overrides?.approvalPrompt;
   return {
     id: overrides?.id ?? "run-1",
     status: overrides?.status ?? "suspended",
@@ -90,7 +92,9 @@ function makeRun(overrides?: {
       name === "main"
         ? {
           getStep: (sn: string) =>
-            sn === "gate" ? { startedAt, status: stepStatus } : undefined,
+            sn === "gate"
+              ? { startedAt, status: stepStatus, approvalPrompt }
+              : undefined,
         }
         : undefined,
   } as unknown as WorkflowRun;
@@ -279,5 +283,70 @@ Deno.test("workflowApprovals: falls back to raw prompt when findEvaluatedWorkflo
   if (completed?.kind === "completed") {
     assertEquals(completed.data.approvals.length, 1);
     assertEquals(completed.data.approvals[0].prompt, "Approve deployment");
+  }
+});
+
+Deno.test("workflowApprovals: each suspended run shows its own resolved prompt", async () => {
+  const wf = makeWorkflow({
+    stepType: "manual_approval",
+    prompt: "Approval marker: ${{ inputs.label }}",
+  });
+  const runOne = makeRun({
+    id: "run-marker-one",
+    inputs: { label: "marker-one" },
+    approvalPrompt: "Approval marker: marker-one",
+  });
+  const runTwo = makeRun({
+    id: "run-marker-two",
+    inputs: { label: "marker-two" },
+    approvalPrompt: "Approval marker: marker-two",
+  });
+  const evaluatedWf = makeWorkflow({
+    stepType: "manual_approval",
+    prompt: "Approval marker: marker-two",
+  });
+  const evaluatedWorkflows = new Map([[WF_ID as string, evaluatedWf]]);
+  const deps = makeDeps(
+    [wf],
+    new Map([[WF_ID as string, [runOne, runTwo]]]),
+    evaluatedWorkflows,
+  );
+  const events = await collect<WorkflowApprovalsEvent>(
+    workflowApprovals(ctx, deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.approvals.length, 2);
+    const approvalOne = completed.data.approvals.find((a) =>
+      a.runId === "run-marker-one"
+    );
+    const approvalTwo = completed.data.approvals.find((a) =>
+      a.runId === "run-marker-two"
+    );
+    assertEquals(approvalOne?.prompt, "Approval marker: marker-one");
+    assertEquals(approvalTwo?.prompt, "Approval marker: marker-two");
+  }
+});
+
+Deno.test("workflowApprovals: falls back to evaluated workflow prompt for runs without approvalPrompt", async () => {
+  const wf = makeWorkflow({ stepType: "manual_approval" });
+  const run = makeRun({ id: "run-legacy" });
+  const evaluatedWf = makeWorkflow({
+    stepType: "manual_approval",
+    prompt: "Evaluated prompt value",
+  });
+  const evaluatedWorkflows = new Map([[WF_ID as string, evaluatedWf]]);
+  const deps = makeDeps(
+    [wf],
+    new Map([[WF_ID as string, [run]]]),
+    evaluatedWorkflows,
+  );
+  const events = await collect<WorkflowApprovalsEvent>(
+    workflowApprovals(ctx, deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.approvals.length, 1);
+    assertEquals(completed.data.approvals[0].prompt, "Evaluated prompt value");
   }
 });


### PR DESCRIPTION
## Summary

- When multiple runs of the same workflow are suspended at a `manual_approval`
  step with different inputs, `swamp workflow approvals` showed the latest run's
  resolved prompt for every run. This happened because the evaluated workflow
  artifact is stored once per workflow — the most recent evaluation overwrites
  previous ones.
- Store the resolved prompt on the `StepRun` entity when it enters
  `waiting_approval`, and read it from there in `workflowApprovals`. Old runs
  without the field fall back to the evaluated workflow then the raw definition.

## Test Plan

- Added regression test: two suspended runs with distinct input-resolved prompts
  assert each run shows its own prompt
- Added backward-compat test: run without `approvalPrompt` falls back to
  evaluated workflow prompt
- Reproduced the bug in a scratch repo, verified fix shows correct per-run
  prompts
- All existing tests pass (10,438 passed; 1 pre-existing unrelated flaky test
  in `serve_ready_test.ts`)

Fixes swamp-club#1705