### PR TITLE
fix(data): scope is_latest by step_name so findBySpec returns all step outputs (swamp-club#1761)

### DIFF
--- a/design/data-query.md
+++ b/design/data-query.md
@@ -200,6 +200,13 @@ All data access functions (`data.findBySpec()`, `data.findByTag()`,
 `context.queryData()`) return unscoped results by default. The predicate
 string is the contract — if it doesn't say it, it isn't happening.
 
+**Step-scoped versioning:** The `is_latest` flag is scoped per
+`(data_name, step_name)`. When different workflow steps write to the same
+data name, each step maintains its own version chain. Collection helpers
+(`findBySpec`, `findByTag`) return the latest version per step, so multiple
+records may be returned for the same data name. `data.latest()` returns the
+single most-recently-written record regardless of step.
+
 **Vault resolution:** JSON attributes containing `vault.get(...)` references
 are resolved automatically in async data access paths (extension methods,
 `data.query()` in CEL). Resolution failures leave the reference unresolved

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -453,6 +453,11 @@ Results are **not** run-scoped — `findBySpec` returns every matching record
 in the catalog. Add a `workflowRunId` predicate via `data.query()` when you
 want to scope to the current run.
 
+When the same model is invoked by different workflow steps that produce data
+with the same spec/instance name, each step's output is treated as a distinct
+record. The version chain is scoped per step: step A's latest version and step
+B's latest version are both returned.
+
 ### data.findByTag(tagKey, tagValue)
 
 Returns all data records across all models with a matching tag. Shortcut for

--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -44,6 +44,28 @@ import { resolveVaultRefsInData } from "../models/data_writer.ts";
 
 const logger = getLogger(["swamp", "domain", "data", "query"]);
 
+/**
+ * Sets `is_latest` on each row so that the highest version per
+ * (model_id, data_name, step_name) group is marked latest.
+ * Different workflow steps writing to the same data name keep
+ * independent latest markers; non-workflow data (step_name = "")
+ * collapses as before.
+ */
+function markLatestPerStep(rows: CatalogRow[]): void {
+  const maxVersions = new Map<string, number>();
+  for (const row of rows) {
+    const key = `${row.model_id}\0${row.data_name}\0${row.step_name}`;
+    const cur = maxVersions.get(key);
+    if (cur === undefined || row.version > cur) {
+      maxVersions.set(key, row.version);
+    }
+  }
+  for (const row of rows) {
+    const key = `${row.model_id}\0${row.data_name}\0${row.step_name}`;
+    row.is_latest = row.version === maxVersions.get(key) ? 1 : 0;
+  }
+}
+
 export interface DataQueryOptions {
   limit?: number;
   /** CEL projection expression. When set, results are projected and returned as unknown[]. */
@@ -508,7 +530,6 @@ export class DataQueryService {
           latest.name,
         );
         if (versions.length === 0) continue;
-        const maxVersion = Math.max(...versions);
         for (const version of versions) {
           try {
             const data = version === latest.version
@@ -526,7 +547,7 @@ export class DataQueryService {
                 data,
                 modelType,
                 modelId,
-                version === maxVersion,
+                false,
               ),
             );
           } catch (error) {
@@ -541,6 +562,11 @@ export class DataQueryService {
       // GC cycle and reclaim intermediate objects from metadata parsing.
       await new Promise<void>((resolve) => setTimeout(resolve, 0));
     }
+
+    // Compute is_latest per (data_name, step_name) group so different
+    // workflow steps writing to the same name keep independent latest
+    // markers.
+    markLatestPerStep(rows);
 
     this.catalogStore.bulkUpsert(rows);
     this.catalogStore.markPopulated();
@@ -573,7 +599,6 @@ export class DataQueryService {
           latest.name,
         );
         if (versions.length === 0) continue;
-        const maxVersion = Math.max(...versions);
         for (const version of versions) {
           try {
             const data = version === latest.version
@@ -591,7 +616,7 @@ export class DataQueryService {
                 data,
                 modelType,
                 modelId,
-                version === maxVersion,
+                false,
               ),
             );
           } catch (error) {
@@ -603,6 +628,7 @@ export class DataQueryService {
         }
       }
     }
+    markLatestPerStep(rows);
     this.catalogStore.bulkUpsert(rows);
     this.catalogStore.markPopulated();
   }

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -142,8 +142,8 @@ function deduplicateByName(records: DataRecord[]): DataRecord[] {
   const byKey = new Map<string, DataRecord>();
   for (const record of records) {
     const key = record.modelName
-      ? `${record.modelName}\0${record.name}`
-      : record.id; // unique per record when modelName is absent
+      ? `${record.modelName}\0${record.name}\0${record.stepName}`
+      : record.id;
     const existing = byKey.get(key);
     if (!existing || record.createdAt > existing.createdAt) {
       byKey.set(key, record);

--- a/src/domain/expressions/model_resolver_test.ts
+++ b/src/domain/expressions/model_resolver_test.ts
@@ -1010,6 +1010,157 @@ Deno.test("findBySpec: returns all data when workflowRunId is not set", async ()
 });
 
 // ============================================================================
+// data.findBySpec() returns distinct records from different workflow steps
+// ============================================================================
+
+Deno.test("findBySpec: returns both records when same data name written by different steps", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalog,
+    );
+    const type = ModelType.create("test/model");
+
+    const model = Definition.create({
+      name: "probe",
+      globalArguments: {},
+    });
+    await defRepo.save(type, model);
+
+    const resultA = Data.create({
+      name: "result",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", specName: "result", modelName: "probe" },
+      ownerDefinition: {
+        ...owner,
+        stepName: "run-good",
+      },
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      resultA,
+      new TextEncoder().encode(JSON.stringify({ exitCode: 0 })),
+    );
+
+    const resultB = Data.create({
+      name: "result",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", specName: "result", modelName: "probe" },
+      ownerDefinition: {
+        ...owner,
+        stepName: "run-bad",
+      },
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      resultB,
+      new TextEncoder().encode(JSON.stringify({ exitCode: 7 })),
+    );
+
+    const dqs = new DataQueryService(catalog, dataRepo);
+    await dqs.query('name == ""');
+
+    const resolver = new ModelResolver(defRepo, {
+      repoDir,
+      dataRepo,
+      dataQueryService: dqs,
+    });
+    const ctx = await resolver.buildContext();
+    assertExists(ctx.data);
+
+    const results = await ctx.data.findBySpec("probe", "result");
+    assertEquals(results.length, 2);
+
+    const exitCodes = results.map(
+      (r) => (r.attributes as { exitCode: number }).exitCode,
+    ).sort();
+    assertEquals(exitCodes, [0, 7]);
+    catalog.close();
+  });
+});
+
+Deno.test("findBySpec: deduplicates same-step same-name to latest version", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalog,
+    );
+    const type = ModelType.create("test/model");
+
+    const model = Definition.create({
+      name: "probe",
+      globalArguments: {},
+    });
+    await defRepo.save(type, model);
+
+    const stepOwner = { ...owner, stepName: "run-good" };
+
+    const v1 = Data.create({
+      name: "result",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", specName: "result", modelName: "probe" },
+      ownerDefinition: stepOwner,
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      v1,
+      new TextEncoder().encode(JSON.stringify({ attempt: 1 })),
+    );
+
+    const v2 = Data.create({
+      name: "result",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", specName: "result", modelName: "probe" },
+      ownerDefinition: stepOwner,
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      v2,
+      new TextEncoder().encode(JSON.stringify({ attempt: 2 })),
+    );
+
+    const dqs = new DataQueryService(catalog, dataRepo);
+    await dqs.query('name == ""');
+
+    const resolver = new ModelResolver(defRepo, {
+      repoDir,
+      dataRepo,
+      dataQueryService: dqs,
+    });
+    const ctx = await resolver.buildContext();
+    assertExists(ctx.data);
+
+    const results = await ctx.data.findBySpec("probe", "result");
+    assertEquals(results.length, 1);
+    assertEquals(
+      (results[0].attributes as { attempt: number }).attempt,
+      2,
+    );
+    catalog.close();
+  });
+});
+
+// ============================================================================
 // workers.connected() returns only non-disconnected workers
 // ============================================================================
 

