### PR TITLE
fix(data): detect retyped model data as orphaned in prune, filter stale query rows (swamp-club#1737)

### DIFF
--- a/integration/data_prune_test.ts
+++ b/integration/data_prune_test.ts
@@ -419,6 +419,102 @@ Deno.test("Data Prune: workflow report data is NOT pruned when workflow definiti
   });
 });
 
+Deno.test("Data Prune: retyped model data is detected as orphaned (swamp-club#1737)", async () => {
+  await withTempDir(async (repoDir) => {
+    await ensureDir(join(repoDir, "models"));
+    await ensureDir(join(repoDir, ".swamp", "data"));
+
+    const oldType = ModelType.create("test/old-type");
+    const modelsRepo = new YamlDefinitionRepository(repoDir);
+
+    // 1. Save a definition under type "test/old-type"
+    const def = Definition.create({ name: "story-analyzer" });
+    await modelsRepo.save(oldType, def);
+
+    // 2. Write data under the old type
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      new CatalogStore(join(repoDir, "_catalog.db")),
+    );
+    await writeData(dataRepo, oldType, def.id, "analysis", 3);
+
+    // 3. Simulate a retype: edit the YAML in place to change type to "test/new-type"
+    const defPath = join(
+      repoDir,
+      "models",
+      "test",
+      "old-type",
+      `${def.name}.yaml`,
+    );
+    const yaml = await Deno.readTextFile(defPath);
+    await Deno.writeTextFile(
+      defPath,
+      yaml.replace("type: test/old-type", "type: test/new-type"),
+    );
+
+    // 4. Prune via createDataPruneDeps — the production code path
+    const deps = createDataPruneDeps(repoDir);
+    const orphans = await deps.findOrphanedData();
+    assertEquals(
+      orphans.length,
+      1,
+      "retyped model data must be detected as orphaned",
+    );
+    assertEquals(orphans[0].modelId, def.id);
+    assertEquals(orphans[0].dataNames, ["analysis"]);
+    assertEquals(orphans[0].versionCount, 3);
+
+    // 5. Prune reclaims the stranded data
+    const result = await deps.deleteOrphanedData({ dryRun: false });
+    assertEquals(result.modelsReclaimed, 1);
+    assertEquals(result.versionsDeleted, 3);
+    assertEquals(await dataRepo.listVersions(oldType, def.id, "analysis"), []);
+  });
+});
+
+Deno.test("Data Prune: retyped model with undefined type is treated as live (legacy safety)", async () => {
+  await withTempDir(async (repoDir) => {
+    await ensureDir(join(repoDir, "models"));
+    await ensureDir(join(repoDir, ".swamp", "data"));
+
+    const type = ModelType.create("test/legacy");
+    const modelsRepo = new YamlDefinitionRepository(repoDir);
+
+    const def = Definition.create({ name: "legacy-model" });
+    await modelsRepo.save(type, def);
+
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      new CatalogStore(join(repoDir, "_catalog.db")),
+    );
+    await writeData(dataRepo, type, def.id, "state", 2);
+
+    // Remove the type field from the YAML to simulate a legacy definition
+    const defPath = join(
+      repoDir,
+      "models",
+      "test",
+      "legacy",
+      `${def.name}.yaml`,
+    );
+    const yaml = await Deno.readTextFile(defPath);
+    await Deno.writeTextFile(
+      defPath,
+      yaml.replace(/^type:.*$/m, ""),
+    );
+
+    const deps = createDataPruneDeps(repoDir);
+    const orphans = await deps.findOrphanedData();
+    assertEquals(
+      orphans.length,
+      0,
+      "definition with undefined type must be treated as live",
+    );
+  });
+});
+
 Deno.test("Data Prune: serve control-plane types are NOT pruned (swamp-club#1749)", async () => {
   await withTempDir(async (repoDir) => {
     await ensureDir(join(repoDir, "models"));

--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -90,6 +90,10 @@ export type ForeignContentFetcher = (
   relPath: string,
 ) => Promise<Uint8Array | null>;
 
+export interface DataQueryServiceOptions {
+  filterStaleRows?: boolean;
+}
+
 export class DataQueryService {
   private readonly queryEnv: Environment;
   private vaultService?: VaultService;
@@ -97,11 +101,14 @@ export class DataQueryService {
   private foreignContentFetcher?: ForeignContentFetcher;
   private readonly foreignContentCache = new Map<string, Uint8Array | null>();
   private backfillPromise: Promise<void> | null = null;
+  private readonly filterStaleRows: boolean;
 
   constructor(
     private readonly catalogStore: CatalogStore,
     private readonly dataRepo: UnifiedDataRepository,
+    options?: DataQueryServiceOptions,
   ) {
+    this.filterStaleRows = options?.filterStaleRows ?? false;
     this.queryEnv = new Environment({
       unlistedVariablesAreDyn: true,
       homogeneousAggregateLiterals: false,
@@ -458,10 +465,33 @@ export class DataQueryService {
     // Hydrate matched records with attributes when the predicate didn't
     // require them for filtering. Only applies to non-projected results —
     // projections handle attribute loading via AST analysis above.
+    // When filterStaleRows is enabled, rows whose backing file is absent
+    // are dropped during hydration — a stale catalog row with isLatest=true
+    // and empty content is worse than a missing row because it wins [0]
+    // selection (swamp-club#1737).
     if (needsHydration) {
+      let writeIndex = 0;
       for (let i = 0; i < results.length; i++) {
-        results[i] = this.rowToRecord(matchedRows[i], true, needsContent);
+        const row = matchedRows[i];
+        if (this.filterStaleRows) {
+          const contentPath = this.dataRepo.getContentPath(
+            ModelType.create(row.type_normalized),
+            row.model_id,
+            row.data_name,
+            row.version,
+          );
+          try {
+            Deno.statSync(contentPath);
+          } catch {
+            logger
+              .debug`Skipping stale catalog row ${row.model_name}/${row.data_name}@v${row.version}: backing file absent`;
+            continue;
+          }
+        }
+        results[writeIndex] = this.rowToRecord(row, true, needsContent);
+        writeIndex++;
       }
+      results.length = writeIndex;
     }
 
     // Apply projection if select expression provided.

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -1642,3 +1642,69 @@ Deno.test("DataQueryService: a non-matching query preserves rows for models with
 
   catalog.close();
 });
+
+Deno.test("DataQueryService: skips stale catalog rows with missing backing files (swamp-club#1737)", () => {
+  const dir = Deno.makeTempDirSync({ prefix: "swamp-query-stale-" });
+  const dbPath = join(dir, ".swamp", "data", "_catalog.db");
+  const catalog = new CatalogStore(dbPath);
+  catalog.markPopulated();
+  const dataRepo = new FileSystemUnifiedDataRepository(dir, undefined, catalog);
+  const service = new DataQueryService(catalog, dataRepo, {
+    filterStaleRows: true,
+  });
+
+  // Insert a catalog row whose backing file does NOT exist on disk.
+  const staleRow = makeRow({
+    model_name: "story-analyzer",
+    data_name: "analysis",
+    type_normalized: "test/stale-type",
+    model_id: "stale-model-id",
+    version: 27,
+    is_latest: 1,
+  });
+  catalog.upsert(staleRow);
+
+  // Insert a live row WITH a backing file on disk.
+  const liveRow = makeRow({
+    model_name: "story-analyzer",
+    data_name: "analysis",
+    type_normalized: "test/live-type",
+    model_id: "live-model-id",
+    version: 1,
+    is_latest: 1,
+    id: "00000000-0000-1000-8000-000000000002",
+  });
+  catalog.upsert(liveRow);
+
+  // Create the backing file for the live row only.
+  const livePath = join(
+    dir,
+    ".swamp",
+    "data",
+    "test",
+    "live-type",
+    "live-model-id",
+    "analysis",
+    "1",
+  );
+  ensureDirSync(livePath);
+  Deno.writeTextFileSync(
+    join(livePath, "raw"),
+    JSON.stringify({ result: "live data" }),
+  );
+
+  const results = service.querySync(
+    'modelName == "story-analyzer"',
+  ) as DataRecord[];
+
+  // Only the live row should be returned; the stale row is skipped.
+  assertEquals(
+    results.length,
+    1,
+    "stale row with missing backing file must be skipped",
+  );
+  assertEquals(results[0].modelId, "live-model-id");
+  assertEquals(results[0].version, 1);
+
+  catalog.close();
+});

--- a/src/infrastructure/persistence/repository_factory.ts
+++ b/src/infrastructure/persistence/repository_factory.ts
@@ -447,7 +447,9 @@ export function createRepositoryContext(
   // Construct the query service alongside its dependencies so consumers
   // never need to reach into the repo to rebuild it. This keeps the
   // catalog handle as an infrastructure detail of the composition root.
-  const dataQueryService = new DataQueryService(catalogStore, unifiedDataRepo);
+  const dataQueryService = new DataQueryService(catalogStore, unifiedDataRepo, {
+    filterStaleRows: true,
+  });
   const outputRepo = new YamlOutputRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.outputs),

--- a/src/libswamp/data/prune.ts
+++ b/src/libswamp/data/prune.ts
@@ -28,6 +28,7 @@ import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { createDefinitionId } from "../../domain/definitions/definition.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
 import {
@@ -166,10 +167,19 @@ export function createDataPruneDeps(
       return (await workflowRepo.findById(createWorkflowId(modelId))) !== null;
     }
 
-    return (await definitionRepo.findById(
+    const definition = await definitionRepo.findById(
       type,
       createDefinitionId(modelId),
-    )) !== null;
+    );
+    if (definition === null) return false;
+    // A retyped model leaves its definition file in the old type directory
+    // with a different type: field. The data under the old type path is
+    // orphaned even though findById locates the file by UUID.
+    if (definition.type !== undefined) {
+      const defType = ModelType.create(definition.type);
+      if (defType.toDirectoryPath() !== type.toDirectoryPath()) return false;
+    }
+    return true;
   };
 
   return {


### PR DESCRIPTION
## Summary

- **Prune fix**: `isModelLive` predicate now verifies the definition's parsed type matches the directory type after `findById`. When a model is retyped (type: field changed, UUID kept), the old data is correctly detected as orphaned and reclaimable through `swamp data prune`.
- **Query fix**: `DataQueryService` gains a `filterStaleRows` option that drops catalog rows whose backing file is absent during hydration. Enabled in the CLI factory for local data paths; defaults off for remote/lazy-hydration scenarios where catalog-only rows are legitimate.
- Two new integration tests for retype detection (type mismatch + undefined-type legacy safety) and one new query test for stale-row filtering.

Closes swamp-club#1737

## Test Plan

- [x] `deno fmt --check` — clean
- [x] `deno lint` — clean
- [x] `deno run test` — 10,706 passed, 0 failed
- [x] `deno run compile` — binary compiles
- [x] Integration test: create definition with type A, write data, change type to B, verify prune detects orphan
- [x] Integration test: definition with undefined type treated as live (legacy safety)
- [x] Unit test: catalog row without backing file skipped when `filterStaleRows: true`
- [x] Reproduced bug in scratch repo before fix: `data prune --dry-run` reports 0 orphans after retype

🤖 Generated with [Claude Code](https://claude.com/claude-code)