### PR TITLE
refactor(output): remove duplicate systemPrefix in favor of labeledPrefix

### DIFF
--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -91,11 +91,6 @@ import {
 } from "../infrastructure/logging/logger.ts";
 import { dim, yellow } from "@std/fmt/colors";
 
-function systemPrefix(): string {
-  const padded = "system".padStart(getSystemPipeWidth() + 1);
-  return dim(`${padded} │`);
-}
-
 export type LockProgressWriter = (message: string) => void;
 
 function labeledPrefix(label: string): string {
@@ -104,7 +99,7 @@ function labeledPrefix(label: string): string {
 }
 
 function defaultLockWriter(message: string): void {
-  console.error(`${systemPrefix()} ${message}`);
+  console.error(`${labeledPrefix("system")} ${message}`);
 }
 
 export function createLockProgressWriter(label: string): LockProgressWriter {


### PR DESCRIPTION
## Summary

- `systemPrefix()` became identical to `labeledPrefix("system")` after #2225 added the generic helper
- Removed the duplicate function and updated `defaultLockWriter` to use `labeledPrefix("system")` directly
- Net -5 lines

## Test plan

- [x] All 51 `repo_context_test.ts` tests pass
- [x] `deno check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>