### PR TITLE
fix(persistence): version the runs index so schema changes trigger rebuild (swamp-club#1740)

### DIFF
--- a/src/infrastructure/persistence/workflow_run_index.ts
+++ b/src/infrastructure/persistence/workflow_run_index.ts
@@ -22,6 +22,10 @@ import { atomicWriteTextFile } from "./atomic_write.ts";
 
 export const RUNS_INDEX_FILENAME = ".runs-index.json";
 
+// Bump when WorkflowRunIndexEntry gains or removes fields so that
+// old on-disk indices are rebuilt instead of serving stale data.
+export const INDEX_SCHEMA_VERSION = 2;
+
 export interface WorkflowRunIndexEntry {
   status: string;
   workflowId: string;
@@ -43,9 +47,14 @@ export function getIndexPath(workflowRunsDir: string): string {
   return join(workflowRunsDir, RUNS_INDEX_FILENAME);
 }
 
+export interface ReadIndexResult {
+  entries: WorkflowRunIndex;
+  version: number;
+}
+
 export async function readRunIndex(
   workflowRunsDir: string,
-): Promise<WorkflowRunIndex | null> {
+): Promise<ReadIndexResult | null> {
   const path = getIndexPath(workflowRunsDir);
   try {
     const content = await Deno.readTextFile(path);
@@ -55,7 +64,19 @@ export async function readRunIndex(
     ) {
       return null;
     }
-    return parsed as WorkflowRunIndex;
+    if (
+      typeof parsed.version === "number" &&
+      parsed.entries !== undefined &&
+      typeof parsed.entries === "object" &&
+      !Array.isArray(parsed.entries)
+    ) {
+      return {
+        entries: parsed.entries as WorkflowRunIndex,
+        version: parsed.version,
+      };
+    }
+    // Unversioned legacy format — return entries with version 0
+    return { entries: parsed as WorkflowRunIndex, version: 0 };
   } catch {
     return null;
   }
@@ -66,7 +87,10 @@ export async function writeRunIndex(
   index: WorkflowRunIndex,
 ): Promise<void> {
   const path = getIndexPath(workflowRunsDir);
-  await atomicWriteTextFile(path, JSON.stringify(index));
+  await atomicWriteTextFile(
+    path,
+    JSON.stringify({ version: INDEX_SCHEMA_VERSION, entries: index }),
+  );
 }
 
 export async function deleteRunIndex(
@@ -109,8 +133,9 @@ export async function listDirEntries(
 }
 
 export function isIndexStale(
-  index: WorkflowRunIndex,
+  result: ReadIndexResult,
   yamlFileCount: number,
 ): boolean {
-  return Object.keys(index).length !== yamlFileCount;
+  return result.version !== INDEX_SCHEMA_VERSION ||
+    Object.keys(result.entries).length !== yamlFileCount;
 }

--- a/src/infrastructure/persistence/workflow_run_index_test.ts
+++ b/src/infrastructure/persistence/workflow_run_index_test.ts
@@ -23,6 +23,7 @@ import {
   countYamlRunFiles,
   deleteRunIndex,
   getIndexPath,
+  INDEX_SCHEMA_VERSION,
   isIndexStale,
   readRunIndex,
   RUNS_INDEX_FILENAME,
@@ -74,7 +75,8 @@ Deno.test("writeRunIndex and readRunIndex: roundtrip", async () => {
   await withTempDir(async (dir) => {
     await writeRunIndex(dir, SAMPLE_INDEX);
     const loaded = await readRunIndex(dir);
-    assertEquals(loaded, SAMPLE_INDEX);
+    assertEquals(loaded?.entries, SAMPLE_INDEX);
+    assertEquals(loaded?.version, INDEX_SCHEMA_VERSION);
   });
 });
 
@@ -159,12 +161,57 @@ Deno.test("countYamlRunFiles: counts only matching files", () => {
 });
 
 Deno.test("isIndexStale: detects count mismatch", () => {
-  assertEquals(isIndexStale(SAMPLE_INDEX, 2), false);
-  assertEquals(isIndexStale(SAMPLE_INDEX, 3), true);
-  assertEquals(isIndexStale(SAMPLE_INDEX, 1), true);
-  assertEquals(isIndexStale(SAMPLE_INDEX, 0), true);
+  const current = { entries: SAMPLE_INDEX, version: INDEX_SCHEMA_VERSION };
+  assertEquals(isIndexStale(current, 2), false);
+  assertEquals(isIndexStale(current, 3), true);
+  assertEquals(isIndexStale(current, 1), true);
+  assertEquals(isIndexStale(current, 0), true);
 });
 
 Deno.test("isIndexStale: empty index matches zero files", () => {
-  assertEquals(isIndexStale({}, 0), false);
+  assertEquals(
+    isIndexStale({ entries: {}, version: INDEX_SCHEMA_VERSION }, 0),
+    false,
+  );
+});
+
+Deno.test("isIndexStale: outdated version is stale even with correct count", () => {
+  const outdated = { entries: SAMPLE_INDEX, version: INDEX_SCHEMA_VERSION - 1 };
+  assertEquals(isIndexStale(outdated, 2), true);
+});
+
+Deno.test("readRunIndex: returns version 0 for unversioned legacy format", async () => {
+  await withTempDir(async (dir) => {
+    await Deno.writeTextFile(
+      getIndexPath(dir),
+      JSON.stringify(SAMPLE_INDEX),
+    );
+    const result = await readRunIndex(dir);
+    assertEquals(result?.entries, SAMPLE_INDEX);
+    assertEquals(result?.version, 0);
+  });
+});
+
+Deno.test("readRunIndex: preserves entries from outdated schema version", async () => {
+  await withTempDir(async (dir) => {
+    await Deno.writeTextFile(
+      getIndexPath(dir),
+      JSON.stringify({
+        version: INDEX_SCHEMA_VERSION - 1,
+        entries: SAMPLE_INDEX,
+      }),
+    );
+    const result = await readRunIndex(dir);
+    assertEquals(result?.entries, SAMPLE_INDEX);
+    assertEquals(result?.version, INDEX_SCHEMA_VERSION - 1);
+  });
+});
+
+Deno.test("readRunIndex: reads current schema version", async () => {
+  await withTempDir(async (dir) => {
+    await writeRunIndex(dir, SAMPLE_INDEX);
+    const result = await readRunIndex(dir);
+    assertEquals(result?.entries, SAMPLE_INDEX);
+    assertEquals(result?.version, INDEX_SCHEMA_VERSION);
+  });
 });

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -25,6 +25,7 @@ import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import {
   countYamlRunFiles,
   deleteRunIndex,
+  INDEX_SCHEMA_VERSION,
   isIndexStale,
   listDirEntries,
   readRunIndex,
@@ -754,12 +755,12 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
     const yamlCount = countYamlRunFiles(entries);
     if (yamlCount === 0) return null;
 
-    const index = await readRunIndex(indexDir);
-    if (!index || isIndexStale(index, yamlCount)) {
+    const result = await readRunIndex(indexDir);
+    if (!result || isIndexStale(result, yamlCount)) {
       return await this.rebuildIndex(runsDir, indexDir);
     }
 
-    return index;
+    return result.entries;
   }
 
   private async rebuildIndex(
@@ -808,16 +809,17 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
     const indexDir = this.getLocalIndexDir(workflowId);
     try {
       await ensureDir(indexDir);
-      const existing = await readRunIndex(indexDir) ?? {};
-      existing[run.id] = {
-        status: run.status,
-        workflowId: run.workflowId,
-        workflowName: run.workflowName,
-        startedAt: run.startedAt?.toISOString(),
-        completedAt: run.completedAt?.toISOString(),
-        tags: run.tags ?? {},
-        inputs: run.inputs ?? {},
-      };
+      const result = await readRunIndex(indexDir);
+      if (result && result.version !== INDEX_SCHEMA_VERSION) {
+        // Stale schema — delete so the next read rebuilds from YAML.
+        // Merging would promote old entries to the new version without
+        // populating fields they're missing.
+        await deleteRunIndex(indexDir);
+        return;
+      }
+      const existing = result?.entries ?? {};
+      const summary = parseWorkflowRunSummary(run.toData());
+      existing[run.id] = summaryToIndexEntry(summary);
       await writeRunIndex(indexDir, existing);
     } catch (error) {
       logger.warn`Failed to update run index, deleting for rebuild: ${error}`;

--- a/src/infrastructure/persistence/yaml_workflow_run_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository_test.ts
@@ -793,8 +793,24 @@ Deno.test("save: creates index entry alongside YAML file", async () => {
     );
     const index = await readRunIndex(runsDir);
     assertNotEquals(index, null);
-    assertEquals(index![run.id]?.status, "running");
-    assertEquals(index![run.id]?.workflowName, "test-workflow");
+    assertEquals(index!.entries[run.id]?.status, "running");
+    assertEquals(index!.entries[run.id]?.workflowName, "test-workflow");
+  });
+});
+
+Deno.test("save: index entry includes triggerSource from run", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlWorkflowRunRepository(dir);
+    const workflow = createTestWorkflow();
+    const run = WorkflowRun.create(workflow, {}, undefined, "schedule");
+    run.start();
+
+    await repo.save(workflow.id, run);
+
+    const runsDir = join(dir, ".swamp", "workflow-runs", workflow.id);
+    const index = await readRunIndex(runsDir);
+    assertNotEquals(index, null);
+    assertEquals(index!.entries[run.id]?.triggerSource, "schedule");
   });
 });
 
@@ -813,7 +829,7 @@ Deno.test("save: updates index entry on status change", async () => {
 
     const runsDir = join(dir, ".swamp", "workflow-runs", workflow.id);
     const index = await readRunIndex(runsDir);
-    assertEquals(index![run.id]?.status, "succeeded");
+    assertEquals(index!.entries[run.id]?.status, "succeeded");
   });
 });
 
