### PR TITLE
feat(verification): pre-PR verification loop with container sandbox and attestation

### DIFF
--- a/.claude/skills/issue-lifecycle/SKILL.md
+++ b/.claude/skills/issue-lifecycle/SKILL.md
@@ -51,6 +51,8 @@ repository root. If these files exist, they customize how each phase works:
   criteria
 - `agent-constraints/implementation-conventions.md` — build, verify, and PR
   conventions
+- `agent-constraints/verification-conventions.md` — container sandbox and
+  verification workflow configuration
 
 If these files do not exist, the skill uses generic defaults documented in each
 reference file.
@@ -106,10 +108,17 @@ approval. Covers: signalling implementation start and doing the work.
 
 After the code is written, read
 [references/code-conformance-review.md](references/code-conformance-review.md)
-**before creating a PR.** This adversarially compares the implemented code
+**before verification.** This adversarially compares the implemented code
 against the approved plan. Deviations are expected — they just need a documented
-justification. The `link_pr` method will fail until all deviations are
-justified.
+justification.
+
+### Phase 4a: Verification Loop
+
+Read [references/verification.md](references/verification.md) **after code
+conformance review is complete.** This runs the same checks as CI (lint, test,
+compile, agent reviews) inside a container sandbox before the PR opens. The
+agent iterates — fixing failures and re-verifying — until all steps pass. Only
+then can a PR be created.
 
 ### Phase 5: Contributor Notification
 
@@ -192,7 +201,8 @@ Use this table to determine what to do next:
 | `classified`     | Read [references/planning.md](references/planning.md)                      |
 | `plan_generated` | Read [references/adversarial-review.md](references/adversarial-review.md)  |
 | `approved`       | Read [references/implementation.md](references/implementation.md)          |
-| `implementing`   | Run code conformance review, then link a PR with `link_pr`                 |
+| `implementing`   | Run code conformance review, then verify                                   |
+| `verifying`      | Read [references/verification.md](references/verification.md)              |
 | `pr_open`        | Wait 3 min, then check PR: `pr_merged` if merged, `pr_failed` if failed    |
 | `pr_failed`      | Fix the issue, then `link_pr` (new PR) or `implement` (major rework)       |
 | `releasing`      | Check release build: `ship` when done, or `complete` as fallback           |

--- a/.claude/skills/issue-lifecycle/references/implementation.md
+++ b/.claude/skills/issue-lifecycle/references/implementation.md
@@ -37,10 +37,19 @@ Report verification results to the human before creating the PR:
 
 ## 3a. Code Conformance Review
 
-**Before creating a PR**, read
+**Before verification**, read
 [code-conformance-review.md](code-conformance-review.md) and run the code
 conformance review. This adversarially compares the implemented code against the
-approved plan. All deviations must be justified before `link_pr` will succeed.
+approved plan. All deviations must be justified before proceeding.
+
+## 3b. Verification Loop
+
+**After code conformance review**, read [verification.md](verification.md) and
+run the verification workflow in the container sandbox. This runs lint, test,
+compile, and agent reviews — the same checks as CI — before a PR is opened. The
+agent iterates until all steps pass.
+
+Do NOT proceed to create a PR until verification passes.
 
 ## 4. Create a PR
 

--- a/.claude/skills/issue-lifecycle/references/verification.md
+++ b/.claude/skills/issue-lifecycle/references/verification.md
@@ -26,6 +26,7 @@ container must be built first (`./verification/container/build.sh`).
 docker run --rm \
   -v <repo-root>:<repo-root> \
   -v ~/Library/Caches/deno:/deno-dir \
+  -e SWAMP_WORKFLOWS_DIR=verification \
   -w <worktree-path> \
   swamp-club/verify:deno-2.8.3 \
   workflow run verify-changes \
@@ -37,6 +38,9 @@ docker run --rm \
 Replace `<repo-root>` with the main repo path and `<worktree-path>` with the
 current working directory. On Linux, use `~/.cache/deno` instead of
 `~/Library/Caches/deno`.
+
+The `SWAMP_WORKFLOWS_DIR=verification` env var tells swamp to look for workflow
+files in the `verification/` directory instead of the default `workflows/`.
 
 The workflow runs lint, fmt check, type check, tests, deps audit, compile, and
 agent reviews as a DAG. Build steps run in parallel; reviews run after builds

--- a/.claude/skills/issue-lifecycle/references/verification.md
+++ b/.claude/skills/issue-lifecycle/references/verification.md
@@ -1,0 +1,103 @@
+# Verification Flow
+
+Read this after code conformance review is complete and all deviations are
+justified. The verification loop runs the same checks as CI in a container
+sandbox **before** opening a PR.
+
+Read `agent-constraints/verification-conventions.md` for repo-specific container
+and workflow configuration.
+
+## 1. Start Verification
+
+Transition the lifecycle to the `verifying` phase:
+
+```
+swamp model @swamp/issue-lifecycle method run verify issue-<N> \
+  --input commit=$(git rev-parse HEAD) \
+  --input branch=$(git branch --show-current)
+```
+
+## 2. Run the Verification Workflow
+
+Run the `verify-changes` workflow inside the verification container. The
+container must be built first (`./verification/container/build.sh`).
+
+```
+docker run --rm \
+  -v <repo-root>:<repo-root> \
+  -v ~/Library/Caches/deno:/deno-dir \
+  -w <worktree-path> \
+  swamp-club/verify:deno-2.8.3 \
+  workflow run verify-changes \
+  --repo-dir <repo-root> \
+  --input commit=$(git rev-parse HEAD) \
+  --input branch=$(git branch --show-current)
+```
+
+Replace `<repo-root>` with the main repo path and `<worktree-path>` with the
+current working directory. On Linux, use `~/.cache/deno` instead of
+`~/Library/Caches/deno`.
+
+The workflow runs lint, fmt check, type check, tests, deps audit, compile, and
+agent reviews as a DAG. Build steps run in parallel; reviews run after builds
+pass. Each review gets its own isolated subprocess.
+
+## 3. Read the Attestation
+
+The workflow produces a verification attestation on completion (pass or fail).
+Look for the attestation in the workflow output — it shows a checklist of every
+step with pass/fail status.
+
+If any step failed, the attestation includes retrieval commands to get the full
+output:
+
+```
+swamp data get <model-name> <data-name>
+```
+
+## 4. Handle the Result
+
+### All steps passed
+
+Call `verification_passed` with the checklist data from the attestation:
+
+```
+swamp model @swamp/issue-lifecycle method run verification_passed issue-<N> \
+  --input workflowRunId=<run-id> \
+  --input commit=<SHA> \
+  --input branch=<branch> \
+  --input steps='[{"job":"static-analysis","step":"lint","model":"@swamp/deno-runner","method":"task","status":"succeeded"}, ...]'
+```
+
+Populate the `steps` array from the attestation output. Include every step with
+its actual status (succeeded, failed, or skipped).
+
+Then proceed to open a PR — read the "Create a PR" section in
+[implementation.md](implementation.md).
+
+### Any step failed
+
+Call `verification_failed` with the failure details:
+
+```
+swamp model @swamp/issue-lifecycle method run verification_failed issue-<N> \
+  --input workflowRunId=<run-id> \
+  --input commit=<SHA> \
+  --input branch=<branch> \
+  --input failureReason="<summary of failures>"
+```
+
+This transitions back to `implementing`. Fix the failing code:
+
+- **Build failures** (lint, fmt, test, compile): fix the code directly
+- **Review failures**: read the findings, address blocking issues
+
+After fixing, return to step 1 and re-verify. Repeat until all steps pass.
+
+## 5. Do NOT Open a PR Without Verification
+
+The `link_pr` method requires a passing verification result. If you skip
+verification and try to link a PR directly, it will be missing the
+`verificationResult` data that the lifecycle checks for.
+
+The loop is: implement → conformance review → verify → fix → re-verify → PR.

--- a/agent-constraints/verification-conventions.md
+++ b/agent-constraints/verification-conventions.md
@@ -12,6 +12,7 @@ Mount the host's Deno cache for fast dependency resolution:
 docker run --rm \
   -v /path/to/repo:/path/to/repo \
   -v ~/Library/Caches/deno:/deno-dir \
+  -e SWAMP_WORKFLOWS_DIR=verification \
   -w /path/to/worktree \
   swamp-club/verify:deno-2.8.3 \
   workflow run verify-changes \

--- a/agent-constraints/verification-conventions.md
+++ b/agent-constraints/verification-conventions.md
@@ -1,0 +1,72 @@
+# Verification Conventions
+
+## Container Sandbox
+
+All verification runs inside the `swamp-club/verify` container. The container
+provides an isolated environment matching CI conditions (Deno 2.8.3, Ubuntu,
+git, unzip).
+
+Mount the host's Deno cache for fast dependency resolution:
+
+```
+docker run --rm \
+  -v /path/to/repo:/path/to/repo \
+  -v ~/Library/Caches/deno:/deno-dir \
+  -w /path/to/worktree \
+  swamp-club/verify:deno-2.8.3 \
+  workflow run verify-changes \
+  --repo-dir /path/to/repo \
+  --input commit=<SHA> \
+  --input branch=<branch>
+```
+
+On Linux, the Deno cache is at `~/.cache/deno`.
+
+## Workflow Structure
+
+The `verify-changes` workflow runs a DAG of verification steps:
+
+**Tier 1 (parallel, no dependencies):**
+
+- `static-analysis` — lint, fmt check, type check (via `@swamp/deno-runner`)
+- `tests` — full test suite in parallel (via `@swamp/deno-runner`)
+- `deps-audit` — vulnerability scan (via `@swamp/deno-runner`)
+
+**Tier 2 (gated on tier 1 passing):**
+
+- `compile` — build binary + binary-check (via `@swamp/deno-runner`)
+- `code-review` — general review (via `@swamp/agent-runner`, own subprocess)
+- `adversarial-review` — guarded on core path changes
+- `ux-review` — guarded on CLI/presentation path changes
+- `ci-security-review` — guarded on `.github/workflows/` changes
+
+Each agent review runs in its own isolated subprocess. Build steps share the
+container context.
+
+## Attestation
+
+On completion (pass or fail), the workflow produces a verification attestation
+report. The attestation is a structured checklist showing every step, its
+status, and retrieval commands for failed step output.
+
+Read the attestation to determine next steps:
+
+- **All pass** → call `verification_passed` with the checklist data
+- **Any fail** → call `verification_failed`, fix the issues, re-verify
+
+## Handling Failures
+
+When verification fails:
+
+1. Read the attestation to identify which steps failed
+2. For failed build steps (lint, test, compile): fix the code directly
+3. For failed agent reviews: read the review findings via
+   `swamp data get <model> <data-name>`, address blocking findings, re-verify
+4. Do NOT open a PR until all verification steps pass
+
+## Review Prompts
+
+Agent review prompts live at `verification/review-prompts/`. Each prompt
+instructs the agent to `git diff main --name-only` and only review changed
+files. The prompts are the single source of truth for review criteria — both
+the verification workflow and CI reference them.

