### PR TITLE
fix(vault): omit trailing newline from piped read-secret output

### DIFF
--- a/src/presentation/renderers/vault_read_secret.ts
+++ b/src/presentation/renderers/vault_read_secret.ts
@@ -26,12 +26,24 @@ import type { OutputMode } from "../output/output.ts";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
 
+const encoder = new TextEncoder();
+
 class LogVaultReadSecretRenderer implements Renderer<VaultReadSecretEvent> {
+  #isTerminal: () => boolean;
+
+  constructor(isTerminal: () => boolean) {
+    this.#isTerminal = isTerminal;
+  }
+
   handlers(): EventHandlers<VaultReadSecretEvent> {
     return {
       resolving: () => {},
       completed: (e) => {
-        writeOutput(e.data.value);
+        if (this.#isTerminal()) {
+          writeOutput(e.data.value);
+        } else {
+          Deno.stdout.writeSync(encoder.encode(e.data.value));
+        }
       },
       error: (e) => {
         throw new UserError(e.error.message);
@@ -56,11 +68,12 @@ class JsonVaultReadSecretRenderer implements Renderer<VaultReadSecretEvent> {
 
 export function createVaultReadSecretRenderer(
   mode: OutputMode,
+  isTerminal: () => boolean = () => Deno.stdout.isTerminal(),
 ): Renderer<VaultReadSecretEvent> {
   switch (mode) {
     case "json":
       return new JsonVaultReadSecretRenderer();
     case "log":
-      return new LogVaultReadSecretRenderer();
+      return new LogVaultReadSecretRenderer(isTerminal);
   }
 }

--- a/src/presentation/renderers/vault_read_secret_test.ts
+++ b/src/presentation/renderers/vault_read_secret_test.ts
@@ -42,13 +42,13 @@ async function* toStream(
   }
 }
 
-Deno.test("LogVaultReadSecretRenderer: writes only the secret value to stdout", async () => {
+Deno.test("LogVaultReadSecretRenderer: writes secret with newline when stdout is a TTY", async () => {
   const logs: string[] = [];
   const originalLog = console.log;
   console.log = (msg: string) => logs.push(msg);
 
   try {
-    const renderer = createVaultReadSecretRenderer("log");
+    const renderer = createVaultReadSecretRenderer("log", () => true);
     const events: VaultReadSecretEvent[] = [
       { kind: "resolving" },
       { kind: "completed", data: makeData() },
@@ -58,6 +58,29 @@ Deno.test("LogVaultReadSecretRenderer: writes only the secret value to stdout", 
     assertEquals(logs[0], "super_secret_value");
   } finally {
     console.log = originalLog;
+  }
+});
+
+Deno.test("LogVaultReadSecretRenderer: writes exact bytes without trailing newline when piped", async () => {
+  const written: Uint8Array[] = [];
+  const originalWriteSync = Deno.stdout.writeSync.bind(Deno.stdout);
+  Deno.stdout.writeSync = (data: Uint8Array): number => {
+    written.push(new Uint8Array(data));
+    return data.length;
+  };
+
+  try {
+    const renderer = createVaultReadSecretRenderer("log", () => false);
+    const events: VaultReadSecretEvent[] = [
+      { kind: "resolving" },
+      { kind: "completed", data: makeData() },
+    ];
+    await consumeStream(toStream(events), renderer.handlers());
+    assertEquals(written.length, 1);
+    const output = new TextDecoder().decode(written[0]);
+    assertEquals(output, "super_secret_value");
+  } finally {
+    Deno.stdout.writeSync = originalWriteSync;
   }
 });
 


### PR DESCRIPTION
## Summary

- `vault read-secret` used `writeOutput()` (which delegates to `console.log()`) to emit the secret value, unconditionally appending a trailing newline — piped or redirected output was `<value>\n` instead of the exact stored bytes, corrupting secrets for external consumers
- When stdout is not a TTY, the renderer now uses `Deno.stdout.writeSync` to emit exact bytes without a trailing newline; interactive terminal output is unchanged
- Added unit test for piped (non-TTY) mode verifying byte-exact output

Closes swamp-club#1768

## Test plan

- [x] Reproduced the bug: `printf 'abc' | swamp vault put ... && swamp vault read-secret ... --yes | xxd` showed 4 bytes (`abc\n`)
- [x] Verified the fix: same command now shows 3 bytes (`abc`) — no trailing newline
- [x] TTY mode confirmed: interactive output still includes newline for readability
- [x] New unit test passes: `deno run test src/presentation/renderers/vault_read_secret_test.ts` (5/5)
- [x] `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)