@@ -856,6 +872,42 @@ Deno.test("findAllSummariesFromIndex: falls back to YAML scan when index missing
     const summaries = await repo.findAllSummariesFromIndex(workflow.id);
     assertEquals(summaries.length, 1);
     assertEquals(summaries[0].status, "running");
+  });
+});
+
+Deno.test("findAllSummariesFromIndex: rebuilds stale index missing triggerSource", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlWorkflowRunRepository(dir);
+    const workflow = createTestWorkflow();
+
+    // Save a run with triggerSource
+    const run = WorkflowRun.create(workflow, {}, undefined, "schedule");
+    run.start();
+    await repo.save(workflow.id, run);
+
+    // Overwrite the index with an old-format file (flat JSON, no
+    // triggerSource) simulating a pre-upgrade cache
+    const runsDir = join(dir, ".swamp", "workflow-runs", workflow.id);
+    const oldIndex: Record<string, unknown> = {
+      [run.id]: {
+        status: "running",
+        workflowId: run.workflowId,
+        workflowName: "test-workflow",
+        startedAt: run.startedAt?.toISOString(),
+        tags: {},
+        inputs: {},
+        // triggerSource deliberately omitted
+      },
+    };
+    await Deno.writeTextFile(
+      getIndexPath(runsDir),
+      JSON.stringify(oldIndex),
+    );
+
+    // The search must rebuild from YAML and return the real triggerSource
+    const summaries = await repo.findAllSummariesFromIndex(workflow.id);
+    assertEquals(summaries.length, 1);
+    assertEquals(summaries[0].triggerSource, "schedule");
   });
 });
 
