### PR TITLE
fix(extensions): warn when install finds an empty lockfile (swamp-club#1736)

### DIFF
--- a/src/cli/commands/extension_rm.ts
+++ b/src/cli/commands/extension_rm.ts
@@ -59,7 +59,9 @@ export const extensionRemoveCommand = withRemoteOptions(
   new Command()
     .name("rm")
     .alias("remove")
-    .description("Remove a pulled extension and its files")
+    .description(
+      "Remove a pulled extension, its files, and its lockfile entry",
+    )
     .example("Remove extension", "swamp extension rm @stack72/aws-ec2")
     .example("Force remove", "swamp extension rm @stack72/aws-ec2 --force")
     .arguments("<extension:string>")

--- a/src/presentation/renderers/extension_install.ts
+++ b/src/presentation/renderers/extension_install.ts
@@ -65,7 +65,9 @@ class LogExtensionInstallRenderer implements Renderer<ExtensionInstallEvent> {
       completed: (e) => {
         const { installed, migrated, upToDate, failed } = e.data;
         if (e.data.entries.length === 0) {
-          logger.info("No extensions in lockfile.");
+          logger.warn(
+            "Lockfile has no entries — nothing to restore. If this is unexpected, check that upstream_extensions.json is populated.",
+          );
           return;
         }
         if (installed === 0 && migrated === 0 && failed === 0) {
@@ -129,7 +131,14 @@ class JsonExtensionInstallRenderer implements Renderer<ExtensionInstallEvent> {
         ));
       },
       completed: (e) => {
-        console.log(JSON.stringify(e.data, null, 2));
+        const output = e.data.entries.length === 0
+          ? {
+            ...e.data,
+            warning:
+              "Lockfile has no entries — nothing to restore. If this is unexpected, check that upstream_extensions.json is populated.",
+          }
+          : e.data;
+        console.log(JSON.stringify(output, null, 2));
       },
       error: (e) => {
         throw new UserError(e.error.message);

--- a/src/presentation/renderers/extension_install_test.ts
+++ b/src/presentation/renderers/extension_install_test.ts
@@ -1,0 +1,79 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import { createExtensionInstallRenderer } from "./extension_install.ts";
+import type { ExtensionInstallData } from "../../libswamp/mod.ts";
+
+await initializeLogging({});
+
+function captureStdout(fn: () => void): string {
+  const originalLog = console.log;
+  const lines: string[] = [];
+  console.log = (...args: unknown[]) => {
+    lines.push(
+      args.map((a) => typeof a === "string" ? a : String(a)).join(" "),
+    );
+  };
+  try {
+    fn();
+  } finally {
+    console.log = originalLog;
+  }
+  return lines.join("\n");
+}
+
+const EMPTY_DATA: ExtensionInstallData = {
+  entries: [],
+  installed: 0,
+  migrated: 0,
+  upToDate: 0,
+  failed: 0,
+};
+
+Deno.test("createExtensionInstallRenderer: json mode adds warning field when lockfile is empty", () => {
+  const renderer = createExtensionInstallRenderer("json");
+  const handlers = renderer.handlers();
+  const out = captureStdout(() => {
+    handlers.completed({ kind: "completed", data: EMPTY_DATA });
+  });
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.entries, []);
+  assertEquals(typeof parsed.warning, "string");
+  assertStringIncludes(parsed.warning, "no entries");
+});
+
+Deno.test("createExtensionInstallRenderer: json mode omits warning field when lockfile has entries", () => {
+  const renderer = createExtensionInstallRenderer("json");
+  const handlers = renderer.handlers();
+  const data: ExtensionInstallData = {
+    entries: [{ name: "@test/ext", version: "1.0.0", status: "up_to_date" }],
+    installed: 0,
+    migrated: 0,
+    upToDate: 1,
+    failed: 0,
+  };
+  const out = captureStdout(() => {
+    handlers.completed({ kind: "completed", data });
+  });
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.warning, undefined);
+  assertEquals(parsed.upToDate, 1);
+});


### PR DESCRIPTION
## Summary

- `extension install` now warns when the lockfile (`upstream_extensions.json`) has no entries, instead of silently reporting success. Log mode uses `warn` level; JSON mode includes a `warning` field.
- `extension rm --help` now discloses that the lockfile entry is also removed ("Remove a pulled extension, its files, and its lockfile entry").
- Adds renderer unit tests for the empty-lockfile warning in both output modes.

Closes swamp-club#1736

## Test Plan

- [x] Reproduced in a scratch repo: `rm` all extensions → `install` → confirmed silent success (before fix)
- [x] Verified fix in same scratch repo: `install --json` now includes `"warning": "Lockfile has no entries — ..."`, log mode shows `[WRN]`
- [x] Verified `rm --help` now mentions lockfile entry
- [x] New renderer unit tests pass (`deno run test src/presentation/renderers/extension_install_test.ts`)
- [x] Full test suite passes (`deno run test`)
- [x] `deno check`, `deno lint`, `deno fmt` clean