### PR TITLE
fix(reports): include non-model steps in workflow summary

### DIFF
--- a/design/reports.md
+++ b/design/reports.md
@@ -101,11 +101,15 @@ contexts additionally carry `extensionFile`.
 | `workflowRunId`    | `string`                         | Run UUID                                      |
 | `workflowName`     | `string`                         | Workflow name                                 |
 | `workflowStatus`   | `"succeeded"` / `"failed"`      | Overall run outcome                           |
-| `stepExecutions`   | `StepExecution[]`                | Per-step details (job, model, method, status) |
+| `stepExecutions`   | `StepExecution[]`                | Per-step details (job, task, status)          |
 
-Each `stepExecutions` entry contains `jobName`, `stepName`, `modelName`,
-`modelType`, `methodName`, `status`, `dataHandles`, `methodArgs`, `modelId`,
-and `globalArgs`.
+Each `stepExecutions` entry contains `jobName`, `stepName`, `taskType`,
+`modelName`, `modelType`, `methodName`, `status`, `dataHandles`, `methodArgs`,
+`modelId`, `globalArgs`, and an optional `errorMessage`. The `taskType` field
+identifies the step's task kind (`model_method`, `assert`, `manual_approval`,
+`workflow`). For non-model tasks, the model-specific fields (`modelName`,
+`modelType`, `methodName`, `modelId`) are empty strings and `errorMessage`
+carries the failure reason when the step failed.
 
 ## Standalone Report Extensions
 

