### PR TITLE
fix(vault): always wire audit repository so write operations are recorded (swamp-club#1767)

### DIFF
--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -185,19 +185,10 @@ export class VaultService {
       }
     }
     vaultService.ensureDefaultVaults();
-    if (vaultService.hasAnyAuditEnabled()) {
-      vaultService.setAuditRepository(
-        new JsonlVaultAuditRepository(repoDir),
-      );
-    }
+    vaultService.setAuditRepository(
+      new JsonlVaultAuditRepository(repoDir),
+    );
     return vaultService;
-  }
-
-  private hasAnyAuditEnabled(): boolean {
-    for (const enabled of this.auditFlags.values()) {
-      if (enabled) return true;
-    }
-    return false;
   }
 
   /**

--- a/src/domain/vaults/vault_service_test.ts
+++ b/src/domain/vaults/vault_service_test.ts
@@ -582,6 +582,53 @@ Deno.test("VaultService - fromRepository auto-remaps renamed vault types", async
   );
 });
 
+Deno.test("VaultService - fromRepository wires audit repository even without auditReads", async () => {
+  const tempDir = await Deno.makeTempDir();
+  try {
+    const vaultDir = join(tempDir, "vaults", "noaudit");
+    await ensureDir(vaultDir);
+    await Deno.writeTextFile(
+      join(vaultDir, "noaudit-id.yaml"),
+      stringifyYaml({
+        id: "noaudit-id",
+        name: "noaudit",
+        type: "mock",
+        config: { "secret-key": "secret-value" },
+        createdAt: new Date(2026, 0, 1).toISOString(),
+      }),
+    );
+
+    const vaultService = await VaultService.fromRepository(tempDir);
+    await vaultService.put("noaudit", "secret-key", "new-value");
+
+    const auditDir = join(tempDir, ".swamp", "audit");
+    let hasAuditFile = false;
+    try {
+      for await (const entry of Deno.readDir(auditDir)) {
+        if (
+          entry.name.startsWith("vault-audit-") && entry.name.endsWith(".jsonl")
+        ) {
+          hasAuditFile = true;
+          const content = await Deno.readTextFile(join(auditDir, entry.name));
+          const record = JSON.parse(content.trim());
+          assertEquals(record.action, "put");
+          assertEquals(record.vaultName, "noaudit");
+          assertEquals(record.secretKey, "secret-key");
+        }
+      }
+    } catch {
+      // audit dir doesn't exist — fail
+    }
+    assertEquals(
+      hasAuditFile,
+      true,
+      "Expected a vault-audit JSONL file to be created",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true }).catch(() => {});
+  }
+});
+
 Deno.test("VaultService - delete", async (t) => {
   await t.step("should delete a secret from a mock vault", async () => {
     const vaultService = new VaultService();


### PR DESCRIPTION
## Summary

- `VaultService.fromRepository()` gated `setAuditRepository()` behind `hasAnyAuditEnabled()`, which only checks if any vault has `auditReads: true`. Write operations (put, delete, annotate) are unconditionally audited in `recordAuditEntry` and only need the audit repository to be non-null — they don't check `auditFlags`. This meant write audit was silently disabled unless a vault happened to have read auditing enabled.
- Removed the `hasAnyAuditEnabled()` guard so the audit repository is always wired up, and deleted the now-unused `hasAnyAuditEnabled()` method.
- Added a `fromRepository`-level test verifying that a vault with no `auditReads` flag still produces audit JSONL entries for write operations.

Fixes swamp-club#1767

## Test Plan

- [x] New test: `fromRepository wires audit repository even without auditReads` — creates a mock vault without `auditReads`, calls `put`, verifies JSONL audit file is created with correct action/vaultName/secretKey
- [x] All existing vault audit tests pass (12 tests, 39 steps)
- [x] `deno fmt --check`, `deno lint`, `deno check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)