### PR TITLE
fix(cli): stop writing runtime warning timestamps to tracked .swamp.yaml

### DIFF
--- a/design/global-skills.md
+++ b/design/global-skills.md
@@ -224,22 +224,6 @@ Once a user upgrades to a CLI version that installs global skills, any repo that
 still has local skill copies is in a conflict state — the local copies shadow the
 global ones and the user may be running stale skills.
 
-**On CLI startup** (once per day per repo), if local bundled skill copies are
-detected:
-
-```
-WRN Swamp skills are now installed globally but this repo still has local
-    copies that take precedence. Run 'swamp repo upgrade' to clean up.
-
-    Local copies found:
-      .claude/skills/swamp/
-      .claude/skills/swamp-getting-started/
-```
-
-The debounce is tracked via a `lastSkillMigrationWarning` timestamp in the
-`.swamp.yaml` marker file. The warning persists until the user deletes the
-local copies manually.
-
 **During `swamp repo upgrade`**, local copies are detected and reported:
 
 ```
@@ -255,12 +239,6 @@ set `skillMigrationDismissed: true` in `.swamp.yaml` to suppress the warning.
 ### Migration Flow
 
 ```
-Any CLI command in a repo:
-  │
-  ├─ Check for local bundled skill copies in enrolled tool dirs
-  ├─ If found and not dismissed: emit warning (once per day)
-  └─ Continue with normal command execution
-
 swamp repo upgrade:
   │
   ├─ For each enrolled tool:

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -96,9 +96,7 @@ import {
   RepoMarkerRepository,
 } from "../infrastructure/persistence/repo_marker_repository.ts";
 import { RepoPath } from "../domain/repo/repo_path.ts";
-import {
-  detectSupersededSkills,
-} from "../domain/repo/repo_service.ts";
+import { detectSupersededSkills } from "../domain/repo/repo_service.ts";
 import { resolvePrimaryTool } from "../domain/repo/primary_tool.ts";
 import { SKILL_DIRS } from "../domain/repo/skill_dirs.ts";
 import { ExtensionAutoResolver } from "../domain/extensions/extension_auto_resolver.ts";

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -97,7 +97,6 @@ import {
 } from "../infrastructure/persistence/repo_marker_repository.ts";
 import { RepoPath } from "../domain/repo/repo_path.ts";
 import {
-  detectLocalBundledSkills,
   detectSupersededSkills,
 } from "../domain/repo/repo_service.ts";
 import { resolvePrimaryTool } from "../domain/repo/primary_tool.ts";
@@ -189,12 +188,6 @@ import type {
   ResolvedSourceDirs,
 } from "../domain/repo/swamp_sources.ts";
 import { discoverManifestCrossKindDirs } from "../domain/extensions/manifest_cross_kind_discovery.ts";
-import { readUpstreamExtensions } from "../infrastructure/persistence/upstream_extensions.ts";
-import { FileExtensionUpdateCheckRepository } from "../infrastructure/persistence/extension_update_check_repository.ts";
-import {
-  findStaleExtensions,
-  formatStalenessWarning,
-} from "../domain/extensions/extension_staleness.ts";
 
 // Import models barrel to trigger self-registration
 import "../domain/models/models.ts";
@@ -475,8 +468,6 @@ export async function configureExtensionLoaders(
   if (!Deno.env.get("SWAMP_SERVE_URL")) {
     await checkForMissingPulledExtensions(repoDir, marker, deferredWarnings);
     await checkForSupersededSkills(repoDir, marker, deferredWarnings);
-    await checkForLocalBundledSkills(repoDir, marker, deferredWarnings);
-    await checkForStaleExtensions(repoDir, marker, lockfilePath, quiet);
   }
 }
 
