### PR TITLE
feat(vault): record audit trail entries for put, delete, and annotate operations (swamp-club#1745)

### DIFF
--- a/design/vaults.md
+++ b/design/vaults.md
@@ -295,7 +295,9 @@ methods are required.
 - **Audit**: Every CLI read emits a `VaultSecretRead` domain event through the
   event bus, recording the vault name, type, and secret key accessed. When
   `auditReads` is enabled on the vault, a persistent audit trail entry is also
-  written to `.swamp/audit/vault-reads-YYYY-MM-DD.jsonl`.
+  written to `.swamp/audit/vault-audit-YYYY-MM-DD.jsonl`. Write operations
+  (`put`, `delete`, `annotate`) are always audited when an audit repository is
+  available.
 
 ### JSON Output
 
@@ -308,13 +310,17 @@ methods are required.
 }
 ```
 
-## Read Access Audit Trail
+## Vault Audit Trail
 
-Optional per-vault audit trail that records every `VaultService.get()` call to
-append-only JSONL files. Designed for security posture verification in
-autonomous agent fleets — proving "which automation read which secret, when."
+Audit trail that records vault operations to append-only JSONL files. Designed
+for security posture verification in autonomous agent fleets — proving "which
+automation accessed which secret, when, and how."
 
-### Enabling
+Write operations (`put`, `delete`, `annotate`) are always recorded when an audit
+repository is available. Read operations (`get`) are opt-in per vault via the
+`auditReads` flag.
+
+### Enabling Read Audit
 
 Set `auditReads: true` in the vault configuration YAML, or use the
 `--audit-reads` flag at creation time:
@@ -326,42 +332,52 @@ swamp vault create local_encryption my-vault --audit-reads
 Existing vaults can enable audit reads by editing their YAML config with
 `swamp vault edit my-vault` and adding `auditReads: true`.
 
+Write operations do not require this flag — they are always audited when the
+audit repository is wired.
+
 ### How It Works
 
-When `auditReads` is enabled on a vault:
-
-1. `VaultService.get()` writes an audit entry after each successful read
-2. Entries are appended to date-partitioned JSONL files:
-   `.swamp/audit/vault-reads-YYYY-MM-DD.jsonl`
-3. Audit writes are awaited but wrapped in try/catch — they never block or fail
-   a secret read
+1. `VaultService.put()`, `.delete()`, `.putAnnotation()`, and
+   `.deleteAnnotation()` write an audit entry after each successful operation,
+   regardless of the per-vault `auditReads` flag
+2. `VaultService.get()` writes an audit entry only when `auditReads` is enabled
+   on that vault
+3. Entries are appended to date-partitioned JSONL files:
+   `.swamp/audit/vault-audit-YYYY-MM-DD.jsonl`
+4. Audit writes are awaited but wrapped in try/catch — they never block or fail
+   the vault operation
 
 All `VaultService.fromRepository()` call sites automatically wire the audit
 repository when any vault has `auditReads` enabled. This covers CLI commands
-(`vault read-secret`, `vault inspect`, `vault migrate`), CEL expression
-evaluation, model method execution, serve/WebSocket, and token operations.
+(`vault put`, `vault delete`, `vault annotate`, `vault read-secret`,
+`vault inspect`, `vault migrate`), CEL expression evaluation, model method
+execution, serve/WebSocket, and token operations.
 
 ### Audit Entry Fields
 
 Each entry captures:
 
-- `timestamp` — ISO-8601 when the read occurred
-- `vaultName` — which vault was read
+- `action` — the operation type: `"get"`, `"put"`, `"delete"`, or `"annotate"`
+- `timestamp` — ISO-8601 when the operation occurred
+- `vaultName` — which vault was accessed
 - `vaultType` — the provider type (e.g. `local_encryption`, `@swamp/aws-sm`)
 - `secretKey` — which secret was accessed
-- `callerContext` — who/what initiated the read (e.g. `cli:vault-read-secret`,
-  `model:mytype/myid:exec`, `unknown`)
+- `callerContext` — who/what initiated the operation (e.g. `cli:vault-put`,
+  `cli:vault-read-secret`, `model:mytype/myid:exec`, `unknown`)
 
 Secret values are never recorded.
 
 ### Querying the Trail
 
 ```bash
-# Recent reads (last 7 days)
+# Recent operations (last 7 days)
 swamp vault audit-trail
 
 # Filter by vault and key
 swamp vault audit-trail --vault my-vault --key API_KEY
+
+# Filter by action
+swamp vault audit-trail --action put
 
 # Time range
 swamp vault audit-trail --since 2026-07-01 --until 2026-07-10
