### PR TITLE
fix(serve): forward all serve flags to daemon enable command (swamp-club#1726)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -407,6 +407,27 @@ export function collectServeExtraArgs(options: AnyOptions): string[] {
   if (options.remoteOnly) {
     args.push("--remote-only");
   }
+  if (options.maxConcurrentRuns) {
+    args.push(
+      "--max-concurrent-runs",
+      String(options.maxConcurrentRuns),
+    );
+  }
+  if (options.maxRunsPerPrincipal) {
+    args.push(
+      "--max-runs-per-principal",
+      String(options.maxRunsPerPrincipal),
+    );
+  }
+  if (options.maxRunDuration) {
+    args.push("--max-run-duration", options.maxRunDuration as string);
+  }
+  if (options.hotReload) {
+    args.push("--hot-reload");
+  }
+  if (options.enableInternalApi) {
+    args.push("--enable-internal-api");
+  }
   return args;
 }
 
@@ -635,6 +656,39 @@ const daemonEnableCommand = new Command()
     "--remote-only",
     "Disable local (loopback) execution — all steps must declare placement " +
       "(env: SWAMP_REMOTE_ONLY)",
+  )
+  .option(
+    "--ws-idle-timeout <duration:string>",
+    "WebSocket idle timeout (env: SWAMP_WS_IDLE_TIMEOUT). Default: 30s",
+  )
+  .option(
+    "--queue-timeout <duration:string>",
+    "Queue timeout for placed steps (env: SWAMP_QUEUE_TIMEOUT). Default: 10m",
+  )
+  .option(
+    "--max-concurrent-runs <count:integer>",
+    "Maximum concurrent detached runs across all principals. Default: 100 " +
+      "(env: SWAMP_MAX_CONCURRENT_RUNS)",
+  )
+  .option(
+    "--max-runs-per-principal <count:integer>",
+    "Maximum concurrent detached runs per authenticated principal " +
+      "(env: SWAMP_MAX_RUNS_PER_PRINCIPAL)",
+  )
+  .option(
+    "--max-run-duration <duration:string>",
+    "Maximum wall-clock time a detached run may execute " +
+      "(env: SWAMP_MAX_RUN_DURATION)",
+  )
+  .option(
+    "--hot-reload",
+    "Enable SIGHUP-based hot-reload for pulled extension bundles. " +
+      "Writes a PID file to .swamp/serve.pid; use 'swamp serve reload' to trigger",
+  )
+  .option(
+    "--enable-internal-api",
+    "Enable the /internal/runs endpoint for full run history access " +
+      "(env: SWAMP_ENABLE_INTERNAL_API)",
   )
   .example("Enable daemon", "swamp serve daemon enable")
   .example(

--- a/src/cli/commands/serve_test.ts
+++ b/src/cli/commands/serve_test.ts
@@ -385,6 +385,36 @@ Deno.test("collectServeExtraArgs: omits --trusted-hosts when not set", () => {
   assertEquals(args, []);
 });
 
+Deno.test("collectServeExtraArgs: forwards --hot-reload", () => {
+  const args = collectServeExtraArgs({ hotReload: true });
+  assertEquals(args, ["--hot-reload"]);
+});
+
+Deno.test("collectServeExtraArgs: omits --hot-reload when false", () => {
+  const args = collectServeExtraArgs({ hotReload: false });
+  assertEquals(args, []);
+});
+
+Deno.test("collectServeExtraArgs: forwards --enable-internal-api", () => {
+  const args = collectServeExtraArgs({ enableInternalApi: true });
+  assertEquals(args, ["--enable-internal-api"]);
+});
+
+Deno.test("collectServeExtraArgs: forwards --max-concurrent-runs", () => {
+  const args = collectServeExtraArgs({ maxConcurrentRuns: 50 });
+  assertEquals(args, ["--max-concurrent-runs", "50"]);
+});
+
+Deno.test("collectServeExtraArgs: forwards --max-runs-per-principal", () => {
+  const args = collectServeExtraArgs({ maxRunsPerPrincipal: 10 });
+  assertEquals(args, ["--max-runs-per-principal", "10"]);
+});
+
+Deno.test("collectServeExtraArgs: forwards --max-run-duration", () => {
+  const args = collectServeExtraArgs({ maxRunDuration: "1h" });
+  assertEquals(args, ["--max-run-duration", "1h"]);
+});
+
 // --- reapOrphanedWorkflowRuns ---
 
 const WORKFLOW_ID = "96968218-50aa-4b91-8161-a6995ce96cae" as WorkflowId;

--- a/src/infrastructure/daemon/systemd_service_scheduler.ts
+++ b/src/infrastructure/daemon/systemd_service_scheduler.ts
@@ -85,6 +85,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 ExecStart=${args.join(" ")}
+ExecReload=/bin/kill -HUP $MAINPID
 WorkingDirectory=${escapedRepoDir}
 Restart=always
 RestartSec=10${envBlock}

--- a/src/infrastructure/daemon/systemd_service_scheduler_test.ts
+++ b/src/infrastructure/daemon/systemd_service_scheduler_test.ts
@@ -141,6 +141,11 @@ Deno.test("buildServeService: omits extraArgs when not provided", () => {
   assertFalse(unit.includes("--no-schedule"));
 });
 
+Deno.test("buildServeService: includes ExecReload for SIGHUP", () => {
+  const unit = buildServeService(baseConfig);
+  assertStringIncludes(unit, "ExecReload=/bin/kill -HUP $MAINPID");
+});
+
 Deno.test("buildServeService: does not include OnCalendar or timer config", () => {
   const unit = buildServeService(baseConfig);
   assertFalse(unit.includes("OnCalendar"));


### PR DESCRIPTION
## Summary

- Adds 7 missing CLI flag options to `swamp serve daemon enable`: `--hot-reload`, `--max-concurrent-runs`, `--max-runs-per-principal`, `--max-run-duration`, `--enable-internal-api`, `--ws-idle-timeout`, and `--queue-timeout`
- Forwards the newly accepted flags through `collectServeExtraArgs()` into the generated systemd/launchd service unit
- Adds `ExecReload=/bin/kill -HUP $MAINPID` to the systemd unit template so `systemctl reload --user swamp-serve` works natively

Closes swamp-club#1726

## Test Plan

- Added 6 new unit tests for `collectServeExtraArgs()` covering all newly forwarded flags (hot-reload, enable-internal-api, max-concurrent-runs, max-runs-per-principal, max-run-duration)
- Added 1 new unit test for `buildServeService()` verifying `ExecReload` is present in the generated systemd unit
- All 10,514 existing tests pass (1 pre-existing flake in `serve_ready_test.ts` unrelated to this change)
- `deno check`, `deno lint`, `deno fmt --check` all pass