### PR TITLE
fix(serve): pass datastore namespace to pushChanged during OAuth token minting

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -3702,6 +3702,7 @@ export const serveCommand = new Command()
             repoContext,
             repoMarker?.defaultVault,
             syncService,
+            serveNamespace,
           );
           const deviceAuthResponse = await handleDeviceAuth(
             req,

--- a/src/serve/device_auth_handler.ts
+++ b/src/serve/device_auth_handler.ts
@@ -297,6 +297,7 @@ async function mintServerTokenImpl(
   repoContext: RepositoryContext,
   defaultVault?: string,
   syncService?: DatastoreSyncService,
+  namespace?: string,
 ): Promise<string> {
   const tokenName = `oauth-${crypto.randomUUID().slice(0, 8)}`;
   const secretKey = serverTokenSecretKey(tokenName);
@@ -366,7 +367,7 @@ async function mintServerTokenImpl(
 
   if (syncService) {
     await syncService.markDirty();
-    await syncService.pushChanged();
+    await syncService.pushChanged({ namespace });
 
     repoContext.catalogStore.invalidate();
     const verifyResult = await findDefinitionByIdOrName(
@@ -400,6 +401,7 @@ export function createDeviceAuthDeps(
   repoContext: RepositoryContext,
   defaultVault?: string,
   syncService?: DatastoreSyncService,
+  namespace?: string,
 ): DeviceAuthDeps {
   return {
     authConfig,
@@ -427,6 +429,7 @@ export function createDeviceAuthDeps(
         rc,
         defaultVault,
         syncService,
+        namespace,
       ),
     storeAccessToken: async (tokenName: string, accessToken: string) => {
       const vaultService = await VaultService.fromRepository(


### PR DESCRIPTION
## Summary

Fixes swamp-club#1776 — OAuth device-token exchange 500s on serve instances with a namespaced datastore (e.g. `@swamp/s3-datastore` with `namespace: agent-harness-dev`).

**Root cause:** `mintServerTokenImpl` in `device_auth_handler.ts` called `syncService.pushChanged()` without the datastore namespace. The S3 datastore extension's sync service binds to the configured namespace during boot hydration, then rejects any subsequent sync call that omits it — causing `"Namespace mismatch: bound to \"...\" but called with undefined"`.

**Fix:** Thread `serveNamespace` from the serve startup through `createDeviceAuthDeps` into `mintServerTokenImpl`, so `pushChanged` receives `{ namespace }`.

- `src/serve/device_auth_handler.ts` — `mintServerTokenImpl` accepts optional `namespace`, passes it to `pushChanged({ namespace })`; `createDeviceAuthDeps` threads it through the mint closure
- `src/cli/commands/serve.ts` — passes `serveNamespace` to `createDeviceAuthDeps`

## Test Plan

- Reproduced locally: MinIO S3 datastore with `namespace: repro-1776`, `swamp serve --auth-mode oauth` → `swamp auth server-login` 500'd with namespace mismatch
- Verified fix: same setup with patched binary → login succeeds, server logs `OAuth device flow completed`
- Existing unit tests pass (23/23 in `device_auth_handler_test.ts`)
- Full verification workflow green: lint, fmt, type-check, tests, compile, code review all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)