### PR TITLE
fix(runtime): use explicit cwd in deno health check to prevent EACCES failures (swamp-club#1706)

### DIFF
--- a/src/infrastructure/process/resolve_command.ts
+++ b/src/infrastructure/process/resolve_command.ts
@@ -57,6 +57,7 @@ const defaultLookupRunner: CommandLookupRunner = async (tool, name) => {
       args: [name],
       stdout: "piped",
       stderr: "piped",
+      cwd: safeCwd(),
     });
     const output = await cmd.output();
     return { success: output.success, stdout: output.stdout };
@@ -65,6 +66,20 @@ const defaultLookupRunner: CommandLookupRunner = async (tool, name) => {
     return { success: false, stdout: new Uint8Array() };
   }
 };
+
+/**
+ * Returns an accessible cwd for subprocess spawning. Falls back to the OS
+ * temp dir or root if the process's working directory is inaccessible (e.g.
+ * when invoked via `sudo -u` from another user's restricted home).
+ */
+function safeCwd(): string {
+  try {
+    Deno.cwd();
+    return Deno.cwd();
+  } catch {
+    return Deno.env.get("TMPDIR") ?? Deno.env.get("TMP") ?? "/";
+  }
+}
 
 /** Picks the platform-appropriate lookup tool name. */
 function lookupTool(): "which" | "where" {

--- a/src/infrastructure/runtime/embedded_deno_runtime.ts
+++ b/src/infrastructure/runtime/embedded_deno_runtime.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join } from "@std/path";
+import { dirname, join } from "@std/path";
 import { getLogger } from "@logtape/logtape";
 import type { DenoRuntime } from "../../domain/runtime/deno_runtime.ts";
 import { DenoVersion } from "../../domain/runtime/deno_version.ts";
