### PR TITLE
fix(verification): populate guard file list and use merge-base diffs

### DIFF
--- a/agent-constraints/verification-conventions.md
+++ b/agent-constraints/verification-conventions.md
@@ -28,11 +28,15 @@ SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-reviews \
 
 The workflow:
 
-1. Detects changed files via `@swamp/git` diff
+1. Detects changed files via `@swamp/git` diff (full diff, then `nameOnly` for
+   the file list used by guards)
 2. Runs applicable reviews in parallel using `command/shell` steps that invoke
    `claude -p` with the review prompt + diff
 3. Each review uses the factory pattern — one `reviewer` model, called once per
    review type with different prompt files and models
+4. Review diffs use `git merge-base main HEAD` so only the branch's own changes
+   are reviewed — not the inverse of what landed on main since the branch
+   diverged
 
 ### Guards
 
@@ -42,7 +46,7 @@ Reviews are guarded by file path — they skip when no relevant files changed:
 | --- | --- | --- |
 | code-review | always | claude-opus-4-6 |
 | adversarial-review | `src/domain/`, `src/infrastructure/`, `src/libswamp/`, `src/serve/`, `src/worker/` | claude-opus-4-6 |
-| ux-review | `src/cli/`, `src/presentation/`, `src/domain/errors.ts`, `src/libswamp/` | claude-sonnet-4-6 |
+| ux-review | `src/cli/commands/`, `src/presentation/`, `src/domain/errors.ts`, `src/libswamp/` | claude-sonnet-4-6 |
 | ci-security-review | `.github/workflows/` | claude-opus-4-6 |
 
 ### Authentication

--- a/verification/workflow-verify-reviews.yaml
+++ b/verification/workflow-verify-reviews.yaml
@@ -27,7 +27,7 @@ concurrency: 4
 jobs:
   # ── Detect Changed Files ──────────────────────────────────────
   - name: detect-changes
-    description: Compute the diff and changed file list.
+    description: Compute the merge-base diff and changed file list.
     steps:
       - name: diff
         task:
@@ -37,6 +37,20 @@ jobs:
           methodName: diff
           inputs:
             base: "main"
+
+      - name: changed-files
+        dependsOn:
+          - step: diff
+            condition:
+              type: succeeded
+        task:
+          type: model_method
+          modelType: "@swamp/git"
+          modelName: repo
+          methodName: diff
+          inputs:
+            base: "main"
+            nameOnly: true
 
   # ── Agent Reviews ────────────────────────────────────────────
   - name: reviews
@@ -55,11 +69,12 @@ jobs:
           inputs:
             run: |
               set -o pipefail
+              MERGE_BASE=$(git merge-base main HEAD)
               PROMPT_FILE=$(mktemp)
               RESULT_FILE=$(mktemp)
               cat verification/review-prompts/code-review.md > "$PROMPT_FILE"
               printf '\n\nOutput your review. Start with a single line: VERDICT: pass or VERDICT: fail\nThen provide your full review.\n\nDIFF:\n' >> "$PROMPT_FILE"
-              git diff main >> "$PROMPT_FILE"
+              git diff "$MERGE_BASE" >> "$PROMPT_FILE"
               claude -p - \
                 --model claude-opus-4-6 \
                 --allowedTools "Read,Glob,Grep" < "$PROMPT_FILE" | tee "$RESULT_FILE"
@@ -81,11 +96,12 @@ jobs:
           inputs:
             run: |
               set -o pipefail
+              MERGE_BASE=$(git merge-base main HEAD)
               PROMPT_FILE=$(mktemp)
               RESULT_FILE=$(mktemp)
               cat verification/review-prompts/adversarial-review.md > "$PROMPT_FILE"
               printf '\n\nOutput your review. Start with a single line: VERDICT: pass or VERDICT: fail\nThen provide your full review.\n\nDIFF:\n' >> "$PROMPT_FILE"
-              git diff main >> "$PROMPT_FILE"
+              git diff "$MERGE_BASE" >> "$PROMPT_FILE"
               claude -p - \
                 --model claude-opus-4-6 \
                 --allowedTools "Read,Glob,Grep" < "$PROMPT_FILE" | tee "$RESULT_FILE"
@@ -98,7 +114,7 @@ jobs:
               fi
 
       - name: ux-review
-        guard: "${{ data.latest('repo', 'diff').attributes.files.filter(f, f.startsWith('src/cli/') || f.startsWith('src/presentation/') || f == 'src/domain/errors.ts' || f.startsWith('src/libswamp/')).size() == 0 }}"
+        guard: "${{ data.latest('repo', 'diff').attributes.files.filter(f, f.startsWith('src/cli/commands/') || f.startsWith('src/presentation/') || f == 'src/domain/errors.ts' || f.startsWith('src/libswamp/')).size() == 0 }}"
         task:
           type: model_method
           modelType: "command/shell"
@@ -107,11 +123,12 @@ jobs:
           inputs:
             run: |
               set -o pipefail
+              MERGE_BASE=$(git merge-base main HEAD)
               PROMPT_FILE=$(mktemp)
               RESULT_FILE=$(mktemp)
               cat verification/review-prompts/ux-review.md > "$PROMPT_FILE"
               printf '\n\nOutput your review. Start with a single line: VERDICT: pass or VERDICT: fail\nThen provide your full review.\n\nDIFF:\n' >> "$PROMPT_FILE"
-              git diff main >> "$PROMPT_FILE"
+              git diff "$MERGE_BASE" >> "$PROMPT_FILE"
               claude -p - \
                 --model claude-sonnet-4-6 \
                 --allowedTools "Read,Glob,Grep" < "$PROMPT_FILE" | tee "$RESULT_FILE"
@@ -133,11 +150,12 @@ jobs:
           inputs:
             run: |
               set -o pipefail
+              MERGE_BASE=$(git merge-base main HEAD)
               PROMPT_FILE=$(mktemp)
               RESULT_FILE=$(mktemp)
               cat verification/review-prompts/ci-security-review.md > "$PROMPT_FILE"
               printf '\n\nOutput your review. Start with a single line: VERDICT: pass or VERDICT: fail\nThen provide your full review.\n\nDIFF:\n' >> "$PROMPT_FILE"
-              git diff main >> "$PROMPT_FILE"
+              git diff "$MERGE_BASE" >> "$PROMPT_FILE"
               claude -p - \
                 --model claude-opus-4-6 \
                 --allowedTools "Read,Glob,Grep" < "$PROMPT_FILE" | tee "$RESULT_FILE"


### PR DESCRIPTION
## Summary

- Add a `changed-files` step with `nameOnly: true` to populate `data.latest('repo', 'diff').attributes.files` for guard expressions — previously the array was always empty, causing all conditional reviews (adversarial, ux, ci-security) to be skipped
- Use `git merge-base main HEAD` in review shell scripts so the diff piped into Claude only contains the branch's own changes, not the inverse of what landed on main since divergence
- Narrow the UX review guard from `src/cli/` to `src/cli/commands/` to match CI's `dorny/paths-filter` pattern

## Test Plan

- Tested locally with `swamp workflow run verify-reviews` against a branch on `main` — verified detect-changes populates files and guards correctly skip ci-security while running code-review
- Tested against `worktree-1792` branch (changes in `src/domain/`, `src/infrastructure/`, `src/cli/`) — verified adversarial and ux guards correctly allow those reviews to run
- Verified merge-base diff prevents false review failures when branch is behind main

🤖 Generated with [Claude Code](https://claude.com/claude-code)