@@ -1150,7 +1202,7 @@ Deno.test("save: index is written to local path, not cache baseDir", async () =>
       const localIndexDir = join(dir, ".swamp", "workflow-runs", workflow.id);
       const localIndex = await readRunIndex(localIndexDir);
       assertNotEquals(localIndex, null, "index must exist under local .swamp/");
-      assertEquals(localIndex![run.id]?.status, "running");
+      assertEquals(localIndex!.entries[run.id]?.status, "running");
 
       // Index must NOT be in the cache baseDir (would pollute sync)
       const cacheIndex = await readRunIndex(join(cacheDir, workflow.id));


### PR DESCRIPTION
## Summary

- Add a versioned envelope (`{ version, entries }`) to `.runs-index.json` so that schema changes (like adding `triggerSource`) automatically invalidate old caches and trigger a rebuild from the YAML source files
- Fix `updateIndexEntry` to use `summaryToIndexEntry` (the same function `rebuildIndex` uses) so the save path includes all index fields — previously it hand-built entries missing `triggerSource`, `instanceId`, `failedStep`, `failureReason`, and `stepProgress`
- Add a stale-version guard in `updateIndexEntry` that deletes outdated indices rather than promoting incomplete entries to the current schema version

## Test Plan

- [x] Unit tests for `readRunIndex` verifying legacy format returns version 0, outdated version preserved with entries, current version roundtrips
- [x] Unit test for `isIndexStale` detecting outdated version as stale even with correct count
- [x] Integration test reproducing the original bug: old-format index missing `triggerSource` on disk → rebuild populates correct value from YAML
- [x] Integration test verifying `save()` writes `triggerSource` to the index entry
- [x] All 60 existing + new tests pass
- [x] `deno check`, `deno lint`, `deno fmt` all pass

Closes swamp-club#1740

🤖 Generated with [Claude Code](https://claude.com/claude-code)