### PR TITLE
fix(extensions): surface method-name collisions as warnings instead of silently dropping files (swamp-club#1734)

### DIFF
--- a/src/domain/extensions/model_kind_adapter.ts
+++ b/src/domain/extensions/model_kind_adapter.ts
@@ -35,6 +35,7 @@ import {
   type MethodResult,
   type ModelDefinition,
   modelRegistry,
+  type ResourceOutputSpec,
   ResourceOutputSpecSchema,
   type VersionUpgrade,
 } from "../models/model.ts";
@@ -53,6 +54,7 @@ import type {
   RegistrationContext,
   ValidationResult,
 } from "./kind_adapter.ts";
+import { emitExtensionLoadWarning } from "../../infrastructure/logging/extension_load_warnings.ts";
 
 const logger = getLogger(["swamp", "models", "loader"]);
 
@@ -579,8 +581,20 @@ export const modelKindAdapter: KindAdapter = {
       return;
     }
 
+    const existingMethodNames = new Set(Object.keys(targetModel.methods));
     const methods: Record<string, MethodDefinition> = {};
+    const collidingMethods: string[] = [];
     for (const [name, method] of Object.entries(flatMethods)) {
+      if (existingMethodNames.has(name)) {
+        collidingMethods.push(name);
+        emitExtensionLoadWarning({
+          kind: "extension",
+          file,
+          error:
+            `method '${name}' already exists on '${ext.type}'; method not registered`,
+        });
+        continue;
+      }
       methods[name] = {
         description: method.description,
         ...(method.kind ? { kind: method.kind as MethodKind } : {}),
@@ -608,24 +622,64 @@ export const modelKindAdapter: KindAdapter = {
           flatChecks[name] = check;
         }
       }
-      checks = Object.fromEntries(
-        Object.entries(flatChecks).map(([name, check]) => [
-          name,
-          {
-            description: check.description,
-            labels: check.labels,
-            appliesTo: check.appliesTo,
-            execute: check.execute,
-          },
-        ]),
+      const existingCheckNames = new Set(
+        Object.keys(targetModel.checks ?? {}),
       );
+      checks = {};
+      for (const [name, check] of Object.entries(flatChecks)) {
+        if (existingCheckNames.has(name)) {
+          emitExtensionLoadWarning({
+            kind: "extension",
+            file,
+            error:
+              `check '${name}' already exists on '${ext.type}'; check not registered`,
+          });
+          continue;
+        }
+        checks[name] = {
+          description: check.description,
+          labels: check.labels,
+          appliesTo: check.appliesTo,
+          execute: check.execute,
+        };
+      }
+      if (Object.keys(checks).length === 0) checks = undefined;
     }
 
-    try {
-      modelRegistry.extend(ext.type, methods, checks, ext.resources);
+    let resources: Record<string, ResourceOutputSpec> | undefined;
+    if (ext.resources) {
+      const existingResourceNames = new Set(
+        Object.keys(targetModel.resources ?? {}),
+      );
+      resources = {};
+      for (const [name, spec] of Object.entries(ext.resources)) {
+        if (existingResourceNames.has(name)) {
+          emitExtensionLoadWarning({
+            kind: "extension",
+            file,
+            error:
+              `resource '${name}' already exists on '${ext.type}'; resource not registered`,
+          });
+          continue;
+        }
+        resources[name] = spec;
+      }
+      if (Object.keys(resources).length === 0) resources = undefined;
+    }
+
+    const hasNewMethods = Object.keys(methods).length > 0;
+    const hasNewChecks = checks !== undefined;
+    const hasNewResources = resources !== undefined;
+
+    if (hasNewMethods || hasNewChecks || hasNewResources) {
+      try {
+        modelRegistry.extend(ext.type, methods, checks, resources);
+        result.extended.push(file);
+      } catch (error) {
+        result.failed.push({ file, error: String(error) });
+      }
+    } else if (collidingMethods.length > 0) {
       result.extended.push(file);
-    } catch (error) {
-      result.failed.push({ file, error: String(error) });
     }
   },
 
@@ -670,17 +724,10 @@ export const modelKindAdapter: KindAdapter = {
       result,
     );
 
-    const genuine: typeof result.failed = [];
     for (const failure of result.failed) {
-      if (String(failure.error).includes("already exists on model type")) {
-        result.extended.push(failure.file);
-      } else {
-        genuine.push(failure);
-        logger
-          .warn`Failed to extend model from ${failure.file}: ${failure.error}`;
-      }
+      logger
+        .warn`Failed to extend model from ${failure.file}: ${failure.error}`;
     }
-    result.failed = genuine;
   },
 
   async attachPendingExtensionsForType(

--- a/src/domain/extensions/model_kind_adapter_test.ts
+++ b/src/domain/extensions/model_kind_adapter_test.ts
@@ -18,11 +18,18 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertRejects } from "@std/assert";
+import { z } from "zod";
 import {
   clearAttachedExtensions,
   modelKindAdapter,
   removeAttachedExtensionsForType,
 } from "./model_kind_adapter.ts";
+import { ModelType } from "../models/model_type.ts";
+import { modelRegistry } from "../models/model.ts";
+import {
+  getExtensionLoadWarnings,
+  resetExtensionLoadWarnings,
+} from "../../infrastructure/logging/extension_load_warnings.ts";
 
 Deno.test("removeAttachedExtensionsForType: does not throw for unknown type", () => {
   removeAttachedExtensionsForType("@nonexistent/type");
@@ -259,4 +266,141 @@ Deno.test("validatePrimaryExport: model with mismatching last toVersion fails", 
     }),
   );
   assertEquals(result.success, false);
+});
+
+// ── processSecondaryExport: method collision pre-filtering ─────────────
+
+const testArgs = z.object({});
+
+function registerTestModel(
+  type: string,
+  methods: Record<string, unknown>,
+): void {
+  modelRegistry.register({
+    type: ModelType.create(type),
+    version: "2026.01.01.0",
+    methods: Object.fromEntries(
+      Object.entries(methods).map(([name, _]) => [
+        name,
+        {
+          description: `Base ${name}`,
+          arguments: testArgs,
+          execute: () => Promise.resolve({ dataHandles: [] }),
+        },
+      ]),
+    ),
+  });
+}
+
+function makeExtension(
+  type: string,
+  methodNames: string[],
+): Record<string, unknown> {
+  return {
+    type,
+    methods: methodNames.map((name) => ({
+      [name]: {
+        description: `Extension ${name}`,
+        arguments: testArgs,
+        execute: () => Promise.resolve({ dataHandles: [] }),
+      },
+    })),
+  };
+}
+
+Deno.test("processSecondaryExport: colliding method is skipped, sibling is merged", () => {
+  const type = "@test/collision-partial";
+  resetExtensionLoadWarnings();
+  registerTestModel(type, { retrieve: true });
+  try {
+    const result = {
+      loaded: [] as string[],
+      extended: [] as string[],
+      failed: [] as { file: string; error: string }[],
+    };
+    modelKindAdapter.processSecondaryExport!(
+      "extensions/models/probe.ts",
+      makeExtension(type, ["retrieve", "probe_marker"]),
+      result,
+    );
+
+    assertEquals(result.extended, ["extensions/models/probe.ts"]);
+    assertEquals(result.failed.length, 0);
+
+    const model = modelRegistry.get(type);
+    assertEquals("probe_marker" in (model?.methods ?? {}), true);
+    assertEquals(model?.methods["retrieve"]?.description, "Base retrieve");
+
+    const warnings = getExtensionLoadWarnings();
+    const collision = warnings.find((w) =>
+      w.error.includes("retrieve") && w.error.includes("already exists")
+    );
+    assertEquals(collision !== undefined, true);
+  } finally {
+    modelRegistry.invalidateType(type);
+    resetExtensionLoadWarnings();
+  }
+});
+
+Deno.test("processSecondaryExport: all methods collide — file marked extended, warnings emitted", () => {
+  const type = "@test/collision-full";
+  resetExtensionLoadWarnings();
+  registerTestModel(type, { run: true, list: true });
+  try {
+    const result = {
+      loaded: [] as string[],
+      extended: [] as string[],
+      failed: [] as { file: string; error: string }[],
+    };
+    modelKindAdapter.processSecondaryExport!(
+      "extensions/models/dupe.ts",
+      makeExtension(type, ["run", "list"]),
+      result,
+    );
+
+    assertEquals(result.extended, ["extensions/models/dupe.ts"]);
+    assertEquals(result.failed.length, 0);
+
+    const warnings = getExtensionLoadWarnings();
+    assertEquals(
+      warnings.filter((w) => w.error.includes("already exists")).length,
+      2,
+    );
+  } finally {
+    modelRegistry.invalidateType(type);
+    resetExtensionLoadWarnings();
+  }
+});
+
+Deno.test("processSecondaryExport: no collision — all methods merged normally", () => {
+  const type = "@test/no-collision";
+  resetExtensionLoadWarnings();
+  registerTestModel(type, { run: true });
+  try {
+    const result = {
+      loaded: [] as string[],
+      extended: [] as string[],
+      failed: [] as { file: string; error: string }[],
+    };
+    modelKindAdapter.processSecondaryExport!(
+      "extensions/models/clean.ts",
+      makeExtension(type, ["custom_method"]),
+      result,
+    );
+
+    assertEquals(result.extended, ["extensions/models/clean.ts"]);
+    assertEquals(result.failed.length, 0);
+
+    const model = modelRegistry.get(type);
+    assertEquals("custom_method" in (model?.methods ?? {}), true);
+
+    const warnings = getExtensionLoadWarnings();
+    assertEquals(
+      warnings.filter((w) => w.error.includes("already exists")).length,
+      0,
+    );
+  } finally {
+    modelRegistry.invalidateType(type);
+    resetExtensionLoadWarnings();
+  }
 });

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -1142,9 +1142,8 @@ export const extension = {
       const result = await loader.load(dir);
 
       assertEquals(result.loaded.length, 1);
-      assertEquals(result.extended.length, 0);
-      assertEquals(result.failed.length, 1);
-      assertStringIncludes(result.failed[0].error, "already exists");
+      assertEquals(result.extended.length, 1);
+      assertEquals(result.failed.length, 0);
     },
   );
 });
