### PR TITLE
feat(serve): add --remote-only flag to disable loopback execution

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -68,7 +68,10 @@ import { DispatchService } from "../../serve/dispatch_service.ts";
 import { DispatchRegistry } from "../../serve/dispatch_registry.ts";
 import { BundleRegistry } from "../../serve/bundle_registry.ts";
 import { DataPlane } from "../../serve/data_plane.ts";
-import { setRemoteStepDispatcher } from "../../domain/remote/remote_dispatch.ts";
+import {
+  setRemoteOnlyMode,
+  setRemoteStepDispatcher,
+} from "../../domain/remote/remote_dispatch.ts";
 import {
   enableServeOutput,
   getSwampLogger,
@@ -397,6 +400,9 @@ export function collectServeExtraArgs(options: AnyOptions): string[] {
   if (options.hydrationTimeout) {
     args.push("--hydration-timeout", options.hydrationTimeout as string);
   }
+  if (options.remoteOnly) {
+    args.push("--remote-only");
+  }
   return args;
 }
 
@@ -620,6 +626,11 @@ const daemonEnableCommand = new Command()
   .option(
     "--hydration-timeout <duration:string>",
     "Startup cache hydration timeout (default: 60s, env: SWAMP_HYDRATION_TIMEOUT)",
+  )
+  .option(
+    "--remote-only",
+    "Disable local (loopback) execution — all steps must declare placement " +
+      "(env: SWAMP_REMOTE_ONLY)",
   )
   .example("Enable daemon", "swamp serve daemon enable")
   .example(
@@ -1011,6 +1022,12 @@ export const serveCommand = new Command()
     "Enable the /internal/runs endpoint for full run history access " +
       "(env: SWAMP_ENABLE_INTERNAL_API)",
   )
+  .option(
+    "--remote-only",
+    "Disable local (loopback) execution — all steps must declare placement " +
+      "and be dispatched to remote workers. Steps without placement will error " +
+      "(env: SWAMP_REMOTE_ONLY)",
+  )
   .example(
     "Enable TLS",
     "swamp serve --cert-file server.crt --key-file server.key",
@@ -1311,6 +1328,12 @@ export const serveCommand = new Command()
     });
     dispatchService.bindGateway(workerGateway);
     setRemoteStepDispatcher(dispatchService);
