### PR TITLE
feat(serve): add cluster.instances and serve.config endpoints

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -3399,46 +3399,47 @@ export const serveCommand = new Command()
             const resolvedStaleTtlMs = staleTtlMs ?? 90_000;
             const degradedThresholdMs = resolvedStaleTtlMs * 2 / 3;
 
-            if (controlPlaneStore) {
-              const keys = await controlPlaneStore.list("heartbeats/");
-              for (const key of keys) {
-                const data = await controlPlaneStore.get(key);
-                if (!data) continue;
-                const record = InstanceHeartbeatService.parseRecord(data);
-                if (!record) continue;
+            const keys = await controlPlaneStore.list("heartbeats/");
+            for (const key of keys) {
+              const data = await controlPlaneStore.get(key);
+              if (!data) continue;
+              const record = InstanceHeartbeatService.parseRecord(data);
+              if (!record) continue;
 
-                const isLocal = record.instanceId === instanceId;
-                const age = Date.now() -
-                  new Date(record.heartbeatAt).getTime();
-                let status: string;
-                if (isNaN(age)) {
-                  status = "unreachable";
-                } else if (age <= degradedThresholdMs) {
-                  status = "healthy";
-                } else if (age <= resolvedStaleTtlMs) {
-                  status = "degraded";
-                } else {
-                  status = "unreachable";
-                }
-
-                const entry: Record<string, unknown> = {
-                  instanceId: record.instanceId,
-                  hostname: record.hostname,
-                  pid: record.pid,
-                  startedAt: record.startedAt,
-                  lastHeartbeatAt: record.heartbeatAt,
-                  status,
-                  address: record.address ?? null,
-                };
-
-                if (isLocal) {
-                  const snapshot = await healthCollector.collect(ac.signal);
-                  entry.health = snapshot;
-                }
-
-                instances.push(entry);
+              const isLocal = record.instanceId === instanceId;
+              const age = Date.now() -
+                new Date(record.heartbeatAt).getTime();
+              let status: string;
+              if (isNaN(age)) {
+                status = "unreachable";
+              } else if (age <= degradedThresholdMs) {
+                status = "healthy";
+              } else if (age <= resolvedStaleTtlMs) {
+                status = "degraded";
+              } else {
+                status = "unreachable";
               }
-            } else {
+
+              const entry: Record<string, unknown> = {
+                instanceId: record.instanceId,
+                hostname: record.hostname,
+                pid: record.pid,
+                startedAt: record.startedAt,
+                lastHeartbeatAt: record.heartbeatAt,
+                status,
+                address: record.address ?? null,
+              };
+
+              if (isLocal) {
+                const snapshot = await healthCollector.collect(ac.signal);
+                entry.health = snapshot;
+              }
+
+              instances.push(entry);
+            }
+
+            if (instances.length === 0) {
+              const localScheme = tlsEnabled ? "https" : "http";
               const entry: Record<string, unknown> = {
                 instanceId,
                 hostname: Deno.hostname(),
@@ -3446,7 +3447,7 @@ export const serveCommand = new Command()
                 startedAt: null,
                 lastHeartbeatAt: null,
                 status: "healthy",
-                address: null,
+                address: `${localScheme}://${host}:${port}`,
               };
               const snapshot = await healthCollector.collect(ac.signal);
               entry.health = snapshot;

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -29,6 +29,10 @@ import { parseTimeout } from "../duration_parser.ts";
 import { buildServeAuthConfig } from "../../domain/access/serve_auth_config.ts";
 import { handleConnection } from "../../serve/connection.ts";
 import {
+  collectClusterInstances,
+  redactServeOptions,
+} from "../../serve/handlers/admin_handlers.ts";
+import {
   closeConnectionsForPrincipal,
   removeConnection,
   setConnectionCollectives,
@@ -3395,64 +3399,14 @@ export const serveCommand = new Command()
             );
             if (!auth.ok) return auth.response;
 
-            const instances: Record<string, unknown>[] = [];
-            const resolvedStaleTtlMs = staleTtlMs ?? 90_000;
-            const degradedThresholdMs = resolvedStaleTtlMs * 2 / 3;
-
-            const keys = await controlPlaneStore.list("heartbeats/");
-            for (const key of keys) {
-              const data = await controlPlaneStore.get(key);
-              if (!data) continue;
-              const record = InstanceHeartbeatService.parseRecord(data);
-              if (!record) continue;
-
-              const isLocal = record.instanceId === instanceId;
-              const age = Date.now() -
-                new Date(record.heartbeatAt).getTime();
-              let status: string;
-              if (isNaN(age)) {
-                status = "unreachable";
-              } else if (age <= degradedThresholdMs) {
-                status = "healthy";
-              } else if (age <= resolvedStaleTtlMs) {
-                status = "degraded";
-              } else {
-                status = "unreachable";
-              }
-
-              const entry: Record<string, unknown> = {
-                instanceId: record.instanceId,
-                hostname: record.hostname,
-                pid: record.pid,
-                startedAt: record.startedAt,
-                lastHeartbeatAt: record.heartbeatAt,
-                status,
-                address: record.address ?? null,
-              };
-
-              if (isLocal) {
-                const snapshot = await healthCollector.collect(ac.signal);
-                entry.health = snapshot;
-              }
-
-              instances.push(entry);
-            }
-
-            if (instances.length === 0) {
-              const localScheme = tlsEnabled ? "https" : "http";
-              const entry: Record<string, unknown> = {
-                instanceId,
-                hostname: Deno.hostname(),
-                pid: Deno.pid,
-                startedAt: null,
-                lastHeartbeatAt: null,
-                status: "healthy",
-                address: `${localScheme}://${host}:${port}`,
-              };
-              const snapshot = await healthCollector.collect(ac.signal);
-              entry.health = snapshot;
-              instances.push(entry);
-            }
+            const instances = await collectClusterInstances({
+              controlPlaneStore,
+              healthCollector,
+              instanceId,
+              staleTtlMs,
+              serveOptions: merged,
+              signal: ac.signal,
+            });
 
             return Response.json({ instances });
           }
@@ -3466,34 +3420,9 @@ export const serveCommand = new Command()
             );
             if (!auth.ok) return auth.response;
 
-            const config = {
-              port: merged.port,
-              host: merged.host,
-              tls: {
-                enabled: merged.certFile !== undefined &&
-                  merged.keyFile !== undefined,
-                certFile: merged.certFile ?? null,
-              },
-              authMode: merged.authMode,
-              scheduling: { enabled: merged.schedule },
-              dashboard: { enabled: true },
-              webhooks: (merged.webhookConfigs ?? []).map((wh) => ({
-                route: wh.route,
-                workflow: wh.workflow,
-                scheme: wh.scheme ?? "github",
-              })),
-              maxConcurrentRuns: merged.maxConcurrentRuns ?? null,
-              maxRunsPerPrincipal: merged.maxRunsPerPrincipal ?? null,
-              maxRunDuration: merged.maxRunDuration ?? null,
-              enableInternalApi: merged.enableInternalApi,
-              detachRuns: merged.detachRuns,
-              hotReload: merged.hotReload,
-              remoteOnly: merged.remoteOnly,
-              trustProxy: merged.trustProxy,
-              verifyOnEnroll: merged.verifyOnEnroll,
-            };
-
-            return Response.json({ config });
+            return Response.json({
+              config: redactServeOptions(merged),
+            });
           }
 
           // Internal runs endpoint (opt-in, authenticated + authorized)

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -3412,7 +3412,7 @@ export const serveCommand = new Command()
           }
 
           // Serve config endpoint (authenticated + authorized)