@@ -370,15 +386,24 @@ swamp vault audit-trail --since 2026-07-01 --until 2026-07-10
 swamp vault audit-trail --vault my-vault --json --limit 50
 ```
 
+### Backwards Compatibility
+
+Pre-existing audit files named `vault-reads-YYYY-MM-DD.jsonl` are still read
+during queries. New entries are written to `vault-audit-YYYY-MM-DD.jsonl`.
+Legacy entries without an `action` field default to `"get"` on deserialization.
+
 ### Architecture
 
 - **Value object**: `VaultAuditEntry` (`src/domain/vaults/vault_audit_entry.ts`)
+  — includes `action` discriminator field
 - **Repository interface**: `VaultAuditRepository`
-  (`src/domain/vaults/vault_audit_repository.ts`)
+  (`src/domain/vaults/vault_audit_repository.ts`) — query options include
+  `action` filter
 - **Infrastructure**: `JsonlVaultAuditRepository` — follows the established
   `JsonlAuditRepository` pattern with date-partitioned JSONL files under
-  `.swamp/audit/`
-- **Interception**: `VaultService` stores `auditReads` flags per vault name.
+  `.swamp/audit/`, reads both legacy and current file prefixes
+- **Interception**: `VaultService` records writes unconditionally when audit repo
+  exists; reads are gated by per-vault `auditReads` flag.
   `setAuditRepository()` injects the repository post-construction, avoiding
   changes to the ~20 `fromRepository()` call sites
 

--- a/src/cli/commands/vault_audit_trail.ts
+++ b/src/cli/commands/vault_audit_trail.ts
@@ -47,14 +47,18 @@ type AnyOptions = any;
 export const vaultAuditTrailCommand = withRemoteOptions(
   new Command()
     .name("audit-trail")
-    .description("View the secret-read audit trail for vaults.")
+    .description("View the vault audit trail.")
     .example(
-      "Show recent reads",
+      "Show recent operations",
       "swamp vault audit-trail",
     )
     .example(
       "Filter by vault",
       "swamp vault audit-trail --vault my-vault",
+    )
+    .example(
+      "Filter by action",
+      "swamp vault audit-trail --action put",
     )
     .example(
       "Filter by key and time range",
@@ -66,6 +70,10 @@ export const vaultAuditTrailCommand = withRemoteOptions(
     )
     .option("--vault <name:string>", "Filter by vault name")
     .option("--key <key:string>", "Filter by secret key")
+    .option(
+      "--action <action:string>",
+      "Filter by action: get, put, delete, annotate",
+    )
     .option(
       "--since <date:string>",
       "Start date, e.g. 2026-07-01 or 2026-07-01T00:00:00Z [default: 7 days ago]",
@@ -99,6 +107,7 @@ export const vaultAuditTrailCommand = withRemoteOptions(
         payload: {
           vaultName: options.vault as string | undefined,
           secretKey: options.key as string | undefined,
+          action: options.action as string | undefined,
           since: since?.toISOString(),
           until: until?.toISOString(),
           limit: options.limit as number | undefined,
@@ -129,6 +138,7 @@ export const vaultAuditTrailCommand = withRemoteOptions(
     vaultAuditTrail(ctx, deps, {
       vaultName: options.vault,
       secretKey: options.key,
+      action: options.action,
       since,
       until,
       limit: options.limit,

--- a/src/domain/vaults/vault_audit_entry.ts
+++ b/src/domain/vaults/vault_audit_entry.ts
@@ -17,7 +17,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+export type VaultAuditAction = "get" | "put" | "delete" | "annotate";
+
 export interface VaultAuditEntry {
+  readonly action: VaultAuditAction;
   readonly timestamp: string;
   readonly vaultName: string;
   readonly vaultType: string;
@@ -26,6 +29,7 @@ export interface VaultAuditEntry {
 }
 
 export interface VaultAuditEntryData {
+  action?: VaultAuditAction;
   timestamp: string;
   vaultName: string;
   vaultType: string;
@@ -34,12 +38,14 @@ export interface VaultAuditEntryData {
 }
 
 export function createVaultAuditEntry(
+  action: VaultAuditAction,
   vaultName: string,
   vaultType: string,
   secretKey: string,
   callerContext: string,
 ): VaultAuditEntry {
   return {
+    action,
     timestamp: new Date().toISOString(),
     vaultName,
     vaultType,
@@ -52,6 +58,7 @@ export function vaultAuditEntryFromData(
   data: VaultAuditEntryData,
 ): VaultAuditEntry {
   return {
+    action: data.action ?? "get",
     timestamp: data.timestamp,
     vaultName: data.vaultName,
     vaultType: data.vaultType,
@@ -64,6 +71,7 @@ export function vaultAuditEntryToData(
   entry: VaultAuditEntry,
 ): VaultAuditEntryData {
   return {
+    action: entry.action,
     timestamp: entry.timestamp,
     vaultName: entry.vaultName,
     vaultType: entry.vaultType,

--- a/src/domain/vaults/vault_audit_entry_test.ts
+++ b/src/domain/vaults/vault_audit_entry_test.ts
@@ -26,12 +26,14 @@ import {
 
 Deno.test("createVaultAuditEntry: creates entry with all fields", () => {
   const entry = createVaultAuditEntry(
+    "get",
     "my-vault",
     "local_encryption",
     "API_KEY",
     "cli:vault-read-secret",
   );
 
+  assertEquals(entry.action, "get");
   assertEquals(entry.vaultName, "my-vault");
   assertEquals(entry.vaultType, "local_encryption");
   assertEquals(entry.secretKey, "API_KEY");
@@ -40,8 +42,22 @@ Deno.test("createVaultAuditEntry: creates entry with all fields", () => {
   assertEquals(new Date(entry.timestamp).toISOString(), entry.timestamp);
 });
 
+Deno.test("createVaultAuditEntry: supports all action types", () => {
+  for (const action of ["get", "put", "delete", "annotate"] as const) {
+    const entry = createVaultAuditEntry(
+      action,
+      "v",
+      "mock",
+      "k",
+      "test",
+    );
+    assertEquals(entry.action, action);
+  }
+});
+
 Deno.test("vaultAuditEntryToData: serializes entry to data", () => {
   const entry = createVaultAuditEntry(
+    "put",
     "my-vault",
     "local_encryption",
     "DB_PASS",
@@ -50,6 +66,7 @@ Deno.test("vaultAuditEntryToData: serializes entry to data", () => {
 
   const data = vaultAuditEntryToData(entry);
 
+  assertEquals(data.action, "put");
   assertEquals(data.vaultName, "my-vault");
   assertEquals(data.vaultType, "local_encryption");
   assertEquals(data.secretKey, "DB_PASS");
@@ -58,6 +75,26 @@ Deno.test("vaultAuditEntryToData: serializes entry to data", () => {
 });
 
 Deno.test("vaultAuditEntryFromData: deserializes data to entry", () => {
+  const data = {
+    action: "delete" as const,
+    timestamp: "2026-07-10T12:00:00.000Z",
+    vaultName: "prod-vault",
+    vaultType: "@swamp/aws-sm",
+    secretKey: "TOKEN",
+    callerContext: "unknown",
+  };
+
+  const entry = vaultAuditEntryFromData(data);
+
+  assertEquals(entry.action, "delete");
+  assertEquals(entry.timestamp, "2026-07-10T12:00:00.000Z");
+  assertEquals(entry.vaultName, "prod-vault");
+  assertEquals(entry.vaultType, "@swamp/aws-sm");
+  assertEquals(entry.secretKey, "TOKEN");
+  assertEquals(entry.callerContext, "unknown");
+});
+
+Deno.test("vaultAuditEntryFromData: defaults missing action to get", () => {
   const data = {
     timestamp: "2026-07-10T12:00:00.000Z",
     vaultName: "prod-vault",
@@ -68,15 +105,12 @@ Deno.test("vaultAuditEntryFromData: deserializes data to entry", () => {
 
   const entry = vaultAuditEntryFromData(data);
 
-  assertEquals(entry.timestamp, "2026-07-10T12:00:00.000Z");
-  assertEquals(entry.vaultName, "prod-vault");
-  assertEquals(entry.vaultType, "@swamp/aws-sm");
-  assertEquals(entry.secretKey, "TOKEN");
-  assertEquals(entry.callerContext, "unknown");
+  assertEquals(entry.action, "get");
 });
 
 Deno.test("vaultAuditEntry: round-trip preserves all fields", () => {
   const original = createVaultAuditEntry(
+    "annotate",
     "test-vault",
     "local_encryption",
     "MY_SECRET",
@@ -86,6 +120,7 @@ Deno.test("vaultAuditEntry: round-trip preserves all fields", () => {
   const data = vaultAuditEntryToData(original);
   const restored = vaultAuditEntryFromData(data);
 
+  assertEquals(restored.action, original.action);
   assertEquals(restored.timestamp, original.timestamp);
   assertEquals(restored.vaultName, original.vaultName);
   assertEquals(restored.vaultType, original.vaultType);

--- a/src/domain/vaults/vault_audit_path.ts
+++ b/src/domain/vaults/vault_audit_path.ts
@@ -19,14 +19,23 @@
 
 import { join } from "@std/path";
 
-const VAULT_AUDIT_FILENAME_PREFIX = "vault-reads-";
+const VAULT_AUDIT_FILENAME_PREFIX = "vault-audit-";
 const VAULT_AUDIT_FILENAME_SUFFIX = ".jsonl";
 
+const VAULT_AUDIT_LEGACY_PREFIX = "vault-reads-";
+
 export const VAULT_AUDIT_FILENAME_PATTERN =
+  /^vault-audit-(\d{4}-\d{2}-\d{2})\.jsonl$/;
+
+export const VAULT_AUDIT_LEGACY_FILENAME_PATTERN =
   /^vault-reads-(\d{4}-\d{2}-\d{2})\.jsonl$/;
 
 export function vaultAuditFilename(date: string): string {
   return `${VAULT_AUDIT_FILENAME_PREFIX}${date}${VAULT_AUDIT_FILENAME_SUFFIX}`;
+}
+
+export function vaultAuditLegacyFilename(date: string): string {
+  return `${VAULT_AUDIT_LEGACY_PREFIX}${date}${VAULT_AUDIT_FILENAME_SUFFIX}`;
 }
 
 function datePartOfIsoTimestamp(iso: string): string {
@@ -42,4 +51,12 @@ export function vaultAuditFilePathForTimestamp(
   isoTimestamp: string,
 ): string {
   return join(auditDir, vaultAuditFilenameForTimestamp(isoTimestamp));
+}
+
+export function vaultAuditLegacyFilePathForTimestamp(
+  auditDir: string,
+  isoTimestamp: string,
+): string {
+  const date = isoTimestamp.split("T")[0];
+  return join(auditDir, vaultAuditLegacyFilename(date));
 }

--- a/src/domain/vaults/vault_audit_path_test.ts
+++ b/src/domain/vaults/vault_audit_path_test.ts
@@ -20,23 +20,26 @@
 import { assertEquals } from "@std/assert";
 import {
   VAULT_AUDIT_FILENAME_PATTERN,
+  VAULT_AUDIT_LEGACY_FILENAME_PATTERN,
   vaultAuditFilename,
   vaultAuditFilenameForTimestamp,
   vaultAuditFilePathForTimestamp,
+  vaultAuditLegacyFilename,
+  vaultAuditLegacyFilePathForTimestamp,
 } from "./vault_audit_path.ts";
 import { assertPathEquals } from "../../infrastructure/persistence/path_test_helpers.ts";
 
 Deno.test("vaultAuditFilename: formats date as vault audit filename", () => {
   assertEquals(
     vaultAuditFilename("2026-07-10"),
-    "vault-reads-2026-07-10.jsonl",
+    "vault-audit-2026-07-10.jsonl",
   );
 });
 
 Deno.test("vaultAuditFilenameForTimestamp: extracts date from ISO timestamp", () => {
   assertEquals(
     vaultAuditFilenameForTimestamp("2026-07-10T15:30:00.000Z"),
-    "vault-reads-2026-07-10.jsonl",
+    "vault-audit-2026-07-10.jsonl",
   );
 });
 
@@ -47,16 +50,23 @@ Deno.test("vaultAuditFilePathForTimestamp: returns full path", () => {
   );
   assertPathEquals(
     path,
-    "/repo/.swamp/audit/vault-reads-2026-07-10.jsonl",
+    "/repo/.swamp/audit/vault-audit-2026-07-10.jsonl",
   );
 });
 
-Deno.test("VAULT_AUDIT_FILENAME_PATTERN: matches valid filenames", () => {
-  const match = "vault-reads-2026-07-10.jsonl".match(
+Deno.test("VAULT_AUDIT_FILENAME_PATTERN: matches new filenames", () => {
+  const match = "vault-audit-2026-07-10.jsonl".match(
     VAULT_AUDIT_FILENAME_PATTERN,
   );
   assertEquals(match !== null, true);
   assertEquals(match![1], "2026-07-10");
+});
+
+Deno.test("VAULT_AUDIT_FILENAME_PATTERN: does not match legacy filenames", () => {
+  const match = "vault-reads-2026-07-10.jsonl".match(
+    VAULT_AUDIT_FILENAME_PATTERN,
+  );
+  assertEquals(match, null);
 });
 
 Deno.test("VAULT_AUDIT_FILENAME_PATTERN: does not match command audit files", () => {
@@ -64,4 +74,30 @@ Deno.test("VAULT_AUDIT_FILENAME_PATTERN: does not match command audit files", ()
     VAULT_AUDIT_FILENAME_PATTERN,
   );
   assertEquals(match, null);
+});
+
+Deno.test("vaultAuditLegacyFilename: formats legacy filename", () => {
+  assertEquals(
+    vaultAuditLegacyFilename("2026-07-10"),
+    "vault-reads-2026-07-10.jsonl",
+  );
+});
+
+Deno.test("VAULT_AUDIT_LEGACY_FILENAME_PATTERN: matches legacy filenames", () => {
+  const match = "vault-reads-2026-07-10.jsonl".match(
+    VAULT_AUDIT_LEGACY_FILENAME_PATTERN,
+  );
+  assertEquals(match !== null, true);
+  assertEquals(match![1], "2026-07-10");
+});
+
+Deno.test("vaultAuditLegacyFilePathForTimestamp: returns full path", () => {
+  const path = vaultAuditLegacyFilePathForTimestamp(
+    "/repo/.swamp/audit",
+    "2026-07-10T15:30:00.000Z",
+  );
+  assertPathEquals(
+    path,
+    "/repo/.swamp/audit/vault-reads-2026-07-10.jsonl",
+  );
 });

--- a/src/domain/vaults/vault_audit_repository.ts
+++ b/src/domain/vaults/vault_audit_repository.ts
@@ -22,6 +22,7 @@ import type { VaultAuditEntry } from "./vault_audit_entry.ts";
 export interface VaultAuditQueryOptions {
   readonly vaultName?: string;
   readonly secretKey?: string;
+  readonly action?: string;
   readonly limit?: number;
 }
 

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -40,7 +40,10 @@ import type { LocalEncryptionConfig } from "./local_encryption_vault_provider.ts
 import { join } from "@std/path";
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
 import { createVaultProvider } from "./vault_provider_factory.ts";
-import { createVaultAuditEntry } from "./vault_audit_entry.ts";
+import {
+  createVaultAuditEntry,
+  type VaultAuditAction,
+} from "./vault_audit_entry.ts";
 import type { VaultAuditRepository } from "./vault_audit_repository.ts";
 import { JsonlVaultAuditRepository } from "../../infrastructure/persistence/jsonl_vault_audit_repository.ts";
 
@@ -244,6 +247,7 @@ export class VaultService {
               getLogger("vaults")
                 .info`Refreshed secret ${secretKey} in vault ${vaultName}`;
               await this.recordAuditEntry(
+                "get",
                 vaultName,
                 secretKey,
                 callerContext,
@@ -263,6 +267,7 @@ export class VaultService {
 
     const value = await provider.get(secretKey);
     await this.recordAuditEntry(
+      "get",
       vaultName,
       secretKey,
       callerContext,
@@ -271,14 +276,17 @@ export class VaultService {
   }
 
   private async recordAuditEntry(
+    action: VaultAuditAction,
     vaultName: string,
     secretKey: string,
     callerContext?: string,
   ): Promise<void> {
-    if (!this.auditRepository || !this.auditFlags.get(vaultName)) return;
+    if (!this.auditRepository) return;
+    if (action === "get" && !this.auditFlags.get(vaultName)) return;
     try {
       const vaultType = this.vaultTypes.get(vaultName) ?? "unknown";
       const entry = createVaultAuditEntry(
+        action,
         vaultName,
         vaultType,
         secretKey,
@@ -324,14 +332,21 @@ export class VaultService {
     secretKey: string,
     secretValue: string,
     options?: VaultPutOptions,
+    callerContext?: string,
   ): Promise<void> {
     const provider = this.requireProvider(vaultName);
     await provider.put(secretKey, secretValue, options);
+    await this.recordAuditEntry("put", vaultName, secretKey, callerContext);
   }
 
-  async delete(vaultName: string, secretKey: string): Promise<void> {
+  async delete(
+    vaultName: string,
+    secretKey: string,
+    callerContext?: string,
+  ): Promise<void> {
     const provider = this.requireDeleteProvider(vaultName);
     await provider.delete(secretKey);
+    await this.recordAuditEntry("delete", vaultName, secretKey, callerContext);
   }
 
   supportsDelete(vaultName: string): boolean {
@@ -384,17 +399,31 @@ export class VaultService {
     vaultName: string,
     secretKey: string,
     annotation: VaultAnnotation,
+    callerContext?: string,
   ): Promise<void> {
     const provider = this.requireAnnotationProvider(vaultName);
     await provider.putAnnotation(secretKey, annotation);
+    await this.recordAuditEntry(
+      "annotate",
+      vaultName,
+      secretKey,
+      callerContext,
+    );
   }
 
   async deleteAnnotation(
     vaultName: string,
     secretKey: string,
+    callerContext?: string,
   ): Promise<void> {
     const provider = this.requireAnnotationProvider(vaultName);
     await provider.deleteAnnotation(secretKey);
+    await this.recordAuditEntry(
+      "annotate",
+      vaultName,
+      secretKey,
+      callerContext,
+    );
   }
 
   supportsRefreshHooks(vaultName: string): boolean {

--- a/src/domain/vaults/vault_service_test.ts
+++ b/src/domain/vaults/vault_service_test.ts
@@ -681,7 +681,7 @@ class InMemoryVaultAuditRepository implements VaultAuditRepository {
 
 Deno.test("VaultService - audit trail", async (t) => {
   await t.step(
-    "should record audit entry when audit is enabled on vault",
+    "should record audit entry with action get when audit is enabled on vault",
     async () => {
       const svc = new VaultService();
       const auditRepo = new InMemoryVaultAuditRepository();
@@ -697,6 +697,7 @@ Deno.test("VaultService - audit trail", async (t) => {
       await svc.get("audited-vault", "key", "test-caller");
 
       assertEquals(auditRepo.entries.length, 1);
+      assertEquals(auditRepo.entries[0].action, "get");
       assertEquals(auditRepo.entries[0].vaultName, "audited-vault");
       assertEquals(auditRepo.entries[0].vaultType, "mock");
       assertEquals(auditRepo.entries[0].secretKey, "key");
@@ -705,7 +706,7 @@ Deno.test("VaultService - audit trail", async (t) => {
   );
 
   await t.step(
-    "should not record audit entry when audit is disabled on vault",
+    "should not record read audit entry when auditReads is disabled",
     async () => {
       const svc = new VaultService();
       const auditRepo = new InMemoryVaultAuditRepository();
@@ -781,6 +782,97 @@ Deno.test("VaultService - audit trail", async (t) => {
 
       const result = await svc.get("vault", "key");
       assertEquals(result, "val");
+    },
+  );
+
+  await t.step(
+    "should record put audit entry even without auditReads flag",
+    async () => {
+      const svc = new VaultService();
+      const auditRepo = new InMemoryVaultAuditRepository();
+      svc.setAuditRepository(auditRepo);
+
+      svc.registerVault({
+        name: "vault",
+        type: "mock",
+        config: {},
+      });
+
+      await svc.put("vault", "secret", "value", undefined, "cli:vault-put");
+
+      assertEquals(auditRepo.entries.length, 1);
+      assertEquals(auditRepo.entries[0].action, "put");
+      assertEquals(auditRepo.entries[0].vaultName, "vault");
+      assertEquals(auditRepo.entries[0].secretKey, "secret");
+      assertEquals(auditRepo.entries[0].callerContext, "cli:vault-put");
+    },
+  );
+
+  await t.step(
+    "should record delete audit entry even without auditReads flag",
+    async () => {
+      const svc = new VaultService();
+      const auditRepo = new InMemoryVaultAuditRepository();
+      svc.setAuditRepository(auditRepo);
+
+      svc.registerVault({
+        name: "vault",
+        type: "mock",
+        config: {},
+      });
+
+      await svc.put("vault", "to-delete", "value");
+      auditRepo.entries.length = 0;
+
+      await svc.delete("vault", "to-delete", "cli:vault-delete");
+
+      assertEquals(auditRepo.entries.length, 1);
+      assertEquals(auditRepo.entries[0].action, "delete");
+      assertEquals(auditRepo.entries[0].secretKey, "to-delete");
+      assertEquals(auditRepo.entries[0].callerContext, "cli:vault-delete");
+    },
+  );
+
+  await t.step(
+    "should record annotate audit entry even without auditReads flag",
+    async () => {
+      const svc = new VaultService();
+      const auditRepo = new InMemoryVaultAuditRepository();
+      svc.setAuditRepository(auditRepo);
+
+      svc.registerVault({
+        name: "vault",
+        type: "local_encryption",
+        config: { auto_generate: true },
+      });
+
+      await svc.put("vault", "key", "value");
+      auditRepo.entries.length = 0;
+
+      const { VaultAnnotation } = await import("./vault_annotation.ts");
+      const annotation = VaultAnnotation.create({ notes: "test" });
+      await svc.putAnnotation("vault", "key", annotation, "cli:vault-annotate");
+
+      assertEquals(auditRepo.entries.length, 1);
+      assertEquals(auditRepo.entries[0].action, "annotate");
+      assertEquals(auditRepo.entries[0].secretKey, "key");
+      assertEquals(auditRepo.entries[0].callerContext, "cli:vault-annotate");
+    },
+  );
+
+  await t.step(
+    "should not record write audit when no audit repository is set",
+    async () => {
+      const svc = new VaultService();
+
+      svc.registerVault({
+        name: "vault",
+        type: "mock",
+        config: {},
+      });
+
+      // Should not throw — put succeeds, audit is silently skipped
+      await svc.put("vault", "key", "val");
     },
   );
 });

--- a/src/infrastructure/persistence/jsonl_vault_audit_repository.ts
+++ b/src/infrastructure/persistence/jsonl_vault_audit_repository.ts
@@ -26,7 +26,10 @@ import {
   vaultAuditEntryFromData,
   vaultAuditEntryToData,
 } from "../../domain/vaults/vault_audit_entry.ts";
-import { vaultAuditFilePathForTimestamp } from "../../domain/vaults/vault_audit_path.ts";
+import {
+  vaultAuditFilePathForTimestamp,
+  vaultAuditLegacyFilePathForTimestamp,
+} from "../../domain/vaults/vault_audit_path.ts";
 import type {
   VaultAuditQueryOptions,
   VaultAuditRepository,
@@ -77,45 +80,55 @@ export class JsonlVaultAuditRepository implements VaultAuditRepository {
       end.setUTCHours(23, 59, 59, 999);
 
       while (current <= end) {
-        const path = vaultAuditFilePathForTimestamp(
-          this.baseDir,
-          current.toISOString(),
-        );
+        const iso = current.toISOString();
+        const paths = [
+          vaultAuditFilePathForTimestamp(this.baseDir, iso),
+          vaultAuditLegacyFilePathForTimestamp(this.baseDir, iso),
+        ];
 
-        try {
-          const content = await Deno.readTextFile(path);
-          const lines = content.split("\n").filter((line) => line.trim());
+        for (const path of paths) {
+          try {
+            const content = await Deno.readTextFile(path);
+            const lines = content.split("\n").filter((line) => line.trim());
 
-          for (const line of lines) {
-            try {
-              const data = JSON.parse(line) as VaultAuditEntryData;
-              const entry = vaultAuditEntryFromData(data);
+            for (const line of lines) {
+              try {
+                const data = JSON.parse(line) as VaultAuditEntryData;
+                const entry = vaultAuditEntryFromData(data);
 
-              const entryTime = new Date(entry.timestamp);
-              if (entryTime < startTime || entryTime > endTime) continue;
-              if (options?.vaultName && entry.vaultName !== options.vaultName) {
-                continue;
+                const entryTime = new Date(entry.timestamp);
+                if (entryTime < startTime || entryTime > endTime) continue;
+                if (
+                  options?.vaultName && entry.vaultName !== options.vaultName
+                ) {
+                  continue;
+                }
+                if (
+                  options?.secretKey && entry.secretKey !== options.secretKey
+                ) {
+                  continue;
+                }
+                if (options?.action && entry.action !== options.action) {
+                  continue;
+                }
+
+                entries.push(entry);
+
+                if (options?.limit && entries.length >= options.limit) {
+                  return entries;
+                }
+              } catch {
+                // Skip malformed lines
               }
-              if (options?.secretKey && entry.secretKey !== options.secretKey) {
-                continue;
-              }
-
-              entries.push(entry);
-
-              if (options?.limit && entries.length >= options.limit) {
-                return entries;
-              }
-            } catch {
-              // Skip malformed lines
             }
-          }
-        } catch (error) {
-          if (!(error instanceof Deno.errors.NotFound)) {
-            if (Deno.env.get("SWAMP_DEBUG")) {
-              console.error(
-                `[VaultAudit] Failed to read ${path}:`,
-                error,
-              );
+          } catch (error) {
+            if (!(error instanceof Deno.errors.NotFound)) {
+              if (Deno.env.get("SWAMP_DEBUG")) {
+                console.error(
+                  `[VaultAudit] Failed to read ${path}:`,
+                  error,
+                );
+              }
             }
           }
         }

--- a/src/infrastructure/persistence/jsonl_vault_audit_repository_test.ts
+++ b/src/infrastructure/persistence/jsonl_vault_audit_repository_test.ts
@@ -36,6 +36,7 @@ function withTempDir(
 
 function makeEntry(overrides: Partial<VaultAuditEntry> = {}): VaultAuditEntry {
   return {
+    action: "get",
     timestamp: "2026-07-10T12:00:00.000Z",
     vaultName: "my-vault",
     vaultType: "local_encryption",

--- a/src/libswamp/vaults/annotate.ts
+++ b/src/libswamp/vaults/annotate.ts
@@ -74,8 +74,13 @@ export interface VaultAnnotateDeps {
     vaultName: string,
     key: string,
     annotation: VaultAnnotation,
+    callerContext?: string,
   ) => Promise<void>;
-  deleteAnnotation: (vaultName: string, key: string) => Promise<void>;
+  deleteAnnotation: (
+    vaultName: string,
+    key: string,
+    callerContext?: string,
+  ) => Promise<void>;
   publishSecretAnnotated: (
     vaultId: string,
     vaultType: string,
@@ -118,13 +123,13 @@ export function createVaultAnnotateDeps(
       const svc = await getVaultService();
       return await svc.getAnnotation(vaultName, key);
     },
-    putAnnotation: async (vaultName, key, annotation) => {
+    putAnnotation: async (vaultName, key, annotation, callerContext) => {
       const svc = await getVaultService();
-      await svc.putAnnotation(vaultName, key, annotation);
+      await svc.putAnnotation(vaultName, key, annotation, callerContext);
     },
-    deleteAnnotation: async (vaultName, key) => {
+    deleteAnnotation: async (vaultName, key, callerContext) => {
       const svc = await getVaultService();
-      await svc.deleteAnnotation(vaultName, key);
+      await svc.deleteAnnotation(vaultName, key, callerContext);
     },
     publishSecretAnnotated: async (
       vaultId,
@@ -215,7 +220,11 @@ export async function* vaultAnnotate(
       }
 
       if (input.clear) {
-        await deps.deleteAnnotation(input.vaultName, input.key);
+        await deps.deleteAnnotation(
+          input.vaultName,
+          input.key,
+          "cli:vault-annotate",
+        );
         ctx.logger.debug`Cleared annotation for ${input.key}`;
 
         await deps.publishSecretAnnotated(
@@ -265,7 +274,12 @@ export async function* vaultAnnotate(
         annotation = annotation.removeLabels(input.removeLabels);
       }
 
-      await deps.putAnnotation(input.vaultName, input.key, annotation);
+      await deps.putAnnotation(
+        input.vaultName,
+        input.key,
+        annotation,
+        "cli:vault-annotate",
+      );
       ctx.logger.debug`Annotation updated for ${input.key}`;
 
       await deps.publishSecretAnnotated(

--- a/src/libswamp/vaults/audit_trail.ts
+++ b/src/libswamp/vaults/audit_trail.ts
@@ -42,6 +42,7 @@ export type VaultAuditTrailEvent =
 export interface VaultAuditTrailInput {
   vaultName?: string;
   secretKey?: string;
+  action?: string;
   since?: Date;
   until?: Date;
   limit?: number;
@@ -111,12 +112,13 @@ export async function* vaultAuditTrail(
       }
 
       ctx.logger
-        .debug`Querying vault audit trail: vault=${input.vaultName}, key=${input.secretKey}, since=${since.toISOString()}, until=${until.toISOString()}, limit=${limit}`;
+        .debug`Querying vault audit trail: vault=${input.vaultName}, key=${input.secretKey}, action=${input.action}, since=${since.toISOString()}, until=${until.toISOString()}, limit=${limit}`;
 
       const fetchLimit = limit + 1;
       const entries = await deps.findByTimeRange(since, until, {
         vaultName: input.vaultName,
         secretKey: input.secretKey,
+        action: input.action,
         limit: fetchLimit,
       });
 

--- a/src/libswamp/vaults/audit_trail_test.ts
+++ b/src/libswamp/vaults/audit_trail_test.ts
@@ -37,6 +37,7 @@ function makeDeps(
 
 function makeEntry(overrides: Partial<VaultAuditEntry> = {}): VaultAuditEntry {
   return {
+    action: "get",
     timestamp: "2026-07-10T12:00:00.000Z",
     vaultName: "my-vault",
     vaultType: "local_encryption",

--- a/src/libswamp/vaults/delete.ts
+++ b/src/libswamp/vaults/delete.ts
@@ -62,7 +62,11 @@ export interface VaultDeleteDeps {
   findVault: (name: string) => Promise<VaultDeleteConfigInfo | null>;
   listVaultNames: () => Promise<string[]>;
   supportsDelete: (vaultName: string) => Promise<boolean>;
-  deleteSecret: (vaultName: string, key: string) => Promise<void>;
+  deleteSecret: (
+    vaultName: string,
+    key: string,
+    callerContext?: string,
+  ) => Promise<void>;
   publishSecretDeleted: (
     vaultId: string,
     vaultType: string,
@@ -95,9 +99,9 @@ export function createVaultDeleteDeps(
       const svc = await getVaultService();
       return svc.supportsDelete(vaultName);
     },
-    deleteSecret: async (vaultName, key) => {
+    deleteSecret: async (vaultName, key, callerContext) => {
       const svc = await getVaultService();
-      await svc.delete(vaultName, key);
+      await svc.delete(vaultName, key, callerContext);
     },
     publishSecretDeleted: async (vaultId, vaultType, vaultName, key) => {
       const event = createVaultSecretDeleted(
@@ -164,7 +168,7 @@ export async function* vaultDelete(
         return;
       }
 
-      await deps.deleteSecret(input.vaultName, input.key);
+      await deps.deleteSecret(input.vaultName, input.key, "cli:vault-delete");
       ctx.logger.debug`Secret deleted successfully`;
 
       await deps.publishSecretDeleted(

--- a/src/libswamp/vaults/put.ts
+++ b/src/libswamp/vaults/put.ts
@@ -80,6 +80,7 @@ export interface VaultPutDeps {
     key: string,
     value: string,
     tags?: Record<string, string>,
+    callerContext?: string,
   ) => Promise<void>;
   publishSecretUpdated: (
     vaultId: string,
@@ -122,9 +123,15 @@ export function createVaultPutDeps(
       const keys = await svc.list(vaultName);
       return keys.includes(key);
     },
-    putSecret: async (vaultName, key, value, tags) => {
+    putSecret: async (vaultName, key, value, tags, callerContext) => {
       const svc = await getVaultService();
-      await svc.put(vaultName, key, value, tags ? { tags } : undefined);
+      await svc.put(
+        vaultName,
+        key,
+        value,
+        tags ? { tags } : undefined,
+        callerContext,
+      );
     },
     publishSecretUpdated: async (vaultId, vaultType, vaultName, key) => {
       const event = createVaultSecretUpdated(
@@ -208,7 +215,13 @@ export async function* vaultPut(
       const tags = input.tags && Object.keys(input.tags).length > 0
         ? input.tags
         : undefined;
-      await deps.putSecret(input.vaultName, input.key, input.value, tags);
+      await deps.putSecret(
+        input.vaultName,
+        input.key,
+        input.value,
+        tags,
+        "cli:vault-put",
+      );
       ctx.logger.debug`Secret stored successfully`;
 
       const appliedLabels: Record<string, string> | undefined = tags;

--- a/src/presentation/renderers/vault_audit_trail.ts
+++ b/src/presentation/renderers/vault_audit_trail.ts
@@ -33,13 +33,14 @@ class LogVaultAuditTrailRenderer implements Renderer<VaultAuditTrailEvent> {
       resolving: () => {},
       completed: (e) => {
         if (e.data.entries.length === 0) {
-          logger.info`No vault read audit entries found.`;
+          logger.info`No vault audit entries found.`;
           return;
         }
-        logger.info`${e.data.returnedCount} vault read(s):`;
+        logger.info`${e.data.returnedCount} vault operation(s):`;
         for (const entry of e.data.entries) {
+          const action = entry.action?.toUpperCase() ?? "GET";
           logger
-            .info`  ${entry.timestamp}  ${entry.vaultName} (${entry.vaultType})/${entry.secretKey}  by ${entry.callerContext}`;
+            .info`  ${entry.timestamp}  ${action}  ${entry.vaultName} (${entry.vaultType})/${entry.secretKey}  by ${entry.callerContext}`;
         }
         if (e.data.truncated) {
           logger.info`  (results truncated — use --limit to see more)`;

--- a/src/serve/handlers/vault_handlers.ts
+++ b/src/serve/handlers/vault_handlers.ts
@@ -833,6 +833,7 @@ export async function handleVaultAuditTrail(
       vaultAuditTrail(libCtx, deps, {
         vaultName: payload?.vaultName,
         secretKey: payload?.secretKey,
+        action: payload?.action,
         since: payload?.since ? new Date(payload.since) : undefined,
         until: payload?.until ? new Date(payload.until) : undefined,
         limit: payload?.limit,

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -540,6 +540,7 @@ export interface VaultEditPayload {
 export interface VaultAuditTrailPayload {
   vaultName?: string;
   secretKey?: string;
+  action?: string;
   since?: string;
   until?: string;
   limit?: number;


### PR DESCRIPTION
## Summary

Closes swamp-club#1745

The vault audit trail previously only recorded read (`get`) operations. This extends it to cover all vault operations (`put`, `delete`, `annotate`) with a new `action` field on `VaultAuditEntry`.

**Key design decision**: Write operations are always audited when an audit repository exists (security baseline). Read audit remains gated by per-vault `auditReads` flag — reads are higher volume and opt-in.

### Changes

- **Domain**: Add `action` field (`"get" | "put" | "delete" | "annotate"`) to `VaultAuditEntry`. Backwards compatible — legacy entries without `action` default to `"get"` on deserialization
- **VaultService**: Record audit entries in `put()`, `delete()`, `putAnnotation()`, `deleteAnnotation()`. Add `callerContext` parameter to write methods
- **Libswamp**: Thread `callerContext` through deps for put, delete, annotate generators
- **File naming**: Rename audit file prefix from `vault-reads-` to `vault-audit-`. Reader checks both patterns for backwards compat
- **Query**: Add `action` filter to `VaultAuditQueryOptions`, libswamp audit trail generator, serve protocol, and CLI (`--action` flag)
- **Presentation**: Display action in audit trail output, update labels from "vault read(s)" to "vault operation(s)"
- **Design doc**: Update `design/vaults.md` audit trail section

### Follow-up

- Filed swamp-club/swamp#2204 for updating external manual docs at `swamp-club/content/manual/reference/vaults.md`

## Test Plan

- [x] `VaultAuditEntry` tests — action field, round-trip, backwards compat for missing action
- [x] `VaultService` audit trail tests — put/delete/annotate audit recording, split gating (writes always-on, reads per-vault)
- [x] `vault_audit_path` tests — new file naming, legacy patterns
- [x] `JsonlVaultAuditRepository` tests — dual file pattern reads
- [x] `audit_trail` libswamp tests — action filter pass-through
- [x] Full test suite: 10,568 tests passing
- [x] `deno check`, `deno lint`, `deno fmt` all clean
