### PR TITLE
fix(serve): thread dataOutputOverrides through remote dispatch pipeline

### DIFF
--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -408,6 +408,8 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
         fileSpecs: executionRequest.fileSpecs,
         traceHeaders: executionRequest.traceHeaders,
         runtimeTags: context.runtimeTags,
+        tagOverrides: context.tagOverrides,
+        dataOutputOverrides: context.dataOutputOverrides,
         workflowName: context.tagOverrides?.workflow,
         jobName: context.tagOverrides?.job,
         stepName: context.tagOverrides?.step,

--- a/src/domain/remote/remote_dispatch.ts
+++ b/src/domain/remote/remote_dispatch.ts
@@ -28,6 +28,7 @@
  */
 
 import type { UnifiedDataRepository } from "../data/repositories.ts";
+import type { DataOutputOverride } from "../models/data_output_override.ts";
 import type { ModelDefinition } from "../models/model.ts";
 import type { ModelType } from "../models/model_type.ts";
 import type { StepPlacement } from "./scheduler.ts";
@@ -54,6 +55,8 @@ export interface RemoteStepRequest {
   /** W3C trace context propagated into the worker's execution. */
   traceHeaders?: Record<string, string>;
   runtimeTags?: Record<string, string>;
+  tagOverrides?: Record<string, string>;
+  dataOutputOverrides?: DataOutputOverride[];
   workflowName?: string;
   jobName?: string;
   stepName?: string;

--- a/src/serve/data_plane.ts
+++ b/src/serve/data_plane.ts
@@ -370,8 +370,8 @@ export class DataPlane {
       dispatch.modelType,
       dispatch.modelId,
       dispatch.modelDef.resources ?? {},
-      undefined, // tagOverrides
-      undefined, // dataOutputOverrides
+      dispatch.tagOverrides,
+      dispatch.dataOutputOverrides,
       dispatch.definitionTags,
       dispatch.runtimeTags,
       dispatch.definitionName,
@@ -439,8 +439,8 @@ export class DataPlane {
       dispatch.modelType,
       dispatch.modelId,
       dispatch.modelDef.files ?? {},
-      undefined, // tagOverrides
-      undefined, // dataOutputOverrides
+      dispatch.tagOverrides,
+      dispatch.dataOutputOverrides,
       undefined, // callbacks
       dispatch.definitionTags,
       dispatch.runtimeTags,

--- a/src/serve/data_plane_test.ts
+++ b/src/serve/data_plane_test.ts
@@ -37,6 +37,7 @@ interface StoredEntry {
   content: Uint8Array;
   data: Record<string, unknown>;
   version: number;
+  lifetime?: string;
 }
 
 function createInMemoryRepo(tempDir: string): {
@@ -87,6 +88,7 @@ function createInMemoryRepo(tempDir: string): {
         content,
         data: { id: data.id, name: data.name },
         version,
+        lifetime: data.lifetime,
       });
       return Promise.resolve({ version });
     },
@@ -625,5 +627,93 @@ Deno.test("DataPlane: per-dispatch redactor scrubs secrets from written resource
     const entry = h.stored.get(key);
     const content = JSON.parse(new TextDecoder().decode(entry!.content!));
     assertEquals(content.value, "output: ***");
+  });
+});
+
+Deno.test("DataPlane: dataOutputOverrides on dispatch override resource lifetime", async () => {
+  const ephemeralModelDef: ModelDefinition = {
+    type: MODEL_TYPE,
+    version: "2026.06.09.1",
+    resources: {
+      "statusResult": {
+        description: "ephemeral output",
+        schema: z.object({ clean: z.boolean() }),
+        lifetime: "ephemeral",
+        garbageCollection: 5,
+      },
+    },
+    methods: {},
+  };
+  await withHarness(async (h) => {
+    const d: ActiveDispatch = {
+      workerName: "w1",
+      dispatchId: "d-1",
+      leaseId: "l-1",
+      modelDef: ephemeralModelDef,
+      modelType: MODEL_TYPE,
+      modelId: "m-1",
+      methodName: "status",
+      definitionName: "test-def",
+      definitionTags: {},
+      dataOutputOverrides: [
+        { specName: "statusResult", lifetime: "infinite" },
+      ],
+    };
+    h.dispatches.register(d);
+
+    const resp = await h.plane.handle(
+      request("/data/resource", {
+        method: "POST",
+        body: JSON.stringify({
+          specName: "statusResult",
+          name: "status",
+          data: { clean: true },
+        }),
+      }),
+    );
+    assertEquals(resp?.status, 200);
+
+    const key = `${MODEL_TYPE.normalized}/m-1/status`;
+    const entry = h.stored.get(key);
+    assertEquals(entry?.lifetime, "infinite");
+  });
+});
+
+Deno.test("DataPlane: tagOverrides on dispatch are applied to written resources", async () => {
+  await withHarness(async (h) => {
+    const d: ActiveDispatch = {
+      workerName: "w1",
+      dispatchId: "d-1",
+      leaseId: "l-1",
+      modelDef: modelDef,
+      modelType: MODEL_TYPE,
+      modelId: "m-1",
+      methodName: "run",
+      definitionName: "test-def",
+      definitionTags: {},
+      tagOverrides: {
+        workflow: "my-workflow",
+        job: "my-job",
+        step: "my-step",
+      },
+    };
+    h.dispatches.register(d);
+
+    const resp = await h.plane.handle(
+      request("/data/resource", {
+        method: "POST",
+        body: JSON.stringify({
+          specName: "result",
+          name: "result",
+          data: { value: "x" },
+        }),
+      }),
+    );
+    assertEquals(resp?.status, 200);
+
+    const handle = await resp!.json();
+    assertEquals(handle.tags.workflow, "my-workflow");
+    assertEquals(handle.tags.job, "my-job");
+    assertEquals(handle.tags.step, "my-step");
   });
 });