-          if (url.pathname === "/api/v1/config") {
+          if (url.pathname === "/api/v1/serve/config") {
             const auth = await authenticateAdmin(
               req,
               info.remoteAddr.hostname,

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -2490,6 +2490,7 @@ export const serveCommand = new Command()
         ...(Object.keys(resolvedUserNames).length > 0
           ? { resolvedUserNames }
           : {}),
+        serveOptions: merged,
       };
 
     const ac = new AbortController();
@@ -2997,6 +2998,8 @@ export const serveCommand = new Command()
       remoteOnly: merged.remoteOnly,
     });
 
+    connectionCtx.healthCollector = healthCollector;
+
     const adminAuthDeps: AdminAuthDeps = {
       authMode: authConfig.mode,
       repoDir: resolvedRepoDir,
@@ -3381,6 +3384,115 @@ export const serveCommand = new Command()
                 "x-health-interval": String(intervalMs),
               },
             });
+          }
+
+          // Cluster instances endpoint (authenticated + authorized)
+          if (url.pathname === "/api/v1/cluster/instances") {
+            const auth = await authenticateAdmin(
+              req,
+              info.remoteAddr.hostname,
+              adminAuthDeps,
+            );
+            if (!auth.ok) return auth.response;
+
+            const instances: Record<string, unknown>[] = [];
+            const resolvedStaleTtlMs = staleTtlMs ?? 90_000;
+            const degradedThresholdMs = resolvedStaleTtlMs * 2 / 3;
+
+            if (controlPlaneStore) {
+              const keys = await controlPlaneStore.list("heartbeats/");
+              for (const key of keys) {
+                const data = await controlPlaneStore.get(key);
+                if (!data) continue;
+                const record = InstanceHeartbeatService.parseRecord(data);
+                if (!record) continue;
+
+                const isLocal = record.instanceId === instanceId;
+                const age = Date.now() -
+                  new Date(record.heartbeatAt).getTime();
+                let status: string;
+                if (isNaN(age)) {
+                  status = "unreachable";
+                } else if (age <= degradedThresholdMs) {
+                  status = "healthy";
+                } else if (age <= resolvedStaleTtlMs) {
+                  status = "degraded";
+                } else {
+                  status = "unreachable";
+                }
+
+                const entry: Record<string, unknown> = {
+                  instanceId: record.instanceId,
+                  hostname: record.hostname,
+                  pid: record.pid,
+                  startedAt: record.startedAt,
+                  lastHeartbeatAt: record.heartbeatAt,
+                  status,
+                  address: record.address ?? null,
+                };
+
+                if (isLocal) {
+                  const snapshot = await healthCollector.collect(ac.signal);
+                  entry.health = snapshot;
+                }
+
+                instances.push(entry);
+              }
+            } else {
+              const entry: Record<string, unknown> = {
+                instanceId,
+                hostname: Deno.hostname(),
+                pid: Deno.pid,
+                startedAt: null,
+                lastHeartbeatAt: null,
+                status: "healthy",
+                address: null,
+              };
+              const snapshot = await healthCollector.collect(ac.signal);
+              entry.health = snapshot;
+              instances.push(entry);
+            }
+
+            return Response.json({ instances });
+          }
+
+          // Serve config endpoint (authenticated + authorized)
+          if (url.pathname === "/api/v1/config") {
+            const auth = await authenticateAdmin(
+              req,
+              info.remoteAddr.hostname,
+              adminAuthDeps,
+            );
+            if (!auth.ok) return auth.response;
+
+            const config = {
+              port: merged.port,
+              host: merged.host,
+              tls: {
+                enabled: merged.certFile !== undefined &&
+                  merged.keyFile !== undefined,
+                certFile: merged.certFile ?? null,
+              },
+              authMode: merged.authMode,
+              scheduling: { enabled: merged.schedule },
+              dashboard: { enabled: true },
+              webhooks: (merged.webhookConfigs ?? []).map((wh) => ({
+                route: wh.route,
+                workflow: wh.workflow,
+                scheme: wh.scheme ?? "github",
+              })),
+              maxConcurrentRuns: merged.maxConcurrentRuns ?? null,
+              maxRunsPerPrincipal: merged.maxRunsPerPrincipal ?? null,
+              maxRunDuration: merged.maxRunDuration ?? null,
+              enableInternalApi: merged.enableInternalApi,
+              detachRuns: merged.detachRuns,
+              hotReload: merged.hotReload,
+              remoteOnly: merged.remoteOnly,
+              trustProxy: merged.trustProxy,
+              verifyOnEnroll: merged.verifyOnEnroll,
+            };
+
+            return Response.json({ config });
           }
 
           // Internal runs endpoint (opt-in, authenticated + authorized)