@@ -1066,99 +1057,6 @@ async function checkForSupersededSkills(
     }
   } catch {
     // Non-fatal — don't block startup for skill dir read errors
-  }
-}
-
-const SKILL_MIGRATION_WARNING_INTERVAL_MS = 24 * 60 * 60 * 1000;
-
-async function checkForLocalBundledSkills(
-  repoDir: string,
-  marker: RepoMarkerData | null,
-  deferredWarnings: DeferredWarning[],
-): Promise<void> {
-  try {
-    if (!marker?.tools?.length) return;
-    if (marker.skillMigrationDismissed) return;
-
-    if (marker.lastSkillMigrationWarning) {
-      const lastWarning = new Date(marker.lastSkillMigrationWarning).getTime();
-      if (Date.now() - lastWarning < SKILL_MIGRATION_WARNING_INTERVAL_MS) {
-        return;
-      }
-    }
-
-    const localCopies = await detectLocalBundledSkills(
-      repoDir,
-      marker.tools,
-    );
-    if (localCopies.length === 0) return;
-
-    const allNames = localCopies.flatMap((c) => c.names);
-    const dirs = localCopies.map((c) =>
-      c.names.map((n) => `  ${join(c.skillsDir, n)}/`)
-    ).flat();
-
-    deferredWarnings.push({
-      kind: "skill-migration",
-      file: repoDir,
-      error:
-        `Local copies of ${allNames.join(", ")} are shadowing the globally ` +
-        "installed skills. Delete them manually:\n\n" +
-        dirs.join("\n"),
-    });
-
-    const repoPath = RepoPath.create(repoDir);
-    const markerRepo = new RepoMarkerRepository();
-    const updatedMarker = {
-      ...marker,
-      lastSkillMigrationWarning: new Date().toISOString(),
-    };
-    await markerRepo.write(repoPath, updatedMarker);
-  } catch {
-    // Non-fatal — don't block startup
-  }
-}
-
-const STALENESS_WARNING_INTERVAL_MS = 24 * 60 * 60 * 1000;
-
-async function checkForStaleExtensions(
-  repoDir: string,
-  marker: RepoMarkerData | null,
-  lockfilePath: string,
-  quiet: boolean,
-): Promise<void> {
-  try {
-    if (quiet || !marker) return;
-
-    if (marker.lastStalenessWarning) {
-      const lastWarning = new Date(marker.lastStalenessWarning).getTime();
-      if (Date.now() - lastWarning < STALENESS_WARNING_INTERVAL_MS) {
-        return;
-      }
-    }
-
-    const lockfile = await readUpstreamExtensions(lockfilePath);
-    if (Object.keys(lockfile).length === 0) return;
-
-    const swampDir = swampPath(repoDir, "");
-    const cacheRepo = new FileExtensionUpdateCheckRepository(swampDir);
-    const cache = await cacheRepo.read();
-    if (Object.keys(cache).length === 0) return;
-
-    const stale = findStaleExtensions(lockfile, cache);
-    if (stale.length === 0) return;
-
-    console.error(`swamp-warning: ${formatStalenessWarning(stale)}`);
-
-    const repoPath = RepoPath.create(repoDir);
-    const markerRepo = new RepoMarkerRepository();
-    const updatedMarker: RepoMarkerData = {
-      ...marker,
-      lastStalenessWarning: new Date().toISOString(),
-    };
-    await markerRepo.write(repoPath, updatedMarker);
-  } catch {
-    // Non-fatal — don't block startup
   }
 }
 

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -515,13 +515,18 @@ export class RepoService {
     await this.migrateRepoLocalTelemetry(repoPath, existingMarker);
 
     if (localSkillCopies.length === 0) {
-      delete updatedMarker.lastSkillMigrationWarning;
       delete updatedMarker.skillMigrationDismissed;
     }
     // When local copies remain, do NOT set skillMigrationDismissed here —
-    // the daily warning should keep firing until the user removes them.
-    // The flag can be set manually in .swamp.yaml for repos that
+    // the flag can be set manually in .swamp.yaml for repos that
     // intentionally keep local skills (e.g., the swamp source repo).
+
+    // Strip legacy runtime-state fields that were previously written to
+    // the tracked .swamp.yaml (see swamp-club#1792).
+    // deno-lint-ignore no-explicit-any
+    const raw = updatedMarker as Record<string, any>;
+    delete raw.lastSkillMigrationWarning;
+    delete raw.lastStalenessWarning;
 
     await this.markerRepo.write(repoPath, updatedMarker);
 

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -60,9 +60,7 @@ export interface RepoMarkerData {
   datastore?: DatastoreConfigData;
   trustedCollectives?: string[];
   trustMemberCollectives?: boolean;
-  lastSkillMigrationWarning?: string;
   skillMigrationDismissed?: boolean;
-  lastStalenessWarning?: string;
   autoGc?: boolean;
   defaultVault?: string;
 }


### PR DESCRIPTION
## Summary

- Remove `checkForStaleExtensions` and `checkForLocalBundledSkills` from the
  global CLI startup path — these wrote `lastStalenessWarning` and
  `lastSkillMigrationWarning` timestamps into the tracked `.swamp.yaml`,
  dirtying a committed config file with per-machine ephemeral state
- Extension staleness is already surfaced by `swamp extension outdated` and
  `swamp extension list --check-updates`; skill migration warnings surface
  during `swamp repo upgrade` — the global startup nags were redundant
- Remove both timestamp fields from `RepoMarkerData` and strip them from
  existing `.swamp.yaml` files during `repo upgrade`
- `skillMigrationDismissed` stays — it is intentionally user-settable config

4 files changed, 8 insertions(+), 129 deletions(-)

Closes swamp-club#1792

## Test Plan

- Verified `deno check` passes on all changed files
- All 10,539 tests pass (0 failed)
- Full verification workflow passed: lint, fmt, type-check, deps audit, tests,
  compile, code review, adversarial review, UX review

Co-authored-by: Randy Bias <randybias@gmail.com>