### PR TITLE
feat(serve): include workflowName in health endpoint schedule entries

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -3544,6 +3544,7 @@ export const serveCommand = new Command()
           if (url.pathname === "/" || url.pathname === "/health") {
             const schedules = scheduledExecution?.listSchedules().map((s) => ({
               workflowId: s.workflowId,
+              workflowName: s.workflowName,
               cronExpression: s.cronExpression,
               nextRun: s.nextRun?.toISOString() ?? null,
               running: scheduledExecution!.isRunning(s.workflowId),

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -240,8 +240,12 @@ export class ScheduledExecutionService {
   /**
    * Returns all registered schedules and their next fire times.
    */
-  listSchedules(): ScheduleEntry[] {
-    return this.scheduler.listSchedules();
+  listSchedules(): Array<ScheduleEntry & { workflowName: string }> {
+    return this.scheduler.listSchedules().map((entry) => ({
+      ...entry,
+      workflowName: this.workflowNames.get(entry.workflowId) ??
+        entry.workflowId,
+    }));
   }
 
   /**

--- a/src/libswamp/workflows/scheduled_execution_test.ts
+++ b/src/libswamp/workflows/scheduled_execution_test.ts
@@ -92,6 +92,7 @@ Deno.test("ScheduledExecutionService: registers schedules from existing workflow
   const schedules = service.listSchedules();
   assertEquals(schedules.length, 1);
   assertEquals(schedules[0].cronExpression, "0 * * * *");
+  assertEquals(schedules[0].workflowName, "scheduled-wf");
 
   // Should have emitted a registration event
   const registered = events.filter((e) => e.kind === "schedule_registered");

--- a/src/serve/health_collector.ts
+++ b/src/serve/health_collector.ts
@@ -38,6 +38,7 @@ export interface HealthSnapshotRun {
 
 export interface HealthSnapshotSchedule {
   readonly workflowId: string;
+  readonly workflowName: string;
   readonly cronExpression: string;
   readonly nextRun: string | null;
   readonly running: boolean;
@@ -69,6 +70,7 @@ export interface HealthSnapshot {
 export interface ScheduleProvider {
   listSchedules(): Array<{
     readonly workflowId: string;
+    readonly workflowName: string;
     readonly cronExpression: string;
     readonly nextRun: Date | null;
   }>;
@@ -142,6 +144,7 @@ export class HealthCollector {
     const schedules: HealthSnapshotSchedule[] = this.#deps.scheduleProvider
       ? this.#deps.scheduleProvider.listSchedules().map((s) => ({
         workflowId: String(s.workflowId),
+        workflowName: s.workflowName,
         cronExpression: s.cronExpression,
         nextRun: s.nextRun?.toISOString() ?? null,
         running: this.#deps.scheduleProvider!.isRunning(String(s.workflowId)),

--- a/src/serve/health_collector_test.ts
+++ b/src/serve/health_collector_test.ts
@@ -110,6 +110,7 @@ Deno.test("HealthCollector: includes schedule entries", async () => {
     scheduleProvider: {
       listSchedules: () => [{
         workflowId: "my-workflow",
+        workflowName: "my-workflow-name",
         cronExpression: "*/5 * * * *",
         nextRun: new Date("2026-01-01T00:05:00Z"),
       }],
@@ -123,6 +124,10 @@ Deno.test("HealthCollector: includes schedule entries", async () => {
   assertEquals(snapshot.scheduling.enabled, true);
   assertEquals(snapshot.scheduling.schedules.length, 1);
   assertEquals(snapshot.scheduling.schedules[0].workflowId, "my-workflow");
+  assertEquals(
+    snapshot.scheduling.schedules[0].workflowName,
+    "my-workflow-name",
+  );
   assertEquals(snapshot.scheduling.schedules[0].cronExpression, "*/5 * * * *");
   assertEquals(snapshot.scheduling.schedules[0].running, false);
 });


### PR DESCRIPTION
Closes #1722

## Summary

- Add `workflowName` field to `HealthSnapshotSchedule` and `ScheduleProvider` interfaces
- Enrich `ScheduledExecutionService.listSchedules()` to include the workflow name from its existing `workflowNames` Map (falls back to `workflowId` if name is unavailable)
- Update `HealthCollector.collect()` and the basic `/health` endpoint to pass `workflowName` through to the response
- The dashboard and health consumers can now display human-readable names instead of UUIDs

**Note:** REST API docs in `swamp-club/swamp-club` should be updated to mention the new `workflowName` field in schedule entries (issues are disabled on that repo).

## Test Plan

- [x] `deno check` — type-check passes
- [x] `deno lint` — no lint issues
- [x] `deno fmt --check` — formatting correct
- [x] `deno run test` — all 10,511 tests pass, 0 failures
- [x] HealthCollector test verifies `workflowName` appears in schedule snapshots
- [x] ScheduledExecutionService test verifies `listSchedules()` returns `workflowName`