### PR TITLE
feat(workflows): add worker affinity for job and workflow-level co-location

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -879,13 +879,31 @@ steps for unavailable workers. The early warning only fires for workers still
 in the in-memory grace window; workers already removed from the pool are not
 checked.
 
-Label + platform matching plus direct targeting is the whole affinity story for
-v1; data-locality affinity is explicitly not pursued yet. Because every capability
-proxies home, **compute location and state location are fully decoupled** — a
-step's data lives at the orchestrator regardless of which worker runs it. v1
-dispatches at the **step** granularity, which is what yields fan-out *across*
-workers; shipping a whole workflow to one worker is just the degenerate
+Label + platform matching, direct targeting, and **worker affinity** are the
+placement and co-location story. Data-locality affinity is not pursued — because
+every capability proxies home, **compute location and state location are fully
+decoupled** — a step's data lives at the orchestrator regardless of which worker
+runs it. v1 dispatches at the **step** granularity, which is what yields fan-out
+*across* workers; shipping a whole workflow to one worker is just the degenerate
 single-worker case.
+
+#### Worker affinity
+
+`affinity: true` can be set at the **workflow** or **job** level. When set, the
+dispatch service pins all remote steps in that scope to the same worker: the
+first step scheduled via the normal label/platform matching picks a worker, and
+all subsequent steps in the group are forced to that worker via an internal
+target override. Workflow-level affinity scopes the group to the entire run;
+job-level scopes it to the job.
+
+If the pinned worker disconnects mid-group — whether between steps or during a
+dispatch — the step fails with a `WorkerAffinityLostError` instead of
+re-dispatching. This preserves the co-location guarantee: silent re-dispatch to
+another worker would violate the contract the author opted into.
+
+The dispatch service maintains the pins in an in-memory `affinityKey → worker`
+map, keyed by `runId` (workflow-level) or `runId:jobName` (job-level). Pins are
+released when the group completes.
 
 A step declares its requirements in workflow YAML with three placement fields —
 `target:` (worker name or `instanceUuid`), `labels:` (selector map), and
@@ -1108,7 +1126,8 @@ Explicit non-goals for v1:
 - **Remote datastore configuration for workers.** Workers never hold datastore
   config; all data terminates at the orchestrator. Revisit only if the ceiling
   bites.
-- **Data-locality scheduler affinity.** Label/platform/direct targeting only.
+- **Data-locality scheduler affinity.** Worker affinity (`affinity: true`)
+  provides explicit co-location; automatic data-locality routing is not pursued.
 - **Shipping cloud/k8s launch integrations.** swamp ships the mint model and
   dial-home contract; the launch models are user-authored extensions.
 

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -3225,6 +3225,7 @@ Deno.test("executeWorkflow - placed steps rebuild full handles from durable reco
         durationMs: 5,
         workerName: "gpu-box-1",
       }),
