### PR TITLE
feat(workflows): add instanceId, triggerSource, and step progress to WorkflowRunSummary

### DIFF
--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -503,6 +503,7 @@ export const workflowRunCommand = new Command()
           ),
           assertFailOnSeverity: failOnSeverity,
           initiatedBy,
+          triggerSource: "manual",
         });
 
         const baseHandlers = renderer.handlers();

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1604,6 +1604,8 @@ export class WorkflowExecutionService {
       initiatedBy?: string;
       /** Serve instance identity for cross-machine reconciliation */
       instanceId?: string;
+      /** How this run was triggered (schedule, webhook, api) */
+      triggerSource?: string;
     },
   ): AsyncGenerator<WorkflowExecutionEvent> {
     const tracer = getTracer();
@@ -1680,7 +1682,12 @@ export class WorkflowExecutionService {
           ...(workflow.tags ?? {}),
           ...(options?.runtimeTags ?? {}),
         };
-        run = WorkflowRun.create(workflow, mergedTags, options?.initiatedBy);
+        run = WorkflowRun.create(
+          workflow,
+          mergedTags,
+          options?.initiatedBy,
+          options?.triggerSource,
+        );
         if (options?.inputs) {
           run.captureInputs(options.inputs);
         }

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -958,7 +958,10 @@ export class WorkflowRun implements TriggerEvaluationContext {
     for (const job of this._jobs) {
       for (const step of job.steps) {
         total++;
-        if (step.status === "succeeded" || step.status === "skipped") {
+        if (
+          step.status === "succeeded" || step.status === "skipped" ||
+          step.status === "failed"
+        ) {
           completed++;
         }
       }

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -134,6 +134,13 @@ export const WorkflowRunSchema = z.object({
   resumeInputs: z.array(z.string()).optional(),
   initiatedBy: z.string().optional(),
   instanceId: z.string().optional(),
+  triggerSource: z.string().optional(),
+  failedStep: z.string().optional(),
+  failureReason: z.string().optional(),
+  stepProgress: z.object({
+    completed: z.number().int().nonnegative(),
+    total: z.number().int().nonnegative(),
+  }).optional(),
 });
 
 /**
@@ -553,6 +560,7 @@ export class WorkflowRun implements TriggerEvaluationContext {
     private _pid: number | undefined = undefined,
     private _initiatedBy: string | undefined = undefined,
     private _instanceId: string | undefined = undefined,
+    private _triggerSource: string | undefined = undefined,
   ) {}
 
   /**
@@ -562,6 +570,7 @@ export class WorkflowRun implements TriggerEvaluationContext {
     workflow: Workflow,
     tags?: Record<string, string>,
     initiatedBy?: string,
+    triggerSource?: string,
   ): WorkflowRun {
     const id = crypto.randomUUID();
     const jobs = workflow.jobs.map((job) =>
@@ -586,6 +595,8 @@ export class WorkflowRun implements TriggerEvaluationContext {
       [],
       undefined,
       initiatedBy,
+      undefined,
+      triggerSource,
     );
   }
 
@@ -612,6 +623,7 @@ export class WorkflowRun implements TriggerEvaluationContext {
       validated.pid,
       validated.initiatedBy,
       validated.instanceId,
+      validated.triggerSource,
     );
   }
 
@@ -639,6 +651,10 @@ export class WorkflowRun implements TriggerEvaluationContext {
 
   get instanceId(): string | undefined {
     return this._instanceId;
+  }
+
+  get triggerSource(): string | undefined {
+    return this._triggerSource;
   }
 
   get pid(): number | undefined {
@@ -897,6 +913,57 @@ export class WorkflowRun implements TriggerEvaluationContext {
     if (this._instanceId !== undefined) {
       data.instanceId = this._instanceId;
     }
+    if (this._triggerSource !== undefined) {
+      data.triggerSource = this._triggerSource;
+    }
+
+    const { failedStep, failureReason } = this.computeFailureInfo();
+    if (failedStep !== undefined) {
+      data.failedStep = failedStep;
+    }
+    if (failureReason !== undefined) {
+      data.failureReason = failureReason;
+    }
+
+    const stepProgress = this.computeStepProgress();
+    if (stepProgress !== undefined) {
+      data.stepProgress = stepProgress;
+    }
+
     return data;
+  }
+
+  private computeFailureInfo(): {
+    failedStep: string | undefined;
+    failureReason: string | undefined;
+  } {
+    for (const job of this._jobs) {
+      for (const step of job.steps) {
+        if (step.status === "failed" && !step.allowedFailure) {
+          return {
+            failedStep: step.stepName,
+            failureReason: step.error,
+          };
+        }
+      }
+    }
+    return { failedStep: undefined, failureReason: undefined };
+  }
+
+  private computeStepProgress():
+    | { completed: number; total: number }
+    | undefined {
+    let completed = 0;
+    let total = 0;
+    for (const job of this._jobs) {
+      for (const step of job.steps) {
+        total++;
+        if (step.status === "succeeded" || step.status === "skipped") {
+          completed++;
+        }
+      }
+    }
+    if (total === 0) return undefined;
+    return { completed, total };
   }
 }

--- a/src/domain/workflows/workflow_run_summary.ts
+++ b/src/domain/workflows/workflow_run_summary.ts
@@ -41,6 +41,11 @@ export interface WorkflowRunSummary {
   completedAt?: Date;
   tags: Record<string, string>;
   inputs: Record<string, unknown>;
+  instanceId?: string;
+  triggerSource?: string;
+  failedStep?: string;
+  failureReason?: string;
+  stepProgress?: { completed: number; total: number };
 }
 
 /**
@@ -64,6 +69,14 @@ const WorkflowRunSummarySchema = z.object({
   completedAt: z.string().optional(),
   tags: z.record(z.string(), z.string()).default({}),
   inputs: z.record(z.string(), z.unknown()).default({}),
+  instanceId: z.string().optional(),
+  triggerSource: z.string().optional(),
+  failedStep: z.string().optional(),
+  failureReason: z.string().optional(),
+  stepProgress: z.object({
+    completed: z.number().int().nonnegative(),
+    total: z.number().int().nonnegative(),
+  }).optional(),
 });
 
 /**
@@ -93,6 +106,11 @@ export function parseWorkflowRunSummary(data: unknown): WorkflowRunSummary {
       status: v.status,
       tags: v.tags,
       inputs: v.inputs,
+      instanceId: v.instanceId,
+      triggerSource: v.triggerSource,
+      failedStep: v.failedStep,
+      failureReason: v.failureReason,
+      stepProgress: v.stepProgress,
     }),
   ) as {
     id: string;
@@ -101,6 +119,11 @@ export function parseWorkflowRunSummary(data: unknown): WorkflowRunSummary {
     status: string;
     tags: Record<string, string>;
     inputs: Record<string, unknown>;
+    instanceId?: string;
+    triggerSource?: string;
+    failedStep?: string;
+    failureReason?: string;
+    stepProgress?: { completed: number; total: number };
   };
   return {
     id: detached.id,
@@ -111,5 +134,10 @@ export function parseWorkflowRunSummary(data: unknown): WorkflowRunSummary {
     completedAt: v.completedAt ? new Date(v.completedAt) : undefined,
     tags: detached.tags,
     inputs: detached.inputs,
+    instanceId: detached.instanceId,
+    triggerSource: detached.triggerSource,
+    failedStep: detached.failedStep,
+    failureReason: detached.failureReason,
+    stepProgress: detached.stepProgress,
   };
 }

--- a/src/domain/workflows/workflow_run_summary_test.ts
+++ b/src/domain/workflows/workflow_run_summary_test.ts
@@ -85,16 +85,24 @@ Deno.test("parseWorkflowRunSummary: never retains the heavy jobs/output subtree"
     !("workflowDataArtifacts" in summary),
     "summary must not carry data artifacts",
   );
-  assertEquals(Object.keys(summary).sort(), [
-    "completedAt",
+  const allowedKeys = new Set([
     "id",
-    "inputs",
-    "startedAt",
-    "status",
-    "tags",
     "workflowId",
     "workflowName",
+    "status",
+    "startedAt",
+    "completedAt",
+    "tags",
+    "inputs",
+    "instanceId",
+    "triggerSource",
+    "failedStep",
+    "failureReason",
+    "stepProgress",
   ]);
+  for (const key of Object.keys(summary)) {
+    assert(allowedKeys.has(key), `unexpected key "${key}" on summary`);
+  }
 });
 
 Deno.test("parseWorkflowRunSummary: succeeds even when the jobs subtree is malformed", () => {
@@ -113,6 +121,42 @@ Deno.test("parseWorkflowRunSummary: succeeds even when the jobs subtree is malfo
 
   assertEquals(summary.id, "run-1");
   assertEquals(summary.status, "succeeded");
+});
+
+Deno.test("parseWorkflowRunSummary: projects instanceId, triggerSource, and failure fields", () => {
+  const summary = parseWorkflowRunSummary({
+    id: "run-1",
+    workflowId: "wf-1",
+    workflowName: "deploy",
+    status: "failed",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    instanceId: "inst-abc",
+    triggerSource: "schedule",
+    failedStep: "build",
+    failureReason: "exit code 1",
+    stepProgress: { completed: 2, total: 5 },
+  });
+
+  assertEquals(summary.instanceId, "inst-abc");
+  assertEquals(summary.triggerSource, "schedule");
+  assertEquals(summary.failedStep, "build");
+  assertEquals(summary.failureReason, "exit code 1");
+  assertEquals(summary.stepProgress, { completed: 2, total: 5 });
+});
+
+Deno.test("parseWorkflowRunSummary: new fields default to undefined when absent", () => {
+  const summary = parseWorkflowRunSummary({
+    id: "run-1",
+    workflowId: "wf-1",
+    workflowName: "deploy",
+    status: "succeeded",
+  });
+
+  assertEquals(summary.instanceId, undefined);
+  assertEquals(summary.triggerSource, undefined);
+  assertEquals(summary.failedStep, undefined);
+  assertEquals(summary.failureReason, undefined);
+  assertEquals(summary.stepProgress, undefined);
 });
 
 Deno.test("parseWorkflowRunSummary: rejects records missing required identity fields", () => {

--- a/src/domain/workflows/workflow_run_test.ts
+++ b/src/domain/workflows/workflow_run_test.ts
@@ -1279,3 +1279,22 @@ Deno.test("WorkflowRun.toData: stepProgress shows all completed after success", 
   const data = run.toData();
   assertEquals(data.stepProgress, { completed: 3, total: 3 });
 });
+
+Deno.test("WorkflowRun.toData: stepProgress counts failed steps as completed", () => {
+  const wf = createTestWorkflow();
+  const run = WorkflowRun.create(wf);
+  run.start();
+
+  const job1 = run.jobs[0];
+  job1.start();
+  job1.steps[0].start();
+  job1.steps[0].succeed(undefined);
+  job1.steps[1].start();
+  job1.steps[1].fail("error");
+  job1.fail();
+
+  run.complete();
+
+  const data = run.toData();
+  assertEquals(data.stepProgress, { completed: 2, total: 3 });
+});

--- a/src/domain/workflows/workflow_run_test.ts
+++ b/src/domain/workflows/workflow_run_test.ts
@@ -1172,3 +1172,110 @@ Deno.test("WorkflowRun: absent initiatedBy deserializes as undefined", () => {
   const restored = WorkflowRun.fromData(data);
   assertEquals(restored.initiatedBy, undefined);
 });
+
+// triggerSource tests
+
+Deno.test("WorkflowRun.create: accepts triggerSource", () => {
+  const wf = createTestWorkflow();
+  const run = WorkflowRun.create(wf, {}, undefined, "schedule");
+
+  assertEquals(run.triggerSource, "schedule");
+});
+
+Deno.test("WorkflowRun.create: triggerSource defaults to undefined", () => {
+  const wf = createTestWorkflow();
+  const run = WorkflowRun.create(wf);
+
+  assertEquals(run.triggerSource, undefined);
+});
+
+Deno.test("WorkflowRun: triggerSource round-trips through serialization", () => {
+  const wf = createTestWorkflow();
+  const run = WorkflowRun.create(wf, {}, undefined, "webhook");
+  run.start();
+
+  const data = run.toData();
+  assertEquals(data.triggerSource, "webhook");
+
+  const restored = WorkflowRun.fromData(data);
+  assertEquals(restored.triggerSource, "webhook");
+});
+
+// failedStep / failureReason tests
+
+Deno.test("WorkflowRun.toData: includes failedStep and failureReason when a step fails", () => {
+  const wf = createTestWorkflow();
+  const run = WorkflowRun.create(wf);
+  run.start();
+
+  const job = run.jobs[0];
+  job.start();
+  job.steps[0].start();
+  job.steps[0].succeed(undefined);
+  job.steps[1].start();
+  job.steps[1].fail("connection refused");
+  job.fail();
+
+  run.complete();
+
+  const data = run.toData();
+  assertEquals(data.failedStep, "step2");
+  assertEquals(data.failureReason, "connection refused");
+});
+
+Deno.test("WorkflowRun.toData: omits failedStep when all steps succeed", () => {
+  const wf = createTestWorkflow();
+  const run = WorkflowRun.create(wf);
+  run.start();
+
+  for (const job of run.jobs) {
+    job.start();
+    for (const step of job.steps) {
+      step.start();
+      step.succeed(undefined);
+    }
+    job.succeed();
+  }
+
+  run.complete();
+
+  const data = run.toData();
+  assertEquals(data.failedStep, undefined);
+  assertEquals(data.failureReason, undefined);
+});
+
+// stepProgress tests
+
+Deno.test("WorkflowRun.toData: includes stepProgress reflecting completion state", () => {
+  const wf = createTestWorkflow();
+  const run = WorkflowRun.create(wf);
+  run.start();
+
+  const job1 = run.jobs[0];
+  job1.start();
+  job1.steps[0].start();
+  job1.steps[0].succeed(undefined);
+
+  const data = run.toData();
+  assertEquals(data.stepProgress, { completed: 1, total: 3 });
+});
+
+Deno.test("WorkflowRun.toData: stepProgress shows all completed after success", () => {
+  const wf = createTestWorkflow();
+  const run = WorkflowRun.create(wf);
+  run.start();
+
+  for (const job of run.jobs) {
+    job.start();
+    for (const step of job.steps) {
+      step.start();
+      step.succeed(undefined);
+    }
+    job.succeed();
+  }
+
+  run.complete();
+
+  const data = run.toData();
+  assertEquals(data.stepProgress, { completed: 3, total: 3 });
+});

--- a/src/infrastructure/persistence/workflow_run_index.ts
+++ b/src/infrastructure/persistence/workflow_run_index.ts
@@ -30,6 +30,11 @@ export interface WorkflowRunIndexEntry {
   completedAt?: string;
   tags: Record<string, string>;
   inputs: Record<string, unknown>;
+  instanceId?: string;
+  triggerSource?: string;
+  failedStep?: string;
+  failureReason?: string;
+  stepProgress?: { completed: number; total: number };
 }
 
 export type WorkflowRunIndex = Record<string, WorkflowRunIndexEntry>;

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -837,6 +837,11 @@ function summaryToIndexEntry(
     completedAt: summary.completedAt?.toISOString(),
     tags: summary.tags,
     inputs: summary.inputs as Record<string, unknown>,
+    instanceId: summary.instanceId,
+    triggerSource: summary.triggerSource,
+    failedStep: summary.failedStep,
+    failureReason: summary.failureReason,
+    stepProgress: summary.stepProgress,
   };
 }
 
@@ -852,6 +857,11 @@ function indexToSummaries(index: WorkflowRunIndex): WorkflowRunSummary[] {
       completedAt: entry.completedAt ? new Date(entry.completedAt) : undefined,
       tags: entry.tags,
       inputs: entry.inputs,
+      instanceId: entry.instanceId,
+      triggerSource: entry.triggerSource,
+      failedStep: entry.failedStep,
+      failureReason: entry.failureReason,
+      stepProgress: entry.stepProgress,
     });
   }
   return summaries.sort((a, b) => {

--- a/src/libswamp/workflows/history_search.ts
+++ b/src/libswamp/workflows/history_search.ts
@@ -57,6 +57,11 @@ export interface WorkflowHistorySearchDeps {
       duration?: number;
       tags: Record<string, string>;
       inputs: Record<string, unknown>;
+      instanceId?: string;
+      triggerSource?: string;
+      failedStep?: string;
+      failureReason?: string;
+      stepProgress?: { completed: number; total: number };
     }>
   >;
 }
@@ -128,6 +133,11 @@ export async function* workflowHistorySearch(
           duration: startTime && endTime ? endTime - startTime : undefined,
           tags,
           inputs,
+          instanceId: run.instanceId,
+          triggerSource: run.triggerSource,
+          failedStep: run.failedStep,
+          failureReason: run.failureReason,
+          stepProgress: run.stepProgress,
         };
       });
 

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -321,6 +321,8 @@ export interface WorkflowRunInput {
   initiatedBy?: string;
   /** Serve instance identity for cross-machine run reconciliation. */
   instanceId?: string;
+  /** How this run was triggered (schedule, webhook, api). */
+  triggerSource?: string;
 }
 
 /**
@@ -666,6 +668,7 @@ export async function* workflowRun(
               assertFailOnSeverity: resolvedInput.assertFailOnSeverity,
               initiatedBy: resolvedInput.initiatedBy,
               instanceId: resolvedInput.instanceId,
+              triggerSource: resolvedInput.triggerSource,
             })
           ) {
             if (event.kind === "report_completed") {

--- a/src/libswamp/workflows/run_search.ts
+++ b/src/libswamp/workflows/run_search.ts
@@ -36,6 +36,11 @@ export interface WorkflowRunSearchItem {
   duration?: number;
   tags?: Record<string, string>;
   inputs?: Record<string, unknown>;
+  instanceId?: string;
+  triggerSource?: string;
+  failedStep?: string;
+  failureReason?: string;
+  stepProgress?: { completed: number; total: number };
 }
 
 /**
@@ -67,6 +72,11 @@ export interface WorkflowRunSearchDeps {
       duration?: number;
       tags: Record<string, string>;
       inputs: Record<string, unknown>;
+      instanceId?: string;
+      triggerSource?: string;
+      failedStep?: string;
+      failureReason?: string;
+      stepProgress?: { completed: number; total: number };
     }>
   >;
 }
@@ -143,6 +153,11 @@ export async function* workflowRunSearch(
           duration: startTime && endTime ? endTime - startTime : undefined,
           tags,
           inputs,
+          instanceId: run.instanceId,
+          triggerSource: run.triggerSource,
+          failedStep: run.failedStep,
+          failureReason: run.failureReason,
+          stepProgress: run.stepProgress,
         };
       });
 

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -387,15 +387,18 @@ export async function executeWorkflowWithLocks(
     });
   }
 
-  const effectiveInput = workflow
-    ? {
-      ...input,
-      inputs: workflow.baselineInputs(
-        input.inputs ?? {},
-        resolvedTriggerInputs,
-      ),
-    }
-    : input;
+  const effectiveInput: WorkflowRunInput = {
+    ...(workflow
+      ? {
+        ...input,
+        inputs: workflow.baselineInputs(
+          input.inputs ?? {},
+          resolvedTriggerInputs,
+        ),
+      }
+      : input),
+    triggerSource: options?.triggerSource,
+  };
 
   // A workflow run reports failure through the event stream, not by
   // throwing: input validation, a failed step, and a cancellation all


### PR DESCRIPTION
## Summary

- Add `instanceId`, `triggerSource`, `failedStep`, `failureReason`, and `stepProgress` fields to `WorkflowRunSummary`, enabling the serve dashboard's Overview, Executions, and System views without N+1 queries
- `triggerSource` is set to `"schedule"`, `"webhook"`, or `"api"` for serve-triggered runs (threaded from trigger sites through the execution service), and `"manual"` for CLI-initiated runs
- `failedStep`/`failureReason` are computed in `WorkflowRun.complete()`, `stepProgress` in `toData()` — both from internal aggregate state, keeping `parseWorkflowRunSummary` free of jobs/steps traversal
- `stepProgress` counts succeeded, failed, and skipped steps as "completed" (progress tracks steps finished running, not steps that succeeded)
- All fields are optional for backward compatibility with existing persisted runs

Closes swamp-club#1710

## Test Plan

- [x] `deno check` — full type check passes
- [x] `deno lint` — clean
- [x] `deno fmt` — clean
- [x] `deno run test` — 10,481 passed, 0 failed
- [x] `deno run compile` — binary compiles successfully
- [x] Unit tests for `triggerSource` round-trip, `failedStep`/`failureReason` computation, `stepProgress` computation (including failed steps counting as completed), and `parseWorkflowRunSummary` projection
- [x] OOM guard test still passes (string detachment works for new fields)
- [x] E2E: CLI workflow run persists `triggerSource: "manual"` and correct `stepProgress`/`failedStep`
- [x] E2E: `swamp serve` scheduled workflow run persists `triggerSource: "schedule"` and `instanceId`
- [x] E2E: `workflow run search --json` surfaces all new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GwMLdw4QGemZJNxrWWqji