### PR TITLE
fix(workflows): resolve modelType on factory-pattern steps with CEL modelName

### DIFF
--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -557,11 +557,15 @@ export class DefaultWorkflowValidationService
     const checkName =
       `Step inputs for '${stepName}' in job '${jobName}' (${modelIdOrName}.${methodName})`;
 
-    // Skip dynamic CEL references — cannot resolve statically
-    if (modelIdOrName.includes("${{")) {
-      return [WorkflowValidationResult.pass(checkName)];
-    }
-    if (modelType?.includes("${{")) {
+    // Skip dynamic CEL references — cannot resolve statically.
+    // For factory-pattern steps (modelType is set), only the modelType
+    // matters for type/method resolution — a CEL modelName does not
+    // prevent resolving the extension type.
+    if (modelType) {
+      if (modelType.includes("${{")) {
+        return [WorkflowValidationResult.pass(checkName)];
+      }
+    } else if (modelIdOrName.includes("${{")) {
       return [WorkflowValidationResult.pass(checkName)];
     }
 

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -1327,6 +1327,114 @@ Deno.test("validateStepInputs: direct-execution step with CEL in modelType skips
   assertEquals(inputResult?.passed, true);
 });
 
+Deno.test("validateStepInputs: direct-execution step with CEL modelName and unresolvable modelType fails", async () => {
+  const resolver = mockResolverWithType({
+    "type:@swamp/nonexistent/type.deploy": {
+      status: "type_unresolvable",
+      modelType: "@swamp/nonexistent/type",
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.directExecution(
+              "@swamp/nonexistent/type",
+              '${{ "sync-" + inputs.host }}',
+              "deploy",
+              { region: "us-east-1" },
+            ),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  assertEquals(inputResult?.passed, false);
+  assertEquals(inputResult?.error?.includes("could not be resolved"), true);
+  assertEquals(inputResult?.error?.includes("@swamp/nonexistent/type"), true);
+});
+
+Deno.test("validateStepInputs: direct-execution step with CEL modelName and valid modelType passes", async () => {
+  const resolver = mockResolverWithType({
+    "type:@swamp/test/model.deploy": {
+      status: "resolved",
+      requiredArgs: ["region"],
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.directExecution(
+              "@swamp/test/model",
+              '${{ "sync-" + inputs.host }}',
+              "deploy",
+              { region: "us-east-1" },
+            ),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  assertEquals(inputResult?.passed, true);
+});
+
+Deno.test("validateStepInputs: direct-execution step with CEL modelName and method not found fails", async () => {
+  const resolver = mockResolverWithType({
+    "type:@swamp/test/model.nonexistent": {
+      status: "method_not_found",
+      modelType: "@swamp/test/model",
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.directExecution(
+              "@swamp/test/model",
+              '${{ "sync-" + inputs.host }}',
+              "nonexistent",
+              { region: "us-east-1" },
+            ),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  assertEquals(inputResult?.passed, false);
+  assertEquals(
+    inputResult?.error?.includes("Method 'nonexistent' not found"),
+    true,
+  );
+});
+
 Deno.test("validateStepInputs: direct-execution step with globalArgs satisfying required arg passes", async () => {
   const resolver = mockResolverWithType({
     "type:@swamp/test/model.create": {


### PR DESCRIPTION
## Summary

Closes swamp-club#1788.

- `workflow validate` was silently skipping `modelType` resolution on factory-pattern steps when `modelName` contained a CEL expression (e.g., `${{ "sync-" + inputs.host }}`)
- Root cause: the CEL skip in `validateModelMethodInputs` checked `modelIdOrName`, which for factory-pattern steps carries the `modelName` value — since factory steps commonly use CEL in `modelName` for fleet fan-out, the entire validation (including `modelType` resolution) was short-circuited to PASS
- Fix: when `modelType` is provided, only skip if `modelType` itself contains CEL — `resolveByType()` doesn't use `modelName` at all, so type/method resolution can proceed regardless
- Added 3 unit tests: CEL modelName + unresolvable type fails, CEL modelName + valid type passes, CEL modelName + method not found fails

**Note:** This is a strictness increase. Factory-pattern steps with CEL model names and latent `modelType` errors will now fail `swamp workflow validate` where they previously passed silently. This is intentional — `design/workflow.md` already documents that unresolvable types must fail, not silently pass.

## Test plan

- [x] 67/67 validation_service_test.ts tests pass (3 new)
- [x] `deno check` — type checking clean
- [x] `deno lint` — no lint errors
- [x] `deno fmt` — formatting clean
- [x] Manual reproduction: factory-pattern step with `@fake/does-not-exist` modelType + CEL modelName now correctly fails with "Model type could not be resolved"
- [x] Code review agent passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)