### PR TITLE
docs: redirect pre-PR verification to container workflow

### DIFF
--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -28,18 +28,16 @@ fi
 
 ## Pre-flight Checks
 
-Run these checks before submitting any PR:
+The verification workflow must have passed before opening a PR. If using the
+issue-lifecycle skill, verification is already enforced — the `link_pr` method
+requires a passing attestation.
 
-```bash
-deno fmt --check
-deno lint
-deno run test
-```
+If working outside the issue lifecycle (e.g. a quick fix), run the verification
+workflow in the container sandbox before submitting. See
+`agent-constraints/verification-conventions.md` for the docker command.
 
-Fix any issues before proceeding. All checks must pass.
-
-If `deno fmt --check` fails, run `deno fmt` to auto-fix formatting, then re-run
-the checks.
+Do not run lint/test/fmt manually as a pre-PR gate — the verification workflow
+covers all checks.
 
 ## Create PR
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,13 +85,20 @@ CLI.
 
 ## Verification
 
-After completing work, run these checks:
+During development, use these commands for quick feedback:
 
 1. `deno check` - Type checking
 2. `deno lint` - Linting
 3. `deno fmt` - Formatting
-4. `deno run test` - Tests
-5. `deno run compile` - Recompile the binary
+4. `deno run test` - Tests (or `deno run test src/path/to_test.ts` for a single file)
+
+Before opening a PR, run the verification workflow in the container sandbox
+instead of these commands individually — it runs all checks (lint, fmt, test,
+compile, deps audit, agent reviews) as a DAG and produces an attestation. See
+`agent-constraints/verification-conventions.md` for the docker command. Do not
+run `deno check`, `deno lint`, `deno fmt`, `deno run test`, or
+`deno run compile` as a pre-PR gate — the verification workflow covers all of
+them.
 
 ## Source Control & Pull Requests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,8 @@ During development, use these commands for quick feedback:
 1. `deno check` - Type checking
 2. `deno lint` - Linting
 3. `deno fmt` - Formatting
-4. `deno run test` - Tests (or `deno run test src/path/to_test.ts` for a single file)
+4. `deno run test` - Tests (or `deno run test src/path/to_test.ts` for a single
+   file)
 
 Before opening a PR, run the verification workflow in the container sandbox
 instead of these commands individually — it runs all checks (lint, fmt, test,


### PR DESCRIPTION
## Summary

- Updates CLAUDE.md `## Verification` to keep the individual commands (`deno check`, `deno lint`, `deno fmt`, `deno run test`) as a quick-feedback reference during development, but redirects the pre-PR gate to the container verification workflow (`agent-constraints/verification-conventions.md`).
- Updates the `github-pr` skill's `## Pre-flight Checks` to replace manual `deno fmt/lint/test` with the verification workflow, covering both the issue-lifecycle path (where attestation is already enforced) and standalone quick-fix PRs.

Agents no longer run 5 sequential commands before every PR — the container workflow runs all checks as a parallel DAG with agent reviews and produces an attestation.

## Test Plan

- Verified `agent-constraints/verification-conventions.md` exists and is correctly referenced
- Changes are documentation-only (CLAUDE.md + skill markdown)