### PR TITLE
feat(tracing): support signal-specific OTLP config

### DIFF
--- a/.claude/skills/swamp/references/troubleshooting/references/tracing.md
+++ b/.claude/skills/swamp/references/troubleshooting/references/tracing.md
@@ -36,24 +36,36 @@ Tracing is most useful when:
 
 ## Configuration
 
-| Variable                      | Purpose                                  | Default         |
-| ----------------------------- | ---------------------------------------- | --------------- |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector URL (telemetry off when unset) | _(unset = off)_ |
-| `OTEL_TRACES_EXPORTER`        | `otlp`, `console`, or `none`             | `otlp`          |
-| `OTEL_LOGS_EXPORTER`          | `otlp`, `console` (stderr), or `none`    | `otlp`          |
-| `OTEL_SERVICE_NAME`           | Service name for traces and logs         | `swamp`         |
-| `OTEL_EXPORTER_OTLP_HEADERS`  | Auth headers (`key=val,key=val`)         | _(none)_        |
-| `OTEL_BLRP_USE`               | Batch log exports (`1` to enable)        | _(per-record)_  |
+| Variable                              | Purpose                                   | Default                |
+| ------------------------------------- | ----------------------------------------- | ---------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`         | Shared collector base URL                 | _(none)_               |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | Complete traces URL; overrides shared URL | shared + `/v1/traces`  |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`    | Complete logs URL; overrides shared URL   | shared + `/v1/logs`    |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Complete future metrics URL               | shared + `/v1/metrics` |
+| `OTEL_EXPORTER_OTLP_HEADERS`          | Shared headers (`key=val,key=val`)        | _(none)_               |
+| `OTEL_EXPORTER_OTLP_TRACES_HEADERS`   | Trace headers; replace shared headers     | shared headers         |
+| `OTEL_EXPORTER_OTLP_LOGS_HEADERS`     | Log headers; replace shared headers       | shared headers         |
+| `OTEL_EXPORTER_OTLP_METRICS_HEADERS`  | Future metrics headers; replace shared    | shared headers         |
+| `OTEL_TRACES_EXPORTER`                | `otlp`, `console`, or `none`              | `otlp`                 |
+| `OTEL_LOGS_EXPORTER`                  | `otlp`, `console` (stderr), or `none`     | `otlp`                 |
+| `OTEL_SERVICE_NAME`                   | Service name for traces and logs          | `swamp`                |
+| `OTEL_BLRP_USE`                       | Batch log exports (`1` to enable)         | _(per-record)_         |
+
+Signal-specific endpoints are complete URLs and take precedence over the shared
+base URL. Signal-specific headers replace, rather than merge with, shared
+headers. Empty signal-specific values fall back to the shared setting. The
+metrics variables reserve the same contract for future native metrics support;
+swamp currently emits traces and logs only.
 
 ### Logs Signal
 
-With an OTLP endpoint set, swamp also exports its structured log lines as OTel
-log records, each correlated with the active `trace_id`/`span_id` so logs sit
-next to their spans in the backend. Run secrets are redacted before export.
-Disable with `OTEL_LOGS_EXPORTER=none` (traces stay on); batch with
-`OTEL_BLRP_USE=1` for long-running `swamp serve`. If logs aren't arriving, check
-that the endpoint is set, `OTEL_LOGS_EXPORTER` is not `none`, and the collector
-accepts `POST /v1/logs`.
+With a shared or logs-specific OTLP endpoint set, swamp also exports its
+structured log lines as OTel log records, each correlated with the active
+`trace_id`/`span_id` so logs sit next to their spans in the backend. Run secrets
+are redacted before export. Disable with `OTEL_LOGS_EXPORTER=none` (traces stay
+on); batch with `OTEL_BLRP_USE=1` for long-running `swamp serve`. If logs aren't
+arriving, check that the endpoint is set, `OTEL_LOGS_EXPORTER` is not `none`,
+and the collector accepts the configured logs URL.
 
 ### Console Exporter (No Collector Needed)
 