@@ -1630,11 +1629,8 @@ export const extension = {
       const result = await loader.load(dir);
 
       assertEquals(result.loaded.length, 1);
-      assertEquals(result.failed.length, 1);
-      assertStringIncludes(
-        result.failed[0].error,
-        "Resource spec 'data' already exists",
-      );
+      assertEquals(result.extended.length, 1);
+      assertEquals(result.failed.length, 0);
     },
   );
 });

--- a/src/infrastructure/logging/extension_load_warnings.ts
+++ b/src/infrastructure/logging/extension_load_warnings.ts
@@ -60,8 +60,7 @@ function getState(): EmitterState {
 const HINT_BY_KIND: Record<ExtensionKind, string> = {
   model:
     "extensions/models/ is auto-discovered — running `swamp extension source add` here is a no-op.",
-  extension:
-    "extensions/models/ is auto-discovered — running `swamp extension source add` here is a no-op.",
+  extension: "run `swamp doctor extensions` for details.",
   vault:
     "extensions/vaults/ is auto-discovered — running `swamp extension source add` here is a no-op.",
   datastore:


### PR DESCRIPTION
## Summary

- When a local method extension declares a method name that a base model type already defines, the collision guard was silently rejecting the **entire** extension file — no error, no warning, `swamp doctor extensions` reported pass. Sibling methods in the same file disappeared too.
- Pre-filter methods, checks, and resources per-name in `processSecondaryExport` before calling `extend()`. Colliding names are skipped with a warning via `emitExtensionLoadWarning`; non-colliding siblings survive.
- Remove the post-hoc swallowing in `importAndExtendBundle` that reclassified "already exists on model type" errors as success — now dead code since `extend()` can no longer throw for collision.

Closes swamp-club#1734

## Test Plan

- [x] 3 new unit tests in `model_kind_adapter_test.ts`: partial collision (sibling survives), full collision (tracking preserved), no collision (baseline)
- [x] Updated 2 existing tests in `user_model_loader_test.ts` to match new behavior (collisions are warnings, not hard failures)
- [x] `deno check` — clean
- [x] `deno lint` — clean
- [x] `deno fmt` — clean
- [x] `deno run test` — 10,544 passed, 0 failed
- [x] `deno run compile` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)