--- a/src/serve/dispatch_registry.ts
+++ b/src/serve/dispatch_registry.ts
@@ -25,6 +25,7 @@
  */
 
 import type { UnifiedDataRepository } from "../domain/data/repositories.ts";
+import type { DataOutputOverride } from "../domain/models/data_output_override.ts";
 import type { ModelDefinition } from "../domain/models/model.ts";
 import type { ModelType } from "../domain/models/model_type.ts";
 import type {
@@ -44,6 +45,8 @@ export interface ActiveDispatch {
   definitionName: string;
   definitionTags: Record<string, string>;
   runtimeTags?: Record<string, string>;
+  tagOverrides?: Record<string, string>;
+  dataOutputOverrides?: DataOutputOverride[];
   dataRepo?: UnifiedDataRepository;
   allowedSecrets?: VaultExtractionResult;
   /** Per-dispatch redactor populated with vault-derived secret values. */

--- a/src/serve/dispatch_service.ts
+++ b/src/serve/dispatch_service.ts
@@ -484,6 +484,8 @@ export class DispatchService {
       definitionName: request.definitionName,
       definitionTags: request.definitionTags,
       runtimeTags: request.runtimeTags,
+      tagOverrides: request.tagOverrides,
+      dataOutputOverrides: request.dataOutputOverrides,
       dataRepo: request.dataRepo,
       allowedSecrets: extractVaultReferences(
         request.globalArgs,

--- a/src/serve/dispatch_service_test.ts
+++ b/src/serve/dispatch_service_test.ts
@@ -803,3 +803,28 @@ Deno.test("executeRemote: concurrent affinity step rejects when first step fails
   assertEquals(results[1].status, "rejected");
   assertEquals(callCount, 1);
 });
+
+Deno.test("executeRemote: dataOutputOverrides and tagOverrides are stored on the active dispatch", async () => {
+  const h = createHarness();
+  const overrides = [
+    { specName: "out", lifetime: "workflow" as const },
+  ];
+  const tags = { workflow: "my-wf", job: "my-job", step: "my-step" };
+  let capturedDispatch: import("./dispatch_registry.ts").ActiveDispatch | null =
+    null;
+  h.setBehavior((_name, _params) => {
+    capturedDispatch = h.dispatches.forWorker("w1")[0] ?? null;
+    return Promise.resolve({
+      status: "success",
+      outputs: [],
+      logs: [],
+      durationMs: 1,
+    });
+  });
+  await h.service.executeRemote(stepRequest({
+    dataOutputOverrides: overrides,
+    tagOverrides: tags,
+  }));
+  assertEquals(capturedDispatch!.dataOutputOverrides, overrides);
+  assertEquals(capturedDispatch!.tagOverrides, tags);
+});


### PR DESCRIPTION
## Summary

Fixes swamp-club#1743.

When a workflow step with `dataOutputOverrides` runs on a remote worker, the worker writes data through the orchestrator's HTTP data plane. The data plane was passing `undefined` for both `tagOverrides` and `dataOutputOverrides` when creating resource and file writers, so the overrides were silently dropped. Resources were written with the extension's declared lifetime (e.g. `ephemeral`) instead of the workflow-overridden one, causing them to be GC'd before downstream steps could read them.

**Root cause:** The remote dispatch pipeline (`RemoteStepRequest` → `ActiveDispatch` → data plane) never carried these two fields — they existed in `MethodContext` but were not threaded through to the serve layer.

**Fix:** Add `dataOutputOverrides` and `tagOverrides` to `RemoteStepRequest` and `ActiveDispatch`, pass them from `#executeRemotely()`, and use them in the data plane's `createResourceWriter()` and `createFileWriterFactory()` calls — matching the local execution path in `InProcessExecutor`.

No wire protocol changes — overrides are applied server-side on the orchestrator's data plane, not on the worker.

- `src/domain/remote/remote_dispatch.ts` — add fields to `RemoteStepRequest`
- `src/domain/models/method_execution_service.ts` — pass from `MethodContext` in `#executeRemotely()`
- `src/serve/dispatch_registry.ts` — add fields to `ActiveDispatch`
- `src/serve/dispatch_service.ts` — thread into `ActiveDispatch` registration
- `src/serve/data_plane.ts` — replace `undefined` with dispatch values at both writer call sites

## Test Plan

- New unit test: `DataPlane: dataOutputOverrides on dispatch override resource lifetime` — registers a dispatch with `dataOutputOverrides` changing `ephemeral` → `infinite`, writes a resource, verifies the stored lifetime is `infinite`
- New unit test: `DataPlane: tagOverrides on dispatch are applied to written resources` — verifies workflow/job/step tags appear on written resource handles
- New unit test: `executeRemote: dataOutputOverrides and tagOverrides are stored on the active dispatch` — captures the `ActiveDispatch` mid-execution and verifies both fields are present
- Full test suite passes (unit + integration)