### PR TITLE
fix(data): skip stale-row filter for foreign namespace catalog rows

### DIFF
--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -471,9 +471,10 @@ export class DataQueryService {
     // selection (swamp-club#1737).
     if (needsHydration) {
       let writeIndex = 0;
+      const ownNamespace = this.dataRepo.namespace;
       for (let i = 0; i < results.length; i++) {
         const row = matchedRows[i];
-        if (this.filterStaleRows) {
+        if (this.filterStaleRows && row.namespace === ownNamespace) {
           const contentPath = this.dataRepo.getContentPath(
             ModelType.create(row.type_normalized),
             row.model_id,

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -1708,3 +1708,42 @@ Deno.test("DataQueryService: skips stale catalog rows with missing backing files
 
   catalog.close();
 });
+
+Deno.test("DataQueryService: filterStaleRows skips foreign namespace rows (no local backing file expected)", () => {
+  const dir = Deno.makeTempDirSync({ prefix: "swamp-query-foreign-stale-" });
+  const dbPath = join(dir, ".swamp", "data", "_catalog.db");
+  const catalog = new CatalogStore(dbPath);
+  catalog.markPopulated();
+  const dataRepo = new FileSystemUnifiedDataRepository(dir, undefined, catalog);
+  const service = new DataQueryService(catalog, dataRepo, {
+    filterStaleRows: true,
+  });
+
+  // Foreign namespace row — no backing file on disk (catalog-only pull).
+  catalog.upsert(makeRow({
+    namespace: "infra",
+    model_name: "scanner",
+    data_name: "results",
+    type_normalized: "test/foreign",
+    model_id: "foreign-model-id",
+    version: 1,
+    is_latest: 1,
+    id: "00000000-0000-1000-8000-000000000099",
+  }));
+
+  // The repo's own namespace is "" (solo mode). The foreign row's namespace
+  // ("infra") differs, so filterStaleRows must NOT stat-check it.
+  const results = service.querySync(
+    'modelName == "scanner"',
+  ) as DataRecord[];
+
+  assertEquals(
+    results.length,
+    1,
+    "foreign namespace rows must not be filtered as stale",
+  );
+  assertEquals(results[0].namespace, "infra");
+  assertEquals(results[0].modelId, "foreign-model-id");
+
+  catalog.close();
+});


### PR DESCRIPTION
## Summary

- PR #2218 enabled `filterStaleRows` unconditionally in `createRepositoryContext`, which stat-checks each row's backing file during query hydration. Foreign namespace rows pulled via `swamp datastore catalog pull` are catalog-only metadata with no local data files, so every foreign row was incorrectly dropped as "stale" — breaking cross-namespace queries (e.g. `data query 'ns == "infra"'` returning `total: 0`).
- Guards the stat check with `row.namespace === ownNamespace` so only the repo's own rows are validated against the local filesystem. Foreign rows pass through untouched — their attributes are hydrated later by the `foreignContentFetcher`.
- Adds a unit test confirming foreign namespace rows survive `filterStaleRows: true`.

## Test Plan

- [x] Existing `filterStaleRows` test still passes (local stale rows are still filtered)
- [x] New unit test: foreign namespace row with no backing file is returned when `filterStaleRows: true`
- [x] All 49 `data_query_service_test.ts` tests pass
- [x] All 8 `giga_swamp_cel_namespace_test.ts` integration tests pass
- [ ] CI: `sync_test.ts` foreign catalog pull test should pass (was failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)