### PR TITLE
fix(workflows): support run ID lookup and datastore in workflow.history.get

### DIFF
--- a/src/cli/commands/workflow_history_get.ts
+++ b/src/cli/commands/workflow_history_get.ts
@@ -45,7 +45,7 @@ type AnyOptions = any;
 
 export async function workflowHistoryGetAction(
   options: AnyOptions,
-  workflowIdOrName: string,
+  runIdOrWorkflow: string,
 ): Promise<void> {
   const cliCtx = createContext(options as GlobalOptions, [
     "workflow",
@@ -63,7 +63,7 @@ export async function workflowHistoryGetAction(
       { server, token },
       {
         type: "workflow.history.get",
-        payload: { workflowIdOrName },
+        payload: { workflowIdOrName: runIdOrWorkflow },
       },
     );
     const renderer = createWorkflowHistoryGetRenderer(cliCtx.outputMode);
@@ -79,7 +79,7 @@ export async function workflowHistoryGetAction(
     return;
   }
 
-  cliCtx.logger.debug`Getting latest run for workflow: ${workflowIdOrName}`;
+  cliCtx.logger.debug`Getting run for: ${runIdOrWorkflow}`;
 
   const { repoDir, repoContext, datastoreResolver } =
     await requireInitializedRepoReadOnly(
@@ -98,7 +98,7 @@ export async function workflowHistoryGetAction(
 
   const renderer = createWorkflowHistoryGetRenderer(cliCtx.outputMode);
   await consumeStream(
-    workflowHistoryGet(ctx, deps, workflowIdOrName),
+    workflowHistoryGet(ctx, deps, runIdOrWorkflow),
     renderer.handlers(),
   );
 
@@ -108,12 +108,12 @@ export async function workflowHistoryGetAction(
 export const workflowHistoryGetCommand = withRemoteOptions(
   new Command()
     .name("get")
-    .description("Show the latest run for a workflow")
+    .description("Show a specific run by ID or the latest run for a workflow")
     .example("Show latest run", "swamp workflow history get deploy-pipeline")
-    .arguments("<workflow_id_or_name:workflow_name>")
+    .example("Show run by ID", "swamp workflow history get abc123")
+    .arguments("<run_id_or_workflow:string>")
     .option(
       "--repo-dir <dir:string>",
       "Repository directory (env: SWAMP_REPO_DIR)",
     ),
-  // @ts-expect-error - Cliffy custom type returns unknown instead of string
 ).action(workflowHistoryGetAction);

--- a/src/libswamp/workflows/history_get.ts
+++ b/src/libswamp/workflows/history_get.ts
@@ -25,13 +25,17 @@ import {
   type WorkflowId,
 } from "../../domain/workflows/workflow_id.ts";
 import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
+import {
+  isPartialId,
+  matchByPartialId,
+} from "../../domain/models/model_lookup.ts";
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
-import { notFound } from "../errors.ts";
+import { notFound, validationFailed } from "../errors.ts";
 import type { WorkflowRunView } from "./workflow_run_view.ts";
 import { toRunData } from "./run.ts";
 
@@ -41,8 +45,17 @@ export type WorkflowHistoryGetEvent =
   | { kind: "completed"; data: WorkflowRunView }
   | { kind: "error"; error: SwampError };
 
+/** Partial ID match result. */
+interface PartialMatchResult {
+  status: "found" | "not_found" | "ambiguous";
+  match?: WorkflowRun;
+  matches?: Array<{ id: string }>;
+}
+
 /** Dependencies for the workflow history get operation. */
 export interface WorkflowHistoryGetDeps {
+  isPartialId: (value: string) => boolean;
+  matchRunByPartialId: (idPrefix: string) => Promise<PartialMatchResult>;
   findWorkflow: (idOrName: string) => Promise<Workflow | null>;
   findLatestRun: (workflowId: WorkflowId) => Promise<WorkflowRun | null>;
   getRunPath: (workflowId: WorkflowId, runId: string) => string;
@@ -64,6 +77,24 @@ export function createWorkflowHistoryGetDeps(
     dsPath(SWAMP_SUBDIRS.workflowRuns),
   );
   return {
+    isPartialId,
+    matchRunByPartialId: async (idPrefix: string) => {
+      const allRuns = await runRepo.findAllGlobal();
+      const result = matchByPartialId(
+        allRuns.map((r) => ({ id: r.run.id, item: r.run })),
+        idPrefix,
+      );
+      if (result.status === "found") {
+        return { status: "found" as const, match: result.match };
+      }
+      if (result.status === "ambiguous") {
+        return {
+          status: "ambiguous" as const,
+          matches: result.matches.map((m) => ({ id: m.id })),
+        };
+      }
+      return { status: "not_found" as const };
+    },
     findWorkflow: async (idOrName) =>
       await workflowRepo.findByName(idOrName) ??
         await workflowRepo.findById(createWorkflowId(idOrName)),
@@ -73,11 +104,11 @@ export function createWorkflowHistoryGetDeps(
   };
 }
 
-/** Retrieves the latest run for a workflow. */
+/** Retrieves a specific run by ID or the latest run for a workflow. */
 export async function* workflowHistoryGet(
   _ctx: LibSwampContext,
   deps: WorkflowHistoryGetDeps,
-  workflowIdOrName: string,
+  runIdOrWorkflow: string,
 ): AsyncIterable<WorkflowHistoryGetEvent> {
   yield* withGeneratorSpan(
     "swamp.workflow.history.get",
@@ -85,26 +116,62 @@ export async function* workflowHistoryGet(
     (async function* () {
       yield { kind: "resolving" };
 
-      const workflow = await deps.findWorkflow(workflowIdOrName);
-      if (!workflow) {
-        yield { kind: "error", error: notFound("Workflow", workflowIdOrName) };
-        return;
+      let run: WorkflowRun | undefined;
+
+      if (deps.isPartialId(runIdOrWorkflow)) {
+        const result = await deps.matchRunByPartialId(runIdOrWorkflow);
+
+        if (result.status === "found" && result.match) {
+          run = result.match;
+        } else if (result.status === "ambiguous" && result.matches) {
+          yield {
+            kind: "error",
+            error: validationFailed(
+              `Ambiguous ID prefix "${runIdOrWorkflow}" matches:\n` +
+                result.matches.map((m) => `  ${m.id}`).join("\n"),
+            ),
+          };
+          return;
+        }
       }
 
-      const latestRun = await deps.findLatestRun(workflow.id);
-      if (!latestRun) {
-        yield {
-          kind: "error",
-          error: notFound(
-            "Workflow run",
-            `no runs for workflow: ${workflow.name}`,
-          ),
-        };
-        return;
+      if (!run) {
+        const workflow = await deps.findWorkflow(runIdOrWorkflow);
+        if (!workflow) {
+          yield {
+            kind: "error",
+            error: {
+              code: "not_found",
+              message: `No workflow run or workflow found: ${runIdOrWorkflow}`,
+              details: {
+                entityType: "Workflow run or workflow",
+                idOrName: runIdOrWorkflow,
+              },
+            },
+          };
+          return;
+        }
+
+        const latestRun = await deps.findLatestRun(workflow.id);
+        if (!latestRun) {
+          yield {
+            kind: "error",
+            error: notFound(
+              "Workflow run",
+              `no runs for workflow: ${workflow.name}`,
+            ),
+          };
+          return;
+        }
+
+        run = latestRun;
       }
 
-      const path = deps.getRunPath(workflow.id, latestRun.id);
-      const data = toRunData(latestRun, path);
+      const path = deps.getRunPath(
+        run.workflowId as WorkflowId,
+        run.id,
+      );
+      const data = toRunData(run, path);
 
       yield { kind: "completed", data };
     })(),

--- a/src/libswamp/workflows/history_get_test.ts
+++ b/src/libswamp/workflows/history_get_test.ts
@@ -48,6 +48,9 @@ function makeDeps(
   overrides: Partial<WorkflowHistoryGetDeps> = {},
 ): WorkflowHistoryGetDeps {
   return {
+    isPartialId: () => false,
+    matchRunByPartialId: () =>
+      Promise.resolve({ status: "not_found" as const }),
     findWorkflow: () => Promise.resolve(testWorkflow),
     findLatestRun: () => Promise.resolve(testRun),
     getRunPath: () => "/repo/.swamp/runs/wf-1/run-1",
@@ -55,7 +58,7 @@ function makeDeps(
   };
 }
 
-Deno.test("workflowHistoryGet yields resolving then completed on happy path", async () => {
+Deno.test("workflowHistoryGet: yields resolving then completed on happy path", async () => {
   const deps = makeDeps();
   const events = await collect<WorkflowHistoryGetEvent>(
     workflowHistoryGet(createLibSwampContext(), deps, "my-workflow"),
@@ -72,7 +75,7 @@ Deno.test("workflowHistoryGet yields resolving then completed on happy path", as
   assertEquals(completed.data.workflowName, "my-workflow");
 });
 
-Deno.test("workflowHistoryGet yields error with not_found when workflow not found", async () => {
+Deno.test("workflowHistoryGet: yields error with not_found when workflow not found", async () => {
   const deps = makeDeps({
     findWorkflow: () => Promise.resolve(null),
   });
@@ -87,7 +90,7 @@ Deno.test("workflowHistoryGet yields error with not_found when workflow not foun
   assertEquals(last.error.code, "not_found");
 });
 
-Deno.test("workflowHistoryGet yields error with not_found when no runs exist", async () => {
+Deno.test("workflowHistoryGet: yields error with not_found when no runs exist", async () => {
   const deps = makeDeps({
     findLatestRun: () => Promise.resolve(null),
   });
@@ -100,4 +103,64 @@ Deno.test("workflowHistoryGet yields error with not_found when no runs exist", a
   const last = events[1] as Extract<WorkflowHistoryGetEvent, { kind: "error" }>;
   assertEquals(last.kind, "error");
   assertEquals(last.error.code, "not_found");
+});
+
+Deno.test("workflowHistoryGet: resolves run by partial ID", async () => {
+  const deps = makeDeps({
+    isPartialId: () => true,
+    matchRunByPartialId: () =>
+      Promise.resolve({ status: "found" as const, match: testRun }),
+  });
+  const events = await collect<WorkflowHistoryGetEvent>(
+    workflowHistoryGet(createLibSwampContext(), deps, "run-1"),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "resolving" });
+  const completed = events[1] as Extract<
+    WorkflowHistoryGetEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.id, "run-1");
+});
+
+Deno.test("workflowHistoryGet: yields error on ambiguous partial ID", async () => {
+  const deps = makeDeps({
+    isPartialId: () => true,
+    matchRunByPartialId: () =>
+      Promise.resolve({
+        status: "ambiguous" as const,
+        matches: [{ id: "run-1" }, { id: "run-2" }],
+      }),
+  });
+  const events = await collect<WorkflowHistoryGetEvent>(
+    workflowHistoryGet(createLibSwampContext(), deps, "run"),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "resolving" });
+  const last = events[1] as Extract<WorkflowHistoryGetEvent, { kind: "error" }>;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "validation_failed");
+});
+
+Deno.test("workflowHistoryGet: partial ID not found falls back to workflow name", async () => {
+  const deps = makeDeps({
+    isPartialId: () => true,
+    matchRunByPartialId: () =>
+      Promise.resolve({ status: "not_found" as const }),
+  });
+  const events = await collect<WorkflowHistoryGetEvent>(
+    workflowHistoryGet(createLibSwampContext(), deps, "my-workflow"),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "resolving" });
+  const completed = events[1] as Extract<
+    WorkflowHistoryGetEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.id, "run-1");
 });

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -551,7 +551,7 @@ export async function handleWorkflowHistoryGet(
     const libCtx = createLibSwampContext();
     const deps = createWorkflowHistoryGetDeps(
       ctx.repoDir,
-      undefined,
+      ctx.datastoreResolver,
       ctx.repoContext.workflowRepo,
     );
 
@@ -615,7 +615,7 @@ export async function handleWorkflowHistoryLogs(
     const libCtx = createLibSwampContext();
     const deps = createWorkflowHistoryLogsDeps(
       ctx.repoDir,
-      undefined,
+      ctx.datastoreResolver,
       ctx.repoContext.workflowRepo,
     );
 


### PR DESCRIPTION
## Summary

Fixes swamp-club#1723 — `workflow.history.get` could not retrieve runs by run ID and could not find CLI-created runs stored in external datastores (S3).

Two root causes:
- **No run ID lookup**: `workflowHistoryGet` only accepted a workflow name/ID and returned the latest run. It now tries partial-ID matching first (using `isPartialId`/`matchByPartialId` from `model_lookup.ts`), falling back to workflow name lookup — the same pattern `workflow.history.logs` already uses.
- **Missing `datastoreResolver` in serve handlers**: Both `handleWorkflowHistoryGet` and `handleWorkflowHistoryLogs` passed `undefined` for `datastoreResolver`, so `YamlWorkflowRunRepository` only searched local `.swamp/workflow-runs/`. Both now pass `ctx.datastoreResolver`.

## Changes

- `src/libswamp/workflows/history_get.ts` — Extended `WorkflowHistoryGetDeps` with `isPartialId`/`matchRunByPartialId`. Updated generator to try run ID matching before workflow name lookup.
- `src/serve/handlers/workflow_handlers.ts` — Pass `ctx.datastoreResolver` instead of `undefined` for both `history.get` and `history.logs` handlers.
- `src/cli/commands/workflow_history_get.ts` — Updated command description, added run-ID example, changed argument type from `workflow_name` to `string`.
- `src/libswamp/workflows/history_get_test.ts` — Added 3 new tests (partial-ID found, ambiguous error, fallback) and updated existing tests with new deps fields.

## Test Plan

- [x] `deno check` — full type check passes
- [x] `deno lint` — clean
- [x] `deno fmt --check` — clean
- [x] `deno run test` — all 10,511 tests pass (0 failures)
- [x] New unit tests cover: partial-ID resolution, ambiguous ID error, fallback to workflow name lookup

Closes swamp-club#1723