--- a/src/infrastructure/persistence/catalog_store.ts
+++ b/src/infrastructure/persistence/catalog_store.ts
@@ -278,8 +278,13 @@ export class CatalogStore {
 
   /**
    * Inserts a row as the new latest version for (type, model, name), clearing
-   * `is_latest` on any prior rows for that triple. The `is_latest` field on
-   * the supplied row is ignored — this method always writes `1`.
+   * `is_latest` on any prior rows for that quadruple including step_name.
+   * The `is_latest` field on the supplied row is ignored — this method
+   * always writes `1`.
+   *
+   * Step-name scoping ensures that different workflow steps writing to the
+   * same data name maintain independent version chains.  Non-workflow data
+   * has step_name = "" and collapses as before.
    *
    * Runs in an IMMEDIATE transaction so concurrent writers serialize
    * through SQLite's reserved lock rather than racing on the flag.
@@ -290,8 +295,15 @@ export class CatalogStore {
       this.db.prepare(
         `UPDATE catalog SET is_latest = 0
          WHERE namespace = ? AND type_normalized = ? AND model_id = ? AND data_name = ?
+           AND step_name = ?
            AND is_latest = 1`,
-      ).run(row.namespace, row.type_normalized, row.model_id, row.data_name);
+      ).run(
+        row.namespace,
+        row.type_normalized,
+        row.model_id,
+        row.data_name,
+        row.step_name,
+      );
       this.upsert({ ...row, is_latest: 1 });
       this.db.exec("COMMIT");
     } catch (error) {

--- a/src/infrastructure/persistence/catalog_store_test.ts
+++ b/src/infrastructure/persistence/catalog_store_test.ts
@@ -163,6 +163,47 @@ Deno.test("CatalogStore: upsertNewVersion does not touch unrelated data names", 
   store.close();
 });
 
+Deno.test("CatalogStore: upsertNewVersion scopes is_latest by step_name", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  store.upsertNewVersion(
+    makeRow({ version: 1, step_name: "step-a" }),
+  );
+  store.upsertNewVersion(
+    makeRow({ version: 2, step_name: "step-b" }),
+  );
+
+  const rows = [...store.iterate()];
+  assertEquals(rows.length, 2);
+  const latestRows = rows.filter((r) => r.is_latest === 1);
+  assertEquals(latestRows.length, 2);
+  assertEquals(latestRows.map((r) => r.step_name).sort(), [
+    "step-a",
+    "step-b",
+  ]);
+  store.close();
+});
+
+Deno.test("CatalogStore: upsertNewVersion clears is_latest within same step_name", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  store.upsertNewVersion(
+    makeRow({ version: 1, step_name: "step-a" }),
+  );
+  store.upsertNewVersion(
+    makeRow({ version: 2, step_name: "step-a" }),
+  );
+
+  const rows = [...store.iterate()];
+  assertEquals(rows.length, 2);
+  const latestRows = rows.filter((r) => r.is_latest === 1);
+  assertEquals(latestRows.length, 1);
+  assertEquals(latestRows[0].version, 2);
+  store.close();
+});
+
 Deno.test("CatalogStore: removeVersion deletes a single version row", () => {
   const dbPath = makeTempDbPath();
   const store = new CatalogStore(dbPath);


### PR DESCRIPTION
## Summary

- Scopes `CatalogStore.upsertNewVersion` `is_latest` clearing by `step_name` so different workflow steps writing to the same data name maintain independent version chains
- Updates `deduplicateByName` in `model_resolver.ts` to include `stepName` in the dedup key, preventing collapse of records from different steps
- Updates catalog backfill (`markLatestPerStep`) to compute `is_latest` per `(data_name, step_name)` group so repopulation doesn't regress the fix

Fixes swamp-club#1761

## Test Plan

- Added 2 catalog store tests verifying step-scoped `is_latest` behavior
- Added 2 model resolver tests: multi-step `findBySpec` returns both records, same-step `findBySpec` deduplicates to latest version
- Verified against reproduction repo at `/tmp/swamp-repro-issue-1761`: `size() == 2` now passes, `all(r, r.content.exitCode == 0)` correctly fails
- Full test suite: 10,566 passed, 0 failed