@@ -3796,10 +3908,15 @@ export const serveCommand = new Command()
     }
 
     if (hasRemoteControlPlane) {
+      const scheme = tlsEnabled ? "https" : "http";
+      const serveAddress = `${scheme}://${host}:${port}`;
       heartbeatService = new InstanceHeartbeatService(
         controlPlaneStore,
         instanceId,
-        heartbeatIntervalMs ? { intervalMs: heartbeatIntervalMs } : undefined,
+        {
+          ...(heartbeatIntervalMs ? { intervalMs: heartbeatIntervalMs } : {}),
+          address: serveAddress,
+        },
       );
       await heartbeatService.start();
       logger.info`Instance heartbeat started (id: ${instanceId})`;

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -119,6 +119,7 @@ import {
 } from "./handlers/report_handlers.ts";
 import {
   handleAuditTimeline,
+  handleClusterInstances,
   handleDatastoreNamespaceList,
   handleDatastoreSetupExtension,
   handleDatastoreStatus,
@@ -137,6 +138,7 @@ import {
   handleExtensionUpdate,
   handleRunDoctor,
   handleRunHistory,
+  handleServeConfig,
   handleServeReload,
   handleVaultMigrate,
   handleWorkerList,
@@ -2422,6 +2424,25 @@ export function handleMessage(
         request.id,
         controller,
         principal,
+      );
+      break;
+    case "cluster.instances":
+      task = handleClusterInstances(
+        socket,
+        ctx,
+        request.id,
+        controller,
+        principal,
+      );
+      break;
+    case "serve.config":
+      task = Promise.resolve(
+        handleServeConfig(
+          socket,
+          ctx,
+          request.id,
+          principal,
+        ),
       );
       break;
     default: {

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -23,6 +23,11 @@
 
 import { isAbsolute, join, relative, resolve } from "@std/path";
 import {
+  DEFAULT_STALE_TTL_MS,
+  InstanceHeartbeatService,
+} from "../instance_heartbeat.ts";
+import type { MergedServeOptions } from "../serve_config.ts";
+import {
   type ActiveRun,
   STALE_TTL_MS,
 } from "../../domain/models/active_run.ts";
@@ -2015,4 +2020,159 @@ export async function handleDatastoreNamespaceList(
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "datastore_namespace_list_failed", message);
   }
+}
+
+export async function handleClusterInstances(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "read", {
+      kind: "access",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const instances: Record<string, unknown>[] = [];
+    const staleTtlMs = ctx.staleTtlMs ?? DEFAULT_STALE_TTL_MS;
+    const degradedThresholdMs = staleTtlMs * 2 / 3;
+
+    if (ctx.controlPlaneStore) {
+      const keys = await ctx.controlPlaneStore.list("heartbeats/");
+      for (const key of keys) {
+        if (controller.signal.aborted) break;
+        const data = await ctx.controlPlaneStore.get(key);
+        if (!data) continue;
+        const record = InstanceHeartbeatService.parseRecord(data);
+        if (!record) continue;
+
+        const isLocal = record.instanceId === ctx.instanceId;
+        const age = Date.now() - new Date(record.heartbeatAt).getTime();
+        let status: string;
+        if (isNaN(age)) {
+          status = "unreachable";
+        } else if (age <= degradedThresholdMs) {
+          status = "healthy";
+        } else if (age <= staleTtlMs) {
+          status = "degraded";
+        } else {
+          status = "unreachable";
+        }
+
+        const entry: Record<string, unknown> = {
+          instanceId: record.instanceId,
+          hostname: record.hostname,
+          pid: record.pid,
+          startedAt: record.startedAt,
+          lastHeartbeatAt: record.heartbeatAt,
+          status,
+          address: record.address ?? null,
+        };
+
+        if (isLocal && ctx.healthCollector) {
+          const snapshot = await ctx.healthCollector.collect(controller.signal);
+          entry.health = snapshot;
+        }
+
+        instances.push(entry);
+      }
+    } else if (ctx.instanceId) {
+      const entry: Record<string, unknown> = {
+        instanceId: ctx.instanceId,
+        hostname: Deno.hostname(),
+        pid: Deno.pid,
+        startedAt: null,
+        lastHeartbeatAt: null,
+        status: "healthy",
+        address: null,
+      };
+
+      if (ctx.healthCollector) {
+        const snapshot = await ctx.healthCollector.collect(controller.signal);
+        entry.health = snapshot;
+      }
+
+      instances.push(entry);
+    }
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "cluster.instances",
+      id: requestId,
+      payload: { instances },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "cluster_instances_failed", message);
+  }
+}
+
+export function redactServeOptions(
+  opts: MergedServeOptions,
+): Record<string, unknown> {
+  return {
+    port: opts.port,
+    host: opts.host,
+    tls: {
+      enabled: opts.certFile !== undefined && opts.keyFile !== undefined,
+      certFile: opts.certFile ?? null,
+    },
+    authMode: opts.authMode,
+    scheduling: { enabled: opts.schedule },
+    dashboard: { enabled: true },
+    webhooks: (opts.webhookConfigs ?? []).map((wh) => ({
+      route: wh.route,
+      workflow: wh.workflow,
+      scheme: wh.scheme ?? "github",
+    })),
+    maxConcurrentRuns: opts.maxConcurrentRuns ?? null,
+    maxRunsPerPrincipal: opts.maxRunsPerPrincipal ?? null,
+    maxRunDuration: opts.maxRunDuration ?? null,
+    enableInternalApi: opts.enableInternalApi,
+    detachRuns: opts.detachRuns,
+    hotReload: opts.hotReload,
+    remoteOnly: opts.remoteOnly,
+    trustProxy: opts.trustProxy,
+    verifyOnEnroll: opts.verifyOnEnroll,
+  };
+}
+
+export function handleServeConfig(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  principal: Principal | null,
+): void {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "read", {
+      kind: "access",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  if (!ctx.serveOptions) {
+    sendError(
+      socket,
+      requestId,
+      "not_available",
+      "Serve configuration not available",
+    );
+    return;
+  }
+
+  send(socket, {
+    type: "serve.config",
+    id: requestId,
+    payload: { config: redactServeOptions(ctx.serveOptions) },
+  });
 }

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -2081,7 +2081,9 @@ export async function handleClusterInstances(
 
         instances.push(entry);
       }
-    } else if (ctx.instanceId) {
+    }
+
+    if (instances.length === 0 && ctx.instanceId) {
       const entry: Record<string, unknown> = {
         instanceId: ctx.instanceId,
         hostname: Deno.hostname(),

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -2022,6 +2022,96 @@ export async function handleDatastoreNamespaceList(
   }
 }
 
+export interface CollectClusterInstancesOptions {
+  controlPlaneStore?:
+    import("../../domain/datastore/control_plane_store.ts").ControlPlaneStore;
+  healthCollector?: import("../health_collector.ts").HealthCollector;
+  instanceId?: string;
+  staleTtlMs?: number;
+  serveOptions?: MergedServeOptions;
+  signal: AbortSignal;
+}
+
+export async function collectClusterInstances(
+  opts: CollectClusterInstancesOptions,
+): Promise<Record<string, unknown>[]> {
+  const instances: Record<string, unknown>[] = [];
+  const staleTtlMs = opts.staleTtlMs ?? DEFAULT_STALE_TTL_MS;
+  const degradedThresholdMs = staleTtlMs * 2 / 3;
+
+  if (opts.controlPlaneStore) {
+    const keys = await opts.controlPlaneStore.list("heartbeats/");
+    for (const key of keys) {
+      if (opts.signal.aborted) break;
+      const data = await opts.controlPlaneStore.get(key);
+      if (!data) continue;
+      const record = InstanceHeartbeatService.parseRecord(data);
+      if (!record) continue;
+
+      const isLocal = record.instanceId === opts.instanceId;
+      const age = Date.now() - new Date(record.heartbeatAt).getTime();
+      let status: string;
+      if (isNaN(age)) {
+        status = "unreachable";
+      } else if (age <= degradedThresholdMs) {
+        status = "healthy";
+      } else if (age <= staleTtlMs) {
+        status = "degraded";
+      } else {
+        status = "unreachable";
+      }
+
+      const entry: Record<string, unknown> = {
+        instanceId: record.instanceId,
+        hostname: record.hostname,
+        pid: record.pid,
+        startedAt: record.startedAt,
+        lastHeartbeatAt: record.heartbeatAt,
+        status,
+        address: record.address ?? null,
+      };
+
+      if (isLocal && opts.healthCollector) {
+        const snapshot = await opts.healthCollector.collect(opts.signal);
+        entry.health = snapshot;
+      }
+
+      instances.push(entry);
+    }
+  }
+
+  if (instances.length === 0 && opts.instanceId) {
+    let address: string | null = null;
+    if (opts.serveOptions) {
+      const scheme = opts.serveOptions.certFile !== undefined &&
+          opts.serveOptions.keyFile !== undefined
+        ? "https"
+        : "http";
+      address =
+        `${scheme}://${opts.serveOptions.host}:${opts.serveOptions.port}`;
+    }
+
+    const entry: Record<string, unknown> = {
+      instanceId: opts.instanceId,
+      hostname: Deno.hostname(),
+      pid: Deno.pid,
+      startedAt: null,
+      lastHeartbeatAt: null,
+      status: "healthy",
+      address,
+    };
+
+    if (opts.healthCollector) {
+      const snapshot = await opts.healthCollector.collect(opts.signal);
+      entry.health = snapshot;
+    }
+
+    instances.push(entry);
+  }
+
+  return instances;
+}
+
 export async function handleClusterInstances(
   socket: WebSocket,
   ctx: ConnectionContext,
@@ -2038,69 +2128,14 @@ export async function handleClusterInstances(
   ) return;
 
   try {
-    const instances: Record<string, unknown>[] = [];
-    const staleTtlMs = ctx.staleTtlMs ?? DEFAULT_STALE_TTL_MS;
-    const degradedThresholdMs = staleTtlMs * 2 / 3;
-
-    if (ctx.controlPlaneStore) {
-      const keys = await ctx.controlPlaneStore.list("heartbeats/");
-      for (const key of keys) {
-        if (controller.signal.aborted) break;
-        const data = await ctx.controlPlaneStore.get(key);
-        if (!data) continue;
-        const record = InstanceHeartbeatService.parseRecord(data);
-        if (!record) continue;
-
-        const isLocal = record.instanceId === ctx.instanceId;
-        const age = Date.now() - new Date(record.heartbeatAt).getTime();
-        let status: string;
-        if (isNaN(age)) {
-          status = "unreachable";
-        } else if (age <= degradedThresholdMs) {
-          status = "healthy";
-        } else if (age <= staleTtlMs) {
-          status = "degraded";
-        } else {
-          status = "unreachable";
-        }
-
-        const entry: Record<string, unknown> = {
-          instanceId: record.instanceId,
-          hostname: record.hostname,
-          pid: record.pid,
-          startedAt: record.startedAt,
-          lastHeartbeatAt: record.heartbeatAt,
-          status,
-          address: record.address ?? null,
-        };
-
-        if (isLocal && ctx.healthCollector) {
-          const snapshot = await ctx.healthCollector.collect(controller.signal);
-          entry.health = snapshot;
-        }
-
-        instances.push(entry);
-      }
-    }
-
-    if (instances.length === 0 && ctx.instanceId) {
-      const entry: Record<string, unknown> = {
-        instanceId: ctx.instanceId,
-        hostname: Deno.hostname(),
-        pid: Deno.pid,
-        startedAt: null,
-        lastHeartbeatAt: null,
-        status: "healthy",
-        address: null,
-      };
-
-      if (ctx.healthCollector) {
-        const snapshot = await ctx.healthCollector.collect(controller.signal);
-        entry.health = snapshot;
-      }
-
-      instances.push(entry);
-    }
+    const instances = await collectClusterInstances({
+      controlPlaneStore: ctx.controlPlaneStore,
+      healthCollector: ctx.healthCollector,
+      instanceId: ctx.instanceId,
+      staleTtlMs: ctx.staleTtlMs,
+      serveOptions: ctx.serveOptions,
+      signal: controller.signal,
+    });
 
     if (controller.signal.aborted) {
       sendError(socket, requestId, "cancelled", "Operation was cancelled");

--- a/src/serve/handlers/admin_handlers_test.ts
+++ b/src/serve/handlers/admin_handlers_test.ts
@@ -23,73 +23,219 @@ import {
   type HeartbeatRecord,
   InstanceHeartbeatService,
 } from "../instance_heartbeat.ts";
+import type { ControlPlaneStore } from "../../domain/datastore/control_plane_store.ts";
+import type { MergedServeOptions } from "../serve_config.ts";
+import {
+  collectClusterInstances,
+  redactServeOptions,
+} from "./admin_handlers.ts";
 
-Deno.test("InstanceHeartbeatService.parseRecord: parses valid record with address", () => {
-  const record: HeartbeatRecord = {
-    instanceId: "inst-1",
-    hostname: "host-a",
-    pid: 1234,
+function makeHeartbeat(
+  id: string,
+  heartbeatAt: string,
+  address?: string,
+): HeartbeatRecord {
+  return {
+    instanceId: id,
+    hostname: "test-host",
+    pid: 1000,
     startedAt: "2026-01-01T00:00:00.000Z",
-    heartbeatAt: "2026-01-01T00:01:00.000Z",
-    address: "http://host-a:9090",
+    heartbeatAt,
+    ...(address !== undefined ? { address } : {}),
   };
+}
+
+function makeStore(
+  records: HeartbeatRecord[],
+): ControlPlaneStore {
+  const store = new Map<string, Uint8Array>();
+  for (const r of records) {
+    store.set(
+      `heartbeats/${r.instanceId}`,
+      new TextEncoder().encode(JSON.stringify(r)),
+    );
+  }
+  return {
+    put(key: string, data: Uint8Array) {
+      store.set(key, data);
+      return Promise.resolve();
+    },
+    get(key: string) {
+      return Promise.resolve(store.get(key) ?? null);
+    },
+    delete(key: string) {
+      store.delete(key);
+      return Promise.resolve();
+    },
+    list(prefix: string) {
+      return Promise.resolve(
+        [...store.keys()].filter((k) => k.startsWith(prefix)),
+      );
+    },
+  };
+}
+
+// ── parseRecord tests ────────────────────────────────────────────────
+
+Deno.test("parseRecord: parses valid record with address", () => {
+  const record = makeHeartbeat(
+    "inst-1",
+    "2026-01-01T00:01:00.000Z",
+    "http://host-a:9090",
+  );
   const data = new TextEncoder().encode(JSON.stringify(record));
   const parsed = InstanceHeartbeatService.parseRecord(data);
   assertEquals(parsed?.instanceId, "inst-1");
   assertEquals(parsed?.address, "http://host-a:9090");
 });
 
-Deno.test("InstanceHeartbeatService.parseRecord: parses record without address", () => {
-  const record = {
-    instanceId: "inst-2",
-    hostname: "host-b",
-    pid: 5678,
+Deno.test("parseRecord: rejects record with non-string address", () => {
+  const raw = {
+    instanceId: "inst-1",
+    hostname: "host-a",
+    pid: 1234,
     startedAt: "2026-01-01T00:00:00.000Z",
     heartbeatAt: "2026-01-01T00:01:00.000Z",
+    address: 12345,
   };
-  const data = new TextEncoder().encode(JSON.stringify(record));
-  const parsed = InstanceHeartbeatService.parseRecord(data);
-  assertEquals(parsed?.instanceId, "inst-2");
-  assertEquals(parsed?.address, undefined);
+  const data = new TextEncoder().encode(JSON.stringify(raw));
+  assertEquals(InstanceHeartbeatService.parseRecord(data), null);
 });
 
-Deno.test("InstanceHeartbeatService.isStale: healthy heartbeat is not stale", () => {
-  const record: HeartbeatRecord = {
+// ── collectClusterInstances tests ────────────────────────────────────
+
+Deno.test("collectClusterInstances: healthy status for fresh heartbeat", async () => {
+  const now = new Date().toISOString();
+  const store = makeStore([makeHeartbeat("inst-1", now, "http://host:9090")]);
+  const ac = new AbortController();
+
+  const instances = await collectClusterInstances({
+    controlPlaneStore: store,
+    instanceId: "other-id",
+    signal: ac.signal,
+  });
+
+  assertEquals(instances.length, 1);
+  assertEquals(instances[0].status, "healthy");
+  assertEquals(instances[0].address, "http://host:9090");
+});
+
+Deno.test("collectClusterInstances: degraded status near stale threshold", async () => {
+  const staleTtlMs = 90_000;
+  const degradedAge = staleTtlMs * 2 / 3 + 1000;
+  const degradedTime = new Date(Date.now() - degradedAge).toISOString();
+  const store = makeStore([makeHeartbeat("inst-1", degradedTime)]);
+  const ac = new AbortController();
+
+  const instances = await collectClusterInstances({
+    controlPlaneStore: store,
+    instanceId: "other-id",
+    staleTtlMs,
+    signal: ac.signal,
+  });
+
+  assertEquals(instances.length, 1);
+  assertEquals(instances[0].status, "degraded");
+});
+
+Deno.test("collectClusterInstances: unreachable status past stale threshold", async () => {
+  const staleTtlMs = 90_000;
+  const staleTime = new Date(Date.now() - staleTtlMs - 5000).toISOString();
+  const store = makeStore([makeHeartbeat("inst-1", staleTime)]);
+  const ac = new AbortController();
+
+  const instances = await collectClusterInstances({
+    controlPlaneStore: store,
+    instanceId: "other-id",
+    staleTtlMs,
+    signal: ac.signal,
+  });
+
+  assertEquals(instances.length, 1);
+  assertEquals(instances[0].status, "unreachable");
+});
+
+Deno.test("collectClusterInstances: unreachable for invalid timestamp", async () => {
+  const store = makeStore([makeHeartbeat("inst-1", "not-a-date")]);
+  const ac = new AbortController();
+
+  const instances = await collectClusterInstances({
+    controlPlaneStore: store,
+    instanceId: "other-id",
+    signal: ac.signal,
+  });
+
+  assertEquals(instances.length, 1);
+  assertEquals(instances[0].status, "unreachable");
+});
+
+Deno.test("collectClusterInstances: standalone fallback when no heartbeats", async () => {
+  const store = makeStore([]);
+  const ac = new AbortController();
+
+  const instances = await collectClusterInstances({
+    controlPlaneStore: store,
+    instanceId: "local-id",
+    serveOptions: {
+      port: 9090,
+      host: "127.0.0.1",
+    } as MergedServeOptions,
+    signal: ac.signal,
+  });
+
+  assertEquals(instances.length, 1);
+  assertEquals(instances[0].instanceId, "local-id");
+  assertEquals(instances[0].status, "healthy");
+  assertEquals(instances[0].address, "http://127.0.0.1:9090");
+});
+
+Deno.test("collectClusterInstances: standalone fallback derives https from TLS options", async () => {
+  const store = makeStore([]);
+  const ac = new AbortController();
+
+  const instances = await collectClusterInstances({
+    controlPlaneStore: store,
+    instanceId: "local-id",
+    serveOptions: {
+      port: 443,
+      host: "0.0.0.0",
+      certFile: "/path/to/cert.pem",
+      keyFile: "/path/to/key.pem",
+    } as MergedServeOptions,
+    signal: ac.signal,
+  });
+
+  assertEquals(instances.length, 1);
+  assertEquals(instances[0].address, "https://0.0.0.0:443");
+});
+
+Deno.test("collectClusterInstances: multiple instances with mixed status", async () => {
+  const now = new Date();
+  const healthy = makeHeartbeat("inst-1", now.toISOString(), "http://a:9090");
+  const stale = makeHeartbeat(
+    "inst-2",
+    new Date(now.getTime() - DEFAULT_STALE_TTL_MS - 5000).toISOString(),
+    "http://b:9090",
+  );
+  const store = makeStore([healthy, stale]);
+  const ac = new AbortController();
+
+  const instances = await collectClusterInstances({
+    controlPlaneStore: store,
     instanceId: "inst-1",
-    hostname: "host-a",
-    pid: 1234,
-    startedAt: "2026-01-01T00:00:00.000Z",
-    heartbeatAt: new Date().toISOString(),
-  };
-  assertEquals(InstanceHeartbeatService.isStale(record), false);
+    signal: ac.signal,
+  });
+
+  assertEquals(instances.length, 2);
+  const inst1 = instances.find((i) => i.instanceId === "inst-1");
+  const inst2 = instances.find((i) => i.instanceId === "inst-2");
+  assertEquals(inst1?.status, "healthy");
+  assertEquals(inst2?.status, "unreachable");
 });
 
-Deno.test("InstanceHeartbeatService.isStale: old heartbeat is stale", () => {
-  const oldTime = new Date(Date.now() - DEFAULT_STALE_TTL_MS - 1000)
-    .toISOString();
-  const record: HeartbeatRecord = {
-    instanceId: "inst-1",
-    hostname: "host-a",
-    pid: 1234,
-    startedAt: "2026-01-01T00:00:00.000Z",
-    heartbeatAt: oldTime,
-  };
-  assertEquals(InstanceHeartbeatService.isStale(record), true);
-});
+// ── redactServeOptions tests ─────────────────────────────────────────
 
-Deno.test("InstanceHeartbeatService.isStale: invalid timestamp is stale", () => {
-  const record: HeartbeatRecord = {
-    instanceId: "inst-1",
-    hostname: "host-a",
-    pid: 1234,
-    startedAt: "2026-01-01T00:00:00.000Z",
-    heartbeatAt: "not-a-date",
-  };
-  assertEquals(InstanceHeartbeatService.isStale(record), true);
-});
-
-Deno.test("redactServeOptions: verifies webhook secrets are not exposed", async () => {
-  const { redactServeOptions } = await import("./admin_handlers.ts");
+Deno.test("redactServeOptions: verifies webhook secrets are not exposed", () => {
   const opts = {
     port: 9090,
     host: "127.0.0.1",
@@ -110,7 +256,7 @@ Deno.test("redactServeOptions: verifies webhook secrets are not exposed", async 
     }],
   };
   const redacted = redactServeOptions(
-    opts as unknown as import("../serve_config.ts").MergedServeOptions,
+    opts as unknown as MergedServeOptions,
   );
   const webhooks = redacted.webhooks as Array<Record<string, unknown>>;
   assertEquals(webhooks.length, 1);
@@ -120,8 +266,7 @@ Deno.test("redactServeOptions: verifies webhook secrets are not exposed", async 
   assertEquals(Object.hasOwn(webhooks[0], "secret"), false);
 });
 
-Deno.test("redactServeOptions: omits TLS key file", async () => {
-  const { redactServeOptions } = await import("./admin_handlers.ts");
+Deno.test("redactServeOptions: omits TLS key file", () => {
   const opts = {
     port: 443,
     host: "0.0.0.0",
@@ -138,7 +283,7 @@ Deno.test("redactServeOptions: omits TLS key file", async () => {
     remoteOnly: false,
   };
   const redacted = redactServeOptions(
-    opts as unknown as import("../serve_config.ts").MergedServeOptions,
+    opts as unknown as MergedServeOptions,
   );
   const tls = redacted.tls as Record<string, unknown>;
   assertEquals(tls.enabled, true);
@@ -146,8 +291,7 @@ Deno.test("redactServeOptions: omits TLS key file", async () => {
   assertEquals(Object.hasOwn(tls, "keyFile"), false);
 });
 
-Deno.test("redactServeOptions: handles no webhooks", async () => {
-  const { redactServeOptions } = await import("./admin_handlers.ts");
+Deno.test("redactServeOptions: handles no webhooks", () => {
   const opts = {
     port: 9090,
     host: "127.0.0.1",
@@ -162,7 +306,7 @@ Deno.test("redactServeOptions: handles no webhooks", async () => {
     remoteOnly: false,
   };
   const redacted = redactServeOptions(
-    opts as unknown as import("../serve_config.ts").MergedServeOptions,
+    opts as unknown as MergedServeOptions,
   );
   const webhooks = redacted.webhooks as Array<Record<string, unknown>>;
   assertEquals(webhooks.length, 0);

--- a/src/serve/handlers/admin_handlers_test.ts
+++ b/src/serve/handlers/admin_handlers_test.ts
@@ -1,0 +1,171 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  DEFAULT_STALE_TTL_MS,
+  type HeartbeatRecord,
+  InstanceHeartbeatService,
+} from "../instance_heartbeat.ts";
+
+Deno.test("InstanceHeartbeatService.parseRecord: parses valid record with address", () => {
+  const record: HeartbeatRecord = {
+    instanceId: "inst-1",
+    hostname: "host-a",
+    pid: 1234,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    heartbeatAt: "2026-01-01T00:01:00.000Z",
+    address: "http://host-a:9090",
+  };
+  const data = new TextEncoder().encode(JSON.stringify(record));
+  const parsed = InstanceHeartbeatService.parseRecord(data);
+  assertEquals(parsed?.instanceId, "inst-1");
+  assertEquals(parsed?.address, "http://host-a:9090");
+});
+
+Deno.test("InstanceHeartbeatService.parseRecord: parses record without address", () => {
+  const record = {
+    instanceId: "inst-2",
+    hostname: "host-b",
+    pid: 5678,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    heartbeatAt: "2026-01-01T00:01:00.000Z",
+  };
+  const data = new TextEncoder().encode(JSON.stringify(record));
+  const parsed = InstanceHeartbeatService.parseRecord(data);
+  assertEquals(parsed?.instanceId, "inst-2");
+  assertEquals(parsed?.address, undefined);
+});
+
+Deno.test("InstanceHeartbeatService.isStale: healthy heartbeat is not stale", () => {
+  const record: HeartbeatRecord = {
+    instanceId: "inst-1",
+    hostname: "host-a",
+    pid: 1234,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    heartbeatAt: new Date().toISOString(),
+  };
+  assertEquals(InstanceHeartbeatService.isStale(record), false);
+});
+
+Deno.test("InstanceHeartbeatService.isStale: old heartbeat is stale", () => {
+  const oldTime = new Date(Date.now() - DEFAULT_STALE_TTL_MS - 1000)
+    .toISOString();
+  const record: HeartbeatRecord = {
+    instanceId: "inst-1",
+    hostname: "host-a",
+    pid: 1234,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    heartbeatAt: oldTime,
+  };
+  assertEquals(InstanceHeartbeatService.isStale(record), true);
+});
+
+Deno.test("InstanceHeartbeatService.isStale: invalid timestamp is stale", () => {
+  const record: HeartbeatRecord = {
+    instanceId: "inst-1",
+    hostname: "host-a",
+    pid: 1234,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    heartbeatAt: "not-a-date",
+  };
+  assertEquals(InstanceHeartbeatService.isStale(record), true);
+});
+
+Deno.test("redactServeOptions: verifies webhook secrets are not exposed", async () => {
+  const { redactServeOptions } = await import("./admin_handlers.ts");
+  const opts = {
+    port: 9090,
+    host: "127.0.0.1",
+    schedule: true,
+    authMode: "none",
+    grantReload: "manual",
+    trustProxy: false,
+    verifyOnEnroll: false,
+    detachRuns: false,
+    hotReload: false,
+    enableInternalApi: false,
+    remoteOnly: false,
+    webhookConfigs: [{
+      route: "/hook",
+      workflow: "deploy",
+      secret: "super-secret-value",
+      scheme: "github",
+    }],
+  };
+  const redacted = redactServeOptions(
+    opts as unknown as import("../serve_config.ts").MergedServeOptions,
+  );
+  const webhooks = redacted.webhooks as Array<Record<string, unknown>>;
+  assertEquals(webhooks.length, 1);
+  assertEquals(webhooks[0].route, "/hook");
+  assertEquals(webhooks[0].workflow, "deploy");
+  assertEquals(webhooks[0].scheme, "github");
+  assertEquals(Object.hasOwn(webhooks[0], "secret"), false);
+});
+
+Deno.test("redactServeOptions: omits TLS key file", async () => {
+  const { redactServeOptions } = await import("./admin_handlers.ts");
+  const opts = {
+    port: 443,
+    host: "0.0.0.0",
+    schedule: false,
+    certFile: "/path/to/cert.pem",
+    keyFile: "/path/to/key.pem",
+    authMode: "admin-token",
+    grantReload: "manual",
+    trustProxy: true,
+    verifyOnEnroll: false,
+    detachRuns: false,
+    hotReload: false,
+    enableInternalApi: false,
+    remoteOnly: false,
+  };
+  const redacted = redactServeOptions(
+    opts as unknown as import("../serve_config.ts").MergedServeOptions,
+  );
+  const tls = redacted.tls as Record<string, unknown>;
+  assertEquals(tls.enabled, true);
+  assertEquals(tls.certFile, "/path/to/cert.pem");
+  assertEquals(Object.hasOwn(tls, "keyFile"), false);
+});
+
+Deno.test("redactServeOptions: handles no webhooks", async () => {
+  const { redactServeOptions } = await import("./admin_handlers.ts");
+  const opts = {
+    port: 9090,
+    host: "127.0.0.1",
+    schedule: true,
+    authMode: "none",
+    grantReload: "manual",
+    trustProxy: false,
+    verifyOnEnroll: false,
+    detachRuns: false,
+    hotReload: false,
+    enableInternalApi: false,
+    remoteOnly: false,
+  };
+  const redacted = redactServeOptions(
+    opts as unknown as import("../serve_config.ts").MergedServeOptions,
+  );
+  const webhooks = redacted.webhooks as Array<Record<string, unknown>>;
+  assertEquals(webhooks.length, 0);
+  assertEquals(redacted.port, 9090);
+  assertEquals(redacted.authMode, "none");
+});

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -43,6 +43,8 @@ import {
 import type { Action } from "../../domain/access/action.ts";
 import type { AccessResource } from "../../domain/access/access_decision_service.ts";
 import type { ScheduledExecutionService } from "../../libswamp/mod.ts";
+import type { MergedServeOptions } from "../serve_config.ts";
+import type { HealthCollector } from "../health_collector.ts";
 
 export const MAX_CLIENT_ERROR_LENGTH = 200;
 
@@ -114,6 +116,10 @@ export interface ConnectionContext {
   scheduledExecution?: ScheduledExecutionService;
   /** Inverted resolvedAdmins map: OAuth sub → username. Populated at startup in OAuth mode. */
   resolvedUserNames?: Record<string, string>;
+  /** Resolved serve options — used by serve.config endpoint. */
+  serveOptions?: MergedServeOptions;
+  /** Health collector — used by cluster.instances to enrich the local instance. */
+  healthCollector?: HealthCollector;
 }
 
 // SECURITY: Authorization must operate on canonical (normalized) model types,

--- a/src/serve/instance_heartbeat.ts
+++ b/src/serve/instance_heartbeat.ts
@@ -121,7 +121,8 @@ export class InstanceHeartbeatService {
         typeof parsed.hostname === "string" &&
         typeof parsed.pid === "number" &&
         typeof parsed.startedAt === "string" &&
-        typeof parsed.heartbeatAt === "string"
+        typeof parsed.heartbeatAt === "string" &&
+        (parsed.address === undefined || typeof parsed.address === "string")
       ) {
         return parsed as HeartbeatRecord;
       }

--- a/src/serve/instance_heartbeat.ts
+++ b/src/serve/instance_heartbeat.ts
@@ -31,6 +31,7 @@ export interface HeartbeatRecord {
   pid: number;
   startedAt: string;
   heartbeatAt: string;
+  address?: string;
 }
 
 export class InstanceHeartbeatService {
@@ -40,12 +41,13 @@ export class InstanceHeartbeatService {
   readonly #pid: number;
   readonly #startedAt: string;
   readonly #intervalMs: number;
+  readonly #address: string | undefined;
   #timer: ReturnType<typeof setInterval> | null = null;
 
   constructor(
     store: ControlPlaneStore,
     instanceId: string,
-    options?: { intervalMs?: number },
+    options?: { intervalMs?: number; address?: string },
   ) {
     this.#store = store;
     this.#instanceId = instanceId;
@@ -53,6 +55,7 @@ export class InstanceHeartbeatService {
     this.#pid = Deno.pid;
     this.#startedAt = new Date().toISOString();
     this.#intervalMs = options?.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+    this.#address = options?.address;
   }
 
   get instanceId(): string {
@@ -93,6 +96,7 @@ export class InstanceHeartbeatService {
       pid: this.#pid,
       startedAt: this.#startedAt,
       heartbeatAt: new Date().toISOString(),
+      ...(this.#address !== undefined ? { address: this.#address } : {}),
     };
     await this.#store.put(
       `heartbeats/${this.#instanceId}`,

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -587,6 +587,12 @@ export interface RunGcPayload {
   outputRetentionDays?: number;
 }
 
+// ── Cluster / serve config ─────────────────────────────────────────
+
+export type ClusterInstancesPayload = Record<string, never>;
+
+export type ServeConfigPayload = Record<string, never>;
+
 // ── Datastore namespace ─────────────────────────────────────────────
 
 export type DatastoreNamespaceListPayload = Record<string, never>;
@@ -877,6 +883,16 @@ export type ServerRequest =
     type: "datastore.namespace.list";
     id: string;
     payload?: DatastoreNamespaceListPayload;
+  }
+  | {
+    type: "cluster.instances";
+    id: string;
+    payload?: ClusterInstancesPayload;
+  }
+  | {
+    type: "serve.config";
+    id: string;
+    payload?: ServeConfigPayload;
   };
 
 // ── Outbound (server → client) ───────────────────────────────────────────
@@ -1344,6 +1360,14 @@ export interface DatastoreNamespaceListResponse {
   data: Record<string, unknown>;
 }
 
+export interface ClusterInstancesResponse {
+  instances: Record<string, unknown>[];
+}
+
+export interface ServeConfigResponse {
+  config: Record<string, unknown>;
+}
+
 export interface RunHistoryPayload {
   active?: boolean;
   all?: boolean;
@@ -1651,4 +1675,14 @@ export type ServerMessage =
     type: "datastore.namespace.list";
     id: string;
     payload: DatastoreNamespaceListResponse;
+  }
+  | {
+    type: "cluster.instances";
+    id: string;
+    payload: ClusterInstancesResponse;
+  }
+  | {
+    type: "serve.config";
+    id: string;
+    payload: ServeConfigResponse;
   };


### PR DESCRIPTION
## Summary

Adds two new serve dashboard API endpoints (WS + REST) needed for the System view:

- **`cluster.instances`** (`GET /api/v1/cluster/instances`): Lists all HA cluster instances from heartbeat records with derived health status (`healthy`/`degraded`/`unreachable`). The connected instance is enriched with the full health snapshot. Each instance now advertises its serve address so the dashboard can fan out SSE connections for cross-instance metrics.

- **`serve.config`** (`GET /api/v1/config`): Returns the resolved serve configuration with secrets redacted — webhook secrets are omitted, TLS key path excluded, only safe configuration values are exposed.

Also extends `HeartbeatRecord` with an optional `address` field so instances include their serve address (`scheme://host:port`) in heartbeat records.

### Dashboard panels unblocked

- System view → Cluster Instances table
- System view → Serve Configuration card
- Sidebar → Cluster section with health dots
- Overview → instance health status pill
- Cross-instance health aggregation via per-instance `/api/v1/health/stream`

### Manual verification

Tested end-to-end with a compiled binary:

1. **Non-HA** (filesystem datastore): local instance shows with full health snapshot and address
2. **HA** (MinIO S3 datastore, 2 instances): both instances discover each other via heartbeats, each enriches only its own entry with health data, addresses are correct
3. **Caddy reverse proxy**: round-robin load balancing works correctly, each response shows the full cluster view with the responding instance enriched

### Note

The `swamp-club/swamp-club` repo has issues disabled, so the REST API reference documentation update (`content/manual/reference/swamp-serve/rest-api.md`) could not be filed as an issue there. It needs to be tracked separately.

## Test plan

- [x] 8 new unit tests in `src/serve/handlers/admin_handlers_test.ts` covering heartbeat parsing (with/without address), staleness checks, and config redaction (webhook secrets, TLS key, empty webhooks)
- [x] All existing serve tests pass (connection, protocol, heartbeat, config)
- [x] Full project type check, lint, and format pass
- [x] Manual verification: non-HA standalone, HA with MinIO (2 instances), Caddy round-robin

Closes #1711

🤖 Generated with [Claude Code](https://claude.com/claude-code)