### PR TITLE
fix(access): write CLI-minted token secrets to _token-secrets control-plane vault

### DIFF
--- a/src/cli/commands/access_token_mint.ts
+++ b/src/cli/commands/access_token_mint.ts
@@ -40,6 +40,15 @@ import {
   withDefaults,
 } from "../../libswamp/mod.ts";
 import { renderServerTokenCreate } from "../../presentation/output/access_token_output.ts";
+import { TOKEN_SECRETS_VAULT_NAME } from "../../domain/vaults/control_plane_vault_provider.ts";
+import { initializeControlPlaneVaultForCli } from "../control_plane_vault.ts";
+import {
+  SERVER_TOKEN_MODEL_TYPE,
+  serverTokenModel,
+} from "../../domain/models/access/server_token_model.ts";
+import { migrateTokenSecrets } from "../../serve/token_secret_migration.ts";
+import { createResourceWriter } from "../../domain/models/data_writer.ts";
+import { VaultService } from "../../domain/vaults/vault_service.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -113,6 +122,22 @@ export const accessTokenMintCommand = new Command()
 
     cliCtx.logger.debug`Minting server token ${name}`;
 
+    const controlPlaneResult = await initializeControlPlaneVaultForCli(
+      repoDir,
+      syncService,
+    );
+
+    let effectiveVault = options.vault as string | undefined;
+    if (controlPlaneResult) {
+      if (effectiveVault !== undefined) {
+        cliCtx.logger.warn(
+          "Ignoring --vault {vault} — token secrets are stored in the {controlPlane} control-plane vault when a datastore is configured",
+          { vault: effectiveVault, controlPlane: TOKEN_SECRETS_VAULT_NAME },
+        );
+      }
+      effectiveVault = TOKEN_SECRETS_VAULT_NAME;
+    }
+
     const libCtx = createLibSwampContext({ logger: cliCtx.logger });
     const deps = await createServerTokenCreateDeps(
       libCtx,
@@ -150,7 +175,7 @@ export const accessTokenMintCommand = new Command()
           principalId: principal,
           principalEmail: email,
           durationMs,
-          vaultName: options.vault as string | undefined,
+          vaultName: effectiveVault,
         }),
         withDefaults<ServerTokenCreateEvent>({
           completed: (event) => {
@@ -168,6 +193,48 @@ export const accessTokenMintCommand = new Command()
       }
 
       renderServerTokenCreate(data, cliCtx.outputMode);
+
+      if (controlPlaneResult) {
+        const migrationVaultService = await VaultService.fromRepository(
+          repoDir,
+        );
+        await migrateTokenSecrets({
+          tokenSecretsVaultName: TOKEN_SECRETS_VAULT_NAME,
+          vaultService: migrationVaultService,
+          dataQueryService: repoContext.dataQueryService,
+          updateTokenVaultName: async (
+            tokenName,
+            newVaultName,
+            currentAttrs,
+          ) => {
+            const def = await repoContext.definitionRepo.findByName(
+              SERVER_TOKEN_MODEL_TYPE,
+              tokenName,
+            );
+            if (!def) {
+              throw new Error(
+                `Definition not found for token '${tokenName}' — skipping migration`,
+              );
+            }
+            const { writeResource } = createResourceWriter(
+              repoContext.unifiedDataRepo,
+              SERVER_TOKEN_MODEL_TYPE,
+              def.id,
+              serverTokenModel.resources!,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              tokenName,
+            );
+            await writeResource(
+              "token",
+              "token-main",
+              { ...currentAttrs, vaultName: newVaultName },
+            );
+          },
+        });
+      }
 
       if (syncService) {
         try {

--- a/src/cli/commands/access_token_rotate.ts
+++ b/src/cli/commands/access_token_rotate.ts
@@ -47,6 +47,15 @@ import {
   withRemoteOptions,
 } from "../remote_run.ts";
 import type { AccessTokenRotateResponse } from "../../serve/protocol.ts";
+import { TOKEN_SECRETS_VAULT_NAME } from "../../domain/vaults/control_plane_vault_provider.ts";
+import { initializeControlPlaneVaultForCli } from "../control_plane_vault.ts";
+import {
+  SERVER_TOKEN_MODEL_TYPE,
+  serverTokenModel,
+} from "../../domain/models/access/server_token_model.ts";
+import { migrateTokenSecrets } from "../../serve/token_secret_migration.ts";
+import { createResourceWriter } from "../../domain/models/data_writer.ts";
+import { VaultService } from "../../domain/vaults/vault_service.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -127,6 +136,60 @@ export const accessTokenRotateCommand = withRemoteOptions(
 
   cliCtx.logger.debug`Rotating server token ${name}`;
 
+  const controlPlaneResult = await initializeControlPlaneVaultForCli(
+    repoDir,
+    syncService,
+  );
+
+  let effectiveVault = options.vault as string | undefined;
+  if (controlPlaneResult) {
+    if (effectiveVault !== undefined) {
+      cliCtx.logger.warn(
+        "Ignoring --vault {vault} — token secrets are stored in the {controlPlane} control-plane vault when a datastore is configured",
+        { vault: effectiveVault, controlPlane: TOKEN_SECRETS_VAULT_NAME },
+      );
+    }
+    effectiveVault = TOKEN_SECRETS_VAULT_NAME;
+
+    const migrationVaultService = await VaultService.fromRepository(repoDir);
+    await migrateTokenSecrets({
+      tokenSecretsVaultName: TOKEN_SECRETS_VAULT_NAME,
+      vaultService: migrationVaultService,
+      dataQueryService: repoContext.dataQueryService,
+      updateTokenVaultName: async (
+        tokenName,
+        newVaultName,
+        currentAttrs,
+      ) => {
+        const def = await repoContext.definitionRepo.findByName(
+          SERVER_TOKEN_MODEL_TYPE,
+          tokenName,
+        );
+        if (!def) {
+          throw new Error(
+            `Definition not found for token '${tokenName}' — skipping migration`,
+          );
+        }
+        const { writeResource } = createResourceWriter(
+          repoContext.unifiedDataRepo,
+          SERVER_TOKEN_MODEL_TYPE,
+          def.id,
+          serverTokenModel.resources!,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          tokenName,
+        );
+        await writeResource(
+          "token",
+          "token-main",
+          { ...currentAttrs, vaultName: newVaultName },
+        );
+      },
+    });
+  }
+
   const libCtx = createLibSwampContext({ logger: cliCtx.logger });
   const deps = await createServerTokenRotateDeps(
     libCtx,
@@ -166,7 +229,7 @@ export const accessTokenRotateCommand = withRemoteOptions(
       serverTokenRotate(libCtx, deps, {
         name,
         durationMs,
-        vaultName: options.vault as string | undefined,
+        vaultName: effectiveVault,
       }),
       withDefaults<ServerTokenRotateEvent>({
         completed: (event) => {

--- a/src/cli/control_plane_vault.ts
+++ b/src/cli/control_plane_vault.ts
@@ -1,0 +1,40 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
+import {
+  type ControlPlaneVaultInitResult,
+  initializeControlPlaneVault,
+} from "../domain/vaults/control_plane_vault_init.ts";
+import { FileSystemControlPlaneStore } from "../infrastructure/persistence/fs_control_plane_store.ts";
+import { swampPath } from "../infrastructure/persistence/paths.ts";
+
+export async function initializeControlPlaneVaultForCli(
+  repoDir: string,
+  syncService?: DatastoreSyncService,
+): Promise<ControlPlaneVaultInitResult | null> {
+  const caps = syncService?.capabilities?.();
+  const hasRemote = !!(caps?.controlPlane && syncService?.controlPlaneStore);
+
+  const store = hasRemote
+    ? syncService!.controlPlaneStore!()
+    : new FileSystemControlPlaneStore(swampPath(repoDir));
+
+  return await initializeControlPlaneVault(store, hasRemote);
+}

--- a/src/domain/vaults/control_plane_vault_init.ts
+++ b/src/domain/vaults/control_plane_vault_init.ts
@@ -1,0 +1,60 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getLogger } from "@logtape/logtape";
+import type { ControlPlaneStore } from "../datastore/control_plane_store.ts";
+import {
+  ControlPlaneVaultProvider,
+  TOKEN_SECRETS_VAULT_NAME,
+} from "./control_plane_vault_provider.ts";
+import { VaultService } from "./vault_service.ts";
+
+const logger = getLogger(["vaults", "control-plane-init"]);
+
+export interface ControlPlaneVaultInitResult {
+  provider: ControlPlaneVaultProvider;
+  isRemote: boolean;
+}
+
+export async function initializeControlPlaneVault(
+  store: ControlPlaneStore,
+  isRemote: boolean,
+): Promise<ControlPlaneVaultInitResult | null> {
+  try {
+    const provider = new ControlPlaneVaultProvider(store);
+    await provider.initialize();
+
+    VaultService.registerGlobalProvider(
+      TOKEN_SECRETS_VAULT_NAME,
+      "control_plane",
+      provider,
+    );
+
+    logger.info`Initialized ${TOKEN_SECRETS_VAULT_NAME} vault (${
+      isRemote ? "remote" : "local"
+    } control plane)`;
+
+    return { provider, isRemote };
+  } catch (err) {
+    logger.warn`Failed to initialize control-plane vault: ${
+      err instanceof Error ? err.message : String(err)
+    }. Token secrets will be stored in the user vault.`;
+    return null;
+  }
+}

--- a/src/domain/vaults/control_plane_vault_init_test.ts
+++ b/src/domain/vaults/control_plane_vault_init_test.ts
@@ -1,0 +1,102 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import type { ControlPlaneStore } from "../datastore/control_plane_store.ts";
+import { initializeControlPlaneVault } from "./control_plane_vault_init.ts";
+import { TOKEN_SECRETS_VAULT_NAME } from "./control_plane_vault_provider.ts";
+
+await initializeLogging({});
+
+function createMockStore(): ControlPlaneStore {
+  const data = new Map<string, Uint8Array>();
+  return {
+    put(key: string, value: Uint8Array): Promise<void> {
+      data.set(key, new Uint8Array(value));
+      return Promise.resolve();
+    },
+    putIfAbsent(key: string, value: Uint8Array): Promise<boolean> {
+      if (data.has(key)) return Promise.resolve(false);
+      data.set(key, new Uint8Array(value));
+      return Promise.resolve(true);
+    },
+    get(key: string): Promise<Uint8Array | null> {
+      return Promise.resolve(data.get(key) ?? null);
+    },
+    delete(key: string): Promise<void> {
+      data.delete(key);
+      return Promise.resolve();
+    },
+    list(prefix: string): Promise<string[]> {
+      return Promise.resolve(
+        [...data.keys()].filter((k) => k.startsWith(prefix)),
+      );
+    },
+  };
+}
+
+function createFailingStore(): ControlPlaneStore {
+  return {
+    put(): Promise<void> {
+      return Promise.reject(new Error("S3 unreachable"));
+    },
+    get(): Promise<Uint8Array | null> {
+      return Promise.reject(new Error("S3 unreachable"));
+    },
+    delete(): Promise<void> {
+      return Promise.reject(new Error("S3 unreachable"));
+    },
+    list(): Promise<string[]> {
+      return Promise.reject(new Error("S3 unreachable"));
+    },
+  };
+}
+
+Deno.test("initializeControlPlaneVault: returns provider with isRemote=true when flagged as remote", async () => {
+  const store = createMockStore();
+  const result = await initializeControlPlaneVault(store, true);
+  assertNotEquals(result, null);
+  assertEquals(result!.isRemote, true);
+  assertEquals(result!.provider.getName(), TOKEN_SECRETS_VAULT_NAME);
+});
+
+Deno.test("initializeControlPlaneVault: returns provider with isRemote=false for local store", async () => {
+  const store = createMockStore();
+  const result = await initializeControlPlaneVault(store, false);
+  assertNotEquals(result, null);
+  assertEquals(result!.isRemote, false);
+  assertEquals(result!.provider.getName(), TOKEN_SECRETS_VAULT_NAME);
+});
+
+Deno.test("initializeControlPlaneVault: provider can round-trip a secret", async () => {
+  const store = createMockStore();
+  const result = await initializeControlPlaneVault(store, false);
+  assertNotEquals(result, null);
+
+  await result!.provider.put("test-key", "test-value");
+  const retrieved = await result!.provider.get("test-key");
+  assertEquals(retrieved, "test-value");
+});
+
+Deno.test("initializeControlPlaneVault: returns null on store failure", async () => {
+  const store = createFailingStore();
+  const result = await initializeControlPlaneVault(store, false);
+  assertEquals(result, null);
+});


### PR DESCRIPTION
## Summary

- Initialize the `ControlPlaneVaultProvider` in `access token mint` and `access token rotate` before running the model method, so CLI-minted token secrets land in the `_token-secrets` control-plane vault instead of a user vault
- Run `migrateTokenSecrets()` after minting to move any pre-existing token secrets from user vaults to `_token-secrets`, preventing orphaned data
- Warn and ignore `--vault` when a control-plane store is available

Fixes swamp-club#1717

## Test Plan

- [x] 4 new unit tests for `initializeControlPlaneVault` (remote, local fallback, round-trip, failure fallback)
- [x] Reproduced the bug in a scratch repo: token minted with old binary writes to `test-vault`
- [x] Verified fix: token minted with new binary writes to `_token-secrets`
- [x] Verified migration: pre-existing `repro-tok` migrated from `test-vault` to `_token-secrets`
- [x] Verified rotate: rotated token writes to `_token-secrets`
- [x] Verified no-vault edge case: mint works with no user vaults configured
- [x] Verified `--vault` override produces warning and is ignored
- [x] All 10533 existing tests pass (1 pre-existing unrelated failure in `http_update_checker_test.ts`)
- [ ] UAT: `cluster_basics_test.ts` in swamp-uat needs un-ignoring after this ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)