### PR TITLE
feat(models): use name-based filenames for model definitions

### DIFF
--- a/.claude/skills/swamp/references/model/guide.md
+++ b/.claude/skills/swamp/references/model/guide.md
@@ -31,6 +31,9 @@ definitions referenced across multiple workflows.
 
 ## Model Creation Rules (when using `model create`)
 
+- **Model names must be lowercase alphanumeric with hyphens or underscores**
+  (e.g. `my-server`, `prod_vpc`). Max 64 characters. Names are used as the
+  filename on disk (`models/{type}/my-server.yaml`).
 - **Never generate model IDs** — no `uuidgen`, `crypto.randomUUID()`, or manual
   UUIDs. Swamp assigns IDs automatically via `swamp model create`.
 - **Never write a model YAML file from scratch** — always use

--- a/.claude/skills/swamp/references/model/reference.md
+++ b/.claude/skills/swamp/references/model/reference.md
@@ -6,17 +6,29 @@ type:
 ```
 models/
   {normalized-type}/
-    {model-id}.yaml
+    {name}.yaml              # default for new models
+    {uuid}.yaml              # legacy format, still supported
 ```
 
 Internal data (evaluated definitions, data artifacts, outputs) lives in
 `.swamp/`:
 
 ```
-.swamp/definitions-evaluated/{normalized-type}/{model-id}.yaml
+.swamp/definitions-evaluated/{normalized-type}/{name}.yaml
 .swamp/data/{normalized-type}/{model-id}/{data-name}/{version}/raw
 .swamp/outputs/{normalized-type}/{model-id}/{output-id}.yaml
 ```
+
+## Finding Model Files
+
+Model files may be named `{name}.yaml` or `{uuid}.yaml` (legacy). **Never guess
+the filename** — use the CLI to get the actual path:
+
+```bash
+swamp model get <name_or_id> --json   # creation path is in `model create --json` output
+```
+
+This works for both naming conventions.
 
 ## Search for Model Types
 
@@ -238,7 +250,7 @@ swamp model delete my-shell --json
     "id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
     "name": "my-shell",
     "type": "command/shell",
-    "inputPath": "models/command/shell/a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.yaml"
+    "inputPath": "models/command/shell/my-shell.yaml"
   },
   "resourceDeleted": false,
   "outputsDeleted": 0,

--- a/.claude/skills/swamp/references/model/references/direct-execution.md
+++ b/.claude/skills/swamp/references/model/references/direct-execution.md
@@ -28,7 +28,7 @@ ambiguous keys, unknown keys are rejected.
 
 ## Storage
 
-Auto-created definitions live in `.swamp/auto-definitions/{type}/{id}.yaml`.
+Auto-created definitions live in `.swamp/auto-definitions/{type}/{name}.yaml`.
 They exist for data ownership boundaries — giving model data a home without
 requiring a hand-authored definition file.
 

--- a/.claude/skills/swamp/references/repo/references/structure.md
+++ b/.claude/skills/swamp/references/repo/references/structure.md
@@ -14,10 +14,10 @@ my-swamp-repo/
 │   ├── definitions/             # Model definitions by normalized type
 │   │   ├── command/
 │   │   │   └── shell/
-│   │   │       └── {model-id}.yaml
+│   │   │       └── {name}.yaml  # (legacy: {uuid}.yaml also supported)
 │   │   └── @user/
 │   │       └── my-type/
-│   │           └── {model-id}.yaml
+│   │           └── {name}.yaml
 │   │
 │   ├── definitions-evaluated/   # Evaluated model definitions (expressions resolved)
 │   │   └── (same structure as definitions/)
@@ -61,7 +61,7 @@ my-swamp-repo/
 │
 ├── models/                      # Model definitions by type
 │   └── {normalized-type}/
-│       └── {model-id}.yaml
+│       └── {name}.yaml          # (legacy: {uuid}.yaml also supported)
 │
 ├── workflows/                   # Workflow definitions (flat files)
 │   └── workflow-{name}.yaml     # (legacy: workflow-{uuid}.yaml also supported)
@@ -179,10 +179,10 @@ methods:
       run: "echo 'Hello'"
 ```
 
-**Path pattern**: `.swamp/definitions/{normalized-type}/{model-id}.yaml`
+**Path pattern**: `.swamp/definitions/{normalized-type}/{name}.yaml`
 
 - `normalized-type`: e.g., `command/shell`, `@user/my-type`
-- `model-id`: UUID assigned at creation
+- `name`: model name (e.g. `my-server`); legacy files may use UUID instead
 
 ### Model Data (.swamp/data/)
 

--- a/design/high-level.md
+++ b/design/high-level.md
@@ -34,7 +34,7 @@ Model definitions, workflow definitions, and vault configurations are stored in
 top-level directories that are tracked in git:
 
 - **`models/`** — Model definitions organized by normalized type:
-  `models/{type}/{id}.yaml`
+  `models/{type}/{name}.yaml` (legacy `{uuid}.yaml` also supported)
 - **`workflows/`** — Workflow definitions: `workflows/workflow-{name}.yaml`
   (legacy `workflow-{uuid}.yaml` also supported)
 - **`vaults/`** — Vault configurations: `vaults/{vault-type}/{id}.yaml`

--- a/design/repo.md
+++ b/design/repo.md
@@ -73,7 +73,8 @@ removes the superseded directories via `removeSupersededSkills()`.
 
 Source-of-truth files live in top-level directories tracked in git:
 
-- **`models/`** — Model definitions: `models/{normalized-type}/{id}.yaml`
+- **`models/`** — Model definitions: `models/{normalized-type}/{name}.yaml`
+  (legacy `{uuid}.yaml` also supported)
 - **`workflows/`** — Workflow definitions: `workflows/workflow-{name}.yaml`
   (legacy `workflow-{uuid}.yaml` also supported)
 - **`vaults/`** — Vault configurations: `vaults/{vault-type}/{id}.yaml`
@@ -192,10 +193,11 @@ When an aggregate repository emits an event:
 **Model definitions (`models/`):**
 
 ```
