### PR TITLE
fix(verification): hard gate on allPassed, config integrity checksums

### DIFF
--- a/.claude/skills/issue-lifecycle/references/verification.md
+++ b/.claude/skills/issue-lifecycle/references/verification.md
@@ -67,20 +67,29 @@ swamp data get <model-name> <data-name>
 
 ### All steps passed
 
-Call `verification_passed` with the checklist data from the attestation:
+**Only proceed when `gate.allPassed` is true — every non-skipped step must have
+succeeded.** A partial pass is NOT a pass. If any step failed, go to "Any step
+failed" below.
 
-```
-swamp model @swamp/issue-lifecycle method run verification_passed issue-<N> \
-  --input workflowRunId=<run-id> \
-  --input commit=<SHA> \
-  --input branch=<branch> \
-  --input steps='[{"job":"static-analysis","step":"lint","model":"@swamp/deno-runner","method":"task","status":"succeeded"}, ...]'
-```
+1. Construct the combined attestation JSON including the `configIntegrity`
+   checksums (see `agent-constraints/verification-conventions.md` for the full
+   schema). The attestation is posted to swamp-club as part of the
+   `verification_passed` call so the team has a permanent, shared record.
 
-Populate the `steps` array from the attestation output. Include every step with
-its actual status (succeeded, failed, or skipped).
+2. Call `verification_passed` with the attestation data:
 
-2. **Present the full verification checklist to the user and wait for their
+   ```
+   swamp model @swamp/issue-lifecycle method run verification_passed issue-<N> \
+     --input workflowRunId=<run-id> \
+     --input commit=<SHA> \
+     --input branch=<branch> \
+     --input steps='[{"job":"static-analysis","step":"lint","model":"build-lint","status":"succeeded"}, ...]'
+   ```
+
+   Populate the `steps` array from the attestation output. Include every step
+   with its actual status (succeeded, failed, or skipped).
+
+3. **Present the full verification checklist to the user and wait for their
    approval before opening the PR.** The checklist must show every step from
    both the build and review workflows — status, model, duration, and for
    reviews the VERDICT and finding count. Include the workflow run file paths so
@@ -90,7 +99,7 @@ its actual status (succeeded, failed, or skipped).
    Do NOT proceed to open a PR until the user has seen the checklist and
    confirmed they are happy with the results.
 
-3. Then proceed to open a PR — read the "Create a PR" section in
+4. Then proceed to open a PR — read the "Create a PR" section in
    [implementation.md](implementation.md).
 
 ### Any step failed

--- a/agent-constraints/verification-conventions.md
+++ b/agent-constraints/verification-conventions.md
@@ -158,6 +158,25 @@ To construct this checklist:
        "os": "<platform>",
        "swampVersion": "<version>"
      },
+     "configIntegrity": {
+       "claudeMd": "<sha256 of CLAUDE.md>",
+       "prompts": {
+         "code-review": "<sha256 of verification/review-prompts/code-review.md>",
+         "adversarial-review": "<sha256 of verification/review-prompts/adversarial-review.md>",
+         "ux-review": "<sha256 of verification/review-prompts/ux-review.md>",
+         "ci-security-review": "<sha256 of verification/review-prompts/ci-security-review.md>"
+       },
+       "workflows": {
+         "verify-build": "<sha256 of verification/workflow-verify-build.yaml>",
+         "verify-reviews": "<sha256 of verification/workflow-verify-reviews.yaml>"
+       }
+     },
+     "reviewConfig": {
+       "code-review": { "model": "claude-opus-4-6", "ran": true },
+       "adversarial-review": { "model": "claude-opus-4-6", "ran": false, "reason": "guard" },
+       "ux-review": { "model": "claude-sonnet-4-6", "ran": false, "reason": "guard" },
+       "ci-security-review": { "model": "claude-opus-4-6", "ran": false, "reason": "guard" }
+     },
      "steps": [
        {
          "job": "static-analysis",
@@ -201,6 +220,15 @@ To construct this checklist:
    }
    ```
 
+   The `configIntegrity` section proves the review prompts, workflows, and
+   CLAUDE.md used match the versions at the verified commit. Anyone can
+   checkout that commit, hash the files, and verify they match. Compute
+   hashes with:
+
+   ```bash
+   sha256sum CLAUDE.md verification/review-prompts/*.md verification/workflow-verify-*.yaml
+   ```
+
 5. Present the checklist AND the workflow run file paths to the user so they
    can inspect the full details:
 
@@ -209,8 +237,13 @@ To construct this checklist:
    Review run: .swamp/workflow-runs/<id>/workflow-run-<review-run-id>.yaml
    ```
 
-6. Determine the overall result:
-   - **All pass** → call `verification_passed` with the checklist data
+6. Determine the overall result. **Only call `verification_passed` when
+   `gate.allPassed` is true — every non-skipped step must have succeeded.**
+   If any step failed, call `verification_failed` instead. Do not treat a
+   partial pass as success.
+
+   - **All pass** → post the attestation JSON to swamp-club as part of the
+     `verification_passed` call so the team has a permanent, shared record
    - **Any fail** → call `verification_failed`, fix the issues, re-verify
 
 ## Handling Failures


### PR DESCRIPTION
## Summary

- **Hard gate**: only call `verification_passed` when `gate.allPassed` is
  true — a partial pass is NOT a pass
- **Config integrity checksums**: attestation JSON now includes sha256
  hashes of CLAUDE.md, all review prompts, and both workflow files. Anyone
  can checkout the commit, hash the files, and verify the review that was
  claimed to run matches the review checked in at that SHA
- **Review config**: attestation records which model and version each
  reviewer used, and whether it ran or was guarded
- **Post to swamp-club**: attestation is posted as part of
  `verification_passed` so the team has a permanent, shared record — not
  just local files on the author's machine

## Context

Addresses the "homework marked by ourselves" concern — while result integrity
(the verdict actually happened) can't be proven when the author controls the
runtime, config integrity (the right checks ran with the right prompts) is
now fully verifiable via checksums in the attestation.

## Test Plan

- [x] No CI changes
- [x] Only modifies verification conventions and lifecycle skill docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)