### PR TITLE
fix(serve): unmask TLS errors on WebSocket client and add --ca-cert for self-signed certs (swamp-club#1748)

### DIFF
--- a/integration/serve_tls_cert_test.ts
+++ b/integration/serve_tls_cert_test.ts
@@ -1,0 +1,146 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertStringIncludes } from "@std/assert";
+import { diagnoseTlsError } from "../src/cli/remote_run.ts";
+
+async function run(cmd: string, args: string[]): Promise<void> {
+  const p = new Deno.Command(cmd, { args, stdout: "null", stderr: "null" });
+  const { success } = await p.output();
+  if (!success) throw new Error(`${cmd} ${args.join(" ")} failed`);
+}
+
+async function withTlsServer(
+  cert: string,
+  key: string,
+  fn: (port: number) => Promise<void>,
+): Promise<void> {
+  const ac = new AbortController();
+  const port = await new Promise<number>((resolve) => {
+    Deno.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      cert,
+      key,
+      signal: ac.signal,
+      onListen({ port: p }) {
+        resolve(p);
+      },
+    }, (req) => {
+      if (req.headers.get("upgrade") === "websocket") {
+        const { socket, response } = Deno.upgradeWebSocket(req);
+        socket.onopen = () => {
+          socket.send("ok");
+          socket.close();
+        };
+        return response;
+      }
+      return new Response("OK");
+    });
+  });
+  try {
+    await fn(port);
+  } finally {
+    ac.abort();
+  }
+}
+
+Deno.test("diagnoseTlsError: detects CaUsedAsEndEntity for CA:TRUE self-signed cert", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    await run("openssl", [
+      "req",
+      "-x509",
+      "-newkey",
+      "ec",
+      "-pkeyopt",
+      "ec_paramgen_curve:P-256",
+      "-keyout",
+      `${tmpDir}/server.key`,
+      "-out",
+      `${tmpDir}/server.crt`,
+      "-days",
+      "1",
+      "-nodes",
+      "-subj",
+      "/CN=localhost",
+      "-addext",
+      "subjectAltName=IP:127.0.0.1",
+    ]);
+    const cert = await Deno.readTextFile(`${tmpDir}/server.crt`);
+    const key = await Deno.readTextFile(`${tmpDir}/server.key`);
+
+    await withTlsServer(cert, key, async (port) => {
+      const diagnosis = await diagnoseTlsError(`wss://127.0.0.1:${port}/`);
+      assert(diagnosis !== undefined, "Expected a TLS diagnosis");
+      assertStringIncludes(diagnosis, "CA:TRUE");
+      assertStringIncludes(diagnosis, "basicConstraints");
+    });
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("diagnoseTlsError: detects UnknownIssuer for untrusted CA:FALSE cert", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    await run("openssl", [
+      "req",
+      "-x509",
+      "-newkey",
+      "ec",
+      "-pkeyopt",
+      "ec_paramgen_curve:P-256",
+      "-keyout",
+      `${tmpDir}/server.key`,
+      "-out",
+      `${tmpDir}/server.crt`,
+      "-days",
+      "1",
+      "-nodes",
+      "-subj",
+      "/CN=localhost",
+      "-addext",
+      "subjectAltName=IP:127.0.0.1",
+      "-addext",
+      "basicConstraints=critical,CA:FALSE",
+    ]);
+    const cert = await Deno.readTextFile(`${tmpDir}/server.crt`);
+    const key = await Deno.readTextFile(`${tmpDir}/server.key`);
+
+    await withTlsServer(cert, key, async (port) => {
+      const diagnosis = await diagnoseTlsError(`wss://127.0.0.1:${port}/`);
+      assert(diagnosis !== undefined, "Expected a TLS diagnosis");
+      assertStringIncludes(diagnosis, "not trusted");
+    });
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("diagnoseTlsError: returns undefined for non-wss URL", async () => {
+  const diagnosis = await diagnoseTlsError("ws://127.0.0.1:4000/");
+  assert(diagnosis === undefined, "Expected no diagnosis for ws:// URL");
+});
+
+Deno.test("diagnoseTlsError: returns error for unreachable host", async () => {
+  const diagnosis = await diagnoseTlsError("wss://127.0.0.1:1/");
+  assert(diagnosis !== undefined, "Expected a diagnosis for unreachable host");
+  assertStringIncludes(diagnosis, "TLS connection failed");
+});

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -220,6 +220,7 @@ import {
   resolveDeploymentMode,
   type VaultClassification,
 } from "../../domain/serve/deployment_mode.ts";
+import { validateEndEntityCert } from "../../infrastructure/runtime/tls_cert_validation.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -1220,6 +1221,12 @@ export const serveCommand = new Command()
       key = await Deno.readTextFile(keyFile);
     }
     const tlsEnabled = cert !== undefined;
+
+    if (cert) {
+      for (const warning of validateEndEntityCert(cert)) {
+        logger.warn("{warning}", { warning: warning.message });
+      }
+    }
     const trustProxy = merged.trustProxy;
 
     const wsIdleTimeoutRaw = merged.wsIdleTimeout;

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -248,6 +248,12 @@ export function requestServerResponse<T>(
                 `Could not connect to ${baseUrl}${detail}`,
               ),
             );