--- a/extensions/models/_lib/schemas.ts
+++ b/extensions/models/_lib/schemas.ts
@@ -46,6 +46,7 @@ export const Phase = z.enum([
   "plan_generated",
   "approved",
   "implementing",
+  "verifying",
   "pr_open",
   "pr_failed",
   "releasing",
@@ -82,7 +83,10 @@ export const TRANSITIONS: Record<string, Phase[]> = {
   resolve_findings: ["plan_generated"],
   code_conformance_review: ["implementing", "pr_failed"],
   justify_deviations: ["implementing", "pr_failed"],
-  link_pr: ["implementing", "pr_open", "pr_failed"],
+  verify: ["implementing"],
+  verification_passed: ["verifying"],
+  verification_failed: ["verifying"],
+  link_pr: ["implementing", "verifying", "pr_open", "pr_failed"],
   pr_merged: ["pr_open"],
   pr_failed: ["pr_open"],
   ship: ["releasing"],
@@ -248,6 +252,33 @@ export const CodeConformanceReviewSchema = z.object({
 export type CodeConformanceReviewData = z.infer<
   typeof CodeConformanceReviewSchema
 >;
+
+// ---------------------------------------------------------------------------
+// Verification Result Schema
+// ---------------------------------------------------------------------------
+
+export const VerificationStepResultSchema = z.object({
+  job: z.string(),
+  step: z.string(),
+  model: z.string(),
+  method: z.string(),
+  status: z.enum(["succeeded", "failed", "skipped"]),
+});
+
+export const VerificationResultSchema = z.object({
+  workflowRunId: z.string(),
+  commit: z.string(),
+  branch: z.string(),
+  allPassed: z.boolean(),
+  stepsCompleted: z.number(),
+  stepsTotal: z.number(),
+  stepsSkipped: z.number(),
+  stepsFailed: z.number(),
+  steps: z.array(VerificationStepResultSchema),
+  verifiedAt: z.string(),
+});
+
+export type VerificationResultData = z.infer<typeof VerificationResultSchema>;
 
 export const PullRequestSchema = z.object({
   url: z.string().min(1).describe(

--- a/extensions/models/_lib/schemas.ts
+++ b/extensions/models/_lib/schemas.ts
@@ -86,7 +86,7 @@ export const TRANSITIONS: Record<string, Phase[]> = {
   verify: ["implementing"],
   verification_passed: ["verifying"],
   verification_failed: ["verifying"],
-  link_pr: ["implementing", "verifying", "pr_open", "pr_failed"],
+  link_pr: ["verifying", "pr_open", "pr_failed"],
   pr_merged: ["pr_open"],
   pr_failed: ["pr_open"],
   ship: ["releasing"],

--- a/extensions/models/_lib/schemas_test.ts
+++ b/extensions/models/_lib/schemas_test.ts
@@ -30,7 +30,9 @@ Deno.test("Phase: includes pr_open, pr_failed, releasing, notify, summarizing be
   const summarizingIdx = phases.indexOf("summarizing");
   const doneIdx = phases.indexOf("done");
 
-  assertEquals(prOpenIdx, implementingIdx + 1);
+  const verifyingIdx = phases.indexOf("verifying");
+  assertEquals(verifyingIdx, implementingIdx + 1);
+  assertEquals(prOpenIdx, verifyingIdx + 1);
   assertEquals(prFailedIdx, prOpenIdx + 1);
   assertEquals(releasingIdx, prFailedIdx + 1);
   assertEquals(notifyIdx, releasingIdx + 1);
@@ -39,7 +41,12 @@ Deno.test("Phase: includes pr_open, pr_failed, releasing, notify, summarizing be
 });
 
 Deno.test("TRANSITIONS: link_pr accepts implementing, pr_open, and pr_failed", () => {
-  assertEquals(TRANSITIONS.link_pr, ["implementing", "pr_open", "pr_failed"]);
+  assertEquals(TRANSITIONS.link_pr, [
+    "implementing",
+    "verifying",
+    "pr_open",
+    "pr_failed",
+  ]);
 });
 
 Deno.test("TRANSITIONS: complete accepts implementing, pr_open, and releasing", () => {

--- a/extensions/models/_lib/schemas_test.ts
+++ b/extensions/models/_lib/schemas_test.ts
@@ -40,9 +40,8 @@ Deno.test("Phase: includes pr_open, pr_failed, releasing, notify, summarizing be
   assertEquals(doneIdx, summarizingIdx + 1);
 });
 
-Deno.test("TRANSITIONS: link_pr accepts implementing, pr_open, and pr_failed", () => {
+Deno.test("TRANSITIONS: link_pr accepts verifying, pr_open, and pr_failed", () => {
   assertEquals(TRANSITIONS.link_pr, [
-    "implementing",
     "verifying",
     "pr_open",
     "pr_failed",
@@ -69,17 +68,17 @@ Deno.test("TRANSITIONS: notify and skip_notify accept only notify phase", () => 
 });
 
 Deno.test("TRANSITIONS: link_pr is rejected from earlier lifecycle phases", () => {
-  // link_pr should only be callable once implementation has begun. Calling
-  // it from any earlier phase is a sequencing bug in the agent and must be
-  // blocked by the valid-transition pre-flight check.
-  const earlierPhases: ReadonlyArray<typeof Phase.options[number]> = [
+  // link_pr requires verification — it's not allowed from implementing
+  // or any earlier phase.
+  const blockedPhases: ReadonlyArray<typeof Phase.options[number]> = [
     "created",
     "triaging",
     "classified",
     "plan_generated",
     "approved",
+    "implementing",
   ];
-  for (const phase of earlierPhases) {
+  for (const phase of blockedPhases) {
     assertEquals(
       TRANSITIONS.link_pr.includes(phase),
       false,

--- a/extensions/models/issue_lifecycle.ts
+++ b/extensions/models/issue_lifecycle.ts
@@ -40,6 +40,7 @@ import {
   StepVerificationSchema,
   SummarySchema,
   TRANSITIONS,
+  VerificationResultSchema,
 } from "./_lib/schemas.ts";
 import { createSwampClubClient, loadAuthFile } from "./_lib/swamp_club.ts";
 
@@ -77,7 +78,7 @@ async function readState(
 
 export const model = {
   type: "@swamp/issue-lifecycle",
-  version: "2026.08.16.1",
+  version: "2026.08.21.1",
   globalArguments: GlobalArgsSchema,
 
   upgrades: [
@@ -182,6 +183,17 @@ export const model = {
       description: "Change Swamp Club API Health Endpoint",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.08.21.1",
+      description:
+        "Pre-PR verification loop — new verifying phase between implementing " +
+        "and pr_open. Three new methods: verify (start verification), " +
+        "verification_passed (record results as checklist), " +
+        "verification_failed (return to implementing). " +
+        "New verificationResult resource stores the checklist data. " +
+        "No globalArguments changes.",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
 
   resources: {
@@ -229,6 +241,15 @@ export const model = {
       schema: CodeConformanceReviewSchema,
       lifetime: "infinite" as const,
       garbageCollection: 10,
+    },
+    "verificationResult": {
+      description:
+        "Verification workflow result — the full checklist of steps, " +
+        "their statuses, and the gate outcome. Written by verification_passed " +
+        "and used as a gate on link_pr.",
+      schema: VerificationResultSchema,
+      lifetime: "infinite" as const,
+      garbageCollection: 5,
     },
     "pullRequest": {
       description:
@@ -1621,6 +1642,226 @@ export const model = {
           summary: "Implementation started",
           emoji: "\u{1F680}",
           payload: {},
+          isVerbose: false,
+        });
+
+        return { dataHandles: [stateHandle] };
+      },
+    },
+
+    verify: {
+      description:
+        "Start verification — transitions to verifying phase. The agent " +
+        "runs the verification workflow in a container sandbox.",
+      arguments: z.object({
+        commit: z.string().describe("Commit SHA being verified"),
+        branch: z.string().describe("Branch being verified"),
+      }),
+      execute: async (
+        args: { commit: string; branch: string },
+        context: {
+          globalArgs: GlobalArgs;
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
+        const { issueNumber } = context.globalArgs;
+
+        const stateHandle = await context.writeResource("state", "state-main", {
+          phase: "verifying",
+          issueNumber,
+          updatedAt: new Date().toISOString(),
+        });
+
+        context.logger.info(
+          "Verification started for commit {commit} on {branch}",
+          { commit: args.commit, branch: args.branch },
+        );
+
+        const sc = await createSwampClubClient(
+          context.globalArgs,
+          context.logger,
+        );
+        await sc?.postLifecycleEntry({
+          step: "verification_started",
+          targetStatus: "in_progress",
+          summary: `Verification started for ${args.commit} on ${args.branch}`,
+          emoji: "\u{1F50D}",
+          payload: { commit: args.commit, branch: args.branch },
+          isVerbose: false,
+        });
+
+        return { dataHandles: [stateHandle] };
+      },
+    },
+
+    verification_passed: {
+      description:
+        "Record that verification passed. Carries the full verification " +
+        "checklist — every step, status, and gate result. This data gates " +
+        "the transition to link_pr.",
+      arguments: z.object({
+        workflowRunId: z.string(),
+        commit: z.string(),
+        branch: z.string(),
+        steps: z.array(z.object({
+          job: z.string(),
+          step: z.string(),
+          model: z.string(),
+          method: z.string(),
+          status: z.enum(["succeeded", "failed", "skipped"]),
+        })),
+      }),
+      execute: async (
+        args: {
+          workflowRunId: string;
+          commit: string;
+          branch: string;
+          steps: Array<{
+            job: string;
+            step: string;
+            model: string;
+            method: string;
+            status: "succeeded" | "failed" | "skipped";
+          }>;
+        },
+        context: {
+          globalArgs: GlobalArgs;
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
+        const { issueNumber } = context.globalArgs;
+        const now = new Date().toISOString();
+
+        const succeeded = args.steps.filter((s) => s.status === "succeeded")
+          .length;
+        const skipped = args.steps.filter((s) => s.status === "skipped").length;
+        const failed = args.steps.filter((s) => s.status === "failed").length;
+
+        const verificationHandle = await context.writeResource(
+          "verificationResult",
+          "verificationResult-main",
+          {
+            workflowRunId: args.workflowRunId,
+            commit: args.commit,
+            branch: args.branch,
+            allPassed: failed === 0,
+            stepsCompleted: succeeded,
+            stepsTotal: args.steps.length,
+            stepsSkipped: skipped,
+            stepsFailed: failed,
+            steps: args.steps,
+            verifiedAt: now,
+          },
+        );
+
+        const stateHandle = await context.writeResource("state", "state-main", {
+          phase: "verifying",
+          issueNumber,
+          updatedAt: now,
+        });
+
+        context.logger.info(
+          "Verification passed: {succeeded}/{total} steps, {skipped} skipped",
+          { succeeded, total: args.steps.length, skipped },
+        );
+
+        const sc = await createSwampClubClient(
+          context.globalArgs,
+          context.logger,
+        );
+        await sc?.postLifecycleEntry({
+          step: "verification_passed",
+          targetStatus: "in_progress",
+          summary:
+            `Verification passed: ${succeeded}/${args.steps.length} steps`,
+          emoji: "✅",
+          payload: {
+            workflowRunId: args.workflowRunId,
+            commit: args.commit,
+            stepsCompleted: succeeded,
+            stepsTotal: args.steps.length,
+          },
+          isVerbose: false,
+        });
+
+        return { dataHandles: [verificationHandle, stateHandle] };
+      },
+    },
+
+    verification_failed: {
+      description:
+        "Record that verification failed. Transitions back to implementing " +
+        "so the agent can fix issues and re-verify.",
+      arguments: z.object({
+        workflowRunId: z.string(),
+        commit: z.string(),
+        branch: z.string(),
+        failureReason: z.string().describe(
+          "Summary of what failed in the verification workflow",
+        ),
+      }),
+      execute: async (
+        args: {
+          workflowRunId: string;
+          commit: string;
+          branch: string;
+          failureReason: string;
+        },
+        context: {
+          globalArgs: GlobalArgs;
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
+        const { issueNumber } = context.globalArgs;
+
+        const stateHandle = await context.writeResource("state", "state-main", {
+          phase: "implementing",
+          issueNumber,
+          updatedAt: new Date().toISOString(),
+        });
+
+        context.logger.info("Verification failed: {reason}", {
+          reason: args.failureReason,
+        });
+
+        const sc = await createSwampClubClient(
+          context.globalArgs,
+          context.logger,
+        );
+        await sc?.postLifecycleEntry({
+          step: "verification_failed",
+          targetStatus: "in_progress",
+          summary: `Verification failed: ${args.failureReason}`,
+          emoji: "❌",
+          payload: {
+            workflowRunId: args.workflowRunId,
+            commit: args.commit,
+            failureReason: args.failureReason,
+          },
           isVerbose: false,
         });
 

--- a/extensions/models/issue_lifecycle.ts
+++ b/extensions/models/issue_lifecycle.ts
@@ -501,6 +501,52 @@ export const model = {
       },
     },
 
+    "verification-clear": {
+      description: "Ensures verification passed before a PR can be linked",
+      labels: ["policy"],
+      appliesTo: ["link_pr"],
+      execute: async (context: {
+        dataRepository: {
+          getContent: (
+            type: string,
+            modelId: string,
+            dataName: string,
+          ) => Promise<Uint8Array | null>;
+        };
+        modelType: string;
+        modelId: string;
+      }) => {
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          "verificationResult-main",
+        );
+        if (!content) {
+          return {
+            pass: false,
+            errors: [
+              "No verification result exists. Run 'verify' and then 'verification_passed' before linking a PR.",
+            ],
+          };
+        }
+
+        const result = JSON.parse(
+          new TextDecoder().decode(content),
+        ) as { allPassed: boolean; stepsFailed: number };
+
+        if (!result.allPassed) {
+          return {
+            pass: false,
+            errors: [
+              `Verification failed (${result.stepsFailed} step(s) failed). Fix the issues and re-verify.`,
+            ],
+          };
+        }
+
+        return { pass: true };
+      },
+    },
+
     "adversarial-review-clear": {
       description:
         "Ensures all critical/high adversarial findings are resolved before approval",

--- a/extensions/models/issue_lifecycle_test.ts
+++ b/extensions/models/issue_lifecycle_test.ts
@@ -322,8 +322,8 @@ Deno.test("model: exposes the new link_pr method definition", () => {
   );
 });
 
-Deno.test("model: version is 2026.08.16.1", () => {
-  assertEquals(model.version, "2026.08.16.1");
+Deno.test("model: version is 2026.08.21.1", () => {
+  assertEquals(model.version, "2026.08.21.1");
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/compile.ts
+++ b/scripts/compile.ts
@@ -204,6 +204,8 @@ async function main() {
       "--exclude",
       "scripts",
       "--exclude",
+      "verification",
+      "--exclude",
       "workflows",
     ];
 

--- a/src/domain/reports/builtin/mod.ts
+++ b/src/domain/reports/builtin/mod.ts
@@ -19,13 +19,17 @@
 
 import { reportRegistry } from "../report_registry.ts";
 import { methodSummaryReport } from "./method_summary_report.ts";
+import { verificationAttestationReport } from "./verification_attestation_report.ts";
 import { workflowSummaryReport } from "./workflow_summary_report.ts";
 
 /** Built-in method-scope report names injected as candidates at call sites. */
 export const BUILTIN_METHOD_REPORTS = ["@swamp/method-summary"];
 
 /** Built-in workflow-scope report names injected as candidates at call sites. */
-export const BUILTIN_WORKFLOW_REPORTS = ["@swamp/workflow-summary"];
+export const BUILTIN_WORKFLOW_REPORTS = [
+  "@swamp/workflow-summary",
+  "@swamp/verification-attestation",
+];
 
 // Register built-in reports (guarded to be idempotent across re-imports)
 if (!reportRegistry.has("@swamp/method-summary")) {
@@ -33,4 +37,10 @@ if (!reportRegistry.has("@swamp/method-summary")) {
 }
 if (!reportRegistry.has("@swamp/workflow-summary")) {
   reportRegistry.register("@swamp/workflow-summary", workflowSummaryReport);
+}
+if (!reportRegistry.has("@swamp/verification-attestation")) {
+  reportRegistry.register(
+    "@swamp/verification-attestation",
+    verificationAttestationReport,
+  );
 }

--- a/src/domain/reports/builtin/verification_attestation_report.ts
+++ b/src/domain/reports/builtin/verification_attestation_report.ts
@@ -1,0 +1,163 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type {
+  ReportContext,
+  WorkflowReportContext,
+} from "../report_context.ts";
+import type { ReportDefinition, ReportResult } from "../report.ts";
+
+function isWorkflowContext(ctx: ReportContext): ctx is WorkflowReportContext {
+  return ctx.scope === "workflow";
+}
+
+export const verificationAttestationReport: ReportDefinition = {
+  description:
+    "Structured attestation of a verification workflow run — captures every step, its result, and the environment for CI validation.",
+  scope: "workflow",
+  labels: ["verification", "attestation"],
+
+  execute(context: ReportContext): Promise<ReportResult> {
+    if (!isWorkflowContext(context)) {
+      throw new Error(
+        "verification-attestation report requires workflow scope context",
+      );
+    }
+
+    const {
+      workflowStatus,
+      workflowName,
+      workflowRunId,
+      workflowId,
+      stepExecutions,
+      inputs,
+    } = context;
+
+    const succeeded = stepExecutions.filter((s) => s.status === "succeeded")
+      .length;
+    const failed = stepExecutions.filter((s) => s.status === "failed").length;
+    const skipped = stepExecutions.filter((s) => s.status === "skipped").length;
+
+    const commit = (inputs?.["commit"] as string) ?? "unknown";
+    const branch = (inputs?.["branch"] as string) ?? "unknown";
+
+    const jobGroups = new Map<
+      string,
+      typeof stepExecutions
+    >();
+    for (const step of stepExecutions) {
+      const group = jobGroups.get(step.jobName) ?? [];
+      group.push(step);
+      jobGroups.set(step.jobName, group);
+    }
+
+    // -- Markdown: human-readable checklist --
+    const lines: string[] = [
+      `# Verification Attestation`,
+      "",
+      `**Commit:** \`${commit}\`  `,
+      `**Branch:** \`${branch}\`  `,
+      `**Status:** ${workflowStatus}  `,
+      `**Steps:** ${succeeded} passed · ${failed} failed · ${skipped} skipped`,
+      "",
+    ];
+
+    const failureDetails: Array<{
+      job: string;
+      step: string;
+      retrievalCommands: string[];
+    }> = [];
+
+    for (const [jobName, steps] of jobGroups) {
+      const jobPassed = steps.every((s) =>
+        s.status === "succeeded" || s.status === "skipped"
+      );
+      const icon = jobPassed ? "✓" : "✗";
+      lines.push(`${icon} **${jobName}**`);
+      for (const step of steps) {
+        const stepIcon = step.status === "succeeded"
+          ? "✓"
+          : step.status === "skipped"
+          ? "○"
+          : "✗";
+        lines.push(
+          `  ${stepIcon} ${step.stepName}  —  ${step.modelType}  (${step.status})`,
+        );
+
+        if (step.status === "failed" && step.dataHandles.length > 0) {
+          const cmds = step.dataHandles.map((h) =>
+            `swamp data get ${step.modelName} ${h.name}`
+          );
+          failureDetails.push({
+            job: step.jobName,
+            step: step.stepName,
+            retrievalCommands: cmds,
+          });
+          for (const cmd of cmds) {
+            lines.push(`    → \`${cmd}\``);
+          }
+        }
+      }
+      lines.push("");
+    }
+
+    lines.push(
+      `**Gate:** ${succeeded}/${stepExecutions.length} passed, ${skipped} skipped`,
+    );
+
+    const markdown = lines.join("\n");
+
+    // -- JSON: structured attestation for CI validation --
+    const json: Record<string, unknown> = {
+      version: "1",
+      type: "verification-attestation",
+      workflowRunId,
+      workflowId,
+      workflowName,
+
+      subject: {
+        commit,
+        branch,
+      },
+
+      steps: stepExecutions.map((s) => ({
+        job: s.jobName,
+        step: s.stepName,
+        model: s.modelType,
+        method: s.methodName,
+        status: s.status,
+        retrievalCommands: s.status === "failed"
+          ? s.dataHandles.map((h) => `swamp data get ${s.modelName} ${h.name}`)
+          : undefined,
+      })),
+
+      failures: failureDetails.length > 0 ? failureDetails : undefined,
+
+      gate: {
+        allPassed: workflowStatus === "succeeded",
+        stepsCompleted: succeeded,
+        stepsTotal: stepExecutions.length,
+        stepsSkipped: skipped,
+        stepsFailed: failed,
+      },
+    };
+
+    return Promise.resolve({ markdown, json });
+  },
+};

--- a/src/domain/reports/builtin/verification_attestation_report_test.ts
+++ b/src/domain/reports/builtin/verification_attestation_report_test.ts
@@ -1,0 +1,314 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { verificationAttestationReport } from "./verification_attestation_report.ts";
+import type { WorkflowReportContext } from "../report_context.ts";
+import { createDataId } from "../../data/data_id.ts";
+
+function makeStepExecution(
+  overrides: Partial<WorkflowReportContext["stepExecutions"][0]> = {},
+): WorkflowReportContext["stepExecutions"][0] {
+  return {
+    jobName: "static-analysis",
+    stepName: "lint",
+    modelName: "lint",
+    modelType: "@swamp/deno-runner",
+    methodName: "task",
+    status: "succeeded",
+    dataHandles: [],
+    methodArgs: {},
+    modelId: "def-1",
+    globalArgs: {},
+    ...overrides,
+  };
+}
+
+function makeWorkflowContext(
+  overrides: Partial<WorkflowReportContext> = {},
+): WorkflowReportContext {
+  return {
+    scope: "workflow",
+    repoDir: "/tmp/test-repo",
+    // deno-lint-ignore no-explicit-any
+    logger: {} as any,
+    // deno-lint-ignore no-explicit-any
+    dataRepository: {} as any,
+    // deno-lint-ignore no-explicit-any
+    definitionRepository: {} as any,
+    workflowId: "wf-1",
+    workflowRunId: "run-1",
+    workflowName: "verify-changes",
+    workflowStatus: "succeeded",
+    inputs: { commit: "abc123", branch: "fix/vault" },
+    stepExecutions: [],
+    ...overrides,
+  };
+}
+
+Deno.test("verificationAttestationReport: all steps pass — markdown shows checkmarks and gate passed", async () => {
+  const ctx = makeWorkflowContext({
+    stepExecutions: [
+      makeStepExecution({ jobName: "static-analysis", stepName: "lint" }),
+      makeStepExecution({ jobName: "static-analysis", stepName: "fmt-check" }),
+      makeStepExecution({ jobName: "tests", stepName: "run-tests" }),
+    ],
+  });
+
+  const result = await verificationAttestationReport.execute(ctx);
+
+  assertStringIncludes(result.markdown, "# Verification Attestation");
+  assertStringIncludes(result.markdown, "`abc123`");
+  assertStringIncludes(result.markdown, "`fix/vault`");
+  assertStringIncludes(result.markdown, "3 passed · 0 failed · 0 skipped");
+  assertStringIncludes(result.markdown, "✓ **static-analysis**");
+  assertStringIncludes(result.markdown, "✓ **tests**");
+  assertStringIncludes(result.markdown, "**Gate:** 3/3 passed, 0 skipped");
+});
+
+Deno.test("verificationAttestationReport: failed step shows cross and retrieval commands", async () => {
+  const ctx = makeWorkflowContext({
+    workflowStatus: "failed",
+    stepExecutions: [
+      makeStepExecution({ jobName: "static-analysis", stepName: "lint" }),
+      makeStepExecution({
+        jobName: "tests",
+        stepName: "run-tests",
+        modelName: "tests",
+        status: "failed",
+        dataHandles: [
+          {
+            name: "result",
+            specName: "result",
+            kind: "resource",
+            dataId: createDataId("d-1"),
+            version: 1,
+            size: 100,
+            tags: {},
+            // deno-lint-ignore no-explicit-any
+            metadata: {} as any,
+          },
+        ],
+      }),
+    ],
+  });
+
+  const result = await verificationAttestationReport.execute(ctx);
+
+  assertStringIncludes(result.markdown, "1 passed · 1 failed · 0 skipped");
+  assertStringIncludes(result.markdown, "✓ **static-analysis**");
+  assertStringIncludes(result.markdown, "✗ **tests**");
+  assertStringIncludes(result.markdown, "✗ run-tests");
+  assertStringIncludes(
+    result.markdown,
+    "→ `swamp data get tests result`",
+  );
+});
+
+Deno.test("verificationAttestationReport: skipped step shows circle icon", async () => {
+  const ctx = makeWorkflowContext({
+    stepExecutions: [
+      makeStepExecution({ jobName: "static-analysis", stepName: "lint" }),
+      makeStepExecution({
+        jobName: "ux-review",
+        stepName: "review",
+        modelType: "@swamp/agent-runner",
+        status: "skipped",
+      }),
+    ],
+  });
+
+  const result = await verificationAttestationReport.execute(ctx);
+
+  assertStringIncludes(result.markdown, "1 passed · 0 failed · 1 skipped");
+  assertStringIncludes(result.markdown, "○ review");
+  assertStringIncludes(result.markdown, "**Gate:** 1/2 passed, 1 skipped");
+});
+
+Deno.test("verificationAttestationReport: inputs default to unknown when missing", async () => {
+  const ctx = makeWorkflowContext({
+    inputs: undefined,
+    stepExecutions: [],
+  });
+
+  const result = await verificationAttestationReport.execute(ctx);
+
+  assertStringIncludes(result.markdown, "`unknown`");
+  const json = result.json as Record<string, Record<string, string>>;
+  assertEquals(json.subject.commit, "unknown");
+  assertEquals(json.subject.branch, "unknown");
+});
+
+Deno.test("verificationAttestationReport: JSON structure matches attestation schema", async () => {
+  const ctx = makeWorkflowContext({
+    stepExecutions: [
+      makeStepExecution({ status: "succeeded" }),
+    ],
+  });
+
+  const result = await verificationAttestationReport.execute(ctx);
+  const json = result.json;
+
+  assertEquals(json.version, "1");
+  assertEquals(json.type, "verification-attestation");
+  assertEquals(json.workflowRunId, "run-1");
+  assertEquals(json.workflowId, "wf-1");
+  assertEquals(json.workflowName, "verify-changes");
+
+  const subject = json.subject as Record<string, string>;
+  assertEquals(subject.commit, "abc123");
+  assertEquals(subject.branch, "fix/vault");
+
+  const gate = json.gate as Record<string, unknown>;
+  assertEquals(gate.allPassed, true);
+  assertEquals(gate.stepsCompleted, 1);
+  assertEquals(gate.stepsTotal, 1);
+  assertEquals(gate.stepsSkipped, 0);
+  assertEquals(gate.stepsFailed, 0);
+
+  assertEquals(json.failures, undefined);
+});
+
+Deno.test("verificationAttestationReport: JSON includes failures array when steps fail", async () => {
+  const ctx = makeWorkflowContext({
+    workflowStatus: "failed",
+    stepExecutions: [
+      makeStepExecution({
+        jobName: "compile",
+        stepName: "binary-check",
+        modelName: "binary-check",
+        modelType: "command/shell",
+        status: "failed",
+        dataHandles: [
+          {
+            name: "result",
+            specName: "result",
+            kind: "resource",
+            dataId: createDataId("d-1"),
+            version: 1,
+            size: 50,
+            tags: {},
+            // deno-lint-ignore no-explicit-any
+            metadata: {} as any,
+          },
+        ],
+      }),
+    ],
+  });
+
+  const result = await verificationAttestationReport.execute(ctx);
+  const json = result.json;
+
+  const gate = json.gate as Record<string, unknown>;
+  assertEquals(gate.allPassed, false);
+  assertEquals(gate.stepsFailed, 1);
+
+  const failures = json.failures as Array<Record<string, unknown>>;
+  assertEquals(failures.length, 1);
+  assertEquals(failures[0].job, "compile");
+  assertEquals(failures[0].step, "binary-check");
+  assertEquals(failures[0].retrievalCommands, [
+    "swamp data get binary-check result",
+  ]);
+
+  const steps = json.steps as Array<Record<string, unknown>>;
+  assertEquals(steps[0].retrievalCommands, [
+    "swamp data get binary-check result",
+  ]);
+});
+
+Deno.test("verificationAttestationReport: multi-job grouping with mixed statuses", async () => {
+  const ctx = makeWorkflowContext({
+    workflowStatus: "failed",
+    stepExecutions: [
+      makeStepExecution({
+        jobName: "static-analysis",
+        stepName: "lint",
+        status: "succeeded",
+      }),
+      makeStepExecution({
+        jobName: "static-analysis",
+        stepName: "fmt-check",
+        status: "succeeded",
+      }),
+      makeStepExecution({
+        jobName: "tests",
+        stepName: "run-tests",
+        status: "succeeded",
+      }),
+      makeStepExecution({
+        jobName: "compile",
+        stepName: "build",
+        status: "succeeded",
+      }),
+      makeStepExecution({
+        jobName: "code-review",
+        stepName: "review",
+        modelType: "@swamp/agent-runner",
+        status: "failed",
+      }),
+    ],
+  });
+
+  const result = await verificationAttestationReport.execute(ctx);
+
+  assertStringIncludes(result.markdown, "4 passed · 1 failed · 0 skipped");
+  assertStringIncludes(result.markdown, "✓ **static-analysis**");
+  assertStringIncludes(result.markdown, "✓ **tests**");
+  assertStringIncludes(result.markdown, "✓ **compile**");
+  assertStringIncludes(result.markdown, "✗ **code-review**");
+  assertStringIncludes(result.markdown, "**Gate:** 4/5 passed, 0 skipped");
+});
+
+Deno.test("verificationAttestationReport: failed step without data handles omits retrieval commands", async () => {
+  const ctx = makeWorkflowContext({
+    workflowStatus: "failed",
+    stepExecutions: [
+      makeStepExecution({
+        status: "failed",
+        dataHandles: [],
+      }),
+    ],
+  });
+
+  const result = await verificationAttestationReport.execute(ctx);
+
+  assert(!result.markdown.includes("→"));
+  assertEquals(result.json.failures, undefined);
+
+  const steps = result.json.steps as Array<Record<string, unknown>>;
+  assertEquals(steps[0].retrievalCommands, []);
+});
+
+Deno.test("verificationAttestationReport: job with all skipped steps shows checkmark", async () => {
+  const ctx = makeWorkflowContext({
+    stepExecutions: [
+      makeStepExecution({
+        jobName: "ux-review",
+        stepName: "review",
+        status: "skipped",
+      }),
+    ],
+  });
+
+  const result = await verificationAttestationReport.execute(ctx);
+
+  assertStringIncludes(result.markdown, "✓ **ux-review**");
+  assertStringIncludes(result.markdown, "○ review");
+});

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -3361,7 +3361,9 @@ Deno.test("CONTRACT: success run emits events in exact order", async () => {
       "step_completed",
       "job_completed",
       // Workflow-scope reports run even without reportFilterOptions
-      // (swamp-club#640) — the builtin workflow summary emits here.
+      // (swamp-club#640) — builtin workflow reports emit here.
+      "report_started",
+      "report_completed",
       "report_started",
       "report_completed",
       "completed",
@@ -3403,7 +3405,9 @@ Deno.test("CONTRACT: step failure emits events in exact order", async () => {
       "step_failed",
       "job_completed",
       // Workflow-scope reports run even without reportFilterOptions
-      // (swamp-club#640) — the builtin workflow summary emits here.
+      // (swamp-club#640) — builtin workflow reports emit here.
+      "report_started",
+      "report_completed",
       "report_started",
       "report_completed",
       "completed",

--- a/src/presentation/renderers/vault_read_secret.ts
+++ b/src/presentation/renderers/vault_read_secret.ts
@@ -26,12 +26,24 @@ import type { OutputMode } from "../output/output.ts";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
 
+const encoder = new TextEncoder();
+
 class LogVaultReadSecretRenderer implements Renderer<VaultReadSecretEvent> {
+  #isTerminal: () => boolean;
+
+  constructor(isTerminal: () => boolean) {
+    this.#isTerminal = isTerminal;
+  }
+
   handlers(): EventHandlers<VaultReadSecretEvent> {
     return {
       resolving: () => {},
       completed: (e) => {
-        writeOutput(e.data.value);
+        if (this.#isTerminal()) {
+          writeOutput(e.data.value);
+        } else {
+          Deno.stdout.writeSync(encoder.encode(e.data.value));
+        }
       },
       error: (e) => {
         throw new UserError(e.error.message);
@@ -56,11 +68,12 @@ class JsonVaultReadSecretRenderer implements Renderer<VaultReadSecretEvent> {
 
 export function createVaultReadSecretRenderer(
   mode: OutputMode,
+  isTerminal: () => boolean = () => Deno.stdout.isTerminal(),
 ): Renderer<VaultReadSecretEvent> {
   switch (mode) {
     case "json":
       return new JsonVaultReadSecretRenderer();
     case "log":
-      return new LogVaultReadSecretRenderer();
+      return new LogVaultReadSecretRenderer(isTerminal);
   }
 }

--- a/src/presentation/renderers/vault_read_secret_test.ts
+++ b/src/presentation/renderers/vault_read_secret_test.ts
@@ -42,13 +42,13 @@ async function* toStream(
   }
 }
 
-Deno.test("LogVaultReadSecretRenderer: writes only the secret value to stdout", async () => {
+Deno.test("LogVaultReadSecretRenderer: writes secret with newline when stdout is a TTY", async () => {
   const logs: string[] = [];
   const originalLog = console.log;
   console.log = (msg: string) => logs.push(msg);
 
   try {
-    const renderer = createVaultReadSecretRenderer("log");
+    const renderer = createVaultReadSecretRenderer("log", () => true);
     const events: VaultReadSecretEvent[] = [
       { kind: "resolving" },
       { kind: "completed", data: makeData() },
@@ -58,6 +58,29 @@ Deno.test("LogVaultReadSecretRenderer: writes only the secret value to stdout", 
     assertEquals(logs[0], "super_secret_value");
   } finally {
     console.log = originalLog;
+  }
+});
+
+Deno.test("LogVaultReadSecretRenderer: writes exact bytes without trailing newline when piped", async () => {
+  const written: Uint8Array[] = [];
+  const originalWriteSync = Deno.stdout.writeSync.bind(Deno.stdout);
+  Deno.stdout.writeSync = (data: Uint8Array): number => {
+    written.push(new Uint8Array(data));
+    return data.length;
+  };
+
+  try {
+    const renderer = createVaultReadSecretRenderer("log", () => false);
+    const events: VaultReadSecretEvent[] = [
+      { kind: "resolving" },
+      { kind: "completed", data: makeData() },
+    ];
+    await consumeStream(toStream(events), renderer.handlers());
+    assertEquals(written.length, 1);
+    const output = new TextDecoder().decode(written[0]);
+    assertEquals(output, "super_secret_value");
+  } finally {
+    Deno.stdout.writeSync = originalWriteSync;
   }
 });
 

--- a/verification/container/.containerignore
+++ b/verification/container/.containerignore
@@ -1,0 +1,6 @@
+.git
+.swamp
+node_modules
+integration
+containers/verify/*.tar
+*.tar.gz

--- a/verification/container/Containerfile
+++ b/verification/container/Containerfile
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1
+#
+# Verification Sandbox Container
+# OCI-compliant image for pre-PR verification loops.
+# Compatible with Docker, Apple Containers, and Kubernetes.
+#
+# The container provides an isolated, reproducible environment matching
+# CI conditions. Agents run verification workflows inside it directly —
+# no orchestrator or worker protocol needed.
+#
+# Build:  ./containers/verify/build.sh
+#
+# Run a verification workflow:
+#   docker run --rm -v $(pwd):/workspace \
+#     swamp-club/verify:latest \
+#     workflow run verify-changes
+#
+# Interactive shell (debugging):
+#   docker run --rm -it -v $(pwd):/workspace \
+#     --entrypoint /bin/bash \
+#     swamp-club/verify:latest
+
+ARG DENO_VERSION=2.8.3
+
+# ── Stage 1: Compile swamp binary ──────────────────────────────
+FROM denoland/deno:${DENO_VERSION} AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends unzip git && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+COPY . .
+RUN deno run -A scripts/compile.ts
+
+# ── Stage 2: Runtime ───────────────────────────────────────────
+FROM denoland/deno:${DENO_VERSION}
+
+# git: repo operations and @swamp/git extension
+# curl: @swamp/deno-runner downloads pinned Deno versions
+# ca-certificates: TLS for registry/API calls
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       git \
+       curl \
+       unzip \
+       ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/swamp /usr/local/bin/swamp
+RUN chmod +x /usr/local/bin/swamp
+
+WORKDIR /workspace
+
+# OCI annotations (build-time labels added by build.sh)
+LABEL org.opencontainers.image.title="swamp-verify" \
+      org.opencontainers.image.description="Verification sandbox for pre-PR verification loops" \
+      org.opencontainers.image.vendor="swamp-club" \
+      org.opencontainers.image.url="https://github.com/swamp-club/swamp" \
+      org.opencontainers.image.source="https://github.com/swamp-club/swamp"
+
+ENV SWAMP_NO_TELEMETRY=1
+
+# The entrypoint is `swamp` — the agent passes the subcommand.
+# Typical use: docker run ... swamp-club/verify workflow run verify-changes
+ENTRYPOINT ["swamp"]

--- a/verification/container/build.sh
+++ b/verification/container/build.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Builds the verification sandbox container as an OCI image.
+#
+# Usage:
+#   ./verification/container/build.sh                     Build for local arch, load into Docker
+#   ./verification/container/build.sh --export             Also export OCI tarball
+#   ./verification/container/build.sh --platform linux/arm64,linux/amd64  Multi-arch
+#   ./verification/container/build.sh --tag v1.0           Custom tag
+#
+# Environment:
+#   DENO_VERSION  Deno version to use (default: 2.8.3)
+#   IMAGE_NAME    Image name (default: swamp-club/verify)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+DENO_VERSION="${DENO_VERSION:-2.8.3}"
+IMAGE_NAME="${IMAGE_NAME:-swamp-club/verify}"
+IMAGE_TAG="deno-${DENO_VERSION}"
+PLATFORM=""
+EXPORT=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --platform)  PLATFORM="$2"; shift 2 ;;
+    --export)    EXPORT=true; shift ;;
+    --tag)       IMAGE_TAG="$2"; shift 2 ;;
+    --help|-h)
+      sed -n '2,/^$/s/^# //p' "$0"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Pick a container builder
+if command -v docker &>/dev/null; then
+  BUILDER="docker"
+elif command -v podman &>/dev/null; then
+  BUILDER="podman"
+else
+  echo "Error: docker or podman required" >&2
+  exit 1
+fi
+
+echo "Building verification sandbox"
+echo "  Builder:  ${BUILDER}"
+echo "  Deno:     ${DENO_VERSION}"
+echo "  Image:    ${IMAGE_NAME}:${IMAGE_TAG}"
+[[ -n "${PLATFORM}" ]] && echo "  Platform: ${PLATFORM}"
+echo ""
+
+GIT_SHA="$(git -C "${REPO_ROOT}" rev-parse HEAD 2>/dev/null || echo unknown)"
+CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+BUILD_ARGS=(
+  --build-arg "DENO_VERSION=${DENO_VERSION}"
+  --file "${SCRIPT_DIR}/Containerfile"
+  --tag "${IMAGE_NAME}:${IMAGE_TAG}"
+  --tag "${IMAGE_NAME}:latest"
+  --label "org.opencontainers.image.created=${CREATED}"
+  --label "org.opencontainers.image.revision=${GIT_SHA}"
+  --label "org.opencontainers.image.version=${IMAGE_TAG}"
+)
+
+[[ -n "${PLATFORM}" ]] && BUILD_ARGS+=(--platform "${PLATFORM}")
+
+# Use .containerignore from the container dir.
+# Docker needs .dockerignore at the build context root — copy it temporarily.
+DOCKERIGNORE="${REPO_ROOT}/.dockerignore"
+CLEANUP_DOCKERIGNORE=false
+if [[ "${BUILDER}" == "docker" && ! -f "${DOCKERIGNORE}" ]]; then
+  cp "${SCRIPT_DIR}/.containerignore" "${DOCKERIGNORE}"
+  CLEANUP_DOCKERIGNORE=true
+fi
+
+cleanup() {
+  if [[ "${CLEANUP_DOCKERIGNORE}" == true ]]; then
+    rm -f "${DOCKERIGNORE}"
+  fi
+}
+trap cleanup EXIT
+
+# Export OCI tarball if requested
+if [[ "${EXPORT}" == true ]]; then
+  OCI_TAR="${SCRIPT_DIR}/verify-${IMAGE_TAG}.tar"
+  echo "Exporting OCI tarball → ${OCI_TAR}"
+
+  if [[ "${BUILDER}" == "docker" ]]; then
+    docker buildx build "${BUILD_ARGS[@]}" \
+      --output "type=oci,dest=${OCI_TAR}" \
+      "${REPO_ROOT}"
+  else
+    podman build "${BUILD_ARGS[@]}" \
+      --format oci \
+      "${REPO_ROOT}"
+    podman save --format oci-archive -o "${OCI_TAR}" "${IMAGE_NAME}:${IMAGE_TAG}"
+  fi
+
+  echo "OCI tarball: ${OCI_TAR}"
+  echo ""
+fi
+
+# Load into local container runtime
+echo "Loading image..."
+if [[ "${BUILDER}" == "docker" ]]; then
+  docker buildx build "${BUILD_ARGS[@]}" --load "${REPO_ROOT}"
+else
+  podman build "${BUILD_ARGS[@]}" "${REPO_ROOT}"
+fi
+
+echo ""
+echo "Done: ${IMAGE_NAME}:${IMAGE_TAG}"
+echo ""
+echo "Run a verification workflow:"
+echo "  ${BUILDER} run --rm \\"
+echo "    -v \$(pwd):/workspace \\"
+echo "    ${IMAGE_NAME}:${IMAGE_TAG} \\"
+echo "    workflow run verify-changes"
+echo ""
+echo "Interactive shell:"
+echo "  ${BUILDER} run --rm -it \\"
+echo "    -v \$(pwd):/workspace \\"
+echo "    --entrypoint /bin/bash \\"
+echo "    ${IMAGE_NAME}:${IMAGE_TAG}"

--- a/verification/review-prompts/adversarial-review.md
+++ b/verification/review-prompts/adversarial-review.md
@@ -1,0 +1,155 @@
+# Adversarial Code Review
+
+You are an ADVERSARIAL code reviewer. Your job is to be the skeptic — assume the
+code is broken until proven otherwise. You are not here to be helpful or
+encouraging. You are here to find problems that the author and a standard
+reviewer would miss.
+
+First, run `git diff main --name-only` to identify the changed files.
+
+Read the project's conventions file (CLAUDE.md) if it exists, then read every
+changed file thoroughly. Only review files in the diff — do not review unchanged
+code.
+
+Your review MUST systematically attempt to break the code across these
+dimensions:
+
+## 1. Logic & Correctness
+
+- Trace every code path mentally. Are there unreachable branches? Wrong
+  operators? Off-by-one errors? Short-circuit evaluation that skips important
+  side effects?
+- What happens with empty arrays, empty strings, zero, negative numbers, NaN,
+  undefined, null?
+- Are there implicit type coercions that could produce surprising results?
+- Do switch statements have missing cases or fallthrough bugs?
+- Are comparisons correct? (`===` vs `==`, `<` vs `<=`, `&&` vs `||`)
+
+## 2. Error Handling & Failure Modes
+
+- What happens when every external call fails? Network timeout? Disk full?
+  Permission denied?
+- Are errors caught and swallowed silently? Are error messages useful or
+  misleading?
+- Can a thrown error leave the system in an inconsistent state? (partial writes,
+  leaked resources)
+- Are try/catch blocks too broad, catching errors they shouldn't?
+- Is cleanup code (finally blocks, resource disposal) actually correct?
+
+## 3. Security — Implementation Patterns
+
+- Command injection via string interpolation in shell commands or subprocess
+  calls
+- Path traversal — can user input escape intended directories? Are `..`
+  components, absolute paths, and symlink targets validated? Does the code use
+  the codebase's existing primitives (`assertSafePath`, `assertContainedPath`,
+  `validateNoSymlinkEscape`) for untrusted paths? New file-handling code that
+  skips these is CRITICAL.
+- Symlink escape — are symlinks from untrusted sources (extension dirs,
+  archives, copied skill directories) detected with lstat and validated to stay
+  within the expected root?
+- Path containment on external data — if file operations (copy, delete, read)
+  use paths from lockfiles, manifests, extension metadata, or repo-controlled
+  JSON, are paths validated to stay within the expected boundary before any
+  filesystem operation?
+- Sensitive data exposure in logs, error messages, or stack traces
+- Prototype pollution, ReDoS, or other JS/TS-specific vulnerabilities
+- Are secrets, tokens, or credentials ever hardcoded or logged?
+- TOCTOU (time-of-check-time-of-use) race conditions on file operations
+
+## 3b. Security — Trust Boundary & Authorization Design
+
+These checks catch design-level security flaws that code-pattern matching
+misses. For every trust boundary crossing in the diff, apply ALL of the
+following:
+
+- Authorization/execution identity consistency — when code authorizes an
+  operation using one value and then executes using a different value (different
+  payload fields, raw vs. normalized forms), that is a CRITICAL authorization
+  bypass. The identity used for the security decision must be the exact same
+  canonical value used for execution.
+- Canonicalization before security decisions — any input that can be represented
+  in multiple forms (`.` vs `/` separators, `::` vs `/`, case variants,
+  whitespace, URL encoding) MUST be normalized to a single canonical form BEFORE
+  authorization or access-control checks.
+- Defense-in-depth at sensitive execution sinks — built-in operations that
+  execute commands, modify access control, or delete resources must
+  independently verify authorization at the point of execution.
+- Confused deputy / privilege delegation — when code acts on behalf of a caller,
+  does the callee operate with the caller's authority? Can the caller influence
+  which authority is used, which code path runs, or which capabilities are
+  exercised beyond what was authorized?
+- Untrusted data round-trip through persistence — if external or repo-controlled
+  data is written to a file and later read back and acted upon, the read-back
+  path must validate data shape AND path/identity containment.
+
+## 3c. Security — Data Flow & Reachability
+
+- Trace untrusted data ingress-to-sink — for each piece of untrusted data in the
+  diff, trace where it enters and where it acts. Every step must validate or be
+  proven safe by its caller.
+- Reachability from unvalidated paths — if a function receives data that was
+  validated at one call site, can the same function be reached from a different
+  path that skips validation?
+- Resource exhaustion — can a client-controlled value cause unbounded memory
+  allocation, CPU consumption, or recursive processing?
+- Error information leakage — do error messages returned to clients leak
+  internal paths, token fragments, or configuration details?
+- Stale authorization — for long-lived connections, are permissions re-evaluated
+  on each request?
+
+## 4. Concurrency & State
+
+- Can concurrent operations corrupt shared state?
+- Are there race conditions in async code? (await ordering, Promise.all error
+  handling)
+- Could event handlers fire in an unexpected order?
+- Are there potential deadlocks or starvation scenarios?
+
+## 5. Data Integrity
+
+- Can data be silently truncated, rounded, or lost during transformation?
+- Are array/object mutations happening where immutability is expected?
+- Could cache staleness cause incorrect behavior?
+- Are database/file operations atomic where they need to be?
+
+## 6. Resource Management
+
+- Are file handles, network connections, or timers properly cleaned up on all
+  paths?
+- Could this code leak memory through growing collections, closures, or event
+  listeners?
+- Are there unbounded loops or recursion that could exhaust the stack or hang?
+
+## 7. API Contract Violations
+
+- Does the change alter any function signatures, return types, or error types
+  that callers depend on?
+- Are there breaking changes to public interfaces without corresponding updates
+  to callers?
+- Do new functions follow existing patterns in the codebase, or do they
+  introduce inconsistencies?
+
+## Review Rules
+
+- Be SPECIFIC. Don't say "this could have edge cases" — name the exact input
+  that breaks it.
+- Be CONCRETE. Don't say "error handling could be improved" — show the exact
+  failure scenario.
+- Every finding must include: the file and line, what's wrong, a concrete
+  example of how it breaks, and a suggested fix.
+- Do NOT flag style issues, naming preferences, or documentation gaps.
+- Focus on what a normal review would miss — logic errors, edge cases, and
+  failure modes.
+- If the code is genuinely solid, say so. Do not invent problems to justify your
+  existence.
+
+## Severity Classification
+
+- **CRITICAL**: Security vulnerabilities, data loss/corruption, or crashes in
+  production paths. These block.
+- **HIGH**: Logic errors that produce wrong results, resource leaks, race
+  conditions that corrupt shared state. These block.
+- **MEDIUM**: Edge cases in uncommon paths, cosmetic concurrency issues. These
+  are warnings.
+- **LOW**: Theoretical issues unlikely in practice. Mention but do not block.

--- a/verification/review-prompts/ci-security-review.md
+++ b/verification/review-prompts/ci-security-review.md
@@ -1,0 +1,106 @@
+# CI Security Review
+
+You are a CI/CD security reviewer. Your job is to audit GitHub Actions workflow
+changes for security vulnerabilities. You are specifically looking for problems
+that could allow attackers to compromise the CI pipeline, exfiltrate secrets, or
+manipulate automated processes.
+
+First, run `git diff main --name-only` to identify the changed files.
+
+Read every changed workflow file thoroughly. Only review files in the diff — do
+not review unchanged workflows. Then review each changed file against the
+following checklist.
+
+## 1. Prompt Injection
+
+This is the HIGHEST PRIORITY check. Any workflow that passes data to an LLM
+(Claude, GPT, etc.) is a potential prompt injection target.
+
+- **Direct interpolation**: Are GitHub event fields (issue title, issue body, PR
+  body, comment bodies, commit messages) interpolated directly into a prompt
+  using expression syntax? This is ALWAYS a finding — attacker-controlled data
+  must never be spliced into prompts. The LLM should fetch the data itself via
+  tool calls.
+- **Tool scope**: If an LLM agent has `Bash` tool access, are the allowed
+  commands tightly scoped? `Bash(gh api:*)` is too broad — it allows arbitrary
+  GitHub API calls. Tools should be restricted to the minimum necessary.
+- **Prompt hardening**: Does each LLM prompt include a security preamble
+  instructing the model to treat fetched content as untrusted data and ignore
+  embedded instructions?
+
+## 2. Expression Injection & Script Injection
+
+- Are expressions used directly in `run:` blocks where they could break out of
+  the intended command? Interpolating event fields directly in a run block is
+  DANGEROUS — content could contain shell metacharacters or command
+  substitution. The safe pattern is to pass untrusted data via environment
+  variables instead.
+- Are expressions used in contexts where they could inject YAML structure (e.g.,
+  in `if:` conditions, `with:` inputs)?
+
+## 3. Dangerous Triggers
+
+- `pull_request_target`: Runs in the BASE repo context with secrets. If combined
+  with `actions/checkout` using the PR HEAD ref, attacker code runs with repo
+  secrets. Flag any `pull_request_target` workflow that checks out PR code.
+- `issue_comment`, `issues`, `discussion_comment`: Triggered by external users.
+  Verify that attacker-controlled content from these events is not used
+  unsafely.
+- `workflow_dispatch` with `inputs`: Check that input values are validated
+  before use.
+
+## 4. Supply Chain
+
+- Are third-party actions pinned to a full commit SHA? Using `@v1` or `@main`
+  means the action code can change without your knowledge. Only `actions/*`
+  (GitHub-owned) are acceptable with tag-only pins.
+- Is `curl | bash` or similar remote script execution used? This should always
+  be replaced with a pinned action or a vendored script.
+- Are `setup-*` actions from trusted publishers (actions/_, denoland/_, etc.)?
+
+## 5. Permissions
+
+- Are permissions scoped at the JOB level, not the workflow level?
+  Workflow-level permissions apply to ALL jobs, including ones that don't need
+  them.
+- Does each job request the MINIMUM permissions it needs? A test job should only
+  need `contents: read`. Only merge/deploy jobs need `contents: write`.
+- Is `id-token: write` present? This allows OIDC token generation — verify it's
+  actually needed.
+
+## 6. Secret Exposure
+
+- Are secrets passed to steps that don't need them?
+- Could secrets leak through log output, error messages, or environment variable
+  dumps?
+- Are secrets used in `run:` blocks where command substitution could expose
+  them?
+- Are PATs (Personal Access Tokens) used where `GITHUB_TOKEN` would suffice?
+
+## 7. Auto-merge & Trust Boundaries
+
+- If the workflow auto-merges PRs, what gates must pass first? Are there human
+  approval requirements, or can automated reviews alone trigger a merge?
+- Can a same-repo contributor bypass review gates by crafting specific PR
+  content?
+- Are fork PRs properly excluded from privileged operations?
+
+## Review Rules
+
+- Be SPECIFIC. Name the exact file, line, expression, and attack scenario.
+- For each finding, explain: what's vulnerable, how an attacker would exploit
+  it, and what the fix is.
+- Do NOT flag non-security issues (style, naming, documentation).
+- If the workflow changes are security-neutral or improve security, say so.
+
+## Severity Classification
+
+- **CRITICAL**: Prompt injection with broad tool access, secret exfiltration,
+  arbitrary code execution via expression injection, unpinned actions in
+  privileged workflows. These block.
+- **HIGH**: Overly broad tool scoping, missing prompt hardening, workflow-level
+  permissions that should be job-level. These block.
+- **MEDIUM**: Missing SHA pins on low-privilege actions, permissions that are
+  broader than necessary but not exploitable. These are warnings.
+- **LOW**: Style issues in workflow files, missing comments. Mention but do not
+  block.

--- a/verification/review-prompts/code-review.md
+++ b/verification/review-prompts/code-review.md
@@ -1,0 +1,32 @@
+# Code Review
+
+Review this change for correctness, conventions, and quality.
+
+First, run `git diff main --name-only` to identify the changed files. Only
+review those files — do not review unchanged code.
+
+Read the project's CLAUDE.md to understand code style, conventions, and
+requirements. Use the `ddd` skill to review for domain-driven design principles.
+
+## Review Dimensions
+
+1. **CLAUDE.md adherence** — does the change follow all conventions and
+   requirements defined in the project's CLAUDE.md?
+2. **Domain-driven design** — are DDD principles applied correctly? (Use the ddd
+   skill.)
+3. **Test coverage** — are there unit tests for new code? Do tests live next to
+   source files?
+4. **Security** — are there vulnerabilities or unsafe patterns?
+5. **Bugs and edge cases** — are there logic errors, off-by-one mistakes, or
+   unhandled scenarios?
+
+Pay special attention to the libswamp import boundary: CLI commands and
+presentation renderers must import from `src/libswamp/mod.ts` — never from
+internal module paths.
+
+## Severity Classification
+
+- **Blocking**: Bugs, security issues, type errors, missing tests for new code,
+  violations of CLAUDE.md requirements. These must be fixed.
+- **Suggestion**: Style preferences, optional refactoring, documentation
+  improvements. These do not block.

--- a/verification/review-prompts/ux-review.md
+++ b/verification/review-prompts/ux-review.md
@@ -1,0 +1,75 @@
+# CLI UX Review
+
+You are a CLI UX reviewer. Your job is to evaluate how this change affects the
+user experience of the swamp CLI tool. You are reviewing from the perspective of
+someone USING the CLI, not reading the code.
+
+Read the project's CLAUDE.md to understand conventions, especially:
+
+- Every command must support both "log" and "json" output modes
+- The CLI uses Cliffy for commands and LogTape for log-mode output
+
+First, run `git diff main --name-only` to identify the changed files.
+
+Then read every changed file. Focus ONLY on files that affect what users see:
+commands, renderers, output formatters, and error handling.
+
+## Review Dimensions
+
+### 1. Help Text & Discoverability
+
+- Are new flags and options documented in the command's help text?
+- Are flag names consistent with existing commands? (check similar commands for
+  patterns)
+- Are option descriptions clear and concise?
+- Do flag names use the same conventions as the rest of the CLI? (e.g.,
+  `--verbose`, `--json`, `--field` vs `--filter`)
+
+### 2. Error Messages
+
+- When the command fails, does the user get a clear, actionable message?
+- Does the error tell the user WHAT went wrong and HOW to fix it?
+- Are error messages consistent in tone and format with existing commands?
+- Read `src/domain/errors.ts` to understand the UserError pattern
+
+### 3. Log-Mode Output (human-readable)
+
+- Is the output readable and scannable?
+- Is the information hierarchy clear? (most important info first)
+- Is formatting consistent with other commands? (check similar renderers for
+  patterns)
+- Are colors, icons, or formatting used consistently?
+
+### 4. JSON-Mode Output (machine-readable)
+
+- Does the JSON output include all the data a script would need?
+- Are field names consistent with other commands' JSON output?
+- Is the shape documented or self-evident?
+- Are there fields that are present in log mode but missing from JSON mode (or
+  vice versa)?
+
+### 5. Behavioral Consistency
+
+- Does the command behave consistently with similar commands in the CLI?
+- Are exit codes correct? (0 for success, non-zero for failure)
+- If the command is destructive, does it require confirmation or support
+  `--force`?
+- Does the output change correctly between normal and `--verbose` modes?
+
+## Review Rules
+
+- Compare against EXISTING commands to check consistency. Don't just review in
+  isolation.
+- Be SPECIFIC — reference the exact flag, message, or output format.
+- Only flag issues that affect the user experience. Ignore internal code
+  quality.
+- If the change doesn't meaningfully affect UX (e.g., only refactors internals),
+  say so and pass.
+
+## Severity Classification
+
+- **Blocking**: Broken help text, misleading error messages, missing JSON output
+  for new functionality, inconsistent flag names that would confuse users. These
+  must be fixed.
+- **Suggestion**: Minor wording improvements, optional additional output,
+  nice-to-have consistency tweaks. These do not block.

--- a/verification/workflow-verify-changes.yaml
+++ b/verification/workflow-verify-changes.yaml
@@ -1,0 +1,247 @@
+id: ae3c59af-767a-4b40-92af-78efb15ad21e
+name: verify-changes
+description: |
+  Pre-PR verification loop. Runs lint, format check, type check, tests,
+  compile, dependency audit, and agent reviews inside a container sandbox.
+  Produces a verification attestation on success.
+version: 1
+
+tags:
+  purpose: pre-pr-verification
+
+inputs:
+  properties:
+    commit:
+      type: string
+      description: Commit SHA being verified.
+    branch:
+      type: string
+      description: Branch name being verified.
+    agentCliVersion:
+      type: string
+      description: Claude Code CLI version for agent reviews.
+      default: "1.0.33"
+    workingDir:
+      type: string
+      description: Directory containing the project checkout.
+      default: /workspace
+  required:
+    - commit
+    - branch
+
+concurrency: 4
+
+jobs:
+  # ── Static Analysis ──────────────────────────────────────────
+  - name: static-analysis
+    description: Lint, format check, and type check.
+    steps:
+      - name: lint
+        task:
+          type: model_method
+          modelType: "@swamp/deno-runner"
+          modelName: lint
+          methodName: task
+          inputs:
+            version: "2.8.3"
+            taskName: "lint"
+            workingDir: "${{ inputs.workingDir }}"
+
+      - name: fmt-check
+        task:
+          type: model_method
+          modelType: "@swamp/deno-runner"
+          modelName: fmt-check
+          methodName: run
+          inputs:
+            version: "2.8.3"
+            args:
+              - fmt
+              - --check
+            workingDir: "${{ inputs.workingDir }}"
+
+      - name: type-check
+        task:
+          type: model_method
+          modelType: "@swamp/deno-runner"
+          modelName: type-check
+          methodName: task
+          inputs:
+            version: "2.8.3"
+            taskName: "check"
+            workingDir: "${{ inputs.workingDir }}"
+
+  # ── Tests ────────────────────────────────────────────────────
+  - name: tests
+    description: Run the full test suite in parallel.
+    steps:
+      - name: run-tests
+        task:
+          type: model_method
+          modelType: "@swamp/deno-runner"
+          modelName: tests
+          methodName: task
+          inputs:
+            version: "2.8.3"
+            taskName: "test"
+            workingDir: "${{ inputs.workingDir }}"
+
+  # ── Dependency Audit ─────────────────────────────────────────
+  - name: deps-audit
+    description: Scan dependencies for known vulnerabilities.
+    steps:
+      - name: vuln-scan
+        task:
+          type: model_method
+          modelType: "@swamp/deno-runner"
+          modelName: audit
+          methodName: task
+          inputs:
+            version: "2.8.3"
+            taskName: "audit"
+            workingDir: "${{ inputs.workingDir }}"
+
+  # ── Compile + Binary Check ────────────────────────────────────
+  - name: compile
+    description: Compile the binary and verify it executes.
+    dependsOn:
+      - job: static-analysis
+        condition:
+          type: succeeded
+      - job: tests
+        condition:
+          type: succeeded
+    steps:
+      - name: build
+        task:
+          type: model_method
+          modelType: "@swamp/deno-runner"
+          modelName: compile
+          methodName: task
+          inputs:
+            version: "2.8.3"
+            taskName: "compile"
+            workingDir: "${{ inputs.workingDir }}"
+            env:
+              DENO_DIR: "/tmp/deno-compile-cache"
+
+      - name: binary-check
+        dependsOn:
+          - step: build
+            condition:
+              type: succeeded
+        task:
+          type: model_method
+          modelType: "command/shell"
+          modelName: binary-check
+          methodName: execute
+          inputs:
+            run: "ls -la swamp && chmod +x swamp && ./swamp --version"
+            workingDir: "${{ inputs.workingDir }}"
+
+  # ── Agent Reviews ────────────────────────────────────────────
+  - name: code-review
+    description: General code review for conventions, DDD, tests, security.
+    dependsOn:
+      - job: static-analysis
+        condition:
+          type: succeeded
+      - job: tests
+        condition:
+          type: succeeded
+      - job: deps-audit
+        condition:
+          type: succeeded
+    steps:
+      - name: review
+        task:
+          type: model_method
+          modelType: "@swamp/agent-runner"
+          modelName: code-review
+          methodName: review
+          globalArgs:
+            version: "${{ inputs.agentCliVersion }}"
+            apiKeyEnvVar: "ANTHROPIC_API_KEY"
+          inputs:
+            promptFile: "verification/review-prompts/code-review.md"
+            model: "claude-opus-4-6"
+            files: ["."]
+            readOnly: true
+
+  - name: adversarial-review
+    description: Adversarial review for logic errors, security, edge cases.
+    dependsOn:
+      - job: static-analysis
+        condition:
+          type: succeeded
+      - job: tests
+        condition:
+          type: succeeded
+    steps:
+      - name: review
+        guard: "${{ hasChanges('src/domain/', 'src/infrastructure/', 'src/libswamp/', 'src/serve/', 'src/worker/') }}"
+        task:
+          type: model_method
+          modelType: "@swamp/agent-runner"
+          modelName: adversarial
+          methodName: review
+          globalArgs:
+            version: "${{ inputs.agentCliVersion }}"
+            apiKeyEnvVar: "ANTHROPIC_API_KEY"
+          inputs:
+            promptFile: "verification/review-prompts/adversarial-review.md"
+            model: "claude-opus-4-6"
+            files: ["."]
+            readOnly: true
+
+  - name: ux-review
+    description: CLI UX review for help text, errors, output consistency.
+    dependsOn:
+      - job: static-analysis
+        condition:
+          type: succeeded
+      - job: tests
+        condition:
+          type: succeeded
+    steps:
+      - name: review
+        guard: "${{ hasChanges('src/cli/', 'src/presentation/', 'src/domain/errors.ts', 'src/libswamp/') }}"
+        task:
+          type: model_method
+          modelType: "@swamp/agent-runner"
+          modelName: ux
+          methodName: review
+          globalArgs:
+            version: "${{ inputs.agentCliVersion }}"
+            apiKeyEnvVar: "ANTHROPIC_API_KEY"
+          inputs:
+            promptFile: "verification/review-prompts/ux-review.md"
+            model: "claude-sonnet-4-6"
+            files: ["."]
+            readOnly: true
+
+  - name: ci-security-review
+    description: Security review of CI/CD workflow changes.
+    dependsOn:
+      - job: static-analysis
+        condition:
+          type: succeeded
+      - job: tests
+        condition:
+          type: succeeded
+    steps:
+      - name: review
+        guard: "${{ hasChanges('.github/workflows/') }}"
+        task:
+          type: model_method
+          modelType: "@swamp/agent-runner"
+          modelName: ci-security
+          methodName: review
+          globalArgs:
+            version: "${{ inputs.agentCliVersion }}"
+            apiKeyEnvVar: "ANTHROPIC_API_KEY"
+          inputs:
+            promptFile: "verification/review-prompts/ci-security-review.md"
+            model: "claude-opus-4-6"
+            files: ["."]
+            readOnly: true


### PR DESCRIPTION
## Summary

- Add a verification phase to the issue lifecycle that runs CI checks (lint, fmt, test, compile, agent reviews) inside an OCI container sandbox **before** opening a PR
- The agent iterates — fixing failures and re-verifying — until all steps pass, then opens a pre-verified PR with a structured attestation
- CI validates the attestation instead of re-running checks

## What's included

**Container sandbox** (`verification/container/`)
- OCI-compliant Containerfile (Deno 2.8.3, Ubuntu, git, unzip)
- Build script supporting Docker and Podman
- Mount host Deno cache at `/deno-dir` for instant dependency resolution

**Verification workflow** (`verification/workflow-verify-changes.yaml`)
- DAG of parallel jobs: static analysis, tests, deps audit → compile, agent reviews
- Uses `@swamp/deno-runner` for build steps, `@swamp/agent-runner` for reviews
- Guard conditions on reviews matching CI (adversarial for core paths, UX for CLI paths, CI security for workflow paths)
- `SWAMP_WORKFLOWS_DIR=verification` env var tells swamp where to find it

**Extracted review prompts** (`verification/review-prompts/`)
- Code review, adversarial review, UX review, CI security review
- Extracted from inline CI YAML — single source of truth for both CI and local verification
- Each prompt instructs the agent to `git diff main --name-only` and review only changed files

**Attestation report** (`@swamp/verification-attestation`)
- New workflow report type producing structured checklist of every step, status, and retrieval commands for failed output
- Registered alongside `@swamp/workflow-summary`

**Lifecycle model changes**
- New `verifying` phase between `implementing` and `pr_open`
- Three new methods: `verify`, `verification_passed`, `verification_failed`
- `verificationResult` resource storing the full checklist data
- Model version bumped to `2026.08.21.1`

**Skill and agent constraints**
- Issue lifecycle skill updated with Phase 4a (Verification Loop)
- New `verification.md` reference with step-by-step agent instructions
- New `verification-conventions.md` agent constraint
- `verification/` excluded from compiled binary

Also includes: fix for vault read-secret trailing newline in piped mode.

## Test plan

- [x] Container builds and runs (`./verification/container/build.sh`)
- [x] Individual checks pass inside container (lint, fmt, type-check, test, compile)
- [x] Workflow DAG executes with correct dependency gating (tier 2 skipped when tier 1 fails)
- [x] Attestation report generates on workflow completion
- [x] `deno check`, `deno lint`, `deno fmt` all pass
- [ ] Full lifecycle run with verification phase (blocked by stale extension bundle cache — first-run bootstrap issue)
- [ ] Agent reviews with `ANTHROPIC_API_KEY` passed to container

🤖 Generated with [Claude Code](https://claude.com/claude-code)