### PR TITLE
fix(data): treat workflow reports and serve control-plane types as live in prune (swamp-club#1749)

### DIFF
--- a/integration/data_prune_test.ts
+++ b/integration/data_prune_test.ts
@@ -58,6 +58,12 @@ import { DefaultDatastorePathResolver } from "../src/infrastructure/persistence/
 import { namespaceFromResolver } from "../src/infrastructure/persistence/repository_factory.ts";
 import type { DatastoreConfig } from "../src/domain/datastore/datastore_config.ts";
 
+import { Workflow } from "../src/domain/workflows/workflow.ts";
+import { Job } from "../src/domain/workflows/job.ts";
+import { Step } from "../src/domain/workflows/step.ts";
+import { StepTask } from "../src/domain/workflows/step_task.ts";
+import { YamlWorkflowRepository } from "../src/infrastructure/persistence/yaml_workflow_repository.ts";
+
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await Deno.makeTempDir({ prefix: "swamp-data-prune-" });
   try {
@@ -346,5 +352,112 @@ Deno.test("Data Prune: namespaced datastore — auto-definition-backed model is 
         await Deno.remove(datastoreDir, { recursive: true });
       }
     }
+  });
+});
+
+Deno.test("Data Prune: workflow report data is NOT pruned when workflow definition exists (swamp-club#1749)", async () => {
+  await withTempDir(async (repoDir) => {
+    await ensureDir(join(repoDir, "models"));
+    await ensureDir(join(repoDir, "workflows"));
+    await ensureDir(join(repoDir, ".swamp", "data"));
+
+    const workflow = Workflow.create({
+      name: "nightly-summary",
+      description: "test workflow",
+      jobs: [
+        Job.create({
+          name: "main",
+          steps: [
+            Step.create({
+              name: "step1",
+              task: StepTask.directExecution(
+                "command/shell",
+                "echo-test",
+                "run",
+              ),
+            }),
+          ],
+        }),
+      ],
+    });
+    const wfRepo = new YamlWorkflowRepository(repoDir);
+    await wfRepo.save(workflow);
+
+    const workflowType = ModelType.create("workflow");
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      new CatalogStore(join(repoDir, "_catalog.db")),
+    );
+    await writeData(
+      dataRepo,
+      workflowType,
+      workflow.id,
+      "report-swamp-workflow-summary",
+      3,
+    );
+
+    const deps = createDataPruneDeps(repoDir);
+    const orphans = await deps.findOrphanedData();
+    assertEquals(
+      orphans.length,
+      0,
+      "workflow report data must NOT be flagged as orphaned when workflow definition exists",
+    );
+
+    const result = await deps.deleteOrphanedData({ dryRun: false });
+    assertEquals(result.modelsReclaimed, 0);
+    assertEquals(
+      (await dataRepo.listVersions(
+        workflowType,
+        workflow.id,
+        "report-swamp-workflow-summary",
+      )).length,
+      3,
+      "workflow report versions must survive prune",
+    );
+  });
+});
+
+Deno.test("Data Prune: serve control-plane types are NOT pruned (swamp-club#1749)", async () => {
+  await withTempDir(async (repoDir) => {
+    await ensureDir(join(repoDir, "models"));
+    await ensureDir(join(repoDir, ".swamp", "data"));
+
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      new CatalogStore(join(repoDir, "_catalog.db")),
+    );
+
+    const serverTokenType = ModelType.create("swamp/server-token");
+    const grantType = ModelType.create("swamp/grant");
+    const tokenId = crypto.randomUUID();
+    const grantId = crypto.randomUUID();
+
+    await writeData(dataRepo, serverTokenType, tokenId, "token-main", 2);
+    await writeData(dataRepo, grantType, grantId, "grant-main", 1);
+
+    const deps = createDataPruneDeps(repoDir);
+    const orphans = await deps.findOrphanedData();
+    assertEquals(
+      orphans.length,
+      0,
+      "serve control-plane data must NOT be flagged as orphaned from a client-side scan",
+    );
+
+    const result = await deps.deleteOrphanedData({ dryRun: false });
+    assertEquals(result.modelsReclaimed, 0);
+    assertEquals(
+      (await dataRepo.listVersions(serverTokenType, tokenId, "token-main"))
+        .length,
+      2,
+      "server-token data must survive prune",
+    );
+    assertEquals(
+      (await dataRepo.listVersions(grantType, grantId, "grant-main")).length,
+      1,
+      "grant data must survive prune",
+    );
   });
 });