+    releaseAffinity: () => {},
   });
   try {
     const { context } = createTestContext({
@@ -3285,6 +3286,7 @@ Deno.test("executeWorkflow - placed step with a vanished output record fails lou
         logs: [],
         durationMs: 1,
       }),
+    releaseAffinity: () => {},
   });
   try {
     const { context } = createTestContext({

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -292,6 +292,7 @@ export interface MethodContext {
     labels?: Record<string, string>;
     platform?: string;
     queueTimeoutMs?: number;
+    affinityKey?: string;
   };
 
   /**

--- a/src/domain/remote/remote_dispatch.ts
+++ b/src/domain/remote/remote_dispatch.ts
@@ -87,6 +87,7 @@ export interface RemoteStepResult {
 
 export interface RemoteStepDispatcher {
   executeRemote(request: RemoteStepRequest): Promise<RemoteStepResult>;
+  releaseAffinity(key: string): void;
 }
 
 let activeDispatcher: RemoteStepDispatcher | null = null;

--- a/src/domain/remote/scheduler.ts
+++ b/src/domain/remote/scheduler.ts
@@ -38,6 +38,12 @@ export interface StepPlacement {
   platform?: string;
   /** Per-step queue timeout in milliseconds; overrides the serve-level default. */
   queueTimeoutMs?: number;
+  /**
+   * When set, all steps sharing the same key are pinned to the worker that
+   * executed the first step in the group. The dispatch service maintains
+   * the key→worker mapping and fails steps whose pinned worker disconnects.
+   */
+  affinityKey?: string;
 }
 
 /** The slice of worker state scheduling looks at. */

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -302,6 +302,11 @@ export interface StepExecutionContext {
   workflowPlacement?: import("./placement.ts").PlacementFields;
   /** Job-level placement defaults (inherited by steps in this job unless overridden) */
   jobPlacement?: import("./placement.ts").PlacementFields;
+  /**
+   * Worker affinity key. When set, all steps sharing this key are pinned
+   * to the same remote worker. Computed from workflow/job affinity settings.
+   */
+  affinityKey?: string;
 }
 
 /**
@@ -598,6 +603,13 @@ export class DefaultStepExecutor implements StepExecutor {
           evaluate,
         ) as typeof resolvedPlacement;
       }
+    }
+
+    if (resolvedPlacement && ctx.affinityKey) {
+      resolvedPlacement = {
+        ...resolvedPlacement,
+        affinityKey: ctx.affinityKey,
+      };
     }
 
     // Resolve whole-field expression strings for inputs/globalArgs that survived
@@ -1002,6 +1014,7 @@ export class DefaultStepExecutor implements StepExecutor {
       labels?: Record<string, string>;
       platform?: string;
       queueTimeoutMs?: number;
+      affinityKey?: string;
     };
   }): Promise<MethodResult> {
     const {
@@ -2993,6 +3006,11 @@ export class WorkflowExecutionService {
           workflowGateService: this.workflowGateService,
           workflowPlacement: workflow.placementFields,
           jobPlacement: job.placementFields,
+          affinityKey: workflow.affinity
+            ? run.id
+            : job.affinity
+            ? `${run.id}:${job.name}`
+            : undefined,
         };
         return this.executor.execute(step, ctx);
       });

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -122,6 +122,7 @@ import { withEventBridge } from "../../infrastructure/stream/event_bridge.ts";
 import type { ReportFilterOptions } from "../reports/report_execution_service.ts";
 import { getTracer, SpanStatusCode } from "../../infrastructure/tracing/mod.ts";
 import { extractSensitiveFieldValues } from "../models/sensitive_field_extractor.ts";
+import { getRemoteStepDispatcher } from "../remote/remote_dispatch.ts";
 
 /**
  * Resolves a task field that may be a record, an expression string, or a
@@ -1625,6 +1626,7 @@ export class WorkflowExecutionService {
     });
 
     let workflowRun: WorkflowRun | undefined;
+    let workflowAffinityKey: string | undefined;
     let workflowLogHandle: string | undefined;
     let wfHeartbeatInterval: ReturnType<typeof setInterval> | undefined;
     try {
@@ -1698,6 +1700,9 @@ export class WorkflowExecutionService {
           run.captureInputs(options.inputs);
         }
         workflowRun = run;
+        if (workflow.affinity) {
+          workflowAffinityKey = run.id;
+        }
 
         // workflowRunId is set here for backward compat; the structured
         // run namespace is populated after run.start() below so that
@@ -2004,6 +2009,9 @@ export class WorkflowExecutionService {
       });
       throw error;
     } finally {
+      if (workflowAffinityKey) {
+        getRemoteStepDispatcher()?.releaseAffinity(workflowAffinityKey);
+      }
       // Always release the per-run log file sink when the generator is
       // disposed — including early abandonment via generator.return() (e.g. a
       // streaming consumer that breaks on socket close). Cleanup placed after a
@@ -2591,6 +2599,12 @@ export class WorkflowExecutionService {
       });
       throw error;
     } finally {
+      const job = workflow.getJob(jobName);
+      if (job?.affinity && !workflow.affinity) {
+        getRemoteStepDispatcher()?.releaseAffinity(
+          `${run.id}:${jobName}`,
+        );
+      }
       jobSpan.end();
     }
   }

--- a/src/domain/workflows/job.ts
+++ b/src/domain/workflows/job.ts
@@ -69,6 +69,7 @@ const JobObjectSchema = z.object({
   dependsOn: JobDependencyFieldSchema,
   weight: z.number().default(0),
   concurrency: z.number().int().nonnegative().optional(),
+  affinity: z.boolean().optional(),
   ...PlacementFieldsSchema.shape,
 });
 
@@ -113,6 +114,7 @@ export interface CreateJobProps {
   dependsOn?: JobDependency[];
   weight?: number;
   concurrency?: number;
+  affinity?: boolean;
   target?: string;
   labels?: Record<string, string>;
   platform?: string;
@@ -137,6 +139,7 @@ export class Job {
     private _dependsOn: JobDependency[],
     readonly weight: number,
     readonly concurrency: number | undefined,
+    readonly affinity: boolean | undefined,
     readonly target: string | undefined,
     readonly labels: Record<string, string> | undefined,
     readonly platform: string | undefined,
@@ -161,6 +164,7 @@ export class Job {
       })),
       weight: props.weight ?? 0,
       concurrency: props.concurrency,
+      affinity: props.affinity,
       target: props.target,
       labels: props.labels,
       platform: props.platform,
@@ -188,6 +192,7 @@ export class Job {
       dependsOn,
       validated.weight,
       validated.concurrency,
+      validated.affinity,
       validated.target,
       validated.labels,
       validated.platform,
@@ -246,6 +251,7 @@ export class Job {
       })),
       weight: this.weight,
       concurrency: this.concurrency,
+      affinity: this.affinity,
       target: this.target,
       labels: this.labels,
       platform: this.platform,

--- a/src/domain/workflows/job_test.ts
+++ b/src/domain/workflows/job_test.ts
@@ -333,6 +333,42 @@ Deno.test("Job placement: undefined when not set", () => {
   });
 });
 
+Deno.test("Job affinity: round-trips through toData/fromData", () => {
+  const job = Job.fromData({
+    name: "build",
+    affinity: true,
+    labels: { gpu: "true" },
+    steps: [{
+      name: "step1",
+      task: {
+        type: "model_method" as const,
+        modelIdOrName: "my-model",
+        methodName: "run",
+      },
+    }],
+  });
+  assertEquals(job.affinity, true);
+  const data = job.toData();
+  assertEquals(data.affinity, true);
+  const restored = Job.fromData(data);
+  assertEquals(restored.affinity, true);
+});
+
+Deno.test("Job affinity: undefined when not set", () => {
+  const job = Job.fromData({
+    name: "local-job",
+    steps: [{
+      name: "step1",
+      task: {
+        type: "model_method" as const,
+        modelIdOrName: "my-model",
+        methodName: "run",
+      },
+    }],
+  });
+  assertEquals(job.affinity, undefined);
+});
+
 Deno.test("JobSchema rejects unknown key with did-you-mean suggestion", () => {
   const error = assertThrows(
     () =>

--- a/src/domain/workflows/placement.ts
+++ b/src/domain/workflows/placement.ts
@@ -33,6 +33,7 @@ export interface ResolvedPlacement {
   labels?: Record<string, string>;
   platform?: string;
   queueTimeoutMs?: number;
+  affinityKey?: string;
 }
 
 /**

--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -175,6 +175,9 @@ export class DefaultWorkflowValidationService
     // 11. Assert expr must not be wrapped in ${{ }}
     results.push(...this.validateAssertExprNotInterpolated(workflow));
 
+    // 12. affinity without placement is a no-op
+    results.push(...this.validateAffinityPlacement(workflow));
+
     return results;
   }
 
@@ -207,6 +210,64 @@ export class DefaultWorkflowValidationService
         }
       }
     }
+    return results;
+  }
+
+  private validateAffinityPlacement(
+    workflow: Workflow,
+  ): WorkflowValidationResult[] {
+    const results: WorkflowValidationResult[] = [];
+
+    if (workflow.affinity) {
+      const hasAnyPlacement = workflow.jobs.some((job) => {
+        const wfFields = mergePlacementFields(
+          workflow.placementFields,
+          job.placementFields,
+        );
+        return job.steps.some((step) => {
+          const effective = mergePlacementFields(
+            wfFields,
+            step.placementFields,
+          );
+          return resolvePlacement(effective) !== undefined;
+        });
+      });
+      if (!hasAnyPlacement) {
+        results.push(
+          WorkflowValidationResult.warning(
+            `affinity without placement at workflow level`,
+            `Workflow has 'affinity: true' but no steps resolve to remote placement — ` +
+              `affinity only applies to remote-execution steps with placement requirements`,
+          ),
+        );
+      }
+    }
+
+    for (const job of workflow.jobs) {
+      if (job.affinity) {
+        const wfFields = mergePlacementFields(
+          workflow.placementFields,
+          job.placementFields,
+        );
+        const hasAnyPlacement = job.steps.some((step) => {
+          const effective = mergePlacementFields(
+            wfFields,
+            step.placementFields,
+          );
+          return resolvePlacement(effective) !== undefined;
+        });
+        if (!hasAnyPlacement) {
+          results.push(
+            WorkflowValidationResult.warning(
+              `affinity without placement in job '${job.name}'`,
+              `Job '${job.name}' has 'affinity: true' but no steps resolve to remote placement — ` +
+                `affinity only applies to remote-execution steps with placement requirements`,
+            ),
+          );
+        }
+      }
+    }
+
     return results;
   }
 

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -1853,3 +1853,78 @@ Deno.test("validate: fails when assert expr uses multiline interpolation", async
   const assertResult = results.find((r) => r.name.includes("Assert expr"));
   assertEquals(assertResult?.passed, false);
 });
+
+Deno.test("validate: warns when workflow affinity is set without placement", async () => {
+  const workflow = Workflow.create({
+    name: "affinity-no-placement",
+    affinity: true,
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "local-step",
+            task: StepTask.model("test-model", "run"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const warning = results.find((r) =>
+    r.name.includes("affinity without placement")
+  );
+  assertEquals(warning?.passed, true);
+  assertEquals(warning?.warning, true);
+});
+
+Deno.test("validate: no warning when workflow affinity is set with placement", async () => {
+  const workflow = Workflow.create({
+    name: "affinity-with-placement",
+    affinity: true,
+    labels: { pool: "gpu" },
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "remote-step",
+            task: StepTask.model("test-model", "run"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const warning = results.find((r) =>
+    r.name.includes("affinity without placement")
+  );
+  assertEquals(warning, undefined);
+});
+
+Deno.test("validate: warns when job affinity is set without placement", async () => {
+  const workflow = Workflow.create({
+    name: "job-affinity-no-placement",
+    jobs: [
+      Job.create({
+        name: "main",
+        affinity: true,
+        steps: [
+          Step.create({
+            name: "local-step",
+            task: StepTask.model("test-model", "run"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const warning = results.find((r) =>
+    r.name.includes("affinity without placement in job")
+  );
+  assertEquals(warning?.passed, true);
+  assertEquals(warning?.warning, true);
+});

--- a/src/domain/workflows/workflow.ts
+++ b/src/domain/workflows/workflow.ts
@@ -105,6 +105,7 @@ const WorkflowObjectSchema = z.object({
   version: z.number().int().positive().default(1),
   concurrency: z.number().int().nonnegative().optional(),
   reports: ReportSelectionSchema,
+  affinity: z.boolean().optional(),
   ...PlacementFieldsSchema.shape,
 });
 
@@ -147,6 +148,7 @@ export interface CreateWorkflowProps {
   version?: number;
   concurrency?: number;
   reports?: ReportSelection;
+  affinity?: boolean;
   target?: string;
   labels?: Record<string, string>;
   platform?: string;
@@ -177,6 +179,7 @@ export class Workflow {
     readonly version: number,
     readonly concurrency: number | undefined,
     readonly reports: ReportSelection | undefined,
+    readonly affinity: boolean | undefined,
     readonly target: string | undefined,
     readonly labels: Record<string, string> | undefined,
     readonly platform: string | undefined,
@@ -204,6 +207,7 @@ export class Workflow {
       version,
       concurrency: props.concurrency,
       reports: props.reports,
+      affinity: props.affinity,
       target: props.target,
       labels: props.labels,
       platform: props.platform,
@@ -234,6 +238,7 @@ export class Workflow {
       data.version,
       data.concurrency,
       data.reports,
+      data.affinity,
       data.target,
       data.labels,
       data.platform,
@@ -259,6 +264,7 @@ export class Workflow {
       validated.version,
       validated.concurrency,
       validated.reports,
+      validated.affinity,
       validated.target,
       validated.labels,
       validated.platform,
@@ -359,6 +365,7 @@ export class Workflow {
       version: this.version,
       concurrency: this.concurrency,
       reports: this.reports,
+      affinity: this.affinity,
       target: this.target,
       labels: this.labels,
       platform: this.platform,

--- a/src/domain/workflows/workflow_test.ts
+++ b/src/domain/workflows/workflow_test.ts
@@ -695,6 +695,30 @@ Deno.test("Workflow placement: undefined when not set", () => {
   });
 });
 
+Deno.test("Workflow affinity: round-trips through toData", () => {
+  const workflow = Workflow.fromData({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "test-workflow",
+    affinity: true,
+    labels: { pool: "gpu" },
+    jobs: [createTestJob("job1").toData()],
+  } as unknown as WorkflowInput);
+  assertEquals(workflow.affinity, true);
+  const data = workflow.toData();
+  assertEquals(data.affinity, true);
+  const restored = Workflow.fromData(data);
+  assertEquals(restored.affinity, true);
+});
+
+Deno.test("Workflow affinity: undefined when not set", () => {
+  const workflow = Workflow.fromData({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "test-workflow",
+    jobs: [createTestJob("job1").toData()],
+  } as unknown as WorkflowInput);
+  assertEquals(workflow.affinity, undefined);
+});
+
 Deno.test("WorkflowSchema rejects unknown top-level key with did-you-mean suggestion", () => {
   const error = assertThrows(
     () =>

--- a/src/serve/dispatch_service.ts
+++ b/src/serve/dispatch_service.ts
@@ -145,6 +145,19 @@ export class DispatchService {
   #poolWaiters: Array<() => void> = [];
   /** Serializes lease transitions (sole-writer rule, like the gateway). */
   #transitionTail: Promise<unknown> = Promise.resolve();
+  /**
+   * Worker affinity pins: maps an affinity key to the worker that
+   * executed the first step in the group. Subsequent steps with the
+   * same key are forced onto that worker; if the worker disconnects,
+   * the step fails with a WorkerAffinityLostError.
+   */
+  readonly #affinityPins = new Map<string, string>();
+  /**
+   * In-flight affinity resolution: when the first step for a key is
+   * being scheduled, concurrent steps with the same key await this
+   * promise to learn which worker was pinned.
+   */
+  readonly #affinityInflight = new Map<string, Promise<string>>();
 
   constructor(options: DispatchServiceOptions) {
     this.#options = options;
@@ -193,6 +206,12 @@ export class DispatchService {
   /** Gateway hook: a worker started draining — wake queued steps to re-evaluate. */
   notifyWorkerDraining(_worker: WorkerSnapshot): void {
     this.#wakePoolWaiters();
+  }
+
+  /** Release a previously-pinned affinity key (e.g. when a job completes). */
+  releaseAffinity(key: string): void {
+    this.#affinityPins.delete(key);
+    this.#affinityInflight.delete(key);
   }
 
   /**
@@ -264,34 +283,67 @@ export class DispatchService {
     const onAbort = () => endQueue("cancel");
     request.signal?.addEventListener("abort", onAbort, { once: true });
 
+    let affinityResolve: ((name: string) => void) | null = null;
     try {
-      if (request.placement.target) {
+      const affinityKey = request.placement.affinityKey;
+      let effectivePlacement = request.placement;
+
+      if (affinityKey) {
+        let pinnedWorker = this.#affinityPins.get(affinityKey);
+        if (!pinnedWorker) {
+          const inflight = this.#affinityInflight.get(affinityKey);
+          if (inflight) {
+            pinnedWorker = await inflight;
+          } else {
+            const { promise, resolve } = Promise.withResolvers<string>();
+            this.#affinityInflight.set(affinityKey, promise);
+            affinityResolve = resolve;
+          }
+        }
+        if (pinnedWorker) {
+          const pool = this.#poolSnapshot();
+          const worker = pool.find((w) => w.name === pinnedWorker);
+          if (!worker || !worker.connected) {
+            throw new WorkerAffinityLostError(pinnedWorker, affinityKey);
+          }
+          effectivePlacement = { ...request.placement, target: pinnedWorker };
+        }
+      }
+
+      if (effectivePlacement.target) {
         const pool = this.#poolSnapshot();
         const targetWorker = pool.find(
           (w) =>
-            w.name === request.placement.target ||
-            w.instanceUuid === request.placement.target,
+            w.name === effectivePlacement.target ||
+            w.instanceUuid === effectivePlacement.target,
         );
         if (targetWorker && !targetWorker.connected) {
+          if (affinityKey) {
+            throw new WorkerAffinityLostError(
+              effectivePlacement.target,
+              affinityKey,
+            );
+          }
           request.onEvent?.({
             kind: "target_disconnected",
-            target: request.placement.target,
+            target: effectivePlacement.target,
           });
           logger.warn(
             "Step targets worker {target} which is disconnected " +
               "(within grace window); use workers.connected() to " +
               "filter dispatchable workers",
-            { target: request.placement.target },
+            { target: effectivePlacement.target },
           );
         }
       }
 
       while (true) {
         request.signal?.throwIfAborted();
-        const workerName = request.skipScheduler && request.placement.target
-          ? request.placement.target
+        const workerName = request.skipScheduler &&
+            effectivePlacement.target
+          ? effectivePlacement.target
           : await this.#acquireWorker(
-            request.placement,
+            effectivePlacement,
             request.signal,
             deadline,
             emitQueued,
@@ -300,9 +352,23 @@ export class DispatchService {
           const result = await this.#dispatchOnce(workerName, request);
           lastDispatchId = result.dispatchId;
           endQueue("mark_dispatched", { dispatchId: result.dispatchId });
+          if (affinityKey && !this.#affinityPins.has(affinityKey)) {
+            this.#affinityPins.set(affinityKey, workerName);
+            if (affinityResolve) {
+              affinityResolve(workerName);
+              this.#affinityInflight.delete(affinityKey);
+              affinityResolve = null;
+            }
+          }
           return result;
         } catch (error) {
           if (error instanceof WorkerLostError) {
+            if (affinityKey) {
+              endQueue("mark_dispatched", {
+                dispatchId: error.dispatchId ?? "unknown",
+              });
+              throw new WorkerAffinityLostError(workerName, affinityKey);
+            }
             if (error.hadWrites) {
               endQueue("mark_dispatched", {
                 dispatchId: error.dispatchId ?? "unknown",
@@ -365,6 +431,9 @@ export class DispatchService {
       }
       throw error;
     } finally {
+      if (affinityResolve && request.placement.affinityKey) {
+        this.#affinityInflight.delete(request.placement.affinityKey);
+      }
       request.signal?.removeEventListener("abort", onAbort);
     }
   }
@@ -699,6 +768,22 @@ export class DispatchService {
         throw new Error(message);
       }
     }
+  }
+}
+
+/** A step's affinity-pinned worker is no longer reachable. */
+export class WorkerAffinityLostError extends Error {
+  readonly workerName: string;
+  readonly affinityKey: string;
+
+  constructor(workerName: string, affinityKey: string) {
+    super(
+      `Worker '${workerName}' required by affinity group '${affinityKey}' ` +
+        `is no longer connected — failing step to preserve co-location guarantee`,
+    );
+    this.name = "WorkerAffinityLostError";
+    this.workerName = workerName;
+    this.affinityKey = affinityKey;
   }
 }
 

--- a/src/serve/dispatch_service.ts
+++ b/src/serve/dispatch_service.ts
@@ -284,6 +284,7 @@ export class DispatchService {
     request.signal?.addEventListener("abort", onAbort, { once: true });
 
     let affinityResolve: ((name: string) => void) | null = null;
+    let affinityReject: ((err: Error) => void) | null = null;
     try {
       const affinityKey = request.placement.affinityKey;
       let effectivePlacement = request.placement;
@@ -295,9 +296,13 @@ export class DispatchService {
           if (inflight) {
             pinnedWorker = await inflight;
           } else {
-            const { promise, resolve } = Promise.withResolvers<string>();
+            const { promise, resolve, reject } = Promise.withResolvers<
+              string
+            >();
+            promise.catch(() => {});
             this.#affinityInflight.set(affinityKey, promise);
             affinityResolve = resolve;
+            affinityReject = reject;
           }
         }
         if (pinnedWorker) {
@@ -358,6 +363,7 @@ export class DispatchService {
               affinityResolve(workerName);
               this.#affinityInflight.delete(affinityKey);
               affinityResolve = null;
+              affinityReject = null;
             }
           }
           return result;
@@ -431,8 +437,14 @@ export class DispatchService {
       }
       throw error;
     } finally {
-      if (affinityResolve && request.placement.affinityKey) {
+      if (affinityReject && request.placement.affinityKey) {
         this.#affinityInflight.delete(request.placement.affinityKey);
+        affinityReject(
+          new WorkerAffinityLostError(
+            "unknown",
+            request.placement.affinityKey,
+          ),
+        );
       }
       request.signal?.removeEventListener("abort", onAbort);
     }

--- a/src/serve/dispatch_service_test.ts
+++ b/src/serve/dispatch_service_test.ts
@@ -766,3 +766,40 @@ Deno.test("executeRemote: concurrent affinity steps pin to the same worker", asy
 
   assertEquals(r1.workerName, r2.workerName);
 });
+
+Deno.test("executeRemote: concurrent affinity step rejects when first step fails", async () => {
+  const h = createHarness({
+    workers: [
+      snapshot({ name: "w1" }),
+      snapshot({ name: "w2" }),
+    ],
+    queueTimeoutMs: 500,
+  });
+  const affinityKey = "run-6:job-fail-race";
+
+  let callCount = 0;
+  h.setBehavior(() => {
+    callCount++;
+    return new Promise((_resolve, reject) => {
+      setTimeout(
+        () => reject(new ChannelClosedError("socket dropped")),
+        50,
+      );
+    });
+  });
+
+  const results = await Promise.allSettled([
+    h.service.executeRemote(stepRequest({
+      placement: { labels: {}, platform: "linux", affinityKey },
+      stepName: "step-a",
+    })),
+    h.service.executeRemote(stepRequest({
+      placement: { labels: {}, platform: "linux", affinityKey },
+      stepName: "step-b",
+    })),
+  ]);
+
+  assertEquals(results[0].status, "rejected");
+  assertEquals(results[1].status, "rejected");
+  assertEquals(callCount, 1);
+});

--- a/src/serve/dispatch_service_test.ts
+++ b/src/serve/dispatch_service_test.ts
@@ -23,6 +23,7 @@ import {
   BUILTIN_BUNDLE_PREFIX,
   type DispatchGateway,
   DispatchService,
+  WorkerAffinityLostError,
 } from "./dispatch_service.ts";
 import { DispatchRegistry } from "./dispatch_registry.ts";
 import { BundleRegistry } from "./bundle_registry.ts";
@@ -609,4 +610,159 @@ Deno.test("executeRemote: no target_disconnected event without explicit target",
     (e) => e.kind === "target_disconnected",
   );
   assertEquals(disconnectedEvents.length, 0);
+});
+
+// --- Worker affinity ---
+
+Deno.test("executeRemote: affinity pins subsequent steps to the same worker", async () => {
+  const h = createHarness({
+    workers: [
+      snapshot({ name: "w1" }),
+      snapshot({ name: "w2" }),
+    ],
+  });
+  const affinityKey = "run-1:job-build";
+
+  const r1 = await h.service.executeRemote(stepRequest({
+    placement: { labels: {}, platform: "linux", affinityKey },
+    stepName: "step-1",
+  }));
+
+  const r2 = await h.service.executeRemote(stepRequest({
+    placement: { labels: {}, platform: "linux", affinityKey },
+    stepName: "step-2",
+  }));
+
+  assertEquals(r1.workerName, r2.workerName);
+  assertEquals(h.dispatchCalls[0].name, h.dispatchCalls[1].name);
+});
+
+Deno.test("executeRemote: affinity fails when pinned worker disconnects", async () => {
+  const h = createHarness({
+    workers: [
+      snapshot({ name: "w1" }),
+      snapshot({ name: "w2" }),
+    ],
+  });
+  const affinityKey = "run-2:job-deploy";
+
+  await h.service.executeRemote(stepRequest({
+    placement: { labels: {}, platform: "linux", affinityKey },
+    stepName: "step-1",
+  }));
+
+  const pinnedWorker = h.dispatchCalls[0].name;
+  const entry = h.pool.get(pinnedWorker)!;
+  h.pool.set(pinnedWorker, { ...entry, connected: false });
+
+  const error = await assertRejects(
+    () =>
+      h.service.executeRemote(stepRequest({
+        placement: { labels: {}, platform: "linux", affinityKey },
+        stepName: "step-2",
+      })),
+    WorkerAffinityLostError,
+  );
+  assertStringIncludes(error.message, "affinity group");
+  assertStringIncludes(error.message, affinityKey);
+});
+
+Deno.test("executeRemote: releaseAffinity clears pin", async () => {
+  const h = createHarness({
+    workers: [
+      snapshot({ name: "w1" }),
+      snapshot({ name: "w2" }),
+    ],
+  });
+  const affinityKey = "run-3:job-test";
+
+  await h.service.executeRemote(stepRequest({
+    placement: { labels: {}, platform: "linux", affinityKey },
+  }));
+
+  h.service.releaseAffinity(affinityKey);
+
+  const r2 = await h.service.executeRemote(stepRequest({
+    placement: { labels: {}, platform: "linux", affinityKey },
+  }));
+
+  assertEquals(typeof r2.workerName, "string");
+});
+
+Deno.test("executeRemote: affinity worker lost mid-dispatch fails instead of re-dispatching", async () => {
+  const h = createHarness({
+    workers: [
+      snapshot({ name: "w1" }),
+      snapshot({ name: "w2" }),
+    ],
+  });
+  const affinityKey = "run-4:job-build";
+
+  let callCount = 0;
+  h.setBehavior((_name, _params) => {
+    callCount++;
+    if (callCount === 1) {
+      throw new ChannelClosedError("socket dropped");
+    }
+    return Promise.resolve({
+      status: "success",
+      outputs: [],
+      logs: [],
+      durationMs: 1,
+    });
+  });
+
+  await assertRejects(
+    () =>
+      h.service.executeRemote(stepRequest({
+        placement: { labels: {}, platform: "linux", affinityKey },
+        stepName: "step-1",
+      })),
+    WorkerAffinityLostError,
+  );
+  assertEquals(callCount, 1);
+});
+
+Deno.test("executeRemote: steps without affinity key are unaffected", async () => {
+  const h = createHarness({
+    workers: [
+      snapshot({ name: "w1" }),
+      snapshot({ name: "w2" }),
+    ],
+  });
+
+  await h.service.executeRemote(stepRequest({
+    placement: { labels: {}, platform: "linux" },
+    stepName: "step-1",
+  }));
+
+  await h.service.executeRemote(stepRequest({
+    placement: { labels: {}, platform: "linux" },
+    stepName: "step-2",
+  }));
+
+  assertEquals(h.dispatchCalls.length, 2);
+});
+
+Deno.test("executeRemote: concurrent affinity steps pin to the same worker", async () => {
+  const h = createHarness({
+    workers: [
+      snapshot({ name: "w1" }),
+      snapshot({ name: "w2" }),
+    ],
+  });
+  const affinityKey = "run-5:job-concurrent";
+
+  const [r1, r2] = await Promise.all([
+    h.service.executeRemote(stepRequest({
+      placement: { labels: {}, platform: "linux", affinityKey },
+      stepName: "step-a",
+    })),
+    h.service.executeRemote(stepRequest({
+      placement: { labels: {}, platform: "linux", affinityKey },
+      stepName: "step-b",
+    })),
+  ]);
+
+  assertEquals(r1.workerName, r2.workerName);
 });


### PR DESCRIPTION
## Summary

- Adds `affinity: true` field at the workflow and job level to guarantee all remote steps in a scope run on the same worker node
- The dispatch service picks a worker for the first step via normal label/platform matching, then pins all subsequent steps to that worker via an internal target override
- If the pinned worker disconnects mid-group, steps fail with a `WorkerAffinityLostError` instead of silently re-dispatching — preserving the co-location guarantee
- Concurrent steps sharing an affinity key are serialized through an in-flight promise so the scheduler race is resolved correctly
- Validation warns when `affinity: true` is set without any placement (a no-op)

## YAML usage

```yaml
# Job-level: all steps in this job share one worker
jobs:
  build-and-test:
    affinity: true
    labels: { gpu: "true" }
    steps:
      - name: checkout
        ...
      - name: build
        ...
```

## Test Plan

- 26 dispatch service unit tests pass (6 new: sequential pin, disconnect failure, release, mid-dispatch loss, no-affinity unaffected, concurrent pin race)
- 4 schema round-trip tests (workflow + job affinity)
- 3 validation tests (affinity without placement warns)
- 10,485 total tests pass, 0 failures
- E2E verified with `swamp serve` + 2 workers: without affinity steps scatter (`wa`/`wb`), with affinity both steps pin to same worker (`wa`/`wa`)