--- a/packages/testing/report_test_context_test.ts
+++ b/packages/testing/report_test_context_test.ts
@@ -102,6 +102,7 @@ Deno.test("createReportTestContext: workflow scope with step executions", () => 
       {
         jobName: "deploy",
         stepName: "create-instance",
+        taskType: "model_method",
         modelName: "ec2",
         modelType: "aws/ec2",
         methodName: "create",
@@ -114,6 +115,7 @@ Deno.test("createReportTestContext: workflow scope with step executions", () => 
       {
         jobName: "deploy",
         stepName: "configure",
+        taskType: "model_method",
         modelName: "config",
         modelType: "aws/ssm",
         methodName: "apply",

--- a/packages/testing/report_types.ts
+++ b/packages/testing/report_types.ts
@@ -157,6 +157,7 @@ export interface WorkflowReportContext extends BaseReportContext {
   stepExecutions: Array<{
     jobName: string;
     stepName: string;
+    taskType: string;
     modelName: string;
     modelType: string;
     methodName: string;
@@ -165,6 +166,7 @@ export interface WorkflowReportContext extends BaseReportContext {
     methodArgs: Record<string, unknown>;
     modelId: string;
     globalArgs: Record<string, unknown>;
+    errorMessage?: string;
   }>;
 }
 

--- a/src/domain/reports/builtin/verification_attestation_report.ts
+++ b/src/domain/reports/builtin/verification_attestation_report.ts
@@ -81,6 +81,8 @@ export const verificationAttestationReport: ReportDefinition = {
     const failureDetails: Array<{
       job: string;
       step: string;
+      taskType: string;
+      errorMessage?: string;
       retrievalCommands: string[];
     }> = [];
 
@@ -96,21 +98,36 @@ export const verificationAttestationReport: ReportDefinition = {
           : step.status === "skipped"
           ? "○"
           : "✗";
+        const typeLabel = step.taskType !== "model_method"
+          ? step.taskType
+          : step.modelType;
         lines.push(
-          `  ${stepIcon} ${step.stepName}  —  ${step.modelType}  (${step.status})`,
+          `  ${stepIcon} ${step.stepName}  —  ${typeLabel}  (${step.status})`,
         );
 
-        if (step.status === "failed" && step.dataHandles.length > 0) {
-          const cmds = step.dataHandles.map((h) =>
-            `swamp data get ${step.modelName} ${h.name}`
-          );
-          failureDetails.push({
-            job: step.jobName,
-            step: step.stepName,
-            retrievalCommands: cmds,
-          });
-          for (const cmd of cmds) {
-            lines.push(`    → \`${cmd}\``);
+        if (step.status === "failed") {
+          if (step.taskType !== "model_method" && step.errorMessage) {
+            failureDetails.push({
+              job: step.jobName,
+              step: step.stepName,
+              taskType: step.taskType,
+              errorMessage: step.errorMessage,
+              retrievalCommands: [],
+            });
+            lines.push(`    ${step.errorMessage}`);
+          } else if (step.dataHandles.length > 0) {
+            const cmds = step.dataHandles.map((h) =>
+              `swamp data get ${step.modelName} ${h.name}`
+            );
+            failureDetails.push({
+              job: step.jobName,
+              step: step.stepName,
+              taskType: step.taskType,
+              retrievalCommands: cmds,
+            });
+            for (const cmd of cmds) {
+              lines.push(`    → \`${cmd}\``);
+            }
           }
         }
       }
@@ -139,9 +156,11 @@ export const verificationAttestationReport: ReportDefinition = {
       steps: stepExecutions.map((s) => ({
         job: s.jobName,
         step: s.stepName,
-        model: s.modelType,
-        method: s.methodName,
+        taskType: s.taskType,
+        model: s.modelType || undefined,
+        method: s.methodName || undefined,
         status: s.status,
+        errorMessage: s.errorMessage,
         retrievalCommands: s.status === "failed"
           ? s.dataHandles.map((h) => `swamp data get ${s.modelName} ${h.name}`)
           : undefined,

--- a/src/domain/reports/builtin/verification_attestation_report_test.ts
+++ b/src/domain/reports/builtin/verification_attestation_report_test.ts
@@ -28,6 +28,7 @@ function makeStepExecution(
   return {
     jobName: "static-analysis",
     stepName: "lint",
+    taskType: "model_method",
     modelName: "lint",
     modelType: "@swamp/deno-runner",
     methodName: "task",
@@ -311,4 +312,60 @@ Deno.test("verificationAttestationReport: job with all skipped steps shows check
 
   assertStringIncludes(result.markdown, "✓ **ux-review**");
   assertStringIncludes(result.markdown, "○ review");
+});
+
+Deno.test("verificationAttestationReport: failed assert step appears in attestation", async () => {
+  const ctx = makeWorkflowContext({
+    workflowStatus: "failed",
+    stepExecutions: [
+      makeStepExecution({
+        jobName: "validate",
+        stepName: "run-model",
+        status: "succeeded",
+      }),
+      {
+        jobName: "validate",
+        stepName: "check-output",
+        taskType: "assert",
+        modelName: "",
+        modelType: "",
+        methodName: "",
+        status: "failed",
+        dataHandles: [],
+        methodArgs: {},
+        modelId: "",
+        globalArgs: {},
+        errorMessage: "Expected output to contain result.",
+      },
+    ],
+  });
+
+  const result = await verificationAttestationReport.execute(ctx);
+
+  assertStringIncludes(result.markdown, "1 passed · 1 failed · 0 skipped");
+  assertStringIncludes(result.markdown, "✗ **validate**");
+  assertStringIncludes(
+    result.markdown,
+    "✗ check-output  —  assert  (failed)",
+  );
+  assertStringIncludes(
+    result.markdown,
+    "Expected output to contain result.",
+  );
+  assertStringIncludes(result.markdown, "**Gate:** 1/2 passed, 0 skipped");
+
+  const json = result.json;
+  const steps = json.steps as Array<Record<string, unknown>>;
+  assertEquals(steps.length, 2);
+  assertEquals(steps[1].taskType, "assert");
+  assertEquals(steps[1].status, "failed");
+  assertEquals(steps[1].errorMessage, "Expected output to contain result.");
+
+  const failures = json.failures as Array<Record<string, unknown>>;
+  assertEquals(failures!.length, 1);
+  assertEquals(failures![0].taskType, "assert");
+  assertEquals(
+    failures![0].errorMessage,
+    "Expected output to contain result.",
+  );
 });

--- a/src/domain/reports/builtin/workflow_summary_report.ts
+++ b/src/domain/reports/builtin/workflow_summary_report.ts
@@ -27,6 +27,13 @@ function isWorkflowContext(ctx: ReportContext): ctx is WorkflowReportContext {
   return ctx.scope === "workflow";
 }
 
+function stepLabel(
+  step: WorkflowReportContext["stepExecutions"][0],
+): string {
+  if (step.taskType !== "model_method") return step.taskType;
+  return `${step.modelName} → ${step.methodName}`;
+}
+
 export const workflowSummaryReport: ReportDefinition = {
   description:
     "Built-in summary of a workflow execution including step statuses, failures, and data produced.",
@@ -58,26 +65,31 @@ export const workflowSummaryReport: ReportDefinition = {
     const lines: string[] = [
       `# ${workflowName}: ${workflowStatus}`,
       "",
-      `${succeeded} succeeded \u00B7 ${failed} failed \u00B7 ${skipped} skipped`,
+      `${succeeded} succeeded · ${failed} failed · ${skipped} skipped`,
     ];
 
     // Failures section — only if any failed steps
     if (failures.length > 0) {
       lines.push("", "## Failures", "");
-      lines.push("| Job | Step | Model | Retrieval Commands |");
-      lines.push("| --- | ---- | ----- | ------------------ |");
+      lines.push("| Job | Step | Task | Detail |");
+      lines.push("| --- | ---- | ---- | ------ |");
       for (const step of failures) {
-        const model = `${step.modelName} \u2192 ${step.methodName}`;
-        if (step.dataHandles.length === 0) {
+        const label = stepLabel(step);
+        if (step.taskType !== "model_method") {
+          const detail = step.errorMessage ?? "No detail.";
           lines.push(
-            `| ${step.jobName} | **${step.stepName}** | ${model} | No data output. |`,
+            `| ${step.jobName} | **${step.stepName}** | ${label} | ${detail} |`,
+          );
+        } else if (step.dataHandles.length === 0) {
+          lines.push(
+            `| ${step.jobName} | **${step.stepName}** | ${label} | No data output. |`,
           );
         } else {
           const firstHandle = step.dataHandles[0];
           const firstCmd =
             `swamp data get ${step.modelName} ${firstHandle.name}`;
           lines.push(
-            `| ${step.jobName} | **${step.stepName}** | ${model} | \`${firstCmd}\` |`,
+            `| ${step.jobName} | **${step.stepName}** | ${label} | \`${firstCmd}\` |`,
           );
           for (let i = 1; i < step.dataHandles.length; i++) {
             const cmd = `swamp data get ${step.modelName} ${
@@ -105,17 +117,17 @@ export const workflowSummaryReport: ReportDefinition = {
         ? "failed"
         : "succeeded";
       lines.push("", `## Job: ${jobName} (${jobStatus})`, "");
-      lines.push("| Step | Model | Status |");
-      lines.push("| ---- | ----- | ------ |");
+      lines.push("| Step | Task | Status |");
+      lines.push("| ---- | ---- | ------ |");
       for (const step of steps) {
-        const model = `${step.modelName} \u2192 ${step.methodName}`;
+        const label = stepLabel(step);
         if (step.status === "failed") {
           lines.push(
-            `| **${step.stepName}** | **${model}** | **${step.status}** |`,
+            `| **${step.stepName}** | **${label}** | **${step.status}** |`,
           );
         } else {
           lines.push(
-            `| ${step.stepName} | ${model} | ${step.status} |`,
+            `| ${step.stepName} | ${label} | ${step.status} |`,
           );
         }
       }
@@ -136,8 +148,10 @@ export const workflowSummaryReport: ReportDefinition = {
       failures: failures.map((s) => ({
         jobName: s.jobName,
         stepName: s.stepName,
-        modelName: s.modelName,
-        methodName: s.methodName,
+        taskType: s.taskType,
+        modelName: s.modelName || undefined,
+        methodName: s.methodName || undefined,
+        errorMessage: s.errorMessage,
         retrievalCommands: s.dataHandles.map((h) =>
           `swamp data get ${s.modelName} ${h.name}`
         ),
@@ -145,10 +159,12 @@ export const workflowSummaryReport: ReportDefinition = {
       steps: stepExecutions.map((s) => ({
         jobName: s.jobName,
         stepName: s.stepName,
-        modelName: s.modelName,
-        modelType: s.modelType,
-        methodName: s.methodName,
+        taskType: s.taskType,
+        modelName: s.modelName || undefined,
+        modelType: s.modelType || undefined,
+        methodName: s.methodName || undefined,
         status: s.status,
+        errorMessage: s.errorMessage,
         retrievalCommands: s.dataHandles.map((h) =>
           `swamp data get ${s.modelName} ${h.name}`
         ),

--- a/src/domain/reports/builtin/workflow_summary_report_test.ts
+++ b/src/domain/reports/builtin/workflow_summary_report_test.ts
@@ -28,6 +28,7 @@ function makeStepExecution(
   return {
     jobName: "deploy-job",
     stepName: "deploy-step",
+    taskType: "model_method",
     modelName: "my-server",
     modelType: "server",
     methodName: "deploy",
@@ -140,7 +141,7 @@ Deno.test("workflowSummaryReport: failures section with data handles shows retri
     failuresIdx < jobIdx,
     "Failures section should appear before Job sections",
   );
-  assertStringIncludes(result.markdown, "| Retrieval Commands |");
+  assertStringIncludes(result.markdown, "| Detail |");
   assertStringIncludes(result.markdown, "| deploy-job | **bad-step** |");
   assertStringIncludes(result.markdown, "my-server \u2192 deploy");
   assertStringIncludes(
@@ -281,13 +282,16 @@ Deno.test("workflowSummaryReport: JSON output structure matches expected shape",
   const stepKeys = [
     "jobName",
     "stepName",
+    "taskType",
     "modelName",
     "modelType",
     "methodName",
     "status",
+    "errorMessage",
     "retrievalCommands",
   ];
   assertEquals(Object.keys(steps[0]).sort(), stepKeys.sort());
+  assertEquals(steps[0].taskType, "model_method");
   assertEquals(steps[0].retrievalCommands, []);
 });
 
@@ -322,4 +326,106 @@ Deno.test("workflowSummaryReport: failure JSON includes retrievalCommands", asyn
   assertEquals(failures[0].retrievalCommands, [
     "swamp data get broken-svc result",
   ]);
+});
+
+Deno.test("workflowSummaryReport: failed assert step is counted and shown with job marked failed", async () => {
+  const ctx = makeWorkflowContext({
+    workflowStatus: "failed",
+    stepExecutions: [
+      makeStepExecution({
+        jobName: "reproduce",
+        stepName: "successful-model-step",
+        status: "succeeded",
+      }),
+      {
+        jobName: "reproduce",
+        stepName: "deliberately-failed-assertion",
+        taskType: "assert",
+        modelName: "",
+        modelType: "",
+        methodName: "",
+        status: "failed",
+        dataHandles: [],
+        methodArgs: {},
+        modelId: "",
+        globalArgs: {},
+        errorMessage: "Deliberate assertion failure for reproduction.",
+      },
+    ],
+  });
+
+  const result = await workflowSummaryReport.execute(ctx);
+
+  assertStringIncludes(
+    result.markdown,
+    "1 succeeded · 1 failed · 0 skipped",
+  );
+  assertStringIncludes(result.markdown, "## Job: reproduce (failed)");
+  assertStringIncludes(
+    result.markdown,
+    "| **deliberately-failed-assertion** | **assert** | **failed** |",
+  );
+  assertStringIncludes(result.markdown, "## Failures");
+  assertStringIncludes(
+    result.markdown,
+    "| reproduce | **deliberately-failed-assertion** | assert | Deliberate assertion failure for reproduction. |",
+  );
+
+  assertEquals(result.json.totalSteps, 2);
+  assertEquals(result.json.succeeded, 1);
+  assertEquals(result.json.failed, 1);
+
+  const failures = result.json.failures as Array<Record<string, unknown>>;
+  assertEquals(failures.length, 1);
+  assertEquals(failures[0].taskType, "assert");
+  assertEquals(failures[0].stepName, "deliberately-failed-assertion");
+  assertEquals(
+    failures[0].errorMessage,
+    "Deliberate assertion failure for reproduction.",
+  );
+});
+
+Deno.test("workflowSummaryReport: mixed model-method and assert steps — correct per-job status", async () => {
+  const ctx = makeWorkflowContext({
+    workflowStatus: "succeeded",
+    stepExecutions: [
+      makeStepExecution({
+        jobName: "check",
+        stepName: "run-model",
+        status: "succeeded",
+      }),
+      {
+        jobName: "check",
+        stepName: "verify-output",
+        taskType: "assert",
+        modelName: "",
+        modelType: "",
+        methodName: "",
+        status: "succeeded",
+        dataHandles: [],
+        methodArgs: {},
+        modelId: "",
+        globalArgs: {},
+      },
+    ],
+  });
+
+  const result = await workflowSummaryReport.execute(ctx);
+
+  assertStringIncludes(
+    result.markdown,
+    "2 succeeded · 0 failed · 0 skipped",
+  );
+  assertStringIncludes(result.markdown, "## Job: check (succeeded)");
+  assertStringIncludes(
+    result.markdown,
+    "| verify-output | assert | succeeded |",
+  );
+
+  assertEquals(result.json.totalSteps, 2);
+  assertEquals(result.json.succeeded, 2);
+
+  const steps = result.json.steps as Array<Record<string, unknown>>;
+  assertEquals(steps.length, 2);
+  assertEquals(steps[1].taskType, "assert");
 });

--- a/src/domain/reports/report_context.ts
+++ b/src/domain/reports/report_context.ts
@@ -128,6 +128,7 @@ export interface WorkflowReportContext extends BaseReportContext {
   stepExecutions: Array<{
     jobName: string;
     stepName: string;
+    taskType: string;
     modelName: string;
     modelType: string;
     methodName: string;
@@ -136,6 +137,7 @@ export interface WorkflowReportContext extends BaseReportContext {
     methodArgs: Record<string, unknown>;
     modelId: string;
     globalArgs: Record<string, unknown>;
+    errorMessage?: string;
   }>;
 }
 

--- a/src/domain/reports/testing_package_compat_test.ts
+++ b/src/domain/reports/testing_package_compat_test.ts
@@ -112,6 +112,7 @@ function _checkWorkflowReportContextFields(ctx: TestingWorkflowReportContext) {
     const step = ctx.stepExecutions[0];
     const _jobName: string = step.jobName;
     const _stepName: string = step.stepName;
+    const _taskType: string = step.taskType;
     const _modelName: string = step.modelName;
     const _modelType: string = step.modelType;
     const _methodName: string = step.methodName;
@@ -119,9 +120,11 @@ function _checkWorkflowReportContextFields(ctx: TestingWorkflowReportContext) {
     const _methodArgs: Record<string, unknown> = step.methodArgs;
     const _modelId: string = step.modelId;
     const _globalArgs: Record<string, unknown> = step.globalArgs;
+    const _errorMessage: string | undefined = step.errorMessage;
     void [
       _jobName,
       _stepName,
+      _taskType,
       _modelName,
       _modelType,
       _methodName,
@@ -129,6 +132,7 @@ function _checkWorkflowReportContextFields(ctx: TestingWorkflowReportContext) {
       _methodArgs,
       _modelId,
       _globalArgs,
+      _errorMessage,
     ];
   }
 

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -341,6 +341,11 @@ export function stepNameFromCompositeKey(key: string): string {
   return idx >= 0 ? key.slice(idx + 1) : "";
 }
 
+export function jobNameFromCompositeKey(key: string): string {
+  const idx = key.indexOf(":");
+  return idx >= 0 ? key.slice(0, idx) : key;
+}
+
 /**
  * Infrastructure dependencies the {@link DefaultStepExecutor} needs to
  * run a model method. Inject this for tests so the executor can be
@@ -1843,7 +1848,6 @@ export class WorkflowExecutionService {
         string,
         "succeeded" | "failed" | "skipped"
       >();
-      const stepJobNames = new Map<string, string>();
       const dataHandlesByStep = new Map<
         string,
         import("../models/model.ts").DataHandle[]
@@ -1876,7 +1880,6 @@ export class WorkflowExecutionService {
               modelId: event.modelId,
               methodName: event.methodName,
             });
-            stepJobNames.set(key, event.jobId);
           } else if (event.kind === "step_completed") {
             const key = `${event.jobId}:${event.stepId}`;
             stepStatuses.set(key, "succeeded");
@@ -1946,7 +1949,6 @@ export class WorkflowExecutionService {
             run,
             modelInfoByStep,
             stepStatuses,
-            stepJobNames,
             dataHandlesByStep,
             options?.reportFilterOptions,
           );
@@ -2240,7 +2242,6 @@ export class WorkflowExecutionService {
         string,
         "succeeded" | "failed" | "skipped"
       >();
-      const stepJobNames = new Map<string, string>();
       const dataHandlesByStep = new Map<
         string,
         import("../models/model.ts").DataHandle[]
@@ -2279,7 +2280,6 @@ export class WorkflowExecutionService {
               modelId: event.modelId,
               methodName: event.methodName,
             });
-            stepJobNames.set(key, event.jobId);
           } else if (event.kind === "step_completed") {
             const key = `${event.jobId}:${event.stepId}`;
             stepStatuses.set(key, "succeeded");
@@ -2336,7 +2336,6 @@ export class WorkflowExecutionService {
         existingRun,
         modelInfoByStep,
         stepStatuses,
-        stepJobNames,
         dataHandlesByStep,
         options?.reportFilterOptions,
       );
@@ -3533,7 +3532,6 @@ export class WorkflowExecutionService {
       }
     >,
     stepStatuses: Map<string, "succeeded" | "failed" | "skipped">,
-    stepJobNames: Map<string, string>,
     dataHandlesByStep: Map<
       string,
       import("../models/model.ts").DataHandle[]
@@ -3548,55 +3546,84 @@ export class WorkflowExecutionService {
     const filterOptions = reportFilterOptions ?? {};
 
     const stepExecutions: WorkflowStepExecutionDetail[] = [];
-    for (const [key, info] of modelInfoByStep) {
-      const status = stepStatuses.get(key) ?? "failed";
-      const jobName = stepJobNames.get(key) ?? "";
+    for (const [key, status] of stepStatuses) {
+      const jobName = jobNameFromCompositeKey(key);
       const stepName = stepNameFromCompositeKey(key);
+      const info = modelInfoByStep.get(key);
 
-      if (status === "skipped") {
+      if (info) {
+        if (status === "skipped") {
+          stepExecutions.push({
+            jobName,
+            stepName,
+            taskType: "model_method",
+            modelName: info.modelName,
+            modelType: info.modelType,
+            methodName: info.methodName,
+            status,
+            dataHandles: [],
+            methodArgs: {},
+            modelId: info.modelId,
+            globalArgs: {},
+          });
+          continue;
+        }
+
+        // Look up the definition for methodArgs and globalArgs only.
+        // The modelId comes from step execution time (info.modelId),
+        // NOT from this lookup — the lookup can return a stale or
+        // different definition for auto-created models.
+        let lookupResult = await this.evaluatedDefRepo.findByNameGlobal(
+          info.modelName,
+        );
+        if (!lookupResult) {
+          lookupResult = await findDefinitionByIdOrName(
+            this.definitionRepo,
+            info.modelName,
+          );
+        }
+
         stepExecutions.push({
           jobName,
           stepName,
+          taskType: "model_method",
           modelName: info.modelName,
           modelType: info.modelType,
           methodName: info.methodName,
           status,
+          dataHandles: dataHandlesByStep.get(key) ?? [],
+          methodArgs: lookupResult
+            ? lookupResult.definition.getMethodArguments(info.methodName)
+            : {},
+          modelId: info.modelId,
+          globalArgs: lookupResult
+            ? lookupResult.definition.globalArguments
+            : {},
+          errorMessage: status === "failed"
+            ? run.getJob(jobName)?.getStep(stepName)?.error
+            : undefined,
+        });
+      } else {
+        const wfStep = workflow.jobs
+          .find((j) => j.name === jobName)?.getStep(stepName);
+        const taskType = wfStep?.task.data.type ?? "unknown";
+        stepExecutions.push({
+          jobName,
+          stepName,
+          taskType,
+          modelName: "",
+          modelType: "",
+          methodName: "",
+          status,
           dataHandles: [],
           methodArgs: {},
-          modelId: info.modelId,
+          modelId: "",
           globalArgs: {},
+          errorMessage: status === "failed"
+            ? run.getJob(jobName)?.getStep(stepName)?.error
+            : undefined,
         });
-        continue;
       }
-
-      // Look up the definition for methodArgs and globalArgs only.
-      // The modelId comes from step execution time (info.modelId),
-      // NOT from this lookup — the lookup can return a stale or
-      // different definition for auto-created models.
-      let lookupResult = await this.evaluatedDefRepo.findByNameGlobal(
-        info.modelName,
-      );
-      if (!lookupResult) {
-        lookupResult = await findDefinitionByIdOrName(
-          this.definitionRepo,
-          info.modelName,
-        );
-      }
-
-      stepExecutions.push({
-        jobName,
-        stepName,
-        modelName: info.modelName,
-        modelType: info.modelType,
-        methodName: info.methodName,
-        status,
-        dataHandles: dataHandlesByStep.get(key) ?? [],
-        methodArgs: lookupResult
-          ? lookupResult.definition.getMethodArguments(info.methodName)
-          : {},
-        modelId: info.modelId,
-        globalArgs: lookupResult ? lookupResult.definition.globalArguments : {},
-      });
     }
 
     const bufferedEvents: WorkflowExecutionEvent[] = [];

--- a/src/domain/workflows/workflow_report_runner.ts
+++ b/src/domain/workflows/workflow_report_runner.ts
@@ -44,6 +44,7 @@ import type { WorkflowExecutionEvent } from "./execution_events.ts";
 export interface WorkflowStepExecutionDetail {
   jobName: string;
   stepName: string;
+  taskType: string;
   modelName: string;
   modelType: string;
   methodName: string;
@@ -52,6 +53,7 @@ export interface WorkflowStepExecutionDetail {
   methodArgs: Record<string, unknown>;
   modelId: string;
   globalArgs: Record<string, unknown>;
+  errorMessage?: string;
 }
 
 /**

--- a/src/domain/workflows/workflow_report_runner_test.ts
+++ b/src/domain/workflows/workflow_report_runner_test.ts
@@ -63,6 +63,7 @@ Deno.test("WorkflowReportContext: existing workflow summary report works with in
       {
         jobName: "deploy-job",
         stepName: "deploy-step",
+        taskType: "model_method",
         modelName: "my-server",
         modelType: "server",
         methodName: "deploy",
@@ -88,6 +89,7 @@ Deno.test("WorkflowReportContext: existing workflow summary report works without
       {
         jobName: "build-job",
         stepName: "build-step",
+        taskType: "model_method",
         modelName: "app",
         modelType: "app",
         methodName: "build",


### PR DESCRIPTION
## Summary

- Rewrites `runWorkflowReports` to iterate `stepStatuses` (all steps) instead of `modelInfoByStep` (model-only), so non-model tasks (assert, manual_approval, workflow) appear in workflow-scope reports
- Adds `taskType` and `errorMessage` fields to `WorkflowStepExecutionDetail`, `WorkflowReportContext`, and the testing package type
- Updates both built-in reports (workflow-summary and verification-attestation) to render non-model steps with task type labels and error details

Fixes swamp-club#1795

## Test plan

- [x] Unit tests: 2 new tests in `workflow_summary_report_test.ts` (failed assert counted/shown, mixed model+assert counts)
- [x] Unit tests: 1 new test in `verification_attestation_report_test.ts` (failed assert in attestation)
- [x] Compat test: `testing_package_compat_test.ts` updated for new fields
- [x] Integration: `workflow_report_data_test.ts` passes (3/3)
- [x] Integration: `workflow_assert_test.ts` passes (8/8)
- [x] All existing tests continue to pass (10711 passed)
- [x] Reproduced bug at `/tmp/swamp-repro-issue-1795` — summary showed 1 step / 0 failures instead of 2 steps / 1 failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)