### PR TITLE
fix(serve): skip pre-flight checks for remotely-placed steps (swamp-club#1721)

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -710,20 +710,23 @@ bundle; the worker prefetches the (small) asset tree via
 before executing, because `extensionFile()` is synchronous and must resolve a
 local path. Assets cache under the fingerprint like the bundle itself.
 
-### Checks and reports run at the orchestrator, around the method body
+### Pre-flight checks are skipped for remote steps; reports run at the orchestrator
 
-As built, checks and reports keep their existing pipeline *position*, which is
-**before and after the execution seam at the orchestrator** — this is where
-they have always run relative to out-of-process execution, and remote dispatch
-enters at exactly that seam (`DefaultMethodExecutionService`, where the
-in-process executor used to be selected). Only the method body moves to the
-worker; pre-flight checks, output records, deletion markers, and follow-up
-actions run at the orchestrator with local repositories, unchanged. This
-supersedes an earlier draft that ran checks worker-side: it preserves today's
-semantics exactly, and report-provider bundles never need to ship. (The
-dispatch protocol reserves `reportBundleFingerprints` should that ever
-change.) Control-plane bookkeeping runs (worker/token/lease transitions)
-skip per-run report artifacts so pool churn stays bounded.
+Pre-flight checks are **skipped** for remotely-placed steps. Checks run on the
+orchestrator, which cannot access worker-local filesystem state — a check like
+`@swamp/git`'s `repo-initialized` that runs `git rev-parse` against a
+worker-local path would always fail on the orchestrator where that path does not
+exist. For remotely-placed steps, the method body runs on the worker where
+filesystem preconditions fail naturally if unmet.
+
+Post-run **reports** keep their existing pipeline position **after the execution
+seam at the orchestrator** — this is where they have always run relative to
+out-of-process execution, and report-provider bundles never need to ship. (The
+dispatch protocol reserves `reportBundleFingerprints` should that ever change.)
+Output records, deletion markers, and follow-up actions also run at the
+orchestrator with local repositories, unchanged. Control-plane bookkeeping runs
+(worker/token/lease transitions) skip per-run report artifacts so pool churn
+stays bounded.
 
 ## Data semantics
 

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -610,8 +610,19 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
         ...rawMethodArgs,
       };
 
+      // Skip pre-flight checks for remotely-placed steps — checks run on
+      // the orchestrator where worker-local filesystem state is unavailable.
+      const isRemotePlacement = context.placement &&
+        hasPlacement(context.placement);
+
+      if (isRemotePlacement && modelDef.checks && isMutatingKind(methodKind)) {
+        context.logger.info(
+          "Skipping pre-flight checks for remotely-placed step",
+        );
+      }
+
       // Run pre-flight checks for mutating methods
