### PR TITLE
fix(serve): return honest cancel status instead of false 'cancelled'

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -122,7 +122,10 @@ import {
   deleteActiveRun,
   writeActiveRun,
 } from "../../serve/active_run_tracker.ts";
-import { RunCancelRegistry } from "../../serve/run_cancel_registry.ts";
+import {
+  type ExecutionType,
+  RunCancelRegistry,
+} from "../../serve/run_cancel_registry.ts";
 import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
 import { reportRegistry } from "../../domain/reports/report_registry.ts";
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
@@ -222,6 +225,68 @@ import {
 type AnyOptions = any;
 
 const logger = getSwampLogger(["serve"]);
+
+export const CANCEL_GRACE_MS = 5_000;
+
+export type CancelStatus = "cancelled" | "cancellation_requested" | "not_found";
+
+export interface CancelResult {
+  status: CancelStatus;
+  executionType: ExecutionType;
+  executionId: string;
+  message?: string;
+}
+
+export interface CancelDeps {
+  cancelRegistry: RunCancelRegistry;
+  activeRunRegistry?: ActiveRunRegistry;
+  scheduledCancelByRunId?: (id: string) => boolean;
+}
+
+export async function cancelExecution(
+  executionType: ExecutionType,
+  executionId: string,
+  deps: CancelDeps,
+  graceMs: number = CANCEL_GRACE_MS,
+): Promise<CancelResult> {
+  let found = deps.cancelRegistry.cancel(executionType, executionId);
+  if (!found && deps.activeRunRegistry) {
+    found = deps.activeRunRegistry.cancel(executionId);
+  }
+  let foundViaScheduled = false;
+  if (
+    !found && executionType === "workflow-run" && deps.scheduledCancelByRunId
+  ) {
+    found = deps.scheduledCancelByRunId(executionId);
+    foundViaScheduled = found;
+  }
+  if (!found) {
+    return {
+      status: "not_found",
+      executionType,
+      executionId,
+      message:
+        `No active ${executionType} with id ${executionId} in this serve instance`,
+    };
+  }
+  const activeRun = deps.activeRunRegistry?.get(executionId);
+  if (activeRun) {
+    await Promise.race([
+      activeRun.completion,
+      new Promise<void>((r) => setTimeout(r, graceMs)),
+    ]);
+    const confirmed = deps.activeRunRegistry?.get(executionId) === undefined;
+    return {
+      status: confirmed ? "cancelled" : "cancellation_requested",
+      executionType,
+      executionId,
+    };
+  }
+  if (foundViaScheduled) {
+    return { status: "cancellation_requested", executionType, executionId };
+  }
+  return { status: "cancelled", executionType, executionId };
+}
 
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
 
@@ -3297,34 +3362,30 @@ export const serveCommand = new Command()
             }
           }
           if (cancelMatch) {
-            const executionType = cancelMatch[1] as
-              | "workflow-run"
-              | "method-run";
+            const executionType = cancelMatch[1] as ExecutionType;
             const executionId = cancelMatch[2];
-            // Check cancel registry first (WebSocket ad-hoc and webhook runs)
-            let found = cancelRegistry.cancel(executionType, executionId);
-            // Then check active run registry (detached runs)
-            if (!found && activeRunRegistry) {
-              found = activeRunRegistry.cancel(executionId);
-            }
-            // For workflow runs, also check scheduled execution service
-            if (
-              !found && executionType === "workflow-run" && scheduledExecution
-            ) {
-              found = scheduledExecution.cancelByRunId(executionId);
-            }
-            if (found) {
+            const result = await cancelExecution(
+              executionType,
+              executionId,
+              {
+                cancelRegistry,
+                activeRunRegistry,
+                scheduledCancelByRunId: scheduledExecution
+                  ? (id) => scheduledExecution.cancelByRunId(id)
+                  : undefined,
+              },
+            );
+            if (result.status === "not_found") {
               return Response.json({
-                status: "cancelled",
-                executionType,
-                executionId,
-              });
+                status: result.status,
+                message: result.message,
+              }, { status: 404 });
             }
             return Response.json({
-              status: "not_found",
-              message:
-                `No active ${executionType} with id ${executionId} in this serve instance`,
-            }, { status: 404 });
+              status: result.status,
+              executionType: result.executionType,
+              executionId: result.executionId,
+            });
           }
           if (url.pathname === "/api/v1/cancel") {
             const body = await req.json().catch(() => ({}));
@@ -3350,7 +3411,7 @@ export const serveCommand = new Command()
             ) {
               count += scheduledExecution.cancelAllRuns();
             }
