### PR TITLE
fix(repo): install bundled skills for custom tools with relative skillsDir

### DIFF
--- a/design/global-skills.md
+++ b/design/global-skills.md
@@ -164,7 +164,12 @@ The registry is a simple JSON array of absolute directory paths:
 ```
 
 Custom tools with repo-relative `skillsDir` (not `~/`-prefixed) are not
-registered — those are project-local directories, not global skill targets.
+registered in the global registry — those are project-local directories, not
+global skill targets. However, during `repo init` and `repo upgrade`, swamp
+resolves the relative path against the repo root and copies bundled skills there.
+This ensures custom tools with relative paths (e.g. `.agents/skills/`) receive
+skills on initialization, even though `swamp update` cannot discover or sync
+them (it runs without repo context).
 
 > **Note:** The original design proposed a separate `globalSkillsDir` field on
 > `CustomToolDefinition`. The current implementation infers global intent from

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -320,7 +320,7 @@ export class RepoService {
     await this.createDataDirectoryStructure(repoPath);
 
     // Install skills globally (deduplicated across tools)
-    const skillsCopied = await this.installGlobalSkills(tools);
+    let skillsCopied = await this.installGlobalSkills(tools);
 
     // Resolve tools to configs and run per-repo scaffolding (instructions,
     // settings, hooks — but NOT skills, which are now global)
@@ -343,6 +343,15 @@ export class RepoService {
 
     // Install skills for custom tools with global (~/prefixed) skillsDir
     await this.installCustomToolGlobalSkills(resolvedConfigs);
+
+    // Install skills for custom tools with repo-relative skillsDir
+    const localSkillNames = await this.installCustomToolLocalSkills(
+      repoPath,
+      resolvedConfigs,
+    );
+    if (localSkillNames.length > 0 && skillsCopied.length === 0) {
+      skillsCopied = localSkillNames;
+    }
 
     // Always manage .gitignore on init (single call with resolved configs)
     const gitignoreAction = await this.ensureGitignoreSection(
@@ -435,7 +444,7 @@ export class RepoService {
     updatedMarker.tools = tools;
 
     // Install skills globally (deduplicated across tools)
-    const skillsUpdated = await this.installGlobalSkills(tools);
+    let skillsUpdated = await this.installGlobalSkills(tools);
 
     // Resolve tools to configs and run per-repo scaffolding (instructions,
     // settings, hooks — but NOT skills, which are now global)
@@ -459,6 +468,15 @@ export class RepoService {
 
     // Install skills for custom tools with global (~/prefixed) skillsDir
     await this.installCustomToolGlobalSkills(resolvedConfigs);
+
+    // Install skills for custom tools with repo-relative skillsDir
+    const localSkillNames = await this.installCustomToolLocalSkills(
+      repoPath,
+      resolvedConfigs,
+    );
+    if (localSkillNames.length > 0 && skillsUpdated.length === 0) {
+      skillsUpdated = localSkillNames;
+    }
 
     // Determine gitignore management: CLI flag > marker preference > default off
     const shouldManageGitignore = options.includeGitignore ??
@@ -631,6 +649,45 @@ export class RepoService {
         }`;
       }
     }
