### PR TITLE
fix(workflows): include .yml files in extension workflow walk

### DIFF
--- a/src/infrastructure/persistence/extension_workflow_repository.ts
+++ b/src/infrastructure/persistence/extension_workflow_repository.ts
@@ -72,7 +72,7 @@ export class ExtensionWorkflowRepository implements WorkflowRepository {
       try {
         for await (
           const entry of walk(dir, {
-            exts: [".yaml"],
+            exts: [".yaml", ".yml"],
             includeDirs: false,
           })
         ) {
@@ -147,7 +147,7 @@ export class ExtensionWorkflowRepository implements WorkflowRepository {
       try {
         for await (
           const entry of walk(dir, {
-            exts: [".yaml"],
+            exts: [".yaml", ".yml"],
             includeDirs: false,
           })
         ) {


### PR DESCRIPTION
## Summary

- The `walk()` calls in `ExtensionWorkflowRepository` only matched `.yaml`, so the `MANIFEST_FILENAMES` guard for `manifest.yml` was dead code and its test exercised the walk filter rather than the guard
- Add `.yml` to the `exts` array in both `findAll()` and `findPath()` so both manifest variants are genuinely filtered, and `.yml` workflow files are also discovered

Follow-up to #2214 — addresses the adversarial review finding.

## Test Plan

- Existing `findAll skips manifest.yml` test now exercises the `MANIFEST_FILENAMES` guard (previously a no-op)
- All 13 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)