### PR TITLE
feat(docker): make official Docker image OCI-compliant (swamp-club#1756)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Generate build date
+        run: echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+
       - name: Copy Dockerfile into build contexts
         run: |
           cp Dockerfile docker-build/linux-amd64/
@@ -219,6 +222,10 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: swampclub/swamp:${{ env.docker_tag }}-amd64
+          build-args: |
+            SWAMP_VERSION=${{ needs.release.outputs.version }}
+            VCS_REF=${{ github.sha }}
+            BUILD_DATE=${{ env.build_date }}
           provenance: mode=max
           sbom: true
 
@@ -229,6 +236,10 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: swampclub/swamp:${{ env.docker_tag }}-arm64
+          build-args: |
+            SWAMP_VERSION=${{ needs.release.outputs.version }}
+            VCS_REF=${{ github.sha }}
+            BUILD_DATE=${{ env.build_date }}
           provenance: mode=max
           sbom: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,33 @@
-FROM denoland/deno:2.7.5
+FROM denoland/deno:2.8.3
+
+ARG SWAMP_VERSION="dev"
+ARG VCS_REF=""
+ARG BUILD_DATE=""
+
+LABEL org.opencontainers.image.title="swamp" \
+      org.opencontainers.image.description="AI Native Automation CLI" \
+      org.opencontainers.image.vendor="swamp-club" \
+      org.opencontainers.image.licenses="AGPL-3.0-only" \
+      org.opencontainers.image.source="https://github.com/swamp-club/swamp" \
+      org.opencontainers.image.version="${SWAMP_VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.created="${BUILD_DATE}"
+
+RUN groupadd --gid 1000 swamp \
+    && useradd --uid 1000 --gid swamp --create-home swamp \
+    && mkdir -p /workspace \
+    && chown swamp:swamp /workspace
+
 COPY swamp /usr/local/bin/swamp
 RUN chmod +x /usr/local/bin/swamp
+
+USER swamp
 WORKDIR /workspace
+
+STOPSIGNAL SIGTERM
+
+# HEALTHCHECK is intentionally omitted — this image runs arbitrary swamp
+# subcommands, not just `swamp serve`. A baked-in healthcheck would fail for
+# non-serve usage. Add your own in docker-compose or k8s when running serve.
+
 ENTRYPOINT ["swamp"]


### PR DESCRIPTION
## Summary

- Add standard `org.opencontainers.image.*` labels to the Dockerfile (title, description, vendor, licenses, source, version, revision, created)
- Create a non-root `swamp` user (UID/GID 1000) instead of running as root
- Add explicit `STOPSIGNAL SIGTERM` for container orchestrator compatibility
- Update base image from `denoland/deno:2.7.5` to `2.8.3` to match CI
- Update `release.yml` to pass version, git SHA, and build date as build args to both arch-specific Docker builds

HEALTHCHECK is intentionally omitted since the image runs arbitrary swamp subcommands, not just `swamp serve`.

Closes swamp-club#1756

## Test Plan

- Built the Docker image locally with test build args
- Verified all 8 OCI labels present via `docker inspect`
- Verified container runs as `swamp` user (non-root)
- Verified `STOPSIGNAL` is set to `SIGTERM`
- `deno fmt`, `deno lint` pass; test failures are pre-existing on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Uhe5JvAsspz6yrt2iVLae