### PR TITLE
fix(workflows): skip manifest.yaml in extension workflow scanner

### DIFF
--- a/src/infrastructure/persistence/extension_workflow_repository.ts
+++ b/src/infrastructure/persistence/extension_workflow_repository.ts
@@ -34,6 +34,9 @@ import { UserError } from "../../domain/errors.ts";
 
 const logger = getLogger(["extension-workflow-repo"]);
 
+// Keep in sync with MANIFEST_FILENAMES in manifest_cross_kind_discovery.ts
+const MANIFEST_FILENAMES = new Set(["manifest.yaml", "manifest.yml"]);
+
 /**
  * Read-only WorkflowRepository that discovers YAML workflows from an
  * extension workflows directory (e.g. `extensions/workflows/`).
@@ -73,6 +76,7 @@ export class ExtensionWorkflowRepository implements WorkflowRepository {
             includeDirs: false,
           })
         ) {
+          if (MANIFEST_FILENAMES.has(entry.name)) continue;
           try {
             const content = await Deno.readTextFile(entry.path);
             const data = parseYaml(content) as WorkflowData;
@@ -147,6 +151,7 @@ export class ExtensionWorkflowRepository implements WorkflowRepository {
             includeDirs: false,
           })
         ) {
+          if (MANIFEST_FILENAMES.has(entry.name)) continue;
           try {
             const content = await Deno.readTextFile(entry.path);
             const data = parseYaml(content) as WorkflowData;

--- a/src/infrastructure/persistence/extension_workflow_repository_test.ts
+++ b/src/infrastructure/persistence/extension_workflow_repository_test.ts
@@ -199,6 +199,75 @@ Deno.test("ExtensionWorkflowRepository save throws UserError", async () => {
   });
 });
 
+Deno.test("ExtensionWorkflowRepository findAll skips manifest.yaml", async () => {
+  await withTempDir(async (dir) => {
+    const workflowData = createWorkflowYaml("real-workflow");
+    await Deno.writeTextFile(
+      join(dir, "deploy.yaml"),
+      stringifyYaml(workflowData),
+    );
+    await Deno.writeTextFile(
+      join(dir, "manifest.yaml"),
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/my-ext",
+        version: "1.0.0",
+      }),
+    );
+
+    const repo = new ExtensionWorkflowRepository(dir);
+    const workflows = await repo.findAll();
+
+    assertEquals(workflows.length, 1);
+    assertEquals(workflows[0].name, "real-workflow");
+  });
+});
+
+Deno.test("ExtensionWorkflowRepository findAll skips manifest.yml", async () => {
+  await withTempDir(async (dir) => {
+    const workflowData = createWorkflowYaml("real-workflow");
+    await Deno.writeTextFile(
+      join(dir, "deploy.yaml"),
+      stringifyYaml(workflowData),
+    );
+    await Deno.writeTextFile(
+      join(dir, "manifest.yml"),
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/my-ext",
+        version: "1.0.0",
+      }),
+    );
+
+    const repo = new ExtensionWorkflowRepository(dir);
+    const workflows = await repo.findAll();
+
+    assertEquals(workflows.length, 1);
+    assertEquals(workflows[0].name, "real-workflow");
+  });
+});
+
+Deno.test("ExtensionWorkflowRepository findPath skips manifest.yaml", async () => {
+  await withTempDir(async (dir) => {
+    const id = crypto.randomUUID();
+    await Deno.writeTextFile(
+      join(dir, "manifest.yaml"),
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/my-ext",
+        id,
+      }),
+    );
+
+    const repo = new ExtensionWorkflowRepository(dir);
+    const path = await repo.findPath(
+      id as ReturnType<typeof repo.nextId>,
+    );
+
+    assertEquals(path, null);
+  });
+});
+
 Deno.test("ExtensionWorkflowRepository delete throws UserError", async () => {
   await withTempDir(async (dir) => {
     const repo = new ExtensionWorkflowRepository(dir);


### PR DESCRIPTION
## Summary

- `ExtensionWorkflowRepository` walked extension directories for `*.yaml` and treated every match as a workflow definition — including `manifest.yaml`, which triggered a spurious "Unknown key 'manifestVersion'" warning and caused `swamp doctor workflows` to report FAIL
- Add a `MANIFEST_FILENAMES` set and skip `manifest.yaml`/`manifest.yml` in both `findAll()` and `findPath()`

Closes swamp-club#1744

## Test Plan

- Added unit test: `findAll` skips `manifest.yaml` co-located with valid workflows
- Added unit test: `findAll` skips `manifest.yml` variant
- Added unit test: `findPath` does not match against manifest files
- All 13 tests pass (10 existing + 3 new)
- Verification workflow: lint, fmt, type-check, tests, deps-audit, compile all pass

🤖 Generated with [Claude Code](https://claude.ai/code)