+          }).catch(() => {
+            reject(
+              new UserError(
+                `Could not connect to ${baseUrl}${connectErrorDetail}`,
+              ),
+            );
           });
         } else {
           reject(
@@ -398,6 +404,12 @@ async function classifyConnectionError(
       return `Authentication failed — run: swamp auth server-login --server ${wsUrl}`;
     }
   }
+  if (originalMessage.includes(H2_MASKED_ERROR)) {
+    try {
+      const diagnosis = await diagnoseTlsError(wsUrl);
+      if (diagnosis) return diagnosis;
+    } catch { /* fall through to other checks */ }
+  }
   if (await probeServerHealth(wsUrl)) {
     return `Authentication failed — run: swamp auth server-login --server ${wsUrl}`;
   }
@@ -413,7 +425,7 @@ async function classifyConnectionError(
 // Caveat: this flag causes Deno to mask all TLS errors (UnknownIssuer,
 // CaUsedAsEndEntity, expired, etc.) as "HTTP/2 not supported by this
 // client" in the WebSocket code path. diagnoseTlsError() below works
-// around this by probing with Deno.connectTls when that message appears.
+// around this by probing with fetch() when that message appears.
 const wsHttpClient = Deno.createHttpClient({ http2: false });
 
 let resolvedEnvCaCerts: string[] | undefined;
@@ -421,8 +433,15 @@ let resolvedEnvCaCerts: string[] | undefined;
 function resolveCaCertPath(): string | undefined {
   const envPath = Deno.env.get("SWAMP_CA_CERT");
   if (envPath) return envPath;
-  const idx = Deno.args.indexOf("--ca-cert");
-  if (idx >= 0 && idx + 1 < Deno.args.length) return Deno.args[idx + 1];
+  // Handle both --ca-cert value and --ca-cert=value forms
+  for (let i = 0; i < Deno.args.length; i++) {
+    if (Deno.args[i] === "--ca-cert" && i + 1 < Deno.args.length) {
+      return Deno.args[i + 1];
+    }
+    if (Deno.args[i].startsWith("--ca-cert=")) {
+      return Deno.args[i].slice("--ca-cert=".length);
+    }
+  }
   return undefined;
 }
 
@@ -437,12 +456,16 @@ function getEnvCaCerts(): string[] | undefined {
   }
   try {
     resolvedEnvCaCerts = [Deno.readTextFileSync(certPath)];
-  } catch {
-    resolvedEnvCaCerts = [];
-    return undefined;
+  } catch (e: unknown) {
+    const detail = e instanceof Error ? e.message : String(e);
+    throw new UserError(
+      `Could not read CA certificate file '${certPath}': ${detail}`,
+    );
   }
   return resolvedEnvCaCerts;
 }
+
+let cachedCaCertClient: Deno.HttpClient | undefined;
 
 function createSocket(
   url: string,
@@ -450,9 +473,18 @@ function createSocket(
   caCerts?: string[],
 ): WebSocket {
   const effectiveCaCerts = caCerts ?? getEnvCaCerts();
-  const client = effectiveCaCerts?.length
-    ? Deno.createHttpClient({ http2: false, caCerts: effectiveCaCerts })
-    : wsHttpClient;
+  let client: Deno.HttpClient;
+  if (effectiveCaCerts?.length) {
+    if (!cachedCaCertClient) {
+      cachedCaCertClient = Deno.createHttpClient({
+        http2: false,
+        caCerts: effectiveCaCerts,
+      });
+    }
+    client = cachedCaCertClient;
+  } else {
+    client = wsHttpClient;
+  }
   const opts: Record<string, unknown> = { client };
   if (headers && Object.keys(headers).length > 0) {
     opts.headers = headers;
@@ -495,17 +527,17 @@ export async function diagnoseTlsError(
       return (
         `TLS certificate rejected: the server certificate has ` +
         `basicConstraints CA:TRUE, which is invalid for a server ` +
-        `(end-entity) certificate. Regenerate the certificate with ` +
-        `"basicConstraints=critical,CA:FALSE" — see the swamp serve ` +
-        `documentation for the exact openssl command`
+        `(end-entity) certificate. Regenerate with ` +
+        `"basicConstraints=critical,CA:FALSE" — restart swamp serve ` +
+        `to see the exact openssl command`
       );
     }
 
     if (msg.includes("UnknownIssuer")) {
       return (
         `TLS certificate rejected: the server's certificate issuer is ` +
-        `not trusted. If using a self-signed certificate, add it to ` +
-        `the system trust store or set DENO_CERT=/path/to/cert.pem`
+        `not trusted. If using a self-signed certificate, pass it with ` +
+        `--ca-cert /path/to/cert.pem or set SWAMP_CA_CERT=/path/to/cert.pem`
       );
     }
 

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -78,6 +78,8 @@ export interface ServerRunOptions {
   signal?: AbortSignal;
   /** Extra headers for proxy/tunnel pass-through (env: SWAMP_SERVE_EXTRA_HEADERS). */
   headers?: Record<string, string>;
+  /** PEM-encoded CA certificates to trust for TLS connections. */
+  caCerts?: string[];
   /** Test seam: WebSocket factory. */
   createSocket?: (url: string, headers?: Record<string, string>) => WebSocket;
 }
@@ -172,6 +174,8 @@ export interface RequestResponseOptions {
   signal?: AbortSignal;
   /** Extra headers for proxy/tunnel pass-through (env: SWAMP_SERVE_EXTRA_HEADERS). */
   headers?: Record<string, string>;
+  /** PEM-encoded CA certificates to trust for TLS connections. */
+  caCerts?: string[];
   createSocket?: (url: string, headers?: Record<string, string>) => WebSocket;
   timeoutMs?: number;
 }
@@ -187,10 +191,9 @@ export function requestServerResponse<T>(
     headers["Authorization"] = `Bearer ${options.token}`;
   }
   const requestId = request.id ?? crypto.randomUUID();
-  const socket = (options.createSocket ?? defaultCreateSocket)(
-    baseUrl,
-    headers,
-  );
+  const socket = options.createSocket
+    ? options.createSocket(baseUrl, headers)
+    : createSocket(baseUrl, headers, options.caCerts);
   const timeoutMs = options.timeoutMs ?? REQUEST_RESPONSE_TIMEOUT_MS;
 
   const raw = new Promise<T>((resolve, reject) => {
@@ -235,11 +238,24 @@ export function requestServerResponse<T>(
       if (!settled) {
         settled = true;
         cleanup();
-        reject(
-          new UserError(
-            `Could not connect to ${baseUrl}${connectErrorDetail}`,
-          ),
-        );
+
+        const errorMsg = connectErrorDetail;
+        if (errorMsg.includes(H2_MASKED_ERROR)) {
+          diagnoseTlsError(baseUrl).then((diagnosis) => {
+            const detail = diagnosis ? `: ${diagnosis}` : connectErrorDetail;
+            reject(
+              new UserError(
+                `Could not connect to ${baseUrl}${detail}`,
+              ),
+            );
+          });
+        } else {
+          reject(
+            new UserError(
+              `Could not connect to ${baseUrl}${connectErrorDetail}`,
+            ),
+          );
+        }
       }
     };
 
@@ -337,6 +353,10 @@ export function withRemoteOptions<T extends AnyCommand>(command: T): T {
     .option(
       "--token <token:string>",
       "Server token in <name>.<secret> format; only applies with --server (overrides stored credentials and SWAMP_SERVER_TOKEN)",
+    )
+    .option(
+      "--ca-cert <path:string>",
+      "Path to PEM-encoded CA certificate to trust for TLS connections to the server (env: SWAMP_CA_CERT)",
     ) as T;
 }
 
@@ -389,17 +409,116 @@ async function classifyConnectionError(
 // this, Deno's default client advertises h2 ALPN, the proxy selects h2, and
 // the HTTP/1.1 WebSocket Upgrade is invalid over HTTP/2.
 // See: https://github.com/denoland/deno/issues/16923
+//
+// Caveat: this flag causes Deno to mask all TLS errors (UnknownIssuer,
+// CaUsedAsEndEntity, expired, etc.) as "HTTP/2 not supported by this
+// client" in the WebSocket code path. diagnoseTlsError() below works
+// around this by probing with Deno.connectTls when that message appears.
 const wsHttpClient = Deno.createHttpClient({ http2: false });
 
-function defaultCreateSocket(
+let resolvedEnvCaCerts: string[] | undefined;
+
+function resolveCaCertPath(): string | undefined {
+  const envPath = Deno.env.get("SWAMP_CA_CERT");
+  if (envPath) return envPath;
+  const idx = Deno.args.indexOf("--ca-cert");
+  if (idx >= 0 && idx + 1 < Deno.args.length) return Deno.args[idx + 1];
+  return undefined;
+}
+
+function getEnvCaCerts(): string[] | undefined {
+  if (resolvedEnvCaCerts !== undefined) {
+    return resolvedEnvCaCerts.length > 0 ? resolvedEnvCaCerts : undefined;
+  }
+  const certPath = resolveCaCertPath();
+  if (!certPath) {
+    resolvedEnvCaCerts = [];
+    return undefined;
+  }
+  try {
+    resolvedEnvCaCerts = [Deno.readTextFileSync(certPath)];
+  } catch {
+    resolvedEnvCaCerts = [];
+    return undefined;
+  }
+  return resolvedEnvCaCerts;
+}
+
+function createSocket(
   url: string,
   headers?: Record<string, string>,
+  caCerts?: string[],
 ): WebSocket {
-  const opts: Record<string, unknown> = { client: wsHttpClient };
+  const effectiveCaCerts = caCerts ?? getEnvCaCerts();
+  const client = effectiveCaCerts?.length
+    ? Deno.createHttpClient({ http2: false, caCerts: effectiveCaCerts })
+    : wsHttpClient;
+  const opts: Record<string, unknown> = { client };
   if (headers && Object.keys(headers).length > 0) {
     opts.headers = headers;
   }
   return new WebSocket(url, opts);
+}
+
+const H2_MASKED_ERROR = "HTTP/2 not supported by this client";
+
+/**
+ * When `createHttpClient({ http2: false })` is used, Deno's WebSocket
+ * masks every TLS validation error as "HTTP/2 not supported by this
+ * client". Probe with a plain `fetch()` (no custom client) to surface
+ * the real error — `fetch` shows the actual TLS rejection reason.
+ * Returns a more helpful message or `undefined` if the probe succeeds
+ * (meaning the WebSocket failure has a different cause).
+ */
+export async function diagnoseTlsError(
+  wsUrl: string,
+): Promise<string | undefined> {
+  let parsed: URL;
+  try {
+    parsed = new URL(wsUrl);
+  } catch {
+    return undefined;
+  }
+  if (parsed.protocol !== "wss:") return undefined;
+
+  parsed.protocol = "https:";
+  try {
+    const resp = await fetch(parsed.href, {
+      signal: AbortSignal.timeout(3_000),
+    });
+    await resp.body?.cancel();
+    return undefined;
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+
+    if (msg.includes("CaUsedAsEndEntity")) {
+      return (
+        `TLS certificate rejected: the server certificate has ` +
+        `basicConstraints CA:TRUE, which is invalid for a server ` +
+        `(end-entity) certificate. Regenerate the certificate with ` +
+        `"basicConstraints=critical,CA:FALSE" — see the swamp serve ` +
+        `documentation for the exact openssl command`
+      );
+    }
+
+    if (msg.includes("UnknownIssuer")) {
+      return (
+        `TLS certificate rejected: the server's certificate issuer is ` +
+        `not trusted. If using a self-signed certificate, add it to ` +
+        `the system trust store or set DENO_CERT=/path/to/cert.pem`
+      );
+    }
+
+    if (msg.includes("expired") || msg.includes("NotValidYet")) {
+      return `TLS certificate rejected: ${msg}`;
+    }
+
+    if (msg.includes("AbortError") || msg.includes("timed out")) {
+      return undefined;
+    }
+
+    return `TLS connection failed: ${msg}`;
+  }
 }
 
 interface OutboundRequest {
@@ -436,10 +555,9 @@ async function* singleConnectionStream(
     headers["Authorization"] = `Bearer ${options.token}`;
   }
   const requestId = crypto.randomUUID();
-  const socket = (options.createSocket ?? defaultCreateSocket)(
-    baseUrl,
-    headers,
-  );
+  const socket = options.createSocket
+    ? options.createSocket(baseUrl, headers)
+    : createSocket(baseUrl, headers, options.caCerts);
 
   const queue: ServerMessage[] = [];
   let wake: (() => void) | null = null;

--- a/src/infrastructure/runtime/tls_cert_validation.ts
+++ b/src/infrastructure/runtime/tls_cert_validation.ts
@@ -1,0 +1,143 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Validate PEM-encoded TLS certificates for common issues that produce
+ * misleading errors at connection time.
+ *
+ * Deno's WebSocket client masks all TLS validation errors as "HTTP/2 not
+ * supported by this client" when `createHttpClient({ http2: false })` is
+ * used. Catching problems at cert-load time gives users actionable
+ * guidance instead of a red herring.
+ */
+
+/** basicConstraints OID 2.5.29.19 in DER encoding (tag 06, length 03). */
+const BASIC_CONSTRAINTS_OID = new Uint8Array([0x06, 0x03, 0x55, 0x1d, 0x13]);
+
+/** ASN.1 BOOLEAN TRUE: tag 01, length 01, value FF. */
+const ASN1_BOOLEAN_TRUE = new Uint8Array([0x01, 0x01, 0xff]);
+
+export interface CertWarning {
+  code: "ca-true";
+  message: string;
+}
+
+/**
+ * Check a PEM certificate for issues that will cause connection failures.
+ * Returns warnings (not errors) — the cert may still work with non-Deno
+ * clients.
+ */
+export function validateEndEntityCert(pemCert: string): CertWarning[] {
+  const warnings: CertWarning[] = [];
+
+  if (hasCaTrue(pemCert)) {
+    warnings.push({
+      code: "ca-true",
+      message:
+        "The TLS certificate has basicConstraints CA:TRUE, which Deno's TLS " +
+        "validator rejects for server (end-entity) use. WebSocket clients — " +
+        "including swamp — will fail to connect. Regenerate with CA:FALSE:\n\n" +
+        "  openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 \\\n" +
+        "    -keyout server.key -out server.crt -days 365 -nodes \\\n" +
+        '    -subj "/CN=$(hostname)" \\\n' +
+        '    -addext "subjectAltName=IP:<your-ip>" \\\n' +
+        '    -addext "basicConstraints=critical,CA:FALSE"',
+    });
+  }
+
+  return warnings;
+}
+
+/**
+ * Detect CA:TRUE in a PEM certificate's basicConstraints extension by
+ * scanning the DER encoding.
+ *
+ * Extension structure:
+ *   OID(2.5.29.19) [BOOLEAN(critical)] OCTET-STRING { SEQUENCE { [BOOLEAN(cA)] } }
+ *
+ * The critical flag is also a BOOLEAN TRUE, so we cannot just scan for
+ * any 01 01 FF after the OID. Instead we locate the OCTET STRING (tag
+ * 04), enter the inner SEQUENCE (tag 30), and check whether its first
+ * element is BOOLEAN TRUE.
+ */
+export function hasCaTrue(pemCert: string): boolean {
+  const der = pemToDer(pemCert);
+  if (!der) return false;
+
+  for (let i = 0; i <= der.length - BASIC_CONSTRAINTS_OID.length; i++) {
+    if (!bytesMatch(der, i, BASIC_CONSTRAINTS_OID)) continue;
+
+    // Scan forward from after the OID to find the OCTET STRING (tag 04)
+    // that wraps the extension value. Skip the optional critical BOOLEAN.
+    let pos = i + BASIC_CONSTRAINTS_OID.length;
+    const limit = Math.min(pos + 10, der.length);
+
+    while (pos < limit && der[pos] !== 0x04) pos++;
+    if (pos >= limit) return false;
+
+    // Skip OCTET STRING tag + length
+    pos++;
+    if (pos >= der.length) return false;
+    pos += der[pos] < 0x80 ? 1 : (der[pos] & 0x7f) + 1;
+    if (pos >= der.length) return false;
+
+    // Now we should be at the inner SEQUENCE (tag 30)
+    if (der[pos] !== 0x30) return false;
+    pos++;
+    if (pos >= der.length) return false;
+    const seqLen = der[pos];
+    pos++;
+
+    // Empty SEQUENCE (30 00) → CA defaults to FALSE
+    if (seqLen === 0) return false;
+
+    // First element of SEQUENCE: check for BOOLEAN TRUE (01 01 FF)
+    if (pos + 2 < der.length && bytesMatch(der, pos, ASN1_BOOLEAN_TRUE)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  return false;
+}
+
+function pemToDer(pem: string): Uint8Array | null {
+  const match = pem.match(
+    /-----BEGIN CERTIFICATE-----\s*([\s\S]+?)\s*-----END CERTIFICATE-----/,
+  );
+  if (!match) return null;
+  try {
+    const binary = atob(match[1].replace(/\s/g, ""));
+    return Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  } catch {
+    return null;
+  }
+}
+
+function bytesMatch(
+  haystack: Uint8Array,
+  offset: number,
+  needle: Uint8Array,
+): boolean {
+  for (let k = 0; k < needle.length; k++) {
+    if (haystack[offset + k] !== needle[k]) return false;
+  }
+  return true;
+}

--- a/src/infrastructure/runtime/tls_cert_validation_test.ts
+++ b/src/infrastructure/runtime/tls_cert_validation_test.ts
@@ -1,0 +1,111 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { hasCaTrue, validateEndEntityCert } from "./tls_cert_validation.ts";
+
+async function generateCert(
+  extraArgs: string[] = [],
+): Promise<string> {
+  const cmd = new Deno.Command("openssl", {
+    args: [
+      "req",
+      "-x509",
+      "-newkey",
+      "ec",
+      "-pkeyopt",
+      "ec_paramgen_curve:P-256",
+      "-keyout",
+      "/dev/null",
+      "-out",
+      "/dev/stdout",
+      "-days",
+      "1",
+      "-nodes",
+      "-subj",
+      "/CN=test",
+      ...extraArgs,
+    ],
+    stdout: "piped",
+    stderr: "null",
+  });
+  const { stdout } = await cmd.output();
+  return new TextDecoder().decode(stdout);
+}
+
+Deno.test("hasCaTrue: returns true for default openssl req -x509 cert", async () => {
+  const cert = await generateCert();
+  assertEquals(hasCaTrue(cert), true);
+});
+
+Deno.test("hasCaTrue: returns false for CA:FALSE cert", async () => {
+  const cert = await generateCert([
+    "-addext",
+    "basicConstraints=critical,CA:FALSE",
+  ]);
+  assertEquals(hasCaTrue(cert), false);
+});
+
+Deno.test("hasCaTrue: returns false for RSA CA:FALSE cert", async () => {
+  const cmd = new Deno.Command("openssl", {
+    args: [
+      "req",
+      "-x509",
+      "-newkey",
+      "rsa:2048",
+      "-keyout",
+      "/dev/null",
+      "-out",
+      "/dev/stdout",
+      "-days",
+      "1",
+      "-nodes",
+      "-subj",
+      "/CN=test",
+      "-addext",
+      "basicConstraints=critical,CA:FALSE",
+    ],
+    stdout: "piped",
+    stderr: "null",
+  });
+  const { stdout } = await cmd.output();
+  const cert = new TextDecoder().decode(stdout);
+  assertEquals(hasCaTrue(cert), false);
+});
+
+Deno.test("hasCaTrue: returns false for invalid PEM", () => {
+  assertEquals(hasCaTrue("not a cert"), false);
+  assertEquals(hasCaTrue(""), false);
+});
+
+Deno.test("validateEndEntityCert: returns ca-true warning for CA:TRUE cert", async () => {
+  const cert = await generateCert();
+  const warnings = validateEndEntityCert(cert);
+  assertEquals(warnings.length, 1);
+  assertEquals(warnings[0].code, "ca-true");
+});
+
+Deno.test("validateEndEntityCert: returns no warnings for CA:FALSE cert", async () => {
+  const cert = await generateCert([
+    "-addext",
+    "basicConstraints=critical,CA:FALSE",
+  ]);
+  const warnings = validateEndEntityCert(cert);
+  assertEquals(warnings.length, 0);
+});

--- a/src/infrastructure/runtime/tls_cert_validation_test.ts
+++ b/src/infrastructure/runtime/tls_cert_validation_test.ts
@@ -18,35 +18,44 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
 import { hasCaTrue, validateEndEntityCert } from "./tls_cert_validation.ts";
 
 async function generateCert(
   extraArgs: string[] = [],
 ): Promise<string> {
-  const cmd = new Deno.Command("openssl", {
-    args: [
-      "req",
-      "-x509",
-      "-newkey",
-      "ec",
-      "-pkeyopt",
-      "ec_paramgen_curve:P-256",
-      "-keyout",
-      "/dev/null",
-      "-out",
-      "/dev/stdout",
-      "-days",
-      "1",
-      "-nodes",
-      "-subj",
-      "/CN=test",
-      ...extraArgs,
-    ],
-    stdout: "piped",
-    stderr: "null",
-  });
-  const { stdout } = await cmd.output();
-  return new TextDecoder().decode(stdout);
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const keyPath = join(tmpDir, "key.pem");
+    const certPath = join(tmpDir, "cert.pem");
+    const cmd = new Deno.Command("openssl", {
+      args: [
+        "req",
+        "-x509",
+        "-newkey",
+        "ec",
+        "-pkeyopt",
+        "ec_paramgen_curve:P-256",
+        "-keyout",
+        keyPath,
+        "-out",
+        certPath,
+        "-days",
+        "1",
+        "-nodes",
+        "-subj",
+        "/CN=test",
+        ...extraArgs,
+      ],
+      stdout: "null",
+      stderr: "null",
+    });
+    const { success } = await cmd.output();
+    if (!success) throw new Error("openssl failed");
+    return await Deno.readTextFile(certPath);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
 }
 
 Deno.test("hasCaTrue: returns true for default openssl req -x509 cert", async () => {
@@ -63,30 +72,38 @@ Deno.test("hasCaTrue: returns false for CA:FALSE cert", async () => {
 });
 
 Deno.test("hasCaTrue: returns false for RSA CA:FALSE cert", async () => {
-  const cmd = new Deno.Command("openssl", {
-    args: [
-      "req",
-      "-x509",
-      "-newkey",
-      "rsa:2048",
-      "-keyout",
-      "/dev/null",
-      "-out",
-      "/dev/stdout",
-      "-days",
-      "1",
-      "-nodes",
-      "-subj",
-      "/CN=test",
-      "-addext",
-      "basicConstraints=critical,CA:FALSE",
-    ],
-    stdout: "piped",
-    stderr: "null",
-  });
-  const { stdout } = await cmd.output();
-  const cert = new TextDecoder().decode(stdout);
-  assertEquals(hasCaTrue(cert), false);
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const keyPath = join(tmpDir, "key.pem");
+    const certPath = join(tmpDir, "cert.pem");
+    const cmd = new Deno.Command("openssl", {
+      args: [
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-keyout",
+        keyPath,
+        "-out",
+        certPath,
+        "-days",
+        "1",
+        "-nodes",
+        "-subj",
+        "/CN=test",
+        "-addext",
+        "basicConstraints=critical,CA:FALSE",
+      ],
+      stdout: "null",
+      stderr: "null",
+    });
+    const { success } = await cmd.output();
+    if (!success) throw new Error("openssl failed");
+    const cert = await Deno.readTextFile(certPath);
+    assertEquals(hasCaTrue(cert), false);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
 });
 
 Deno.test("hasCaTrue: returns false for invalid PEM", () => {

--- a/src/worker/connect.ts
+++ b/src/worker/connect.ts
@@ -50,6 +50,12 @@ const logger = getSwampLogger(["worker", "connect"]);
 
 // Force HTTP/1.1 ALPN for wss:// so WebSocket upgrades succeed through
 // HTTP/2-capable reverse proxies. See: https://github.com/denoland/deno/issues/16923
+//
+// Caveat: this flag causes Deno to mask all TLS errors as "HTTP/2 not
+// supported by this client" in the WebSocket code path. The CLI side
+// (remote_run.ts) diagnoses the real error; here we log it as-is since
+// the worker connect loop retries and the serve-side startup warning
+// catches the most common cert issue (CA:TRUE).
 const wsHttpClient = Deno.createHttpClient({ http2: false });
 
 /** Refresh the session credential when 2/3 of its lifetime has elapsed. */


### PR DESCRIPTION
## Summary

- **Client-side error diagnostic**: `Deno.createHttpClient({ http2: false })` masks all TLS validation errors as "HTTP/2 not supported by this client" in the WebSocket code path. When this masked error appears, a `fetch()` probe now surfaces the real TLS error with actionable guidance (e.g., "certificate has CA:TRUE — regenerate with CA:FALSE" or "issuer not trusted — set DENO_CERT")
- **`--ca-cert` flag and `SWAMP_CA_CERT` env var**: lets the client trust the serve's self-signed certificate directly, making the WebSocket connection succeed without installing the cert in the OS trust store. Works across all `--server` commands automatically
- **Serve startup warning**: detects `CA:TRUE` in the server certificate's `basicConstraints` extension and warns with the exact `openssl` command to regenerate with `CA:FALSE`

Fixes swamp-club#1748.

## Test Plan

- 6 unit tests for cert validation utility (`hasCaTrue`, `validateEndEntityCert` — CA:TRUE, CA:FALSE, RSA, invalid PEM)
- 4 integration tests for `diagnoseTlsError` (CaUsedAsEndEntity, UnknownIssuer, non-wss URL, unreachable host)
- Full test suite: 10,572 passed
- Compiled binary verified on **macOS** (5/5) and **Debian 13 x86_64 via Docker** (4/4):
  - Serve warns on CA:TRUE cert at startup
  - Client unmasks CA:TRUE error (no longer shows "HTTP/2 not supported")
  - `--ca-cert /path/to/cert.pem` enables WebSocket connection
  - `SWAMP_CA_CERT=/path/to/cert.pem` enables WebSocket connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)