### PR TITLE
docs(skills): add worker affinity to workflow skill

### DIFF
--- a/.claude/skills/swamp/references/workflow/reference.md
+++ b/.claude/skills/swamp/references/workflow/reference.md
@@ -487,6 +487,60 @@ Placement requires running under `swamp serve`. See
 [references/remote-execution.md](references/remote-execution.md) for worker
 provisioning, matching semantics, and full examples.
 
+## Affinity (Worker Co-location)
+
+Add `affinity: true` at the **workflow** or **job** level to guarantee all
+remote steps in that scope run on the same worker. The first dispatched step
+picks a worker via normal label/platform matching; all subsequent steps in the
+group are pinned to that worker.
+
+```yaml
+# Workflow-level: all remote steps in the run share one worker
+name: full-pipeline
+affinity: true
+labels:
+  pool: build
+jobs:
+  - name: build
+    steps:
+      - name: compile
+        task: ...
+      - name: test
+        task: ...
+  - name: deploy
+    steps:
+      - name: push
+        task: ...
+```
+
+```yaml
+# Job-level: steps within each job share a worker, but different jobs may land
+# on different workers
+jobs:
+  - name: build-and-test
+    affinity: true
+    labels: { gpu: "true" }
+    steps:
+      - name: checkout
+        task: ...
+      - name: build
+        task: ...
+  - name: deploy
+    steps:
+      - name: push
+        task: ... # no affinity — dispatched independently
+```
+
+**Key behaviors:**
+
+- Workflow-level affinity scopes to the entire run; job-level scopes to the job
+- If the pinned worker disconnects mid-group, steps fail with a
+  `WorkerAffinityLostError` instead of silently re-dispatching — preserving the
+  co-location guarantee
+- Validation warns when `affinity: true` is set without any placement (a no-op
+  since there are no remote steps to co-locate)
+- Requires `swamp serve` (same as all placement features)
+
 ## Concurrency Limits
 
 Add `concurrency: N` at the workflow, job, or step level to cap parallel

--- a/.claude/skills/swamp/references/workflow/references/remote-execution.md
+++ b/.claude/skills/swamp/references/workflow/references/remote-execution.md
@@ -89,6 +89,31 @@ all-busy queues the step, and no eligible worker fails the step fast. `forEach`
 is the fan-out construct — expand a step over a list and the instances spread
 across matching workers (each worker runs one dispatch at a time).
 
+## Affinity (worker co-location)
+
+Add `affinity: true` at the **workflow** or **job** level to pin all remote
+steps in that scope to the same worker. The first step dispatched via normal
+label/platform matching picks the worker; every subsequent step in the group is
+forced to that worker via an internal target override.
+
+```yaml
+jobs:
+  - name: build-and-test
+    affinity: true
+    labels: { gpu: "true" }
+    steps:
+      - name: checkout
+        task: ...
+      - name: build
+        task: ...
+```
+
+Workflow-level affinity scopes the pin to the entire run; job-level scopes it to
+the job. If the pinned worker disconnects mid-group, steps fail with a
+`WorkerAffinityLostError` rather than silently re-dispatching — the co-location
+contract is preserved. Validation warns when `affinity: true` is set without any
+placement fields (a no-op).
+
 ## Running workflows through the orchestrator
 
 `swamp serve` is the orchestrator, so placed workflows must run through it. From


### PR DESCRIPTION
## Summary

- Documents the `affinity: true` field at the workflow and job level in the swamp workflow skill
- Adds a new "Affinity (Worker Co-location)" section to the main workflow reference with YAML examples for both scopes
- Adds a corresponding section to the remote-execution skill reference
- Covers key behaviors: scoping, `WorkerAffinityLostError` on disconnect, and validation warning for affinity without placement

## Test Plan

- `deno fmt --check` passes
- `deno lint` passes
- `npx tessl skill review .claude/skills/swamp` scores 95%

🤖 Generated with [Claude Code](https://claude.com/claude-code)