### PR TITLE
fix(verification): inject API key via docker env-file for agent reviews

### DIFF
--- a/.claude/skills/issue-lifecycle/references/verification.md
+++ b/.claude/skills/issue-lifecycle/references/verification.md
@@ -27,6 +27,7 @@ docker run --rm \
   -v <repo-root>:<repo-root> \
   -v ~/Library/Caches/deno:/deno-dir \
   -e SWAMP_WORKFLOWS_DIR=verification \
+  $([ -f ~/.config/swamp/verify.env ] && echo "--env-file $HOME/.config/swamp/verify.env") \
   -w <worktree-path> \
   swamp-club/verify:deno-2.8.3 \
   workflow run verify-changes \
@@ -38,6 +39,11 @@ docker run --rm \
 Replace `<repo-root>` with the main repo path and `<worktree-path>` with the
 current working directory. On Linux, use `~/.cache/deno` instead of
 `~/Library/Caches/deno`.
+
+The `--env-file` flag injects `ANTHROPIC_API_KEY` into the container for agent
+reviews. If `~/.config/swamp/verify.env` does not exist, the flag is omitted and
+agent reviews fail gracefully while build verification still runs. See
+`agent-constraints/verification-conventions.md` for setup.
 
 The `SWAMP_WORKFLOWS_DIR=verification` env var tells swamp to look for workflow
 files in the `verification/` directory instead of the default `workflows/`.

--- a/agent-constraints/verification-conventions.md
+++ b/agent-constraints/verification-conventions.md
@@ -6,13 +6,16 @@ All verification runs inside the `swamp-club/verify` container. The container
 provides an isolated environment matching CI conditions (Deno 2.8.3, Ubuntu,
 git, unzip).
 
-Mount the host's Deno cache for fast dependency resolution:
+Mount the host's Deno cache for fast dependency resolution. If
+`~/.config/swamp/verify.env` exists, pass it as `--env-file` so agent reviews
+have access to `ANTHROPIC_API_KEY`:
 
 ```
 docker run --rm \
   -v /path/to/repo:/path/to/repo \
   -v ~/Library/Caches/deno:/deno-dir \
   -e SWAMP_WORKFLOWS_DIR=verification \
+  $([ -f ~/.config/swamp/verify.env ] && echo "--env-file $HOME/.config/swamp/verify.env") \
   -w /path/to/worktree \
   swamp-club/verify:deno-2.8.3 \
   workflow run verify-changes \
@@ -22,6 +25,20 @@ docker run --rm \
 ```
 
 On Linux, the Deno cache is at `~/.cache/deno`.
+
+### Agent review API key
+
+Agent reviews (code-review, adversarial-review, ux-review, ci-security-review)
+need an `ANTHROPIC_API_KEY` inside the container. Create the env file:
+
+```
+echo "ANTHROPIC_API_KEY=sk-ant-..." > ~/.config/swamp/verify.env
+chmod 600 ~/.config/swamp/verify.env
+```
+
+The key is injected via `--env-file` at docker runtime and never enters the host
+shell environment. Without it, agent reviews fail gracefully — build verification
+(lint, test, compile) still works.
 
 ## Workflow Structure
 


### PR DESCRIPTION
## Summary

- Add conditional `--env-file ~/.config/swamp/verify.env` to the docker run
  command templates in both the issue-lifecycle skill and verification
  conventions docs
- Document the env file setup (`ANTHROPIC_API_KEY=...`, `chmod 600`)
- The key is read by docker at runtime and never enters the host shell
  environment; without the file, agent reviews fail gracefully while build
  verification still runs
- Each agent review runs in its own subprocess with `clearEnv: true`, so the
  key is isolated per-review and never reaches build steps (lint, test, compile)

## Test Plan

- [x] Verified compile + binary-check pass in the container sandbox
- [x] Verified `clearEnv: true` in deno-runner strips `ANTHROPIC_API_KEY`
  from build step subprocesses
- [x] Verified agent-runner subprocess isolation (each review gets only the
  curated env allowlist + API key)
- [x] Confirmed `--env-file` flag is conditional — omitting the file leaves
  current behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)