-            return Response.json({ status: "cancelled", count });
+            return Response.json({ status: "cancellation_requested", count });
           }
         }
 

--- a/src/cli/commands/serve_test.ts
+++ b/src/cli/commands/serve_test.ts
@@ -21,10 +21,17 @@ import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 import {
   assertOffLoopbackSecurity,
+  cancelExecution,
   collectServeExtraArgs,
   reapOrphanedWorkflowRuns,
   validateWebSocketOrigin,
 } from "./serve.ts";
+import {
+  type ActiveRun,
+  ActiveRunRegistry,
+} from "../../serve/active_run_registry.ts";
+import { RunCancelRegistry } from "../../serve/run_cancel_registry.ts";
+import { RunEventBuffer } from "../../serve/run_event_buffer.ts";
 import { UserError } from "../../domain/errors.ts";
 import { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
@@ -689,4 +696,143 @@ Deno.test("reapOrphanedWorkflowRuns: reaps run with foreign instanceId when trac
   assertEquals(result.skipped, 0);
   assertEquals(run.status, "failed");
   assertEquals(saved.length, 1);
+});
+
+// --- cancelExecution ---
+
+function makeActiveRun(
+  runId: string,
+  completion: Promise<void>,
+): ActiveRun {
+  return {
+    runId,
+    kind: "workflow-run",
+    resourceName: "test-workflow",
+    buffer: new RunEventBuffer(100),
+    controller: new AbortController(),
+    startedAt: new Date(),
+    completion,
+    principalId: null,
+  };
+}
+
+Deno.test("cancelExecution: returns not_found when run is absent from all registries", async () => {
+  const cancelRegistry = new RunCancelRegistry();
+  const activeRunRegistry = new ActiveRunRegistry();
+  const result = await cancelExecution(
+    "workflow-run",
+    "missing-run",
+    { cancelRegistry, activeRunRegistry },
+  );
+  assertEquals(result.status, "not_found");
+  assertEquals(result.executionId, "missing-run");
+});
+
+Deno.test("cancelExecution: returns cancelled when run deregisters within grace period", async () => {
+  const cancelRegistry = new RunCancelRegistry();
+  const activeRunRegistry = new ActiveRunRegistry();
+  const controller = new AbortController();
+  let resolveCompletion!: () => void;
+  const completion = new Promise<void>((r) => {
+    resolveCompletion = r;
+  });
+  const run = makeActiveRun("run-1", completion);
+  Object.assign(run, { controller });
+
+  cancelRegistry.register("workflow-run", "run-1", controller);
+  activeRunRegistry.register(run);
+
+  const resultPromise = cancelExecution(
+    "workflow-run",
+    "run-1",
+    { cancelRegistry, activeRunRegistry },
+    100,
+  );
+
+  // Simulate the run stopping: deregister and resolve completion
+  activeRunRegistry.deregister("run-1");
+  resolveCompletion();
+
+  const result = await resultPromise;
+  assertEquals(result.status, "cancelled");
+  assertEquals(result.executionType, "workflow-run");
+  assertEquals(result.executionId, "run-1");
+});
+
+Deno.test("cancelExecution: returns cancellation_requested when run stays active past grace period", async () => {
+  const cancelRegistry = new RunCancelRegistry();
+  const activeRunRegistry = new ActiveRunRegistry();
+  const controller = new AbortController();
+  // Completion never resolves — simulates a stuck run
+  const completion = new Promise<void>(() => {});
+  const run = makeActiveRun("run-stuck", completion);
+  Object.assign(run, { controller });
+
+  cancelRegistry.register("workflow-run", "run-stuck", controller);
+  activeRunRegistry.register(run);
+
+  const result = await cancelExecution(
+    "workflow-run",
+    "run-stuck",
+    { cancelRegistry, activeRunRegistry },
+    50,
+  );
+  assertEquals(result.status, "cancellation_requested");
+  assertEquals(result.executionId, "run-stuck");
+
+  // Clean up: deregister to avoid dangling state
+  activeRunRegistry.deregister("run-stuck");
+});
+
+Deno.test("cancelExecution: returns cancellation_requested for scheduled runs", async () => {
+  const cancelRegistry = new RunCancelRegistry();
+  const activeRunRegistry = new ActiveRunRegistry();
+
+  const result = await cancelExecution(
+    "workflow-run",
+    "sched-1",
+    {
+      cancelRegistry,
+      activeRunRegistry,
+      scheduledCancelByRunId: (id) => id === "sched-1",
+    },
+  );
+  assertEquals(result.status, "cancellation_requested");
+  assertEquals(result.executionId, "sched-1");
+});
+
+Deno.test("cancelExecution: returns cancelled when run already left active registry", async () => {
+  const cancelRegistry = new RunCancelRegistry();
+  const activeRunRegistry = new ActiveRunRegistry();
+  const controller = new AbortController();
+  cancelRegistry.register("method-run", "run-done", controller);
+  // Run is in cancel registry but not in active registry (already completed)
+
+  const result = await cancelExecution(
+    "method-run",
+    "run-done",
+    { cancelRegistry, activeRunRegistry },
+  );
+  assertEquals(result.status, "cancelled");
+  assertEquals(result.executionType, "method-run");
+  assertEquals(result.executionId, "run-done");
+});
+
+Deno.test("cancelExecution: scheduled fallback not checked for method-run type", async () => {
+  const cancelRegistry = new RunCancelRegistry();
+  let scheduledCalled = false;
+
+  const result = await cancelExecution(
+    "method-run",
+    "run-x",
+    {
+      cancelRegistry,
+      scheduledCancelByRunId: (_id) => {
+        scheduledCalled = true;
+        return true;
+      },
+    },
+  );
+  assertEquals(result.status, "not_found");
+  assertEquals(scheduledCalled, false);
 });

