### PR TITLE
fix(serve): plumb --ca-cert through diagnostic probes and auth server-login (#1794)

### DIFF
--- a/src/cli/commands/auth_server_login.ts
+++ b/src/cli/commands/auth_server_login.ts
@@ -20,7 +20,7 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { UserError } from "../../domain/errors.ts";
-import { resolveServeUrl } from "../remote_run.ts";
+import { getEnvCaCerts, resolveServeUrl } from "../remote_run.ts";
 import { FileServerCredentialRepository } from "../../infrastructure/persistence/server_credential_repository.ts";
 import { normalizeServerUrl } from "../../domain/auth/server_url.ts";
 import { splitServerToken } from "../../serve/token_auth.ts";
@@ -52,6 +52,10 @@ export const authServerLoginCommand = new Command()
   .option(
     "--token <token:string>",
     "Server token in <name>.<secret> format (skips OAuth flow)",
+  )
+  .option(
+    "--ca-cert <path:string>",
+    "Path to PEM-encoded CA certificate to trust for TLS connections to the server (env: SWAMP_CA_CERT)",
   )
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -145,7 +149,11 @@ async function handleOAuthFlow(
     );
   }
   const normalizedUrl = normalizeServerUrl(rawUrl);
-  const deps = createServerLoginDeps();
+  const caCerts = getEnvCaCerts();
+  const httpClient = caCerts?.length
+    ? Deno.createHttpClient({ caCerts })
+    : undefined;
+  const deps = createServerLoginDeps({ httpClient });
   const input = { serverUrl: rawUrl, signal: AbortSignal.timeout(300_000) };
 
   for await (const event of serverLogin(deps, input)) {

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -378,9 +378,12 @@ export async function probeServerHealth(wsUrl: string): Promise<boolean> {
   const httpUrl = toHttpUrl(wsUrl);
   try {
     const healthUrl = new URL("/health", httpUrl);
-    const response = await fetch(healthUrl, {
+    const fetchClient = getCaCertFetchClient();
+    const fetchOpts: Record<string, unknown> = {
       signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
-    });
+    };
+    if (fetchClient) fetchOpts.client = fetchClient;
+    const response = await fetch(healthUrl, fetchOpts);
     if (!response.ok) return false;
     const body = await response.json();
     return typeof body === "object" && body !== null &&
@@ -445,7 +448,7 @@ function resolveCaCertPath(): string | undefined {
   return undefined;
 }
 
-function getEnvCaCerts(): string[] | undefined {
+export function getEnvCaCerts(): string[] | undefined {
   if (resolvedEnvCaCerts !== undefined) {
     return resolvedEnvCaCerts.length > 0 ? resolvedEnvCaCerts : undefined;
   }
@@ -466,6 +469,17 @@ function getEnvCaCerts(): string[] | undefined {
 }
 
 let cachedCaCertClient: Deno.HttpClient | undefined;
+
+let cachedCaCertFetchClient: Deno.HttpClient | undefined;
+
+function getCaCertFetchClient(): Deno.HttpClient | undefined {
+  const caCerts = getEnvCaCerts();
+  if (!caCerts?.length) return undefined;
+  if (!cachedCaCertFetchClient) {
+    cachedCaCertFetchClient = Deno.createHttpClient({ caCerts });
+  }
+  return cachedCaCertFetchClient;
+}
 
 function createSocket(
   url: string,
@@ -496,9 +510,13 @@ const H2_MASKED_ERROR = "HTTP/2 not supported by this client";
 
 /**
  * When `createHttpClient({ http2: false })` is used, Deno's WebSocket
- * masks every TLS validation error as "HTTP/2 not supported by this
- * client". Probe with a plain `fetch()` (no custom client) to surface
- * the real error — `fetch` shows the actual TLS rejection reason.
+ * masks every TLS validation error — and also HTTP error codes like 401
+ * — as "HTTP/2 not supported by this client". Probe with `fetch()` to
+ * surface the real error. Uses the CA cert from `--ca-cert` /
+ * `SWAMP_CA_CERT` when available so the probe reflects the same trust
+ * configuration as the WebSocket connection; without this, a server
+ * that rejects an unauthenticated upgrade (401) is misdiagnosed as a
+ * TLS failure because the bare probe fails on an untrusted issuer.
  * Returns a more helpful message or `undefined` if the probe succeeds
  * (meaning the WebSocket failure has a different cause).
  */
@@ -514,10 +532,13 @@ export async function diagnoseTlsError(
   if (parsed.protocol !== "wss:") return undefined;
 
   parsed.protocol = "https:";
+  const fetchClient = getCaCertFetchClient();
+  const fetchOpts: Record<string, unknown> = {
+    signal: AbortSignal.timeout(3_000),
+  };
+  if (fetchClient) fetchOpts.client = fetchClient;
   try {
-    const resp = await fetch(parsed.href, {
-      signal: AbortSignal.timeout(3_000),
-    });
+    const resp = await fetch(parsed.href, fetchOpts);
     await resp.body?.cancel();
     return undefined;
   } catch (e: unknown) {

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -25,6 +25,7 @@ import {
 } from "@std/assert";
 import { UserError } from "../domain/errors.ts";
 import {
+  diagnoseTlsError,
   normalizeServerUrl,
   probeServerHealth,
   requestServerResponse,
@@ -1232,5 +1233,25 @@ Deno.test({
     } finally {
       await server.shutdown();
     }
+  },
+});
+
+// ── diagnoseTlsError tests ────────────────────────────────────────────
+
+Deno.test({
+  name: "diagnoseTlsError: returns undefined for non-wss URLs",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    assertEquals(await diagnoseTlsError("ws://127.0.0.1:9999"), undefined);
+  },
+});
+
+Deno.test({
+  name: "diagnoseTlsError: returns undefined for invalid URL",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    assertEquals(await diagnoseTlsError("not-a-url"), undefined);
   },
 });

--- a/src/libswamp/auth/server_login.ts
+++ b/src/libswamp/auth/server_login.ts
@@ -120,17 +120,26 @@ function wsToHttp(url: string): string {
 }
 
 /**
- * Create production dependencies for server login.
+ * Create production dependencies for server login. When an httpClient
+ * is provided (e.g. one carrying custom CA certs from `--ca-cert`), it
+ * is used for all REST calls to the serve instance.
  */
-export function createServerLoginDeps(): ServerLoginDeps {
+export function createServerLoginDeps(
+  options?: { httpClient?: Deno.HttpClient },
+): ServerLoginDeps {
   const repo = new FileServerCredentialRepository();
+  const clientOpts: Record<string, unknown> = {};
+  if (options?.httpClient) clientOpts.client = options.httpClient;
   return {
     discoverAuthMode: async (
       serverUrl: string,
       signal: AbortSignal,
     ): Promise<AuthDiscovery> => {
       const httpUrl = wsToHttp(serverUrl);
-      const resp = await fetch(`${httpUrl}/auth/info`, { signal });
+      const resp = await fetch(`${httpUrl}/auth/info`, {
+        signal,
+        ...clientOpts,
+      });
       if (!resp.ok) {
         throw new UserError(
           `Failed to discover auth mode: ${resp.status} ${resp.statusText}`,
@@ -147,6 +156,7 @@ export function createServerLoginDeps(): ServerLoginDeps {
       const resp = await fetch(`${httpUrl}/auth/device`, {
         method: "POST",
         signal,
+        ...clientOpts,
       });
       if (!resp.ok) {
         throw new UserError(
@@ -167,6 +177,7 @@ export function createServerLoginDeps(): ServerLoginDeps {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ deviceCode }),
         signal,
+        ...clientOpts,
       });
       if (resp.status === 202) {
         throw new DeviceAuthPendingError();


### PR DESCRIPTION
## Summary

- **Root cause**: When a server runs `--auth-mode token`, Deno's WebSocket
  masks HTTP 401 rejections as "HTTP/2 not supported by this client".
  `diagnoseTlsError()` and `probeServerHealth()` then probe with bare
  `fetch()` without the user's CA cert, causing the probe itself to fail on
  TLS and misdiagnose the auth rejection as "TLS certificate rejected"
- Adds `getCaCertFetchClient()` and plumbs CA certs through both diagnostic
  probes so `classifyConnectionError` correctly reports "Authentication
  failed" instead of a false TLS error
- Adds `--ca-cert` to `auth server-login` (was missing entirely) and threads
  an `httpClient` through `createServerLoginDeps()` so OAuth device flow REST
  calls work with custom CA certs

Fixes swamp-club#1794.

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno run test src/cli/remote_run_test.ts` — 39 passed
- [x] `deno run test src/libswamp/auth/server_login_test.ts` — 6 passed
- [x] `deno run test src/cli/commands/auth_server_login_test.ts` — 2 passed
- [x] Verification workflow: 7/7 build steps passed, code review verdict: pass
- [x] Manual reproduction: `--ca-cert` with `--auth-mode token` now reports
  "Authentication failed" (was "TLS certificate rejected")
- [x] `auth server-login --ca-cert` now accepts the flag (was "Unknown option")

🤖 Generated with [Claude Code](https://claude.com/claude-code)