### PR TITLE
fix(auth): document SWAMP_API_KEY in CLI help text

### DIFF
--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -35,7 +35,10 @@ export const authTokenCommand = new Command()
 
 export const authCommand = new Command()
   .name("auth")
-  .description("Manage swamp-club authentication")
+  .description(
+    "Manage swamp-club authentication.\n\n" +
+      "For non-interactive use, set the SWAMP_API_KEY environment variable.",
+  )
   .action(groupCommandAction)
   .command("login", authLoginCommand)
   .command("logout", authLogoutCommand)

--- a/src/cli/commands/auth_login.ts
+++ b/src/cli/commands/auth_login.ts
@@ -41,15 +41,23 @@ type AnyOptions = any;
 
 export const authLoginCommand = new Command()
   .name("login")
-  .description("Authenticate with a swamp-club server")
+  .description(
+    "Authenticate with a swamp-club server.\n\n" +
+      "For non-interactive use (CI, agents, scripts), set the SWAMP_API_KEY\n" +
+      "environment variable instead of running this command.",
+  )
   .example("Login via browser", "swamp auth login")
   .example(
     "Login to custom server",
     "swamp auth login --server https://registry.example.com",
   )
   .example(
-    "Non-interactive login",
-    "swamp auth login --username alice --password secret --no-browser",
+    "Non-interactive login (env var)",
+    "export SWAMP_API_KEY=swamp_abc123...",
+  )
+  .example(
+    "Non-interactive login (piped stdin)",
+    "printf 'mypassword\\n' | swamp auth login --username alice --no-browser",
   )
   .option(
     "--server <url:string>",


### PR DESCRIPTION
## Summary

- Document `SWAMP_API_KEY` env var in `swamp auth login --help` and `swamp auth --help` descriptions so the safe non-interactive auth path is discoverable from the CLI
- Replace the `--password secret` argv example with env var and piped stdin examples — the first thing an integrator copies is now the safe path
- No behavioral changes — the env var has worked since #941, this just makes it visible in `--help`

Closes swamp-club#1789

## Test Plan

- [x] `deno check` passes on changed files
- [x] `deno lint` passes (1930 files checked)
- [x] `deno fmt --check` passes (2076 files checked)
- [x] `deno run test` passes (10,709 tests)
- [x] `deno run compile` succeeds
- [x] Verified `swamp auth login --help` shows SWAMP_API_KEY guidance and safe examples
- [x] Verified `swamp auth --help` mentions SWAMP_API_KEY for non-interactive use

🤖 Generated with [Claude Code](https://claude.com/claude-code)