### PR TITLE
fix(repo): switch all built-in tools to name-based skill references (swamp-club#1754)

### DIFF
--- a/design/global-skills.md
+++ b/design/global-skills.md
@@ -53,6 +53,19 @@ const GLOBAL_SKILL_DIRS: Record<string, string> = {
 These are relative paths resolved against the user's home directory at
 runtime.
 
+### Skill Reference Style
+
+All built-in tools use `skillReferenceStyle: "name"`, meaning generated
+instructions files (CLAUDE.md, AGENTS.md, `.cursor/rules/swamp.mdc`,
+`.kiro/steering/swamp-rules.md`) reference skills by name (e.g. "use the
+`swamp` skill") rather than by project-local path. This is required because
+skills are installed globally — project-local skill directories no longer
+exist after init, so path-based references would dangle.
+
+Custom tools may use either `"name"` or `"path"`. Tools with `"path"` style
+must install skills to a project-local directory or provide a mechanism for
+the agent to resolve the referenced paths.
+
 After deduplication, swamp writes to at most three directories:
 
 - `~/.claude/skills/swamp/` and `~/.claude/skills/swamp-getting-started/`

--- a/src/domain/repo/custom_tool.ts
+++ b/src/domain/repo/custom_tool.ts
@@ -115,7 +115,7 @@ export function builtInToolConfig(tool: AiTool): ToolConfig {
         instructionsMode: "shared",
         frontmatter:
           "---\ndescription: Swamp automation rules\nalwaysApply: true\n---\n",
-        skillReferenceStyle: "path",
+        skillReferenceStyle: "name",
       };
     case "opencode":
       return {
@@ -124,7 +124,7 @@ export function builtInToolConfig(tool: AiTool): ToolConfig {
         skillsDir: ".agents/skills",
         instructionsFile: "AGENTS.md",
         instructionsMode: "shared",
-        skillReferenceStyle: "path",
+        skillReferenceStyle: "name",
       };
     case "codex":
       return {
@@ -133,7 +133,7 @@ export function builtInToolConfig(tool: AiTool): ToolConfig {
         skillsDir: ".agents/skills",
         instructionsFile: "AGENTS.md",
         instructionsMode: "shared",
-        skillReferenceStyle: "path",
+        skillReferenceStyle: "name",
       };
     case "copilot":
       return {
@@ -142,7 +142,7 @@ export function builtInToolConfig(tool: AiTool): ToolConfig {
         skillsDir: ".agents/skills",
         instructionsFile: "AGENTS.md",
         instructionsMode: "shared",
-        skillReferenceStyle: "path",
+        skillReferenceStyle: "name",
       };
     case "kiro":
       return {
@@ -152,7 +152,7 @@ export function builtInToolConfig(tool: AiTool): ToolConfig {
         instructionsFile: ".kiro/steering/swamp-rules.md",
         instructionsMode: "shared",
         frontmatter: "---\ninclusion: always\n---\n",
-        skillReferenceStyle: "path",
+        skillReferenceStyle: "name",
       };
     case "none":
       return {

--- a/src/domain/repo/custom_tool_test.ts
+++ b/src/domain/repo/custom_tool_test.ts
@@ -117,7 +117,7 @@ Deno.test("builtInToolConfig: cursor config", () => {
   assertEquals(config.skillsDir, ".cursor/skills");
   assertEquals(config.instructionsFile, ".cursor/rules/swamp.mdc");
   assertEquals(config.instructionsMode, "shared");
-  assertEquals(config.skillReferenceStyle, "path");
+  assertEquals(config.skillReferenceStyle, "name");
   assertEquals(config.frontmatter !== undefined, true);
 });
 
@@ -128,6 +128,7 @@ Deno.test("builtInToolConfig: kiro config", () => {
   assertEquals(config.skillsDir, ".kiro/skills");
   assertEquals(config.instructionsFile, ".kiro/steering/swamp-rules.md");
   assertEquals(config.instructionsMode, "shared");
+  assertEquals(config.skillReferenceStyle, "name");
 });
 
 Deno.test("builtInToolConfig: opencode/codex/copilot share AGENTS.md", () => {

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -1907,7 +1907,7 @@ the full tree, and \`swamp help model method run\` scopes to a subtree.
       tools: ["read", "write", "shell", "grep", "glob", "thinking", "todo"],
       resources: [
         "file://.kiro/steering/**/*.md",
-        "skill://.kiro/skills/**/SKILL.md",
+        "skill://~/.kiro/skills/**/SKILL.md",
       ],
       toolsSettings: {
         shell: {

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -715,9 +715,9 @@ export class RepoService {
           const c = await this.ensureKiroCliDefaultAgent(repoPath);
           settingsChanged = s || h || a || c;
           if (s) changedFiles.push(".vscode/settings.local.json");
-          if (h) changedFiles.push(".kiro/hooks.json");
-          if (a) changedFiles.push(".kiro/agents/swamp.agent.md");
-          if (c) changedFiles.push(".kiro/config.json");
+          if (h) changedFiles.push(".kiro/hooks/swamp-audit.kiro.hook");
+          if (a) changedFiles.push(".kiro/agents/swamp.json");
+          if (c) changedFiles.push(".kiro/settings/cli.json");
           break;
         }
         case "opencode": {

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -1429,7 +1429,7 @@ Deno.test("RepoService.upgrade without flag honors marker from init", async () =
 
 // Kiro tool tests
 
-Deno.test("RepoService.init with kiro creates .kiro/skills/ and steering file with frontmatter", async () => {
+Deno.test("RepoService.init with kiro creates steering file with name-based skill references", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
@@ -1454,6 +1454,9 @@ Deno.test("RepoService.init with kiro creates .kiro/skills/ and steering file wi
     assertStringIncludes(content, "---\ninclusion: always\n---");
     assertStringIncludes(content, "swamp");
     assertStringIncludes(content, "## Skills");
+    // Must use name-based references, not project-local paths
+    assertStringIncludes(content, "the `swamp` skill");
+    assertEquals(content.includes(".kiro/skills/swamp/SKILL.md"), false);
 
     // Check .vscode/settings.local.json created with trusted commands
     const settingsPath = join(tempDir, ".vscode", "settings.local.json");
@@ -1755,7 +1758,7 @@ Deno.test("RepoService.init with kiro creates .kiro/agents/swamp.json", async ()
     );
     assertStringIncludes(
       JSON.stringify(config.resources),
-      "skill://.kiro/skills/**/SKILL.md",
+      "skill://~/.kiro/skills/**/SKILL.md",
     );
   });
 });


### PR DESCRIPTION
## Summary

- Switch `skillReferenceStyle` from `"path"` to `"name"` for all non-Claude built-in tools (Kiro, Cursor, OpenCode, Codex, Copilot) so generated instructions files reference skills by name instead of dangling project-local paths
- Update Kiro agent config's `skill://` resource to use `~/.kiro/skills/**/SKILL.md` — the portable home-directory expansion [documented by Kiro](https://kiro.dev/docs/skills/)
- Fix stale `changedFiles` entries in Kiro upgrade output (`.kiro/hooks.json` → `.kiro/hooks/swamp-audit.kiro.hook`, etc.)
- Update `design/global-skills.md` to document that all built-in tools now use name-based references

Fixes swamp-club#1754
Fixes #2203

## Context

Since #1653 (June 2026), skills are installed globally (`~/.kiro/skills/`, `~/.agents/skills/`, etc.) rather than per-repo. Claude was updated to `skillReferenceStyle: "name"` in that PR, but all other tools were left with `"path"` — generating references like `.kiro/skills/swamp/SKILL.md` to directories that no longer exist after init.

## Related

- swamp-club/swamp-uat#352 — UAT issue for comprehensive scaffolding verification tests

## Test Plan

- All 119 `repo_service_test.ts` tests pass (new assertions verify name-based refs and `skill://~/` glob)
- `custom_tool_test.ts` updated and passing for new `skillReferenceStyle` values
- Manual verification: `swamp repo init -t kiro` produces 0 dangling path refs, 4 name-based refs, and `skill://~/.kiro/skills/**/SKILL.md` in agent config
- Same verified for Cursor (`swamp.mdc`) and OpenCode (`AGENTS.md`)
- Full suite: `deno check`, `deno lint`, `deno fmt`, `deno run test` all pass