@@ -76,6 +88,16 @@ export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=YOUR_API_KEY"
 # Grafana Cloud
 export OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-us-east-0.grafana.net/otlp
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic YOUR_BASE64_TOKEN"
+
+# Axiom with separate trace and log datasets
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://api.axiom.co/v1/traces
+export OTEL_EXPORTER_OTLP_TRACES_HEADERS="Authorization=Bearer YOUR_TOKEN,X-Axiom-Dataset=swamp-traces"
+export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=https://api.axiom.co/v1/logs
+export OTEL_EXPORTER_OTLP_LOGS_HEADERS="Authorization=Bearer YOUR_TOKEN,X-Axiom-Dataset=swamp-logs"
+
+# Reserved for future native metrics export
+export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=https://api.axiom.co/v1/metrics
+export OTEL_EXPORTER_OTLP_METRICS_HEADERS="Authorization=Bearer YOUR_TOKEN,X-Axiom-Metrics-Dataset=swamp-metrics"
 ```
 
 ## What Gets Traced

--- a/README.md
+++ b/README.md
@@ -327,7 +327,8 @@ Priority order (highest to lowest): `-q` / `--log-level` flag →
 Swamp has native OpenTelemetry tracing for diagnosing slow or failing
 operations. Tracing is opt-in and has zero overhead when disabled.
 
-Set `OTEL_EXPORTER_OTLP_ENDPOINT` to enable:
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` to enable both signals through a shared
+collector, or configure a signal-specific endpoint:
 
 ```bash
 # Send traces to a local Jaeger instance
@@ -343,14 +344,14 @@ in-process extensions and Docker containers via `TRACEPARENT`.
 
 ### Logs
 
-When an OTLP endpoint is configured, swamp also emits its structured log lines
-as native OpenTelemetry **log records** over OTLP, using the same
-`OTEL_EXPORTER_OTLP_*` configuration as traces. Each record is stamped with the
-active `trace_id`/`span_id`, so logs correlate with the spans they belong to and
-are filterable by trace, service, and severity in the backend — no need to read
-a local log file. This is most useful for long-running `swamp serve` daemons.
-Secrets registered for a run are redacted from log bodies and attributes before
-they leave the process, just as they are in the persisted per-run log files.
+When a generic or logs-specific OTLP endpoint is configured, swamp also emits
+its structured log lines as native OpenTelemetry **log records** over OTLP. Each
+record is stamped with the active `trace_id`/`span_id`, so logs correlate with
+the spans they belong to and are filterable by trace, service, and severity in
+the backend — no need to read a local log file. This is most useful for
+long-running `swamp serve` daemons. Secrets registered for a run are redacted
+from log bodies and attributes before they leave the process, just as they are
+in the persisted per-run log files.
 
 Opt out with `OTEL_LOGS_EXPORTER=none` (traces stay on). For high-volume
 `swamp serve`, set `OTEL_BLRP_USE=1` to batch log exports instead of sending one
@@ -376,14 +377,39 @@ Then open `http://localhost:16686` and search for the `swamp` service.
 
 ### Configuration
 
-| Variable                      | Purpose                                  | Default         |
-| ----------------------------- | ---------------------------------------- | --------------- |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector URL (telemetry off when unset) | _(unset = off)_ |
-| `OTEL_TRACES_EXPORTER`        | `otlp`, `console`, or `none`             | `otlp`          |
-| `OTEL_LOGS_EXPORTER`          | `otlp`, `console` (stderr), or `none`    | `otlp`          |
-| `OTEL_SERVICE_NAME`           | Service name for traces and logs         | `swamp`         |
-| `OTEL_EXPORTER_OTLP_HEADERS`  | Auth headers (`key=val,key=val`)         | _(none)_        |
-| `OTEL_BLRP_USE`               | Batch log exports (`1` to enable)        | _(per-record)_  |
+| Variable                              | Purpose                                   | Default                |
+| ------------------------------------- | ----------------------------------------- | ---------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`         | Shared collector base URL                 | _(none)_               |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | Complete traces URL; overrides shared URL | shared + `/v1/traces`  |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`    | Complete logs URL; overrides shared URL   | shared + `/v1/logs`    |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Complete future metrics URL               | shared + `/v1/metrics` |
+| `OTEL_EXPORTER_OTLP_HEADERS`          | Shared headers (`key=val,key=val`)        | _(none)_               |
+| `OTEL_EXPORTER_OTLP_TRACES_HEADERS`   | Trace headers; replace shared headers     | shared headers         |
+| `OTEL_EXPORTER_OTLP_LOGS_HEADERS`     | Log headers; replace shared headers       | shared headers         |
+| `OTEL_EXPORTER_OTLP_METRICS_HEADERS`  | Future metrics headers; replace shared    | shared headers         |
+| `OTEL_TRACES_EXPORTER`                | `otlp`, `console`, or `none`              | `otlp`                 |
+| `OTEL_LOGS_EXPORTER`                  | `otlp`, `console` (stderr), or `none`     | `otlp`                 |
+| `OTEL_SERVICE_NAME`                   | Service name for traces and logs          | `swamp`                |
+| `OTEL_BLRP_USE`                       | Batch log exports (`1` to enable)         | _(per-record)_         |
+
+Signal-specific endpoint values are complete URLs and take precedence over the
+shared base URL. Signal-specific headers replace, rather than merge with, the
+shared headers. Empty signal-specific values fall back to the shared setting.
+The metrics variables establish the same configuration contract for future
+native metrics support; swamp currently emits traces and logs only.
+
+For a backend such as Axiom that routes each signal to a different dataset:
+
+```bash
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://api.axiom.co/v1/traces
+export OTEL_EXPORTER_OTLP_TRACES_HEADERS="Authorization=Bearer TOKEN,X-Axiom-Dataset=swamp-traces"
+export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=https://api.axiom.co/v1/logs
+export OTEL_EXPORTER_OTLP_LOGS_HEADERS="Authorization=Bearer TOKEN,X-Axiom-Dataset=swamp-logs"
+
+# Reserved for future native metrics export
+export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=https://api.axiom.co/v1/metrics
+export OTEL_EXPORTER_OTLP_METRICS_HEADERS="Authorization=Bearer TOKEN,X-Axiom-Metrics-Dataset=swamp-metrics"
+```
 
 ## Telemetry
 