-      if (modelDef.checks && isMutatingKind(methodKind)) {
+      if (modelDef.checks && isMutatingKind(methodKind) && !isRemotePlacement) {
         const defChecks = currentDefinition.checkSelection;
         const requiredCheckNames = new Set(defChecks?.require ?? []);
         const skippedCheckNames = new Set(defChecks?.skip ?? []);
@@ -825,11 +836,7 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
       let result: MethodResult;
       let executionContext: MethodContext = context;
 
-      if (
-        method.rollbackOnFailure &&
-        context.placement &&
-        hasPlacement(context.placement)
-      ) {
+      if (method.rollbackOnFailure && isRemotePlacement) {
         throw new Error(
           `Method '${methodName}' declares rollbackOnFailure but has remote ` +
             `placement — deferred-latest writes are not yet supported for ` +
@@ -838,11 +845,11 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
       }
 
       try {
-        if (context.placement && hasPlacement(context.placement)) {
+        if (isRemotePlacement) {
           // Remote placement: the method body runs on a matching worker; the
-          // surrounding pipeline (checks above, output records and follow-up
-          // actions below) stays at the orchestrator. See
-          // design/remote-execution.md.
+          // surrounding pipeline (output records and follow-up actions below)
+          // stays at the orchestrator. Pre-flight checks are skipped (they
+          // cannot access worker-local state). See design/remote-execution.md.
           const remoteResult = await this.#executeRemotely(
             context,
             executionRequest,

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -3181,6 +3181,124 @@ Deno.test("executeWorkflow: check unresolvedMethodArgs filters unresolved expres
   assertEquals(capturedArgs?.apiKey, undefined);
 });
 
+Deno.test("executeWorkflow - remote placement skips pre-flight checks (swamp-club#1721)", async () => {
+  const service = new DefaultMethodExecutionService();
+  const checkExecuted = { value: false };
+  const model = createCheckModel({
+    "fs-check": {
+      description: "Filesystem check that would fail on orchestrator",
+      execute: () => {
+        checkExecuted.value = true;
+        return Promise.resolve({ pass: false, errors: ["Path not found"] });
+      },
+    },
+  });
+
+  const definition = Definition.create({
+    name: "remote-def",
+    globalArguments: {},
+  });
+
+  const written = Data.create({
+    name: "data-out",
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 10,
+    tags: { type: "resource", specName: "data" },
+    ownerDefinition: { ownerType: "model-method", ownerRef: "remote-def" },
+    version: 1,
+    size: 2,
+  });
+  const baseRepo = createMockDataRepoWithData([written]);
+  const repo: UnifiedDataRepository = {
+    ...baseRepo,
+    findByName: (_type, _modelId, dataName, version) =>
+      Promise.resolve(
+        dataName === "data-out" && version === 1 ? written : null,
+      ),
+    getContent: () => Promise.resolve(new TextEncoder().encode("{}")),
+  };
+
+  setRemoteStepDispatcher({
+    executeRemote: () =>
+      Promise.resolve({
+        outputs: [{
+          dataId: String(written.id),
+          version: 1,
+          name: "data-out",
+          specName: "data",
+          type: "resource" as const,
+        }],
+        logs: [],
+        durationMs: 1,
+        workerName: "w1",
+      }),
+    releaseAffinity: () => {},
+  });
+  try {
+    const { context } = createTestContext({
+      modelType: model.type,
+      dataRepository: repo,
+      placement: { labels: { tier: "remote" } },
+    });
+    const result = await service.executeWorkflow(
+      definition,
+      model,
+      "create",
+      context,
+    );
+    assertEquals(result !== undefined, true);
+    assertEquals(checkExecuted.value, false);
+  } finally {
+    setRemoteStepDispatcher(null);
+  }
+});
+
+Deno.test("executeWorkflow - local execution still runs pre-flight checks", async () => {
+  const service = new DefaultMethodExecutionService();
+  const model = createCheckModel({
+    "local-check": {
+      description: "Check that runs locally",
+      execute: () => Promise.resolve({ pass: false, errors: ["Check failed"] }),
+    },
+  });
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {},
+  });
+  const { context } = createTestContext({ modelType: model.type });
+  await assertRejects(
+    () => service.executeWorkflow(definition, model, "create", context),
+    UserError,
+    "local-check",
+  );
+});
+
+Deno.test("executeWorkflow - empty placement still runs checks", async () => {
+  const service = new DefaultMethodExecutionService();
+  const model = createCheckModel({
+    "check-with-empty-placement": {
+      description: "Should still run",
+      execute: () => Promise.resolve({ pass: false, errors: ["Check failed"] }),
+    },
+  });
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {},
+  });
+  const { context } = createTestContext({
+    modelType: model.type,
+    placement: {},
+  });
+  await assertRejects(
+    () => service.executeWorkflow(definition, model, "create", context),
+    UserError,
+    "check-with-empty-placement",
+  );
+});
+
 Deno.test("executeWorkflow - placed steps rebuild full handles from durable records (swamp-club#535)", async () => {
   const service = new DefaultMethodExecutionService();
   const model = createTestModel({});


### PR DESCRIPTION
## Summary

- Skip pre-flight checks for remotely-placed steps in `method_execution_service.ts` — checks run on the orchestrator where worker-local filesystem state (e.g. `@swamp/git`'s `repo-initialized` check running `git rev-parse` against a worker-local path) is unavailable
- Emit an info-level log when checks are skipped due to remote placement
- Update `design/remote-execution.md` to reflect the new behavior
- Extract `isRemotePlacement` variable to DRY up three redundant `hasPlacement(context.placement)` checks

Closes swamp-club#1721

## Test Plan

- [x] Added unit test: remote placement skips pre-flight checks (failing check does not run)
- [x] Added unit test: local execution still runs pre-flight checks (failing check throws UserError)
- [x] Added unit test: empty placement `{}` still runs checks (hasPlacement returns false)
- [x] All 10,521 existing tests pass
- [x] `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)