--- a/src/libswamp/data/prune.ts
+++ b/src/libswamp/data/prune.ts
@@ -25,8 +25,10 @@ import {
 } from "../../domain/data/data_lifecycle_service.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
+import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { createDefinitionId } from "../../domain/definitions/definition.ts";
+import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
 import {
   createCatalogStore,
@@ -36,6 +38,23 @@ import type { DatastorePathResolver } from "../../domain/datastore/datastore_pat
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+/**
+ * Serve-side control-plane types whose definitions are minted by `swamp serve`
+ * and exist only in the serve's repo. A client-side scan can never resolve
+ * them, so they must be treated as unconditionally live.
+ * Mirrors the internal-type list in src/domain/models/models.ts.
+ */
+const SERVE_CONTROL_PLANE_TYPES = new Set([
+  "swamp/enrollment-token",
+  "swamp/worker",
+  "swamp/step-lease",
+  "swamp/pending-dispatch",
+  "swamp/fleet-probe",
+  "swamp/server-token",
+  "swamp/grant",
+  "swamp/group",
+]);
 
 /** Preview item for a single orphaned model whose data would be reclaimed. */
 export interface DataPrunePreviewItem {
@@ -134,8 +153,24 @@ export function createDataPruneDeps(
     undefined,
     autoDefDir ?? undefined,
   );
-  const isModelLive: IsModelLive = async (type, modelId) =>
-    (await definitionRepo.findById(type, createDefinitionId(modelId))) !== null;
+
+  // Workflow report data is stored under ModelType "workflow" with the
+  // workflow UUID as modelId. Workflow definitions live in workflows/, not
+  // models/ or auto-definitions/, so we need a separate lookup.
+  const workflowRepo = new YamlWorkflowRepository(repoDir);
+
+  const isModelLive: IsModelLive = async (type, modelId) => {
+    if (SERVE_CONTROL_PLANE_TYPES.has(type.toDirectoryPath())) return true;
+
+    if (type.toDirectoryPath() === "workflow") {
+      return (await workflowRepo.findById(createWorkflowId(modelId))) !== null;
+    }
+
+    return (await definitionRepo.findById(
+      type,
+      createDefinitionId(modelId),
+    )) !== null;
+  };
 
   return {
     findOrphanedData: () => service.findOrphanedData(isModelLive),


### PR DESCRIPTION
## Summary

Fixes two false-positive classes in `data prune`'s orphan detection that caused live records to be misclassified as reclaimable:

- **Workflow report data**: Reports stored under `ModelType("workflow")` were invisible to the `isModelLive` predicate, which only checked `YamlDefinitionRepository` (`models/` and `auto-definitions/`). Workflow definitions live in `workflows/` via `YamlWorkflowRepository` — now consulted for the `"workflow"` type.
- **Serve control-plane types**: `swamp/server-token`, `swamp/grant`, and 6 other serve-side types are minted by `swamp serve` and only exist in the serve's repo. Operator clones sharing the namespace can never resolve their definitions locally. These 8 types are now treated as unconditionally live.

Closes swamp-club#1749

## Test Plan

- Added integration test: workflow with a live definition in `workflows/` has its report data correctly recognized as live (was previously flagged as orphaned)
- Added integration test: `swamp/server-token` and `swamp/grant` data with no local definition are correctly recognized as live
- All 4 existing `data_prune_test.ts` integration tests continue to pass
- Full test suite: 10,543 passed, 0 failed