### PR TITLE
fix(workflows): include globalArgs in validate required-inputs check (swamp-club#1751)

### DIFF
--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -523,6 +523,9 @@ export class DefaultWorkflowValidationService
                   ? undefined
                   : taskData.inputs,
                 taskData.modelType,
+                typeof taskData.globalArgs === "string"
+                  ? undefined
+                  : taskData.globalArgs,
               ),
             );
           }
@@ -549,6 +552,7 @@ export class DefaultWorkflowValidationService
     methodName: string,
     inputs: Record<string, unknown> | undefined,
     modelType?: string,
+    globalArgs?: Record<string, unknown>,
   ): Promise<WorkflowValidationResult[]> {
     const checkName =
       `Step inputs for '${stepName}' in job '${jobName}' (${modelIdOrName}.${methodName})`;
@@ -601,6 +605,7 @@ export class DefaultWorkflowValidationService
       case "resolved": {
         const provided = new Set<string>([
           ...Object.keys(inputs ?? {}),
+          ...Object.keys(globalArgs ?? {}),
           ...(resolution.definitionProvidedArgs ?? []),
         ]);
         const missing = resolution.requiredArgs.filter((arg) =>

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -1327,6 +1327,111 @@ Deno.test("validateStepInputs: direct-execution step with CEL in modelType skips
   assertEquals(inputResult?.passed, true);
 });
 
+Deno.test("validateStepInputs: direct-execution step with globalArgs satisfying required arg passes", async () => {
+  const resolver = mockResolverWithType({
+    "type:@swamp/test/model.create": {
+      status: "resolved",
+      requiredArgs: ["name", "region"],
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.directExecution(
+              "@swamp/test/model",
+              "my-instance",
+              "create",
+              { region: "us-east-1" },
+              { name: "my-resource" },
+            ),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  assertEquals(inputResult?.passed, true);
+});
+
+Deno.test("validateStepInputs: direct-execution step with CEL expression in globalArgs passes", async () => {
+  const resolver = mockResolverWithType({
+    "type:@swamp/test/model.create": {
+      status: "resolved",
+      requiredArgs: ["name"],
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.directExecution(
+              "@swamp/test/model",
+              "my-instance",
+              "create",
+              undefined,
+              { name: '${{ "Swamp Tests " + inputs.suffix }}' },
+            ),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  assertEquals(inputResult?.passed, true);
+});
+
+Deno.test("validateStepInputs: direct-execution step missing required globalArg still fails", async () => {
+  const resolver = mockResolverWithType({
+    "type:@swamp/test/model.create": {
+      status: "resolved",
+      requiredArgs: ["name", "region"],
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.directExecution(
+              "@swamp/test/model",
+              "my-instance",
+              "create",
+              { region: "us-east-1" },
+            ),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  assertEquals(inputResult?.passed, false);
+  assertEquals(inputResult?.error?.includes("name"), true);
+});
+
 // ---------- validateGlobalArgInputRefs ----------
 
 Deno.test("validateGlobalArgInputRefs: fails when step does not supply referenced input", async () => {


### PR DESCRIPTION
## Summary

- `workflow validate` was reporting false "Missing required inputs" for any
  required global argument supplied via step-level `globalArgs` — both literal
  values and CEL expressions like `${{ "Swamp Tests " + inputs.suffix }}`
- Root cause: `validateModelMethodInputs` never received `globalArgs`, so
  its keys were never included in the "provided" set while global requirements
  were correctly included in the "required" set
- Fix: thread `globalArgs` through from `validateStepInputs` and include its
  keys in the provided set, with the same `recordOrExpression` string-type
  guard used for `inputs`

Closes swamp-club#1751

## Test Plan

- [x] Added test: direct-execution step with globalArgs satisfying a required arg passes
- [x] Added test: direct-execution step with CEL expression in globalArgs passes
- [x] Added test: direct-execution step missing a required globalArg still fails
- [x] All 64 validation_service_test.ts tests pass
- [x] `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)