+  }
+
+  /**
+   * Installs bundled skills to repo-local directories for custom tools whose
+   * skillsDir is a relative path (not ~/prefixed). These are project-local
+   * directories that can't be discovered by `swamp update`, so they are only
+   * synced during repo init and upgrade.
+   */
+  private async installCustomToolLocalSkills(
+    repoPath: RepoPath,
+    configs: readonly ToolConfig[],
+  ): Promise<string[]> {
+    const localConfigs = configs.filter((c) =>
+      !c.isBuiltIn && !c.skillsDir.startsWith("~/")
+    );
+    if (localConfigs.length === 0) return [];
+
+    const seen = new Set<string>();
+    let skillNames: string[] = [];
+
+    for (const config of localConfigs) {
+      const localDir = join(repoPath.value, config.skillsDir);
+      if (seen.has(localDir)) continue;
+      seen.add(localDir);
+
+      try {
+        await this.skillAssets.copySkillsTo(localDir);
+        await removeSupersededSkills(localDir);
+        skillNames = this.skillAssets.getSkillNames();
+        logger
+          .info`Installed local skills to ${localDir} for custom tool ${config.name}`;
+      } catch (err) {
+        logger
+          .warn`Failed to install local skills for custom tool ${config.name}: ${
+          err instanceof Error ? err.message : String(err)
+        }`;
+      }
+    }
+    return skillNames;
   }
 
   /**

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -31,6 +31,7 @@ import {
   type AiTool,
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { writeCustomTools } from "../../infrastructure/persistence/custom_tools_repository.ts";
 
 // Helper to create a temp directory for testing
 async function withTempDir(
@@ -2886,5 +2887,81 @@ Deno.test("RepoService.upgrade: returns empty when no lockfile exists", async ()
     const result = await newService.upgrade(repoPath);
 
     assertEquals(result.untrustedCollectives, []);
+  });
+});
+
+Deno.test("RepoService.init: custom tool with relative skillsDir gets skills copied locally", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeCustomTools(tempDir, [{
+      name: "pi",
+      skillsDir: ".agents/skills",
+      instructionsFile: "AGENTS.md",
+      instructionsMode: "shared",
+      skillReferenceStyle: "path",
+    }]);
+
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+    const result = await service.init(repoPath, { tools: ["pi"] });
+
+    assertEquals(result.tools[0], "pi");
+    assertEquals(result.skillsCopied.includes("swamp"), true);
+
+    const skillPath = join(tempDir, ".agents", "skills", "swamp", "SKILL.md");
+    const stat = await Deno.stat(skillPath);
+    assertEquals(stat.isFile, true);
+  });
+});
+
+Deno.test("RepoService.init: custom tool with nested relative skillsDir gets skills copied", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeCustomTools(tempDir, [{
+      name: "myagent",
+      skillsDir: ".myagent/skills",
+      instructionsFile: "AGENTS.md",
+      instructionsMode: "shared",
+      skillReferenceStyle: "path",
+    }]);
+
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+    const result = await service.init(repoPath, { tools: ["myagent"] });
+
+    assertEquals(result.skillsCopied.includes("swamp"), true);
+
+    const skillPath = join(
+      tempDir,
+      ".myagent",
+      "skills",
+      "swamp",
+      "SKILL.md",
+    );
+    const stat = await Deno.stat(skillPath);
+    assertEquals(stat.isFile, true);
+  });
+});
+
+Deno.test("RepoService.upgrade: custom tool with relative skillsDir gets skills updated", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeCustomTools(tempDir, [{
+      name: "pi",
+      skillsDir: ".agents/skills",
+      instructionsFile: "AGENTS.md",
+      instructionsMode: "shared",
+      skillReferenceStyle: "path",
+    }]);
+
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+    await service.init(repoPath, { tools: ["pi"] });
+
+    const newService = new RepoService("0.2.0");
+    const result = await newService.upgrade(repoPath);
+
+    assertEquals(result.skillsUpdated.includes("swamp"), true);
+
+    const skillPath = join(tempDir, ".agents", "skills", "swamp", "SKILL.md");
+    const stat = await Deno.stat(skillPath);
+    assertEquals(stat.isFile, true);
   });
 });


### PR DESCRIPTION
## Summary

- Custom tools with repo-relative `skillsDir` (e.g. `.agents/skills/`) were not receiving bundled skills during `repo init` or `repo upgrade`
- The global skills migration (PR #1653) removed the per-repo skill copy from `applyToolScaffolding()` and replaced it with global-only handlers that only cover built-in tools and `~/`-prefixed custom tools
- Adds `installCustomToolLocalSkills()` to handle custom tools with relative paths — resolves against the repo root and copies bundled skills there during init and upgrade

## Test Plan

- [x] 3 new unit tests: init with relative skillsDir, init with nested relative skillsDir, upgrade with relative skillsDir
- [x] Manual reproduction: `swamp repo init --tool pi` with `.agents/skills` as skillsDir now populates skills correctly
- [x] All 122 existing tests pass
- [x] Container verification: lint, fmt, type check, tests, deps audit, compile all pass

Closes swamp-club#1765

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>