### PR TITLE
chore(workflows): update docstring and add .yml discovery test

### DIFF
--- a/src/infrastructure/persistence/extension_workflow_repository.ts
+++ b/src/infrastructure/persistence/extension_workflow_repository.ts
@@ -42,7 +42,8 @@ const MANIFEST_FILENAMES = new Set(["manifest.yaml", "manifest.yml"]);
  * extension workflows directory (e.g. `extensions/workflows/`).
  *
  * Extension workflows are read-only — save() and delete() throw UserError.
- * Any `*.yaml` file in the directory tree is treated as a workflow definition.
+ * Any `*.yaml` / `*.yml` file in the directory tree is treated as a workflow
+ * definition; `manifest.yaml` and `manifest.yml` are skipped.
  */
 export class ExtensionWorkflowRepository implements WorkflowRepository {
   private readonly workflowsDirs: string[];

--- a/src/infrastructure/persistence/extension_workflow_repository_test.ts
+++ b/src/infrastructure/persistence/extension_workflow_repository_test.ts
@@ -86,6 +86,22 @@ Deno.test("ExtensionWorkflowRepository discovers YAML workflows from directory",
   });
 });
 
+Deno.test("ExtensionWorkflowRepository discovers .yml workflow files", async () => {
+  await withTempDir(async (dir) => {
+    const workflowData = createWorkflowYaml("yml-workflow");
+    await Deno.writeTextFile(
+      join(dir, "deploy.yml"),
+      stringifyYaml(workflowData),
+    );
+
+    const repo = new ExtensionWorkflowRepository(dir);
+    const workflows = await repo.findAll();
+
+    assertEquals(workflows.length, 1);
+    assertEquals(workflows[0].name, "yml-workflow");
+  });
+});
+
 Deno.test("ExtensionWorkflowRepository discovers workflows in subdirectories", async () => {
   await withTempDir(async (dir) => {
     const subdir = join(dir, "aws");


### PR DESCRIPTION
## Summary

- Update `ExtensionWorkflowRepository` class docstring to reflect that both `.yaml` and `.yml` files are walked and manifest files are skipped
- Add test confirming `.yml` workflow files are discovered by `findAll()`

Follow-up to #2215 — addresses both review suggestions.

## Test Plan

- All 14 tests pass (13 existing + 1 new `.yml` discovery test)

🤖 Generated with [Claude Code](https://claude.ai/code)