+    if (merged.remoteOnly) {
+      setRemoteOnlyMode(true);
+      logger.info(
+        "Remote-only mode enabled — all steps require explicit placement",
+      );
+    }
     const dataPlane = new DataPlane({
       repoDir: resolvedRepoDir,
       repoContext,
@@ -2971,6 +2994,7 @@ export const serveCommand = new Command()
       scheduleProvider: scheduledExecution,
       scheduleEnabled: enableSchedule,
       webhookProvider: webhookService ?? null,
+      remoteOnly: merged.remoteOnly,
     });
 
     const adminAuthDeps: AdminAuthDeps = {
@@ -3494,6 +3518,7 @@ export const serveCommand = new Command()
             return Response.json({
               status: "ok",
               version: "1",
+              remoteOnly: merged.remoteOnly,
               scheduling: {
                 enabled: enableSchedule,
                 schedules,
@@ -3690,6 +3715,7 @@ export const serveCommand = new Command()
       }
       rejectionGuard.dispose();
       setRemoteStepDispatcher(null);
+      setRemoteOnlyMode(false);
       ac.abort();
       if (pidPath) {
         try {

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -54,6 +54,7 @@ import {
 } from "../../infrastructure/tracing/mod.ts";
 import {
   getRemoteStepDispatcher,
+  isRemoteOnlyMode,
   type RemoteStepResult,
 } from "../remote/remote_dispatch.ts";
 import type { RpcStreamEvent } from "../remote/protocol.ts";
@@ -864,6 +865,14 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
               .followUpActions as FollowUpAction[] | undefined,
             executor: remoteResult.workerName,
           };
+        } else if (isRemoteOnlyMode()) {
+          throw new UserError(
+            `Step '${methodName}' on model '${context.modelType.normalized}' ` +
+              `has no placement but the server is running in remote-only mode. ` +
+              `Add a placement block (target, labels, or platform) to the ` +
+              `workflow step, job, or workflow so it can be dispatched to a ` +
+              `remote worker.`,
+          );
         } else {
           // Execute in-process — the single-host path (see
           // design/remote-execution.md "No execution drivers").

--- a/src/domain/remote/remote_dispatch.ts
+++ b/src/domain/remote/remote_dispatch.ts
@@ -101,3 +101,14 @@ export function setRemoteStepDispatcher(
 export function getRemoteStepDispatcher(): RemoteStepDispatcher | null {
   return activeDispatcher;
 }
+
+let remoteOnlyMode = false;
+
+/** Called by the orchestrator at startup when --remote-only is set. */
+export function setRemoteOnlyMode(enabled: boolean): void {
+  remoteOnlyMode = enabled;
+}
+
+export function isRemoteOnlyMode(): boolean {
+  return remoteOnlyMode;
+}

--- a/src/domain/remote/remote_dispatch_test.ts
+++ b/src/domain/remote/remote_dispatch_test.ts
@@ -1,0 +1,39 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { isRemoteOnlyMode, setRemoteOnlyMode } from "./remote_dispatch.ts";
+
+Deno.test("setRemoteOnlyMode: defaults to false", () => {
+  setRemoteOnlyMode(false);
+  assertEquals(isRemoteOnlyMode(), false);
+});
+
+Deno.test("setRemoteOnlyMode: can be enabled", () => {
+  setRemoteOnlyMode(true);
+  assertEquals(isRemoteOnlyMode(), true);
+  setRemoteOnlyMode(false);
+});
+
+Deno.test("setRemoteOnlyMode: can be disabled after enabling", () => {
+  setRemoteOnlyMode(true);
+  assertEquals(isRemoteOnlyMode(), true);
+  setRemoteOnlyMode(false);
+  assertEquals(isRemoteOnlyMode(), false);
+});

--- a/src/serve/health_collector.ts
+++ b/src/serve/health_collector.ts
@@ -52,6 +52,7 @@ export interface HealthSnapshotWebhook {
 export interface HealthSnapshot {
   readonly instanceId: string;
   readonly deploymentMode: string;
+  readonly remoteOnly: boolean;
   readonly uptimeMs: number;
   readonly ready: boolean;
   readonly activeRuns: HealthSnapshotRun[];
@@ -98,6 +99,7 @@ export interface HealthCollectorDeps {
   readonly scheduleProvider: ScheduleProvider | null;
   readonly scheduleEnabled: boolean;
   readonly webhookProvider: WebhookProvider | null;
+  readonly remoteOnly: boolean;
 }
 
 export class HealthCollector {
@@ -159,6 +161,7 @@ export class HealthCollector {
     return {
       instanceId: this.#deps.instanceId,
       deploymentMode: this.#deps.deploymentMode,
+      remoteOnly: this.#deps.remoteOnly,
       uptimeMs: now - this.#deps.startedAt,
       ready: this.#deps.isReady(),
       activeRuns,

--- a/src/serve/health_collector_test.ts
+++ b/src/serve/health_collector_test.ts
@@ -40,6 +40,7 @@ function makeDeps(
     scheduleProvider: null,
     scheduleEnabled: false,
     webhookProvider: null,
+    remoteOnly: false,
     ...overrides,
   };
 }
@@ -51,6 +52,7 @@ Deno.test("HealthCollector: collects minimal snapshot with no subsystems", async
 
   assertEquals(snapshot.instanceId, "test-instance-id");
   assertEquals(snapshot.deploymentMode, "standalone");
+  assertEquals(snapshot.remoteOnly, false);
   assertEquals(snapshot.ready, true);
   assertGreater(snapshot.uptimeMs, 0);
   assertEquals(snapshot.activeRuns, []);

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -54,6 +54,7 @@ export const SERVE_ENV_MAP: Readonly<Record<string, string>> = {
   maxRunsPerPrincipal: "SWAMP_MAX_RUNS_PER_PRINCIPAL",
   maxRunDuration: "SWAMP_MAX_RUN_DURATION",
   enableInternalApi: "SWAMP_ENABLE_INTERNAL_API",
+  remoteOnly: "SWAMP_REMOTE_ONLY",
 };
 
 // ── Webhook Config Types ──────────────────────────────────────────────
@@ -117,6 +118,7 @@ export interface ServeConfigFile {
   "max-run-duration"?: string;
   "hydration-timeout"?: string;
   "enable-internal-api"?: boolean;
+  "remote-only"?: boolean;
 }
 
 // ── Known Keys ────────────────────────────────────────────────────────
@@ -147,6 +149,7 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
   "max-run-duration",
   "hydration-timeout",
   "enable-internal-api",
+  "remote-only",
 ]);
 
 const KNOWN_AUTH_KEYS = new Set([
@@ -329,6 +332,17 @@ function validateConfigValues(
     throw new UserError(
       `Invalid verify-on-enroll in ${path}: expected boolean, got ${typeof raw[
         "verify-on-enroll"
+      ]}`,
+    );
+  }
+
+  if (
+    raw["remote-only"] !== undefined &&
+    typeof raw["remote-only"] !== "boolean"
+  ) {
+    throw new UserError(
+      `Invalid remote-only in ${path}: expected boolean, got ${typeof raw[
+        "remote-only"
       ]}`,
     );
   }
@@ -628,6 +642,7 @@ export interface MergedServeOptions {
   maxRunDuration?: string;
   hydrationTimeout?: string;
   enableInternalApi: boolean;
+  remoteOnly: boolean;
 }
 
 export function mergeServeOptions(
@@ -964,6 +979,13 @@ export function mergeServeOptions(
     false,
   );
 
+  const remoteOnly = resolveBoolean(
+    "remote-only",
+    cliOptions.remoteOnly as boolean,
+    config?.["remote-only"],
+    false,
+  );
+
   // Webhooks: CLI --webhook flags replace config file webhooks entirely.
   // Config-file webhooks are passed as raw entries — secret resolution
   // (which may need async vault access) happens later at startup.
@@ -1020,6 +1042,7 @@ export function mergeServeOptions(
     maxRunDuration,
     hydrationTimeout,
     enableInternalApi,
+    remoteOnly,
   };
 }
 

--- a/src/serve/serve_config_test.ts
+++ b/src/serve/serve_config_test.ts
@@ -1065,6 +1065,83 @@ Deno.test("writeServeConfigFile: replace semantics for trigger entries", async (
   }
 });
 
+// ── remote-only merge ─────────────────────────────────────────────────
+
+Deno.test("mergeServeOptions: remote-only defaults to false", () => {
+  const merged = mergeServeOptions(
+    null,
+    {},
+    new Set<string>(),
+    () => undefined,
+  );
+  assertEquals(merged.remoteOnly, false);
+});
+
+Deno.test("mergeServeOptions: remote-only CLI flag wins over config and env", () => {
+  const config: ServeConfigFile = { "remote-only": false };
+  const cliOptions = { remoteOnly: true };
+  const explicitFlags = new Set(["remote-only"]);
+  const envLookup = () => undefined;
+
+  const merged = mergeServeOptions(
+    config,
+    cliOptions,
+    explicitFlags,
+    envLookup,
+  );
+  assertEquals(merged.remoteOnly, true);
+});
+
+Deno.test("mergeServeOptions: remote-only env var wins over config when CLI not explicit", () => {
+  const config: ServeConfigFile = { "remote-only": false };
+  const cliOptions = {};
+  const explicitFlags = new Set<string>();
+  const envLookup = (name: string) =>
+    name === "SWAMP_REMOTE_ONLY" ? "true" : undefined;
+
+  const merged = mergeServeOptions(
+    config,
+    cliOptions,
+    explicitFlags,
+    envLookup,
+  );
+  assertEquals(merged.remoteOnly, true);
+});
+
+Deno.test("mergeServeOptions: remote-only from config when no CLI or env", () => {
+  const config: ServeConfigFile = { "remote-only": true };
+  const cliOptions = {};
+  const explicitFlags = new Set<string>();
+  const envLookup = () => undefined;
+
+  const merged = mergeServeOptions(
+    config,
+    cliOptions,
+    explicitFlags,
+    envLookup,
+  );
+  assertEquals(merged.remoteOnly, true);
+});
+
+Deno.test("loadServeConfig: non-boolean remote-only produces error", () => {
+  withTempDir((dir) => {
+    writeConfig(dir, { "remote-only": "yes" });
+    assertThrows(
+      () => loadServeConfig(undefined, dir),
+      Error,
+      "Invalid remote-only",
+    );
+  });
+});
+
+Deno.test("loadServeConfig: boolean remote-only is accepted", () => {
+  withTempDir((dir) => {
+    writeConfig(dir, { "remote-only": true });
+    const config = loadServeConfig(undefined, dir);
+    assertEquals(config?.["remote-only"], true);
+  });
+});
+
 Deno.test("readServeConfigFile: returns null when file does not exist", async () => {
   const dir = await Deno.makeTempDir();
   try {


### PR DESCRIPTION
## Summary

- Adds `--remote-only` flag to `swamp serve` (and `swamp serve daemon enable`) that disables the loopback executor — when enabled, all steps must declare explicit placement (`target`, `labels`, or `platform`) to be dispatched to a remote worker. Steps without placement error immediately instead of running in-process on the serve host.
- Configurable via CLI flag, `remote-only: true` in `serve.yaml`, or `SWAMP_REMOTE_ONLY=true` environment variable.
- Surfaces `remoteOnly` in both the root `/` and `/api/v1/health` JSON responses so clients can discover the server's execution mode.

## Test Plan

- Added 9 unit tests covering config merge priority (CLI > env > config > default), config file validation, and module-level flag state
- Verified with compiled binary: started `swamp serve --remote-only`, confirmed startup log message, confirmed `remoteOnly: true` in both `/` and `/api/v1/health` responses
- Ran `swamp model method run` against the server — confirmed clear error: _"Step 'execute' on model 'command/shell' has no placement but the server is running in remote-only mode"_
- Ran `swamp workflow run` against the server — confirmed workflow starts, step fails with the same error
- All existing tests pass (90 total across serve_config, health_collector, remote_dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)