--- a/integration/otel_signal_routing_test.ts
+++ b/integration/otel_signal_routing_test.ts
@@ -1,0 +1,213 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { join, toFileUrl } from "@std/path";
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  headers: Headers;
+  body: string;
+}
+
+const ROOT = join(import.meta.dirname!, "..");
+const DENO_CONFIG = join(ROOT, "deno.json");
+const LOGGER_MODULE = toFileUrl(
+  join(ROOT, "src", "infrastructure", "logging", "logger.ts"),
+).href;
+const TRACING_MODULE = toFileUrl(
+  join(ROOT, "src", "infrastructure", "tracing", "mod.ts"),
+).href;
+
+function childEnvironment(
+  otel: Record<string, string>,
+): Record<string, string> {
+  const env: Record<string, string> = {
+    SWAMP_NO_TELEMETRY: "1",
+    NO_COLOR: "1",
+    ...otel,
+  };
+  for (
+    const key of [
+      "PATH",
+      "HOME",
+      "DENO_DIR",
+      "TMPDIR",
+      "USERPROFILE",
+      "SystemRoot",
+    ]
+  ) {
+    const value = Deno.env.get(key);
+    if (value) env[key] = value;
+  }
+  return env;
+}
+
+async function emitTelemetry(env: Record<string, string>): Promise<void> {
+  const script = `
+import { getSwampLogger, initializeLogging } from ${
+    JSON.stringify(LOGGER_MODULE)
+  };
+import { initTracing, shutdownLogs, shutdownTracing, withSpan } from ${
+    JSON.stringify(TRACING_MODULE)
+  };
+
+await initTracing();
+await initializeLogging({ jsonMode: true });
+const logger = getSwampLogger(["integration", "otel-routing"]);
+await withSpan("swamp.integration.otel-routing", {}, () => {
+  logger.info\`otel routing integration marker\`;
+  return Promise.resolve();
+});
+await shutdownLogs();
+await shutdownTracing();
+`;
+
+  const child = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--config",
+      DENO_CONFIG,
+      "--allow-env",
+      "--allow-read",
+      "--allow-net=127.0.0.1",
+      "-",
+    ],
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "piped",
+    clearEnv: true,
+    env: childEnvironment(env),
+  }).spawn();
+  const writer = child.stdin.getWriter();
+  await writer.write(new TextEncoder().encode(script));
+  await writer.close();
+
+  const output = await child.output();
+  if (!output.success) {
+    throw new Error(
+      `telemetry child failed: ${new TextDecoder().decode(output.stderr)}`,
+    );
+  }
+}
+
+async function withCollector(
+  run: (baseUrl: string, captured: CapturedRequest[]) => Promise<void>,
+): Promise<void> {
+  const captured: CapturedRequest[] = [];
+  const server = Deno.serve(
+    { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+    async (request) => {
+      captured.push({
+        url: request.url,
+        method: request.method,
+        headers: new Headers(request.headers),
+        body: await request.text(),
+      });
+      return new Response(null, { status: 200 });
+    },
+  );
+  const port = (server.addr as Deno.NetAddr).port;
+  try {
+    await run(`http://127.0.0.1:${port}`, captured);
+  } finally {
+    await server.shutdown();
+  }
+}
+
+function requestFor(
+  captured: CapturedRequest[],
+  url: string,
+): CapturedRequest {
+  const request = captured.find((candidate) => candidate.url === url);
+  assert(request, `no OTLP request captured for ${url}`);
+  return request;
+}
+
+Deno.test("OTLP signal routing: signal-specific endpoints and headers override generic configuration", async () => {
+  await withCollector(async (baseUrl, captured) => {
+    const tracesUrl = `${baseUrl}/custom/trace-ingest`;
+    const logsUrl = `${baseUrl}/custom/log-ingest`;
+    await emitTelemetry({
+      OTEL_EXPORTER_OTLP_ENDPOINT: `${baseUrl}/generic-decoy`,
+      OTEL_EXPORTER_OTLP_HEADERS: "x-generic=generic,x-shared=generic",
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: tracesUrl,
+      OTEL_EXPORTER_OTLP_TRACES_HEADERS: "x-trace-only=trace,x-shared=trace",
+      OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: logsUrl,
+      OTEL_EXPORTER_OTLP_LOGS_HEADERS: "x-log-only=log,x-shared=log",
+    });
+
+    assertEquals(
+      new Set(captured.map((request) => request.url)),
+      new Set([tracesUrl, logsUrl]),
+    );
+
+    const traces = requestFor(captured, tracesUrl);
+    assertEquals(traces.method, "POST");
+    assertEquals(traces.headers.get("x-trace-only"), "trace");
+    assertEquals(traces.headers.get("x-shared"), "trace");
+    assertEquals(traces.headers.get("x-generic"), null);
+    assertEquals(traces.headers.get("x-log-only"), null);
+    assertEquals(traces.headers.get("content-type"), "application/json");
+    assertStringIncludes(traces.body, "resourceSpans");
+    assertStringIncludes(traces.body, "swamp.integration.otel-routing");
+
+    const logs = requestFor(captured, logsUrl);
+    assertEquals(logs.method, "POST");
+    assertEquals(logs.headers.get("x-log-only"), "log");
+    assertEquals(logs.headers.get("x-shared"), "log");
+    assertEquals(logs.headers.get("x-generic"), null);
+    assertEquals(logs.headers.get("x-trace-only"), null);
+    assertEquals(logs.headers.get("content-type"), "application/json");
+    assertStringIncludes(logs.body, "resourceLogs");
+    assertStringIncludes(logs.body, "otel routing integration marker");
+  });
+});
+
+Deno.test("OTLP signal routing: generic endpoint and headers retain existing behavior", async () => {
+  await withCollector(async (baseUrl, captured) => {
+    await emitTelemetry({
+      OTEL_EXPORTER_OTLP_ENDPOINT: `${baseUrl}/collector///`,
+      OTEL_EXPORTER_OTLP_HEADERS:
+        "Authorization=Bearer generic-token,x-shared=generic",
+    });
+
+    const tracesUrl = `${baseUrl}/collector/v1/traces`;
+    const logsUrl = `${baseUrl}/collector/v1/logs`;
+    assertEquals(
+      new Set(captured.map((request) => request.url)),
+      new Set([tracesUrl, logsUrl]),
+    );
+
+    const traces = requestFor(captured, tracesUrl);
+    const logs = requestFor(captured, logsUrl);
+    for (const request of [traces, logs]) {
+      assertEquals(request.method, "POST");
+      assertEquals(
+        request.headers.get("authorization"),
+        "Bearer generic-token",
+      );
+      assertEquals(request.headers.get("x-shared"), "generic");
+      assertEquals(request.headers.get("content-type"), "application/json");
+    }
+    assertStringIncludes(traces.body, "resourceSpans");
+    assertStringIncludes(logs.body, "resourceLogs");
+  });
+});

--- a/src/infrastructure/tracing/otel_config.ts
+++ b/src/infrastructure/tracing/otel_config.ts
@@ -17,14 +17,38 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+export type OtlpSignal = "traces" | "logs" | "metrics";
+
+/** Resolves the complete OTLP/HTTP endpoint for a signal. */
+export function resolveOtlpEndpoint(
+  signal: OtlpSignal,
+  config?: { genericEndpoint?: string; signalEndpoint?: string },
+): string | undefined {
+  const signalName = signal.toUpperCase();
+  const signalEndpoint = config
+    ? config.signalEndpoint
+    : Deno.env.get(`OTEL_EXPORTER_OTLP_${signalName}_ENDPOINT`);
+  if (signalEndpoint) return signalEndpoint;
+
+  const genericEndpoint = config
+    ? config.genericEndpoint
+    : Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
+  if (!genericEndpoint) return undefined;
+
+  return `${genericEndpoint.replace(/\/+$/, "")}/v1/${signal}`;
+}
+
 /**
- * Parses the `OTEL_EXPORTER_OTLP_HEADERS` env var (`key=val,key=val`) into a
- * record. Shared by the trace and log exporters so both signals authenticate to
- * the collector identically. Returns an empty record when the var is unset.
+ * Parses the signal-specific or generic OTLP headers (`key=val,key=val`) into a
+ * record. Signal-specific headers replace generic headers when set.
  */
-export function parseOtlpHeaders(): Record<string, string> {
+export function parseOtlpHeaders(
+  signal: OtlpSignal,
+): Record<string, string> {
   const headers: Record<string, string> = {};
-  const raw = Deno.env.get("OTEL_EXPORTER_OTLP_HEADERS");
+  const signalName = signal.toUpperCase();
+  const raw = Deno.env.get(`OTEL_EXPORTER_OTLP_${signalName}_HEADERS`) ||
+    Deno.env.get("OTEL_EXPORTER_OTLP_HEADERS");
   if (raw) {
     for (const pair of raw.split(",")) {
       const eqIdx = pair.indexOf("=");

--- a/src/infrastructure/tracing/otel_config_test.ts
+++ b/src/infrastructure/tracing/otel_config_test.ts
@@ -18,56 +18,140 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { parseOtlpHeaders } from "./otel_config.ts";
+import { parseOtlpHeaders, resolveOtlpEndpoint } from "./otel_config.ts";
+
+const SIGNALS = ["traces", "logs", "metrics"] as const;
+const ENV_KEYS = [
+  "OTEL_EXPORTER_OTLP_ENDPOINT",
+  "OTEL_EXPORTER_OTLP_HEADERS",
+  ...SIGNALS.flatMap((signal) => [
+    `OTEL_EXPORTER_OTLP_${signal.toUpperCase()}_ENDPOINT`,
+    `OTEL_EXPORTER_OTLP_${signal.toUpperCase()}_HEADERS`,
+  ]),
+];
+
+function withEnv(
+  vars: Record<string, string | undefined>,
+  fn: () => void,
+): void {
+  const saved = new Map(ENV_KEYS.map((key) => [key, Deno.env.get(key)]));
+  try {
+    for (const key of ENV_KEYS) Deno.env.delete(key);
+    for (const [key, value] of Object.entries(vars)) {
+      if (value !== undefined) Deno.env.set(key, value);
+    }
+    fn();
+  } finally {
+    for (const [key, value] of saved) {
+      if (value === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, value);
+    }
+  }
+}
 
 function withHeaders(
   value: string | undefined,
   fn: () => void,
 ): void {
-  const saved = Deno.env.get("OTEL_EXPORTER_OTLP_HEADERS");
-  try {
-    if (value === undefined) Deno.env.delete("OTEL_EXPORTER_OTLP_HEADERS");
-    else Deno.env.set("OTEL_EXPORTER_OTLP_HEADERS", value);
-    fn();
-  } finally {
-    if (saved === undefined) Deno.env.delete("OTEL_EXPORTER_OTLP_HEADERS");
-    else Deno.env.set("OTEL_EXPORTER_OTLP_HEADERS", saved);
-  }
+  withEnv({ OTEL_EXPORTER_OTLP_HEADERS: value }, fn);
 }
+
+Deno.test("resolveOtlpEndpoint: signal-specific endpoints take precedence and remain complete URLs", () => {
+  for (const signal of SIGNALS) {
+    const specific = `https://${signal}.example/custom/`;
+    withEnv(
+      {
+        OTEL_EXPORTER_OTLP_ENDPOINT: "https://collector.example/base",
+        [`OTEL_EXPORTER_OTLP_${signal.toUpperCase()}_ENDPOINT`]: specific,
+      },
+      () => assertEquals(resolveOtlpEndpoint(signal), specific),
+    );
+  }
+});
+
+Deno.test("resolveOtlpEndpoint: appends the signal path to the generic endpoint", () => {
+  for (const signal of SIGNALS) {
+    withEnv(
+      { OTEL_EXPORTER_OTLP_ENDPOINT: "https://collector.example/base///" },
+      () =>
+        assertEquals(
+          resolveOtlpEndpoint(signal),
+          `https://collector.example/base/v1/${signal}`,
+        ),
+    );
+  }
+});
+
+Deno.test("resolveOtlpEndpoint: empty signal-specific endpoints fall back to generic", () => {
+  for (const signal of SIGNALS) {
+    withEnv(
+      {
+        OTEL_EXPORTER_OTLP_ENDPOINT: "https://collector.example",
+        [`OTEL_EXPORTER_OTLP_${signal.toUpperCase()}_ENDPOINT`]: "",
+      },
+      () =>
+        assertEquals(
+          resolveOtlpEndpoint(signal),
+          `https://collector.example/v1/${signal}`,
+        ),
+    );
+  }
+});
+
+Deno.test("resolveOtlpEndpoint: returns undefined when no endpoint is set", () => {
+  for (const signal of SIGNALS) {
+    withEnv({}, () => assertEquals(resolveOtlpEndpoint(signal), undefined));
+  }
+});
+
+Deno.test("resolveOtlpEndpoint: explicit config bypasses process environment", () => {
+  withEnv(
+    { OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "https://environment.example" },
+    () =>
+      assertEquals(
+        resolveOtlpEndpoint("traces", {
+          genericEndpoint: "https://injected.example/",
+        }),
+        "https://injected.example/v1/traces",
+      ),
+  );
+});
 
 Deno.test("parseOtlpHeaders: returns an empty record when unset", () => {
   withHeaders(undefined, () => {
-    assertEquals(parseOtlpHeaders(), {});
+    assertEquals(parseOtlpHeaders("traces"), {});
   });
 });
 
 Deno.test("parseOtlpHeaders: returns an empty record for an empty string", () => {
   withHeaders("", () => {
-    assertEquals(parseOtlpHeaders(), {});
+    assertEquals(parseOtlpHeaders("traces"), {});
   });
 });
 
 Deno.test("parseOtlpHeaders: parses a single key=value pair", () => {
   withHeaders("x-honeycomb-team=abc123", () => {
-    assertEquals(parseOtlpHeaders(), { "x-honeycomb-team": "abc123" });
+    assertEquals(parseOtlpHeaders("traces"), {
+      "x-honeycomb-team": "abc123",
+    });
   });
 });
 
 Deno.test("parseOtlpHeaders: parses multiple comma-separated pairs", () => {
   withHeaders("a=1,b=2,c=3", () => {
-    assertEquals(parseOtlpHeaders(), { a: "1", b: "2", c: "3" });
+    assertEquals(parseOtlpHeaders("traces"), { a: "1", b: "2", c: "3" });
   });
 });
 
 Deno.test("parseOtlpHeaders: trims whitespace around keys and values", () => {
   withHeaders(" a = 1 , b = 2 ", () => {
-    assertEquals(parseOtlpHeaders(), { a: "1", b: "2" });
+    assertEquals(parseOtlpHeaders("traces"), { a: "1", b: "2" });
   });
 });
 
 Deno.test("parseOtlpHeaders: only the first '=' splits, so values may contain '='", () => {
   withHeaders("Authorization=Basic dXNlcj1wYXNz=", () => {
-    assertEquals(parseOtlpHeaders(), {
+    assertEquals(parseOtlpHeaders("traces"), {
       Authorization: "Basic dXNlcj1wYXNz=",
     });
   });
@@ -75,7 +159,10 @@ Deno.test("parseOtlpHeaders: only the first '=' splits, so values may contain '=
 
 Deno.test("parseOtlpHeaders: drops entries with no '='", () => {
   withHeaders("valid=1,garbage,also-valid=2", () => {
-    assertEquals(parseOtlpHeaders(), { valid: "1", "also-valid": "2" });
+    assertEquals(parseOtlpHeaders("traces"), {
+      valid: "1",
+      "also-valid": "2",
+    });
   });
 });
 
@@ -84,6 +171,49 @@ Deno.test("parseOtlpHeaders: splits on commas (values with literal commas are no
   // percent-encoded; a raw comma is treated as a delimiter. This documents that
   // known behavior rather than endorsing it.
   withHeaders("Authorization=Bearer a,b,c", () => {
-    assertEquals(parseOtlpHeaders(), { Authorization: "Bearer a" });
+    assertEquals(parseOtlpHeaders("traces"), {
+      Authorization: "Bearer a",
+    });
   });
+});
+
+Deno.test("parseOtlpHeaders: signal-specific headers replace generic headers", () => {
+  for (const signal of SIGNALS) {
+    withEnv(
+      {
+        OTEL_EXPORTER_OTLP_HEADERS: "generic=1,shared=generic",
+        [`OTEL_EXPORTER_OTLP_${signal.toUpperCase()}_HEADERS`]:
+          "specific=1,shared=specific",
+      },
+      () =>
+        assertEquals(parseOtlpHeaders(signal), {
+          specific: "1",
+          shared: "specific",
+        }),
+    );
+  }
+});
+
+Deno.test("parseOtlpHeaders: every signal falls back to generic headers", () => {
+  for (const signal of SIGNALS) {
+    withEnv(
+      { OTEL_EXPORTER_OTLP_HEADERS: "Authorization=Bearer token" },
+      () =>
+        assertEquals(parseOtlpHeaders(signal), {
+          Authorization: "Bearer token",
+        }),
+    );
+  }
+});
+
+Deno.test("parseOtlpHeaders: empty signal-specific headers fall back to generic", () => {
+  for (const signal of SIGNALS) {
+    withEnv(
+      {
+        OTEL_EXPORTER_OTLP_HEADERS: "generic=1",
+        [`OTEL_EXPORTER_OTLP_${signal.toUpperCase()}_HEADERS`]: "",
+      },
+      () => assertEquals(parseOtlpHeaders(signal), { generic: "1" }),
+    );
+  }
 });

--- a/src/infrastructure/tracing/otel_init.ts
+++ b/src/infrastructure/tracing/otel_init.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { Context } from "@opentelemetry/api";
+import { parseOtlpHeaders, resolveOtlpEndpoint } from "./otel_config.ts";
 
 /** Handle to the provider so we can flush on shutdown. */
 let providerRef: { shutdown(): Promise<void> } | undefined;
@@ -32,7 +33,7 @@ export interface InitTracingConfig {
 }
 
 /**
- * Initializes OpenTelemetry tracing if `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+ * Initializes OpenTelemetry tracing if an OTLP traces endpoint is configured.
  *
  * All SDK packages are dynamically imported so they impose zero cost when
  * tracing is disabled. `@opentelemetry/api` is statically imported because it
@@ -41,8 +42,9 @@ export interface InitTracingConfig {
 export async function initTracing(
   config?: InitTracingConfig,
 ): Promise<Context | undefined> {
-  const endpoint = config?.endpoint ??
-    Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
+  const endpoint = config?.endpoint !== undefined
+    ? resolveOtlpEndpoint("traces", { genericEndpoint: config.endpoint })
+    : resolveOtlpEndpoint("traces");
   const exporterKind = config?.exporterKind ??
     Deno.env.get("OTEL_TRACES_EXPORTER") ?? "otlp";
 
@@ -99,12 +101,10 @@ export async function initTracing(
     // Fetch-based OTLP/HTTP exporter — uses Deno's native fetch instead of
     // Node.js http/https modules, which fail TLS in compiled binaries.
     const { FetchOtlpExporter } = await import("./fetch_otlp_exporter.ts");
-    const { parseOtlpHeaders } = await import("./otel_config.ts");
-
-    const headers = parseOtlpHeaders();
+    const headers = parseOtlpHeaders("traces");
 
     const exporter = new FetchOtlpExporter({
-      url: `${endpoint!.replace(/\/+$/, "")}/v1/traces`,
+      url: endpoint!,
       headers,
     });
     provider.addSpanProcessor(wrapProcessor(exporter));

--- a/src/infrastructure/tracing/otel_init_test.ts
+++ b/src/infrastructure/tracing/otel_init_test.ts
@@ -21,12 +21,15 @@ import { assertEquals, assertExists } from "@std/assert";
 import { propagation, trace } from "@opentelemetry/api";
 import { initTracing, shutdownTracing } from "./otel_init.ts";
 
-Deno.test("initTracing: no-op when OTEL_EXPORTER_OTLP_ENDPOINT is not set", async () => {
-  // Ensure env var is not set
+Deno.test("initTracing: no-op when no endpoint is set", async () => {
   const original = Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
+  const originalSpecific = Deno.env.get(
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+  );
   const originalExporter = Deno.env.get("OTEL_TRACES_EXPORTER");
   try {
     Deno.env.delete("OTEL_EXPORTER_OTLP_ENDPOINT");
+    Deno.env.delete("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
     Deno.env.delete("OTEL_TRACES_EXPORTER");
 
     const parentCtx = await initTracing();
@@ -43,8 +46,42 @@ Deno.test("initTracing: no-op when OTEL_EXPORTER_OTLP_ENDPOINT is not set", asyn
     await shutdownTracing();
   } finally {
     if (original) Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", original);
+    if (originalSpecific) {
+      Deno.env.set("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", originalSpecific);
+    }
     if (originalExporter) {
       Deno.env.set("OTEL_TRACES_EXPORTER", originalExporter);
+    }
+  }
+});
+
+Deno.test("initTracing: initializes from the signal-specific traces endpoint", async () => {
+  const keys = [
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "OTEL_TRACES_EXPORTER",
+  ];
+  const saved = new Map(keys.map((key) => [key, Deno.env.get(key)]));
+  try {
+    for (const key of keys) Deno.env.delete(key);
+    Deno.env.set(
+      "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+      "http://localhost:4318/v1/traces",
+    );
+
+    await initTracing();
+
+    const span = trace.getTracer("test").startSpan("specific-endpoint");
+    assertEquals(
+      span.spanContext().traceId !== "00000000000000000000000000000000",
+      true,
+    );
+    span.end();
+  } finally {
+    await shutdownTracing();
+    for (const [key, value] of saved) {
+      if (value === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, value);
     }
   }
 });

--- a/src/infrastructure/tracing/otel_logs_init.ts
+++ b/src/infrastructure/tracing/otel_logs_init.ts
@@ -25,9 +25,8 @@ import type {
 import { ExportResultCode } from "@opentelemetry/core";
 import type { ExportResult } from "@opentelemetry/core";
 // Static import is deliberate: otel_config.ts is a tiny leaf with no SDK deps,
-// so it costs nothing eagerly. (otel_init.ts imports it dynamically only because
-// it already batches all its SDK imports inside the function body.)
-import { parseOtlpHeaders } from "./otel_config.ts";
+// so it costs nothing eagerly.
+import { parseOtlpHeaders, resolveOtlpEndpoint } from "./otel_config.ts";
 
 /**
  * Handle to the provider so we can flush on shutdown and short-circuit a
@@ -92,7 +91,7 @@ export interface InitLogsConfig {
  * and is given this provider by injection — this module never imports logging,
  * so no import cycle forms). Returns `undefined` when logs export is disabled.
  *
- * Enabled when `OTEL_EXPORTER_OTLP_ENDPOINT` is set and `OTEL_LOGS_EXPORTER` is
+ * Enabled when an OTLP logs endpoint is configured and `OTEL_LOGS_EXPORTER` is
  * not `none`, OR when `OTEL_LOGS_EXPORTER` is `console`. All SDK packages are
  * dynamically imported so they impose zero cost when logs export is disabled.
  *
@@ -111,8 +110,9 @@ export async function initLogs(
     return providerRef;
   }
 
-  const endpoint = config?.endpoint ??
-    Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
+  const endpoint = config?.endpoint !== undefined
+    ? resolveOtlpEndpoint("logs", { genericEndpoint: config.endpoint })
+    : resolveOtlpEndpoint("logs");
   const exporterKind = config?.exporterKind ??
     Deno.env.get("OTEL_LOGS_EXPORTER") ?? "otlp";
 
@@ -152,8 +152,8 @@ export async function initLogs(
       "./fetch_otlp_log_exporter.ts"
     );
     exporter = new FetchOtlpLogExporter({
-      url: `${endpoint!.replace(/\/+$/, "")}/v1/logs`,
-      headers: parseOtlpHeaders(),
+      url: endpoint!,
+      headers: parseOtlpHeaders("logs"),
     });
   }
 

--- a/src/infrastructure/tracing/otel_logs_init_test.ts
+++ b/src/infrastructure/tracing/otel_logs_init_test.ts
@@ -22,9 +22,11 @@ import { initLogs, shutdownLogs } from "./otel_logs_init.ts";
 
 const ENV_KEYS = [
   "OTEL_EXPORTER_OTLP_ENDPOINT",
+  "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
   "OTEL_LOGS_EXPORTER",
   "OTEL_BLRP_USE",
   "OTEL_EXPORTER_OTLP_HEADERS",
+  "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
 ];
 
 async function withEnv(
@@ -73,6 +75,20 @@ Deno.test("initLogs: disabled when OTEL_LOGS_EXPORTER=none even with an endpoint
 Deno.test("initLogs: enabled (returns a provider) when an endpoint is set", async () => {
   await withEnv(
     { OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318" },
+    async () => {
+      const provider = await initLogs();
+      assertExists(provider);
+      assertEquals(typeof provider.getLogger, "function");
+      await shutdownLogs();
+    },
+  );
+});
+
+Deno.test("initLogs: enabled when only the signal-specific logs endpoint is set", async () => {
+  await withEnv(
+    {
+      OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "http://localhost:4318/v1/logs",
+    },
     async () => {
       const provider = await initLogs();
       assertExists(provider);


### PR DESCRIPTION
## Summary

- prefer signal-specific OTLP endpoints and headers for traces and logs while retaining generic collector fallback
- define the same endpoint and header contract for future metrics emission without adding a metrics exporter
- document precedence and Axiom split-dataset configuration
- add subprocess integration coverage for signal-specific and legacy generic routing

## Test Plan

- `deno check`
- `deno lint`
- `deno fmt --check`
- `env -u SWAMP_API_KEY deno run test integration/otel_signal_routing_test.ts` (2 passed)
- `deno run compile`
- `deno run license-headers`
- focused tracing tests (33 passed)
- compiled-binary UAT coverage: https://github.com/swamp-club/swamp-uat/pull/351

## Notes

- The full local suite passed 10,418 tests and hit one unrelated process-mock race; that update test passed in isolation (9 passed). CI is the authoritative full parallel run.
- Tessl skill review was attempted but requires an authenticated Tessl session in this environment.
- Tracks https://swamp-club.com/lab/1713.