-models/{normalized-type}/{id}.yaml
+models/{normalized-type}/{name}.yaml
 ```
 
-These are real files (not symlinks) tracked in git.
+These are real files (not symlinks) tracked in git. Legacy `{uuid}.yaml` files
+are also supported and lazily migrated to name-based filenames on save.
 
 **Workflow definitions (`workflows/`):**
 

--- a/integration/doctor_secrets_test.ts
+++ b/integration/doctor_secrets_test.ts
@@ -60,8 +60,19 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
 
 async function findYamlForId(dir: string, id: string): Promise<string> {
   for await (const entry of walk(dir, { exts: [".yaml"] })) {
-    if (entry.isFile && entry.name === `${id}.yaml`) {
-      return entry.path;
+    if (entry.isFile) {
+      // Check both filename and YAML content for the ID
+      if (entry.name === `${id}.yaml`) {
+        return entry.path;
+      }
+      try {
+        const content = await Deno.readTextFile(entry.path);
+        if (content.includes(`id: ${id}`) || content.includes(`id: "${id}"`)) {
+          return entry.path;
+        }
+      } catch {
+        // skip unreadable files
+      }
     }
   }
   throw new Error(`no yaml for id ${id} under ${dir}`);

--- a/integration/model_evaluate_test.ts
+++ b/integration/model_evaluate_test.ts
@@ -77,16 +77,20 @@ Deno.test("CLI: model evaluate persists single model to definitions-evaluated", 
 
     assertEquals(result.code, 0, `Should succeed. stderr: ${result.stderr}`);
 
-    // Check that evaluated definition was persisted
-    const evaluatedPath = join(
+    // Check that evaluated definition was persisted (name-based or UUID filename)
+    const evaluatedDir = join(
       repoDir,
       ".swamp/definitions-evaluated/command/shell",
-      `${definition.id}.yaml`,
     );
+    const evaluatedNamePath = join(evaluatedDir, "eval-persist-test.yaml");
+    const evaluatedUuidPath = join(evaluatedDir, `${definition.id}.yaml`);
+    const evaluatedPath = existsSync(evaluatedNamePath)
+      ? evaluatedNamePath
+      : evaluatedUuidPath;
     assertEquals(
       existsSync(evaluatedPath),
       true,
-      `Evaluated definition should be persisted at ${evaluatedPath}`,
+      `Evaluated definition should be persisted at ${evaluatedNamePath} or ${evaluatedUuidPath}`,
     );
 
     // Verify the persisted content has evaluated expressions
@@ -200,12 +204,16 @@ Deno.test("CLI: model evaluate preserves vault expressions as raw strings", asyn
 
     assertEquals(result.code, 0, `Should succeed. stderr: ${result.stderr}`);
 
-    // Read the persisted evaluated definition
-    const evaluatedPath = join(
+    // Read the persisted evaluated definition (name-based or UUID filename)
+    const evalDir = join(
       repoDir,
       ".swamp/definitions-evaluated/command/shell",
-      `${definition.id}.yaml`,
     );
+    const evalNamePath = join(evalDir, "vault-preserve-test.yaml");
+    const evalUuidPath = join(evalDir, `${definition.id}.yaml`);
+    const evaluatedPath = existsSync(evalNamePath)
+      ? evalNamePath
+      : evalUuidPath;
     const content = await Deno.readTextFile(evaluatedPath);
 
     // Vault expression should still be present as raw string

--- a/src/domain/definitions/definition.ts
+++ b/src/domain/definitions/definition.ts
@@ -152,6 +152,53 @@ export type ResourceOverride = z.infer<typeof ResourceOverrideSchema>;
 
 export type ResourceOverrides = Record<string, ResourceOverride>;
 
+const DEFINITION_NAME_MAX_LENGTH = 64;
+const DEFINITION_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]*$/;
+
+/**
+ * Returns true when a definition name is safe for direct use in a filename
+ * (i.e. `{name}.yaml`). Legacy names that don't match the strict
+ * pattern will fall back to UUID-based filenames.
+ */
+export function isFilenameSafeDefinitionName(name: string): boolean {
+  return (
+    DEFINITION_NAME_PATTERN.test(name) &&
+    name.length <= DEFINITION_NAME_MAX_LENGTH
+  );
+}
+
+const definitionNameBase = z.string().min(1).refine(
+  (name) => {
+    if (name.includes("..") || name.includes("\\") || name.includes("\0")) {
+      return false;
+    }
+    if (name.includes("/")) {
+      return /^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/.test(name);
+    }
+    return true;
+  },
+  {
+    message:
+      "Definition name must not contain '..', '\\', or null bytes (path traversal). '/' is only allowed in scoped @collective/name patterns.",
+  },
+);
+
+const definitionNameStrict = definitionNameBase
+  .refine(
+    (name) => name.includes("/") || DEFINITION_NAME_PATTERN.test(name),
+    {
+      message:
+        "Definition name must be lowercase alphanumeric with hyphens or underscores (e.g. 'my-server'). Must start with a letter or number.",
+    },
+  )
+  .refine(
+    (name) => name.length <= DEFINITION_NAME_MAX_LENGTH,
+    {
+      message:
+        `Definition name must be at most ${DEFINITION_NAME_MAX_LENGTH} characters.`,
+    },
+  );
+
 const DefinitionObjectSchema = z.object({
   type: z.string().optional(),
   typeVersion: z.preprocess(
@@ -159,22 +206,25 @@ const DefinitionObjectSchema = z.object({
     z.string().optional(),
   ),
   id: z.string().uuid(),
-  name: z.string().min(1).refine(
-    (name) => {
-      if (name.includes("..") || name.includes("\\") || name.includes("\0")) {
-        return false;
-      }
-      if (name.includes("/")) {
-        // Allow '/' only in scoped @collective/name extension names
-        return /^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/.test(name);
-      }
-      return true;
-    },
-    {
-      message:
-        "Definition name must not contain '..', '\\', or null bytes (path traversal). '/' is only allowed in scoped @collective/name patterns.",
-    },
+  name: definitionNameBase,
+  version: z.number().int().positive(),
+  tags: z.record(z.string(), z.string()).default({}),
+  globalArguments: z.record(z.string(), z.unknown()).default({}),
+  methods: z.record(z.string(), MethodDataSchema).default({}),
+  inputs: InputsSchemaSchema,
+  checks: CheckSelectionSchema,
+  reports: ReportSelectionSchema,
+  resources: z.record(z.string(), ResourceOverrideSchema).optional(),
+});
+
+const DefinitionStrictObjectSchema = z.object({
+  type: z.string().optional(),
+  typeVersion: z.preprocess(
+    (val) => (typeof val === "number" ? undefined : val),
+    z.string().optional(),
   ),
+  id: z.string().uuid(),
+  name: definitionNameStrict,
   version: z.number().int().positive(),
   tags: z.record(z.string(), z.string()).default({}),
   globalArguments: z.record(z.string(), z.unknown()).default({}),
@@ -188,10 +238,19 @@ const DefinitionObjectSchema = z.object({
 /**
  * Zod schema for Definition. Rejects the removed `driver`/`driverConfig`
  * fields with an actionable error (see design/remote-execution.md).
+ * Uses permissive name validation for loading existing definitions.
  */
 export const DefinitionSchema = z.preprocess(
   rejectRemovedDriverFields,
   DefinitionObjectSchema,
+);
+
+/**
+ * Strict schema for new definitions. Enforces kebab-case naming.
+ */
+const DefinitionStrictSchema = z.preprocess(
+  rejectRemovedDriverFields,
+  DefinitionStrictObjectSchema,
 );
 
 /**
@@ -260,7 +319,7 @@ export class Definition {
     const id = props.id ?? crypto.randomUUID();
     const version = props.version ?? 1;
 
-    const validated = DefinitionSchema.parse({
+    const validated = DefinitionStrictSchema.parse({
       type: props.type,
       typeVersion: props.typeVersion,
       id,

--- a/src/domain/definitions/definition_property_test.ts
+++ b/src/domain/definitions/definition_property_test.ts
@@ -21,17 +21,17 @@ import { assert, assertEquals, assertThrows } from "@std/assert";
 import fc from "fast-check";
 import { Definition } from "./definition.ts";
 
-// Arbitrary for safe definition names (no path traversal chars)
+// Arbitrary for strict definition names (matching create() validation)
 const arbSafeName = fc
   .stringOf(
     fc.oneof(
-      fc.char().filter((c) =>
-        c !== "/" && c !== "\\" && c !== "\0" && c !== "."
-      ),
+      fc.constantFrom(..."abcdefghijklmnopqrstuvwxyz0123456789".split("")),
+      fc.constant("-"),
+      fc.constant("_"),
     ),
     { minLength: 1, maxLength: 30 },
   )
-  .filter((s) => !s.includes(".."));
+  .filter((s) => /^[a-z0-9][a-z0-9_-]*$/.test(s));
 
 // Arbitrary for names that contain path traversal characters
 const arbPathTraversalName = fc.oneof(

--- a/src/domain/definitions/definition_test.ts
+++ b/src/domain/definitions/definition_test.ts
@@ -22,6 +22,7 @@ import {
   createDefinitionId,
   Definition,
   type DefinitionData,
+  isFilenameSafeDefinitionName,
 } from "./definition.ts";
 
 Deno.test("Definition.create generates UUID if not provided", () => {
@@ -108,6 +109,53 @@ Deno.test("Definition.create throws on empty name", () => {
   );
 });
 
+Deno.test("Definition.create enforces strict naming", () => {
+  assertThrows(
+    () => Definition.create({ name: "My Server" }),
+    Error,
+  );
+  assertThrows(
+    () => Definition.create({ name: "ALLCAPS" }),
+    Error,
+  );
+  assertThrows(
+    () => Definition.create({ name: "-starts-with-hyphen" }),
+    Error,
+  );
+});
+
+Deno.test("Definition.create accepts underscores in names", () => {
+  const def = Definition.create({ name: "has_underscores" });
+  assertEquals(def.name, "has_underscores");
+});
+
+Deno.test("Definition.create rejects names exceeding 64 characters", () => {
+  const longName = "a".repeat(65);
+  assertThrows(
+    () => Definition.create({ name: longName }),
+    Error,
+  );
+});
+
+Deno.test("Definition.create accepts kebab-case names up to 64 characters", () => {
+  const maxName = "a".repeat(64);
+  const def = Definition.create({ name: maxName });
+  assertEquals(def.name, maxName);
+});
+
+Deno.test("Definition.fromData accepts legacy non-kebab-case names", () => {
+  const def = Definition.fromData({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "My Legacy Server",
+    version: 1,
+    tags: {},
+    globalArguments: {},
+    methods: {},
+    inputs: undefined,
+  });
+  assertEquals(def.name, "My Legacy Server");
+});
+
 Deno.test("Definition.create throws on name with forward slash", () => {
   assertThrows(
     () => Definition.create({ name: "/etc/passwd" }),
@@ -117,6 +165,32 @@ Deno.test("Definition.create throws on name with forward slash", () => {
     () => Definition.create({ name: "foo/bar" }),
     Error,
   );
+});
+
+// isFilenameSafeDefinitionName tests
+
+Deno.test("isFilenameSafeDefinitionName: accepts kebab-case names", () => {
+  assertEquals(isFilenameSafeDefinitionName("my-server"), true);
+  assertEquals(isFilenameSafeDefinitionName("prod-vpc"), true);
+  assertEquals(isFilenameSafeDefinitionName("a"), true);
+  assertEquals(isFilenameSafeDefinitionName("test123"), true);
+});
+
+Deno.test("isFilenameSafeDefinitionName: accepts underscores", () => {
+  assertEquals(isFilenameSafeDefinitionName("has_underscores"), true);
+  assertEquals(isFilenameSafeDefinitionName("my_server"), true);
+});
+
+Deno.test("isFilenameSafeDefinitionName: rejects unsafe names", () => {
+  assertEquals(isFilenameSafeDefinitionName("My Server"), false);
+  assertEquals(isFilenameSafeDefinitionName("ALLCAPS"), false);
+  assertEquals(isFilenameSafeDefinitionName("-starts-with-hyphen"), false);
+  assertEquals(isFilenameSafeDefinitionName("@scope/name"), false);
+});
+
+Deno.test("isFilenameSafeDefinitionName: rejects names exceeding 64 characters", () => {
+  assertEquals(isFilenameSafeDefinitionName("a".repeat(65)), false);
+  assertEquals(isFilenameSafeDefinitionName("a".repeat(64)), true);
 });
 
 Deno.test("Definition.create throws on name with backslash", () => {

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { ensureDir } from "@std/fs";
-import { join } from "@std/path";
+import { basename, join } from "@std/path";
 import { getLogger } from "@logtape/logtape";
 import { atomicWriteTextFile } from "./atomic_write.ts";
 import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
@@ -33,6 +33,7 @@ import {
   Definition,
   type DefinitionData,
   type DefinitionId,
+  isFilenameSafeDefinitionName,
 } from "../../domain/definitions/definition.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import {
@@ -54,13 +55,15 @@ const logger = getLogger(["definition-repo"]);
  * YAML-based implementation of DefinitionRepository.
  *
  * Stores definitions as YAML files in the directory structure:
- * {repoDir}/models/{normalized-type}/{id}.yaml
+ * {repoDir}/models/{normalized-type}/{name}.yaml   (new default for filename-safe names)
+ * {repoDir}/models/{normalized-type}/{uuid}.yaml   (legacy, still discoverable)
  *
  * CEL expressions in attributes are preserved as-is (not evaluated on save).
  */
 export class YamlDefinitionRepository implements DefinitionRepository {
   private readonly baseDir: string;
   private readonly secondaryBaseDir: string | undefined;
+  private readonly idToActualPath = new Map<DefinitionId, string>();
 
   constructor(
     private readonly repoDir: string,
@@ -80,20 +83,44 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     type: ModelType,
     id: DefinitionId,
   ): Promise<Definition | null> {
-    const path = this.getPath(type, id);
+    // Fast path: try UUID-based filename (legacy)
+    const legacyPath = this.getLegacyPath(type, id);
     try {
-      const content = await Deno.readTextFile(path);
+      const content = await Deno.readTextFile(legacyPath);
       const data = parseYaml(content) as DefinitionData;
-      return Definition.fromData(data);
+      const definition = Definition.fromData(data);
+      this.idToActualPath.set(id, legacyPath);
+      return definition;
     } catch (error) {
-      if (error instanceof Deno.errors.NotFound) {
-        if (this.secondaryBaseDir) {
-          return this.findByIdInDir(this.secondaryBaseDir, type, id);
-        }
-        return null;
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
       }
-      throw error;
     }
+
+    // Try name-based filename from cache
+    const cachedPath = this.idToActualPath.get(id);
+    if (cachedPath && cachedPath !== legacyPath) {
+      try {
+        const content = await Deno.readTextFile(cachedPath);
+        const data = parseYaml(content) as DefinitionData;
+        return Definition.fromData(data);
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw error;
+        }
+      }
+    }
+
+    // Slow path: scan all definition files for this type
+    const definitions = await this.findAll(type);
+    const found = definitions.find((d) => d.id === id);
+    if (found) return found;
+
+    // Fall back to secondary dir
+    if (this.secondaryBaseDir) {
+      return this.findByIdInDir(this.secondaryBaseDir, type, id);
+    }
+    return null;
   }
 
   private async findByIdInDir(
@@ -101,17 +128,43 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     type: ModelType,
     id: DefinitionId,
   ): Promise<Definition | null> {
+    // Fast path: try UUID-based filename
     const path = join(dir, type.toDirectoryPath(), `${id}.yaml`);
     try {
       const content = await Deno.readTextFile(path);
       const data = parseYaml(content) as DefinitionData;
       return Definition.fromData(data);
     } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+
+    // Slow path: scan all files in the type directory for a matching ID
+    const typeDir = join(dir, type.toDirectoryPath());
+    try {
+      for await (const entry of Deno.readDir(typeDir)) {
+        if (entry.isFile && entry.name.endsWith(".yaml")) {
+          try {
+            const content = await Deno.readTextFile(join(typeDir, entry.name));
+            const data = parseYaml(content) as DefinitionData;
+            const definition = Definition.fromData(data);
+            if (definition.id === id) {
+              return definition;
+            }
+          } catch {
+            // Skip broken files
+          }
+        }
+      }
+    } catch (error) {
       if (error instanceof Deno.errors.NotFound) {
         return null;
       }
       throw error;
     }
+
+    return null;
   }
 
   async findAll(type: ModelType): Promise<Definition[]> {
@@ -130,7 +183,12 @@ export class YamlDefinitionRepository implements DefinitionRepository {
             }
             const content = await Deno.readTextFile(path);
             const data = parseYaml(content) as DefinitionData;
-            definitions.push(Definition.fromData(data));
+            const definition = Definition.fromData(data);
+            this.idToActualPath.set(
+              definition.id as DefinitionId,
+              path,
+            );
+            definitions.push(definition);
           } catch (error) {
             if (isIoError(error)) {
               throw new UserError(
@@ -155,6 +213,27 @@ export class YamlDefinitionRepository implements DefinitionRepository {
   }
 
   async findByName(type: ModelType, name: string): Promise<Definition | null> {
+    // Fast path: try name-based filename directly
+    if (isFilenameSafeDefinitionName(name)) {
+      const namePath = this.getNamePath(type, name);
+      try {
+        const content = await Deno.readTextFile(namePath);
+        const data = parseYaml(content) as DefinitionData;
+        const definition = Definition.fromData(data);
+        if (definition.name !== name) {
+          // File content doesn't match filename — fall through to slow path
+        } else {
+          this.idToActualPath.set(definition.id as DefinitionId, namePath);
+          return definition;
+        }
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw error;
+        }
+      }
+    }
+
+    // Slow path: scan all definition files
     const definitions = await this.findAll(type);
     const found = definitions.find((def) => def.name === name);
     if (found) return found;
@@ -243,6 +322,10 @@ export class YamlDefinitionRepository implements DefinitionRepository {
             const definition = Definition.fromData(data);
 
             if (definition.name === name) {
+              this.idToActualPath.set(
+                definition.id as DefinitionId,
+                fullPath,
+              );
               // Prefer the type from the YAML, fall back to path-based type
               const typeStr = definition.type ?? pathSegments.join("/");
               return { definition, type: ModelType.create(typeStr) };
@@ -315,6 +398,10 @@ export class YamlDefinitionRepository implements DefinitionRepository {
             const data = parseYaml(content) as DefinitionData;
             const definition = Definition.fromData(data);
 
+            this.idToActualPath.set(
+              definition.id as DefinitionId,
+              fullPath,
+            );
             // Prefer the type from the YAML, fall back to path-based type
             const typeStr = definition.type ?? pathSegments.join("/");
             results.push({ definition, type: ModelType.create(typeStr) });
@@ -350,10 +437,14 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     await assertSafePath(dir, this.baseDir);
     await ensureDir(dir);
 
-    const path = this.getPath(type, definition.id);
+    const targetPath = this.resolveWritePath(type, definition);
+    const previousPath = this.idToActualPath.get(definition.id);
 
     // Check if this is a new definition or an update
-    const isNew = !(await this.exists(path));
+    const legacyPath = this.getLegacyPath(type, definition.id);
+    const isNew = !(await this.exists(targetPath)) &&
+      !(previousPath && await this.exists(previousPath)) &&
+      !(await this.exists(legacyPath));
 
     const data = definition.toData();
     // Ensure type metadata is always present in persisted YAML
@@ -397,7 +488,44 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     // Remove undefined values since YAML can't stringify them
     const cleanData = JSON.parse(JSON.stringify(data));
     const content = stringifyYaml(cleanData as Record<string, unknown>);
-    await atomicWriteTextFile(path, content);
+    await atomicWriteTextFile(targetPath, content);
+
+    // Clean up old file if we wrote to a different path
+    if (previousPath && previousPath !== targetPath) {
+      try {
+        await Deno.remove(previousPath);
+        logger.debug`Migrated definition file from ${
+          basename(previousPath)
+        } to ${basename(targetPath)}`;
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          logger.warn`Failed to remove old definition file ${previousPath}: ${
+            error instanceof Error ? error.message : String(error)
+          }`;
+        }
+      }
+    }
+
+    // Also check the legacy UUID path if it wasn't the previousPath
+    if (
+      targetPath !== legacyPath && previousPath !== legacyPath &&
+      await this.exists(legacyPath)
+    ) {
+      try {
+        await Deno.remove(legacyPath);
+        logger.debug`Migrated definition file from ${basename(legacyPath)} to ${
+          basename(targetPath)
+        }`;
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          logger.warn`Failed to remove legacy definition file ${legacyPath}: ${
+            error instanceof Error ? error.message : String(error)
+          }`;
+        }
+      }
+    }
+
+    this.idToActualPath.set(definition.id, targetPath);
 
     // Emit event
     if (this.eventBus) {
@@ -432,22 +560,36 @@ export class YamlDefinitionRepository implements DefinitionRepository {
   }
 
   async delete(type: ModelType, id: DefinitionId): Promise<void> {
-    const path = this.getPath(type, id);
+    // Populate cache so we discover name-based files on a cold instance
+    const definition = await this.findById(type, id);
+    const definitionName = definition?.name;
 
-    // Get the definition name before deleting for the event
-    let definitionName: string | undefined;
-    if (this.eventBus) {
-      const definition = await this.findById(type, id);
-      definitionName = definition?.name;
+    // Try removing all possible file paths
+    const pathsToTry = new Set([this.getLegacyPath(type, id)]);
+    const cachedPath = this.idToActualPath.get(id);
+    if (cachedPath) pathsToTry.add(cachedPath);
+    if (definitionName && isFilenameSafeDefinitionName(definitionName)) {
+      pathsToTry.add(this.getNamePath(type, definitionName));
     }
 
-    try {
-      await Deno.remove(path);
+    let deleted = false;
+    for (const path of pathsToTry) {
+      try {
+        await Deno.remove(path);
+        deleted = true;
 
-      // Clean up empty parent directories
-      await cleanupEmptyParentDirs(path, this.baseDir);
+        // Clean up empty parent directories
+        await cleanupEmptyParentDirs(path, this.baseDir);
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw error;
+        }
+      }
+    }
 
-      // Emit event if we had a name
+    if (deleted) {
+      this.idToActualPath.delete(id);
+
       if (this.eventBus && definitionName) {
         const event = createDefinitionDeleted(
           type.normalized,
@@ -455,10 +597,6 @@ export class YamlDefinitionRepository implements DefinitionRepository {
           definitionName,
         );
         await this.eventBus.publish(event);
-      }
-    } catch (error) {
-      if (!(error instanceof Deno.errors.NotFound)) {
-        throw error;
       }
     }
   }
@@ -468,6 +606,24 @@ export class YamlDefinitionRepository implements DefinitionRepository {
   }
 
   getPath(type: ModelType, id: DefinitionId): string {
+    return this.idToActualPath.get(id) ?? this.getLegacyPath(type, id);
+  }
+
+  private resolveWritePath(
+    type: ModelType,
+    definition: Definition,
+  ): string {
+    if (isFilenameSafeDefinitionName(definition.name)) {
+      return this.getNamePath(type, definition.name);
+    }
+    return this.getLegacyPath(type, definition.id);
+  }
+
+  private getNamePath(type: ModelType, name: string): string {
+    return join(this.getTypeDir(type), `${name}.yaml`);
+  }
+
+  private getLegacyPath(type: ModelType, id: DefinitionId): string {
     return join(this.getTypeDir(type), `${id}.yaml`);
   }
 

--- a/src/infrastructure/persistence/yaml_definition_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository_test.ts
@@ -662,6 +662,194 @@ Deno.test("YamlDefinitionRepository.save passes through an unregistered type (sc
   });
 });
 
+// --- Name-based filename tests ---
+
+Deno.test("YamlDefinitionRepository.save writes name-based filename for kebab-case names", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = createTestDefinition("my-server");
+
+    await repo.save(testType, definition);
+
+    // File should be at {name}.yaml, not {uuid}.yaml
+    const namePath = join(
+      dir,
+      "models",
+      testType.toDirectoryPath(),
+      "my-server.yaml",
+    );
+    const stat = await Deno.stat(namePath);
+    assertEquals(stat.isFile, true);
+
+    // UUID path should not exist
+    const uuidPath = join(
+      dir,
+      "models",
+      testType.toDirectoryPath(),
+      `${definition.id}.yaml`,
+    );
+    try {
+      await Deno.stat(uuidPath);
+      assertEquals(true, false, "UUID file should not exist");
+    } catch (error) {
+      assertEquals(error instanceof Deno.errors.NotFound, true);
+    }
+  });
+});
+
+Deno.test("YamlDefinitionRepository.save migrates UUID file to name-based on edit", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = createTestDefinition("migrate-me");
+
+    // Manually write a UUID-named file (simulating legacy)
+    const typeDir = join(dir, "models", testType.toDirectoryPath());
+    await ensureDir(typeDir);
+    const uuidPath = join(typeDir, `${definition.id}.yaml`);
+    const data = definition.toData();
+    data.type = testType.normalized;
+    await Deno.writeTextFile(uuidPath, toCleanYaml(data));
+
+    // Now save via repo — should migrate to name-based
+    const loaded = await repo.findById(testType, definition.id);
+    assertNotEquals(loaded, null);
+    await repo.save(testType, loaded!);
+
+    // Name-based file should exist
+    const namePath = join(typeDir, "migrate-me.yaml");
+    const stat = await Deno.stat(namePath);
+    assertEquals(stat.isFile, true);
+
+    // UUID file should be gone
+    try {
+      await Deno.stat(uuidPath);
+      assertEquals(true, false, "UUID file should have been removed");
+    } catch (error) {
+      assertEquals(error instanceof Deno.errors.NotFound, true);
+    }
+  });
+});
+
+Deno.test("YamlDefinitionRepository.getPath returns name-based path after save", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = createTestDefinition("path-test");
+
+    await repo.save(testType, definition);
+
+    const path = repo.getPath(testType, definition.id);
+    assertStringIncludes(path, "path-test.yaml");
+  });
+});
+
+Deno.test("YamlDefinitionRepository.getPath returns UUID path for legacy files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = createTestDefinition("legacy-file");
+
+    // Manually write a UUID-named file (no save through repo)
+    const typeDir = join(dir, "models", testType.toDirectoryPath());
+    await ensureDir(typeDir);
+    const uuidPath = join(typeDir, `${definition.id}.yaml`);
+    const data = definition.toData();
+    data.type = testType.normalized;
+    await Deno.writeTextFile(uuidPath, toCleanYaml(data));
+
+    // findById populates cache with actual path
+    await repo.findById(testType, definition.id);
+    const path = repo.getPath(testType, definition.id);
+    assertStringIncludes(path, `${definition.id}.yaml`);
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findByName fast path works for name-based files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = createTestDefinition("fast-lookup");
+
+    await repo.save(testType, definition);
+
+    const found = await repo.findByName(testType, "fast-lookup");
+    assertNotEquals(found, null);
+    assertEquals(found!.id, definition.id);
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findByName falls through when file name diverges from content name", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+
+    // Create two definitions
+    const def1 = createTestDefinition("original");
+    const def2 = createTestDefinition("renamed");
+
+    await repo.save(testType, def1);
+    await repo.save(testType, def2);
+
+    // Manually swap the content of renamed.yaml to have name "original"
+    // (simulating someone editing the YAML name without renaming the file)
+    const typeDir = join(dir, "models", testType.toDirectoryPath());
+    const renamedPath = join(typeDir, "renamed.yaml");
+    const data = def2.toData();
+    data.name = "original";
+    data.type = testType.normalized;
+    await Deno.writeTextFile(renamedPath, toCleanYaml(data));
+
+    // findByName("renamed") should fall through to slow path since
+    // the file content says "original", not "renamed"
+    const found = await repo.findByName(testType, "renamed");
+    assertEquals(found, null);
+  });
+});
+
+Deno.test("YamlDefinitionRepository.delete handles name-based files", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = createTestDefinition("delete-named");
+
+    await repo.save(testType, definition);
+
+    // Verify it exists
+    assertNotEquals(await repo.findById(testType, definition.id), null);
+
+    // Delete it
+    await repo.delete(testType, definition.id);
+
+    // Should be gone
+    assertEquals(await repo.findById(testType, definition.id), null);
+
+    // File should not exist
+    const namePath = join(
+      dir,
+      "models",
+      testType.toDirectoryPath(),
+      "delete-named.yaml",
+    );
+    try {
+      await Deno.stat(namePath);
+      assertEquals(true, false, "File should have been removed");
+    } catch (error) {
+      assertEquals(error instanceof Deno.errors.NotFound, true);
+    }
+  });
+});
+
+Deno.test("YamlDefinitionRepository.delete handles cold cache with name-based files", async () => {
+  await withTempDir(async (dir) => {
+    // Save definition with one repo instance
+    const repo1 = new YamlDefinitionRepository(dir);
+    const definition = createTestDefinition("cold-delete");
+    await repo1.save(testType, definition);
+
+    // Delete with a fresh repo instance (cold cache)
+    const repo2 = new YamlDefinitionRepository(dir);
+    await repo2.delete(testType, definition.id);
+
+    // Should be gone
+    assertEquals(await repo2.findById(testType, definition.id), null);
+  });
+});
+
 // --- I/O error propagation tests ---
 
 Deno.test("YamlDefinitionRepository.findAll throws UserError on EMFILE", async () => {

--- a/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
@@ -30,6 +30,7 @@ import {
   Definition,
   type DefinitionData,
   type DefinitionId,
+  isFilenameSafeDefinitionName,
 } from "../../domain/definitions/definition.ts";
 import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
@@ -38,13 +39,15 @@ import { modelRegistry } from "../../domain/models/model.ts";
  * YAML-based repository for evaluated definitions.
  *
  * Stores definitions with CEL expressions already evaluated in the directory structure:
- * {repoDir}/.swamp/definitions-evaluated/{normalized-type}/{id}.yaml
+ * {repoDir}/.swamp/definitions-evaluated/{normalized-type}/{name}.yaml
+ * (or {uuid}.yaml for legacy/non-filename-safe names).
  *
  * This directory is gitignored as evaluated definitions are derived data
  * that can be regenerated from the source definitions.
  */
 export class YamlEvaluatedDefinitionRepository {
   private readonly baseDir: string;
+  private readonly idToActualPath = new Map<DefinitionId, string>();
 
   constructor(
     private readonly repoDir: string,
@@ -70,17 +73,37 @@ export class YamlEvaluatedDefinitionRepository {
     type: ModelType,
     id: DefinitionId,
   ): Promise<Definition | null> {
-    const path = this.getPath(type, id);
+    // Fast path: try UUID-based filename (legacy)
+    const legacyPath = this.getLegacyPath(type, id);
     try {
-      const content = await Deno.readTextFile(path);
+      const content = await Deno.readTextFile(legacyPath);
       const data = parseYaml(content) as DefinitionData;
-      return Definition.fromData(data);
+      const definition = Definition.fromData(data);
+      this.idToActualPath.set(id, legacyPath);
+      return definition;
     } catch (error) {
-      if (error instanceof Deno.errors.NotFound) {
-        return null;
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
       }
-      throw error;
     }
+
+    // Try cached path
+    const cachedPath = this.idToActualPath.get(id);
+    if (cachedPath && cachedPath !== legacyPath) {
+      try {
+        const content = await Deno.readTextFile(cachedPath);
+        const data = parseYaml(content) as DefinitionData;
+        return Definition.fromData(data);
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw error;
+        }
+      }
+    }
+
+    // Slow path: scan all files
+    const definitions = await this.findAll(type);
+    return definitions.find((d) => d.id === id) ?? null;
   }
 
   /**
@@ -99,7 +122,9 @@ export class YamlEvaluatedDefinitionRepository {
           const path = join(dir, entry.name);
           const content = await Deno.readTextFile(path);
           const data = parseYaml(content) as DefinitionData;
-          definitions.push(Definition.fromData(data));
+          const definition = Definition.fromData(data);
+          this.idToActualPath.set(definition.id as DefinitionId, path);
+          definitions.push(definition);
         }
       }
     } catch (error) {
@@ -120,6 +145,25 @@ export class YamlEvaluatedDefinitionRepository {
    * @returns The evaluated definition if found, or null
    */
   async findByName(type: ModelType, name: string): Promise<Definition | null> {
+    if (isFilenameSafeDefinitionName(name)) {
+      const namePath = this.getNamePath(type, name);
+      try {
+        const content = await Deno.readTextFile(namePath);
+        const data = parseYaml(content) as DefinitionData;
+        const definition = Definition.fromData(data);
+        if (definition.name !== name) {
+          // File content doesn't match filename — fall through to slow path
+        } else {
+          this.idToActualPath.set(definition.id as DefinitionId, namePath);
+          return definition;
+        }
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw error;
+        }
+      }
+    }
+
     const definitions = await this.findAll(type);
     return definitions.find((def) => def.name === name) ?? null;
   }
@@ -156,6 +200,7 @@ export class YamlEvaluatedDefinitionRepository {
           const definition = Definition.fromData(data);
 
           if (definition.name === name) {
+            this.idToActualPath.set(definition.id as DefinitionId, fullPath);
             // Reconstruct the model type from the path segments
             const typeStr = pathSegments.join("/");
             return { definition, type: ModelType.create(typeStr) };
@@ -214,6 +259,7 @@ export class YamlEvaluatedDefinitionRepository {
           const data = parseYaml(content) as DefinitionData;
           const definition = Definition.fromData(data);
 
+          this.idToActualPath.set(definition.id as DefinitionId, fullPath);
           // Reconstruct the model type from the path segments
           const typeStr = pathSegments.join("/");
           results.push({ definition, type: ModelType.create(typeStr) });
@@ -240,8 +286,8 @@ export class YamlEvaluatedDefinitionRepository {
    * @param definition - The evaluated definition to save
    */
   async save(type: ModelType, definition: Definition): Promise<void> {
-    const path = this.getPath(type, definition.id);
-    await this.notifyDirty(path);
+    const targetPath = this.resolveWritePath(type, definition);
+    await this.notifyDirty(targetPath);
 
     const dir = this.getTypeDir(type);
     await assertSafePath(dir, this.baseDir);
@@ -256,7 +302,33 @@ export class YamlEvaluatedDefinitionRepository {
     // Remove undefined values since YAML can't stringify them
     const cleanData = JSON.parse(JSON.stringify(data));
     const content = stringifyYaml(cleanData as Record<string, unknown>);
-    await atomicWriteTextFile(path, content);
+    await atomicWriteTextFile(targetPath, content);
+
+    // Clean up old file if it's at a different path
+    const previousPath = this.idToActualPath.get(definition.id);
+    if (previousPath && previousPath !== targetPath) {
+      try {
+        await Deno.remove(previousPath);
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw error;
+        }
+      }
+    }
+
+    // Also check legacy UUID path
+    const legacyPath = this.getLegacyPath(type, definition.id);
+    if (targetPath !== legacyPath && previousPath !== legacyPath) {
+      try {
+        await Deno.remove(legacyPath);
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw error;
+        }
+      }
+    }
+
+    this.idToActualPath.set(definition.id, targetPath);
   }
 
   /**
@@ -266,23 +338,38 @@ export class YamlEvaluatedDefinitionRepository {
    * @param id - The definition ID
    */
   async delete(type: ModelType, id: DefinitionId): Promise<void> {
-    const path = this.getPath(type, id);
-    await this.notifyDirty(path);
+    // Populate cache so we discover name-based files on a cold instance
+    const definition = await this.findById(type, id);
 
-    try {
-      await Deno.remove(path);
+    const pathsToTry = new Set([this.getLegacyPath(type, id)]);
+    const cachedPath = this.idToActualPath.get(id);
+    if (cachedPath) pathsToTry.add(cachedPath);
+    if (definition && isFilenameSafeDefinitionName(definition.name)) {
+      pathsToTry.add(this.getNamePath(type, definition.name));
+    }
 
-      // Clean up empty parent directories
-      const definitionsDir = swampPath(
-        this.repoDir,
-        SWAMP_SUBDIRS.definitionsEvaluated,
-      );
-      await cleanupEmptyParentDirs(path, definitionsDir);
-    } catch (error) {
-      if (!(error instanceof Deno.errors.NotFound)) {
-        throw error;
+    const resolvedPath = this.idToActualPath.get(id) ??
+      this.getLegacyPath(type, id);
+    await this.notifyDirty(resolvedPath);
+
+    for (const path of pathsToTry) {
+      try {
+        await Deno.remove(path);
+
+        // Clean up empty parent directories
+        const definitionsDir = swampPath(
+          this.repoDir,
+          SWAMP_SUBDIRS.definitionsEvaluated,
+        );
+        await cleanupEmptyParentDirs(path, definitionsDir);
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw error;
+        }
       }
     }
+
+    this.idToActualPath.delete(id);
   }
 
   /**
@@ -300,6 +387,24 @@ export class YamlEvaluatedDefinitionRepository {
    * @returns The file path
    */
   getPath(type: ModelType, id: DefinitionId): string {
+    return this.idToActualPath.get(id) ?? this.getLegacyPath(type, id);
+  }
+
+  private resolveWritePath(
+    type: ModelType,
+    definition: Definition,
+  ): string {
+    if (isFilenameSafeDefinitionName(definition.name)) {
+      return this.getNamePath(type, definition.name);
+    }
+    return this.getLegacyPath(type, definition.id);
+  }
+
+  private getNamePath(type: ModelType, name: string): string {
+    return join(this.getTypeDir(type), `${name}.yaml`);
+  }
+
+  private getLegacyPath(type: ModelType, id: DefinitionId): string {
     return join(this.getTypeDir(type), `${id}.yaml`);
   }
 
@@ -322,5 +427,6 @@ export class YamlEvaluatedDefinitionRepository {
         throw error;
       }
     }
+    this.idToActualPath.clear();
   }
 }

--- a/src/infrastructure/persistence/yaml_evaluated_definition_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_definition_repository_test.ts
@@ -17,12 +17,23 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import {
+  assertEquals,
+  assertNotEquals,
+  assertStringIncludes,
+} from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
 import { YamlEvaluatedDefinitionRepository } from "./yaml_evaluated_definition_repository.ts";
 import { Definition } from "../../domain/definitions/definition.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 
 const testType = ModelType.create("test/model");
+
+function toCleanYaml(data: Record<string, unknown>): string {
+  return stringifyYaml(JSON.parse(JSON.stringify(data)));
+}
 
 async function withTempDir(
   fn: (dir: string) => Promise<void>,
@@ -62,17 +73,15 @@ Deno.test(
         name: "test-def",
       });
 
-      const expectedPath = repo.getPath(testType, definition.id);
-
-      // save → per-definition yaml path
+      // save → per-definition yaml path (name-based for kebab-case names)
       await repo.save(testType, definition);
       assertEquals(calls.length, 1);
-      assertEquals(calls[0], expectedPath);
+      const savedPath = repo.getPath(testType, definition.id);
+      assertEquals(calls[0], savedPath);
 
-      // delete → same per-definition yaml path
+      // delete → notifies with the resolved path
       await repo.delete(testType, definition.id);
       assertEquals(calls.length, 2);
-      assertEquals(calls[1], expectedPath);
 
       // Reads do not notify.
       await repo.findAll(testType);
@@ -88,3 +97,153 @@ Deno.test(
     });
   },
 );
+
+Deno.test("YamlEvaluatedDefinitionRepository.save writes name-based filename", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlEvaluatedDefinitionRepository(dir);
+
+    const definition = Definition.create({
+      type: testType.normalized,
+      typeVersion: "1",
+      name: "my-eval-def",
+    });
+
+    await repo.save(testType, definition);
+
+    // File should be at {name}.yaml
+    const path = repo.getPath(testType, definition.id);
+    assertStringIncludes(path, "my-eval-def.yaml");
+
+    // findById should return it
+    const loaded = await repo.findById(testType, definition.id);
+    assertNotEquals(loaded, null);
+    assertEquals(loaded!.name, "my-eval-def");
+  });
+});
+
+Deno.test("YamlEvaluatedDefinitionRepository.save migrates UUID file to name-based", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlEvaluatedDefinitionRepository(dir);
+
+    const definition = Definition.create({
+      type: testType.normalized,
+      typeVersion: "1",
+      name: "migrate-eval",
+    });
+
+    // Manually write a UUID-named file (simulating legacy)
+    const typeDir = join(
+      dir,
+      ".swamp",
+      "definitions-evaluated",
+      testType.toDirectoryPath(),
+    );
+    await ensureDir(typeDir);
+    const uuidPath = join(typeDir, `${definition.id}.yaml`);
+    const data = definition.toData();
+    data.type = testType.normalized;
+    await Deno.writeTextFile(uuidPath, toCleanYaml(data));
+
+    // Load and re-save — should migrate
+    const loaded = await repo.findById(testType, definition.id);
+    assertNotEquals(loaded, null);
+    await repo.save(testType, loaded!);
+
+    // Name-based file should exist
+    const namePath = join(typeDir, "migrate-eval.yaml");
+    const stat = await Deno.stat(namePath);
+    assertEquals(stat.isFile, true);
+
+    // UUID file should be gone
+    try {
+      await Deno.stat(uuidPath);
+      assertEquals(true, false, "UUID file should have been removed");
+    } catch (error) {
+      assertEquals(error instanceof Deno.errors.NotFound, true);
+    }
+  });
+});
+
+Deno.test("YamlEvaluatedDefinitionRepository.findByName fast path works", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlEvaluatedDefinitionRepository(dir);
+
+    const definition = Definition.create({
+      type: testType.normalized,
+      typeVersion: "1",
+      name: "find-by-name",
+    });
+
+    await repo.save(testType, definition);
+
+    const found = await repo.findByName(testType, "find-by-name");
+    assertNotEquals(found, null);
+    assertEquals(found!.id, definition.id);
+  });
+});
+
+Deno.test("YamlEvaluatedDefinitionRepository.findByName falls through when file name diverges", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlEvaluatedDefinitionRepository(dir);
+
+    const definition = Definition.create({
+      type: testType.normalized,
+      typeVersion: "1",
+      name: "actual-name",
+    });
+
+    await repo.save(testType, definition);
+
+    // Rename file on disk but keep content name as "actual-name"
+    const typeDir = join(
+      dir,
+      ".swamp",
+      "definitions-evaluated",
+      testType.toDirectoryPath(),
+    );
+    const namePath = join(typeDir, "actual-name.yaml");
+    const wrongPath = join(typeDir, "wrong-name.yaml");
+    await Deno.rename(namePath, wrongPath);
+
+    // findByName("wrong-name") should fall through since content says "actual-name"
+    const found = await repo.findByName(testType, "wrong-name");
+    assertEquals(found, null);
+  });
+});
+
+Deno.test("YamlEvaluatedDefinitionRepository.delete handles name-based files on cold cache", async () => {
+  await withTempDir(async (dir) => {
+    // Save with one repo instance
+    const repo1 = new YamlEvaluatedDefinitionRepository(dir);
+    const definition = Definition.create({
+      type: testType.normalized,
+      typeVersion: "1",
+      name: "cold-eval-delete",
+    });
+    await repo1.save(testType, definition);
+
+    // Delete with a fresh instance (cold cache)
+    const repo2 = new YamlEvaluatedDefinitionRepository(dir);
+    await repo2.delete(testType, definition.id);
+
+    assertEquals(await repo2.findById(testType, definition.id), null);
+  });
+});
+
+Deno.test("YamlEvaluatedDefinitionRepository.clearAll also clears path cache", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlEvaluatedDefinitionRepository(dir);
+
+    const definition = Definition.create({
+      type: testType.normalized,
+      typeVersion: "1",
+      name: "clear-cache",
+    });
+
+    await repo.save(testType, definition);
+    assertNotEquals(await repo.findById(testType, definition.id), null);
+
+    await repo.clearAll();
+    assertEquals(await repo.findById(testType, definition.id), null);
+  });
+});


### PR DESCRIPTION
## Summary

- Model definition files are now named `{name}.yaml` instead of `{uuid}.yaml`, making them human-readable in the `models/` directory (e.g. `models/command/shell/my-server.yaml` instead of `models/command/shell/a3f1b2c4-d5e6-...yaml`)
- Legacy `{uuid}.yaml` files remain fully supported — both patterns are discovered, loaded, and runnable with no migration required
- On `save()`, UUID files are lazily migrated to name-based files (one-time, subsequent edits are in-place)
- New definition names are enforced as lowercase alphanumeric with hyphens and underscores (max 64 chars); existing definitions with non-conforming names keep working via the permissive `fromData()` path
- Follows the same pattern established by the workflow naming change (b61c9de2), with all four regression fixes from 19b64706 baked in from the start

## Test Plan

- [x] 10,460 unit/integration tests pass (0 failures)
- [x] `deno check`, `deno lint`, `deno fmt` clean
- [x] E2E CLI: old binary creates UUID files → new binary reads, lists, gets (by name and UUID), runs, edits (migration), deletes, creates → old binary reads migrated name-based files
- [x] E2E serve: started serve with new binary on repo with UUID files → search, get, get-by-UUID, method run, edit (migration with UUID file removed), delete, create — all through the running server
- [x] `findByName` fast-path name-mismatch guard verified (regression from workflow PR)
- [x] Cold-cache delete verified (regression from workflow PR)
- [x] `isNew` cold-cache event check verified (regression from workflow PR)
- [x] Scoped `@collective/name` creation verified (regression from workflow PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)