--- a/src/cli/commands/workflow_cancel.ts
+++ b/src/cli/commands/workflow_cancel.ts
@@ -177,21 +177,27 @@ export const workflowCancelCommand = withRemoteOptions(
           }`,
         );
       }
-      if (body.status !== "cancelled") {
+      if (
+        body.status !== "cancelled" &&
+        body.status !== "cancellation_requested"
+      ) {
         throw new UserError(
           (body.message as string | undefined) ??
             `Failed to cancel run ${options.run as string}: ${body.status}`,
         );
       }
+      const runId = options.run as string;
       if (cliCtx.outputMode === "json") {
         console.log(JSON.stringify({
-          runId: body.executionId ?? options.run,
-          status: "cancelled",
+          runId: body.executionId ?? runId,
+          status: body.status,
           reason: options.reason ?? "Cancelled by user",
         }));
+      } else if (body.status === "cancelled") {
+        cliCtx.logger.info`Cancelled run ${runId} on server`;
       } else {
         cliCtx.logger
-          .info`Cancelled run ${options.run as string} on server`;
+          .warn`Cancellation requested for run ${runId} on server (run may still be active — check health endpoint to confirm)`;
       }
       return;
     }


### PR DESCRIPTION
## Summary

- The cancel endpoint (`POST /api/v1/cancel/:type/:id`) immediately returned `{"status":"cancelled"}` after firing a cooperative abort signal, even when the run kept executing. This made `swamp workflow cancel --server` claim "Cancelled run X" for runs that were still going.
- Extract a `cancelExecution()` helper that fires the abort then awaits the run's `completion` promise with a 5-second grace period. Returns `"cancelled"` if the run actually stops, `"cancellation_requested"` if it's still active.
- The CLI client now distinguishes both statuses — confirmed cancels print an info message, unconfirmed ones print a warning.
- Bulk cancel (`POST /api/v1/cancel`) returns `"cancellation_requested"` since it can't confirm each run individually.

Closes #1738

## Test Plan

- [x] 6 new unit tests covering all cancel status outcomes: not_found, confirmed cancel within grace, stuck run past grace, scheduled run, already-completed run, and method-run type filter
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] Full `deno run test` passes (all tests green)
- [ ] Doc issue filed as #2190 for REST API reference update

🤖 Generated with [Claude Code](https://claude.com/claude-code)