@@ -98,11 +98,12 @@ export class EmbeddedDenoRuntime implements DenoRuntime {
         await Deno.stat(targetBinary);
         logger
           .debug`Deno ${embeddedVersion} already extracted at ${targetBinary}`;
-        if (await this.healthCheck(targetBinary)) {
+        const check = await this.healthCheck(targetBinary);
+        if (check.ok) {
           return targetBinary;
         }
         logger
-          .warn`Extracted deno at ${targetBinary} failed health check — re-extracting`;
+          .warn`Extracted deno at ${targetBinary} failed health check — re-extracting: ${check.stderr}`;
       }
     } catch {
       // Version marker missing or binary missing — need to extract
@@ -134,13 +135,14 @@ export class EmbeddedDenoRuntime implements DenoRuntime {
     logger
       .debug`Extracted deno ${embeddedVersion} (${embeddedBinary.length} bytes)`;
 
-    if (await this.healthCheck(targetBinary)) {
+    const postExtract = await this.healthCheck(targetBinary);
+    if (postExtract.ok) {
       return targetBinary;
     }
 
     // Extracted binary still unhealthy — fall back to system deno in PATH.
     logger
-      .warn`Embedded deno at ${targetBinary} failed health check after extraction — falling back to system deno`;
+      .warn`Embedded deno at ${targetBinary} failed health check after extraction — falling back to system deno: ${postExtract.stderr}`;
     const systemDeno = await this.findSystemDeno();
     if (systemDeno) {
       logger.warn`Using system deno at ${systemDeno}`;
@@ -149,24 +151,33 @@ export class EmbeddedDenoRuntime implements DenoRuntime {
 
     throw new Error(
       `Embedded deno at ${targetBinary} failed health check and no system deno found in PATH. ` +
-        `Try: xattr -c ${targetBinary}`,
+        this.platformHint(targetBinary) +
+        (postExtract.stderr ? ` Detail: ${postExtract.stderr}` : ""),
     );
   }
 
   /**
    * Returns true if the binary at the given path executes cleanly.
+   * Uses an explicit cwd so the child process doesn't inherit an
+   * inaccessible working directory (e.g. when invoked via sudo -u
+   * from another user's restricted home).
    */
-  private async healthCheck(binaryPath: string): Promise<boolean> {
+  private async healthCheck(
+    binaryPath: string,
+  ): Promise<{ ok: boolean; stderr: string }> {
     try {
       const result = await new Deno.Command(binaryPath, {
         args: ["--version"],
         stdout: "null",
-        stderr: "null",
+        stderr: "piped",
+        cwd: dirname(binaryPath),
         env: this.getDenoEnv(),
       }).output();
-      return result.success;
-    } catch {
-      return false;
+      const stderr = new TextDecoder().decode(result.stderr).trim()
+        .slice(0, 500);
+      return { ok: result.success, stderr };
+    } catch (e) {
+      return { ok: false, stderr: String(e).slice(0, 500) };
     }
   }
 
@@ -187,6 +198,7 @@ export class EmbeddedDenoRuntime implements DenoRuntime {
         args: ["-c", binaryPath],
         stdout: "null",
         stderr: "null",
+        cwd: dirname(binaryPath),
       }).output();
       logger.debug`Cleared macOS extended attributes on ${binaryPath}`;
     } catch {
@@ -236,6 +248,19 @@ export class EmbeddedDenoRuntime implements DenoRuntime {
    */
   private getSwampDenoDir(): string {
     return join(getSwampDataDir(), "deno");
+  }
+
+  private platformHint(binaryPath: string): string {
+    if (Deno.build.os === "darwin") {
+      return `Try: xattr -c ${binaryPath}`;
+    }
+    if (Deno.build.os === "linux") {
+      return (
+        `Ensure the working directory is accessible to the running user, ` +
+        `or set SWAMP_HOME to a writable location.`
+      );
+    }
+    return `Check file permissions on ${binaryPath}`;
   }
 
   /**

--- a/src/infrastructure/runtime/embedded_deno_runtime_test.ts
+++ b/src/infrastructure/runtime/embedded_deno_runtime_test.ts
@@ -46,38 +46,43 @@ Deno.test("EmbeddedDenoRuntime caches the deno path", async () => {
   assertEquals(first, second);
 });
 
-Deno.test("subprocess spawn fails with inaccessible cwd, succeeds with explicit cwd", async () => {
-  const testDir = await Deno.makeTempDir({ prefix: "cwd-test-" });
-  const restrictedDir = `${testDir}/restricted`;
-  await Deno.mkdir(restrictedDir);
-  await Deno.chmod(restrictedDir, 0o000);
+Deno.test({
+  name:
+    "subprocess spawn fails with inaccessible cwd, succeeds with explicit cwd",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    const testDir = await Deno.makeTempDir({ prefix: "cwd-test-" });
+    const restrictedDir = `${testDir}/restricted`;
+    await Deno.mkdir(restrictedDir);
+    await Deno.chmod(restrictedDir, 0o000);
 
-  try {
-    // Spawn with inaccessible cwd fails
-    let threw = false;
     try {
-      await new Deno.Command(Deno.execPath(), {
-        args: ["--version"],
-        cwd: restrictedDir,
-        stdout: "null",
-        stderr: "piped",
-      }).output();
-    } catch (e) {
-      threw = true;
-      assertStringIncludes(String(e), "Permission denied");
-    }
-    assertEquals(threw, true, "should throw when cwd is inaccessible");
+      // Spawn with inaccessible cwd fails
+      let threw = false;
+      try {
+        await new Deno.Command(Deno.execPath(), {
+          args: ["--version"],
+          cwd: restrictedDir,
+          stdout: "null",
+          stderr: "piped",
+        }).output();
+      } catch (e) {
+        threw = true;
+        assertStringIncludes(String(e), "Permission denied");
+      }
+      assertEquals(threw, true, "should throw when cwd is inaccessible");
 
-    // Spawn with explicit accessible cwd succeeds
-    const result = await new Deno.Command(Deno.execPath(), {
-      args: ["--version"],
-      cwd: testDir,
-      stdout: "null",
-      stderr: "null",
-    }).output();
-    assertEquals(result.success, true);
-  } finally {
-    await Deno.chmod(restrictedDir, 0o755);
-    await Deno.remove(testDir, { recursive: true });
-  }
+      // Spawn with explicit accessible cwd succeeds
+      const result = await new Deno.Command(Deno.execPath(), {
+        args: ["--version"],
+        cwd: testDir,
+        stdout: "null",
+        stderr: "null",
+      }).output();
+      assertEquals(result.success, true);
+    } finally {
+      await Deno.chmod(restrictedDir, 0o755);
+      await Deno.remove(testDir, { recursive: true });
+    }
+  },
 });

--- a/src/infrastructure/runtime/embedded_deno_runtime_test.ts
+++ b/src/infrastructure/runtime/embedded_deno_runtime_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { EmbeddedDenoRuntime } from "./embedded_deno_runtime.ts";
 
 // The Stream 0 multi-line `which`/`where` parsing regression is exercised
@@ -44,4 +44,40 @@ Deno.test("EmbeddedDenoRuntime caches the deno path", async () => {
 
   // Should return the same path both times (cached)
   assertEquals(first, second);
+});
+
+Deno.test("subprocess spawn fails with inaccessible cwd, succeeds with explicit cwd", async () => {
+  const testDir = await Deno.makeTempDir({ prefix: "cwd-test-" });
+  const restrictedDir = `${testDir}/restricted`;
+  await Deno.mkdir(restrictedDir);
+  await Deno.chmod(restrictedDir, 0o000);
+
+  try {
+    // Spawn with inaccessible cwd fails
+    let threw = false;
+    try {
+      await new Deno.Command(Deno.execPath(), {
+        args: ["--version"],
+        cwd: restrictedDir,
+        stdout: "null",
+        stderr: "piped",
+      }).output();
+    } catch (e) {
+      threw = true;
+      assertStringIncludes(String(e), "Permission denied");
+    }
+    assertEquals(threw, true, "should throw when cwd is inaccessible");
+
+    // Spawn with explicit accessible cwd succeeds
+    const result = await new Deno.Command(Deno.execPath(), {
+      args: ["--version"],
+      cwd: testDir,
+      stdout: "null",
+      stderr: "null",
+    }).output();
+    assertEquals(result.success, true);
+  } finally {
+    await Deno.chmod(restrictedDir, 0o755);
+    await Deno.remove(testDir, { recursive: true });
+  }
 });


### PR DESCRIPTION
## Summary

- Fix `healthCheck()` in `EmbeddedDenoRuntime` to use `cwd: dirname(binaryPath)` instead of inheriting the parent's working directory. When swamp runs as a service user from another user's restricted home (e.g. `sudo -u svc` from a 0700 dir), the child process fails on `chdir → EACCES` before deno is ever exec'd.
- Capture stderr on health check failure to surface the actual error instead of the misleading "failed health check" message.
- Make the error hint OS-aware: `xattr -c` on macOS, CWD/SWAMP_HOME guidance on Linux, generic hint on Windows.
- Apply the same `cwd` fix to `clearMacOSExtendedAttributes()` and `defaultLookupRunner` in `resolve_command.ts` (the `findSystemDeno()` fallback).

Closes swamp-club#1706

## Test Plan

- Added unit test proving inaccessible cwd causes spawn failure and explicit accessible cwd succeeds
- Verified all 11 existing + new tests pass
- Full `deno check`, `deno lint`, `deno fmt` pass
- Reproduced the exact failure scenario with a restricted temp directory on macOS