### PR TITLE
fix(verification): run workflows in a fresh git worktree

### DIFF
--- a/agent-constraints/verification-conventions.md
+++ b/agent-constraints/verification-conventions.md
@@ -4,8 +4,9 @@
 
 Build checks run as a swamp workflow on the host — native filesystem speed,
 same Deno that's already installed. Isolation comes from a fresh `git worktree`
-at the verified commit in `/tmp/swamp-verify-build-<commit>`. This guarantees
-the build verifies exactly what was committed, not whatever is on disk.
+at the verified commit in `/tmp/swamp-verify-build-<run-id>`. Each workflow run
+gets its own unique directory (keyed by run ID, not commit SHA) so multiple
+verifications can run in parallel without colliding.
 
 ```
 SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-build \
@@ -25,7 +26,7 @@ lint, test, and compile failures are reported accurately.
 Reviews run as a swamp workflow on the host (not in a container) so the claude
 CLI has full project context — CLAUDE.md, skills, and the codebase. Like the
 build workflow, reviews run in a fresh `git worktree` at the verified commit
-(`/tmp/swamp-verify-reviews-<commit>`) so that `claude -p`'s Read/Glob/Grep
+(`/tmp/swamp-verify-reviews-<run-id>`) so that `claude -p`'s Read/Glob/Grep
 tools see the committed file state, not the caller's working tree.
 
 ```

--- a/agent-constraints/verification-conventions.md
+++ b/agent-constraints/verification-conventions.md
@@ -3,8 +3,9 @@
 ## Build Verification (Host Workflow)
 
 Build checks run as a swamp workflow on the host — native filesystem speed,
-same Deno that's already installed. Isolation comes from running in a fresh
-checkout.
+same Deno that's already installed. Isolation comes from a fresh `git worktree`
+at the verified commit in `/tmp/swamp-verify-build-<commit>`. This guarantees
+the build verifies exactly what was committed, not whatever is on disk.
 
 ```
 SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-build \
@@ -12,13 +13,20 @@ SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-build \
   --input branch=<branch>
 ```
 
+The workflow creates the worktree in a `setup` job, runs all build steps with
+`workingDir` pointing at it, and removes the worktree in a `cleanup` job that
+fires regardless of pass/fail.
+
 All steps use `command/shell` which correctly fails on non-zero exit code —
 lint, test, and compile failures are reported accurately.
 
 ## Agent Reviews (Host Workflow)
 
 Reviews run as a swamp workflow on the host (not in a container) so the claude
-CLI has full project context — CLAUDE.md, skills, and the codebase.
+CLI has full project context — CLAUDE.md, skills, and the codebase. Like the
+build workflow, reviews run in a fresh `git worktree` at the verified commit
+(`/tmp/swamp-verify-reviews-<commit>`) so that `claude -p`'s Read/Glob/Grep
+tools see the committed file state, not the caller's working tree.
 
 ```
 SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-reviews \
@@ -28,15 +36,18 @@ SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-reviews \
 
 The workflow:
 
-1. Detects changed files via `@swamp/git` diff (full diff, then `nameOnly` for
+1. Creates a clean worktree at the verified commit
+2. Detects changed files via `@swamp/git` diff (full diff, then `nameOnly` for
    the file list used by guards)
-2. Runs applicable reviews in parallel using `command/shell` steps that invoke
-   `claude -p` with the review prompt + diff
-3. Each review uses the factory pattern — one `reviewer` model, called once per
+3. Runs applicable reviews in parallel using `command/shell` steps that invoke
+   `claude -p` with the review prompt + diff, with `workingDir` set to the
+   worktree
+4. Each review uses the factory pattern — one `reviewer` model, called once per
    review type with different prompt files and models
-4. Review diffs use `git merge-base main HEAD` so only the branch's own changes
+5. Review diffs use `git merge-base main HEAD` so only the branch's own changes
    are reviewed — not the inverse of what landed on main since the branch
    diverged
+6. Cleans up the worktree regardless of pass/fail
 
 ### Guards
 

--- a/verification/workflow-verify-build.yaml
+++ b/verification/workflow-verify-build.yaml
@@ -37,7 +37,7 @@ jobs:
           inputs:
             run: |
               set -e
-              CHECKOUT_DIR="/tmp/swamp-verify-build-${{ inputs.commit }}"
+              CHECKOUT_DIR="/tmp/swamp-verify-build-${{ run.id }}"
               rm -rf "$CHECKOUT_DIR"
               git worktree prune
               git worktree add --detach "$CHECKOUT_DIR" "${{ inputs.commit }}"
@@ -58,7 +58,7 @@ jobs:
           methodName: execute
           inputs:
             run: "deno lint"
-            workingDir: "/tmp/swamp-verify-build-${{ inputs.commit }}"
+            workingDir: "/tmp/swamp-verify-build-${{ run.id }}"
 
       - name: fmt-check
         task:
@@ -68,7 +68,7 @@ jobs:
           methodName: execute
           inputs:
             run: "deno fmt --check"
-            workingDir: "/tmp/swamp-verify-build-${{ inputs.commit }}"
+            workingDir: "/tmp/swamp-verify-build-${{ run.id }}"
 
       - name: type-check
         task:
@@ -78,7 +78,7 @@ jobs:
           methodName: execute
           inputs:
             run: "deno task check"
-            workingDir: "/tmp/swamp-verify-build-${{ inputs.commit }}"
+            workingDir: "/tmp/swamp-verify-build-${{ run.id }}"
 
   # ── Tests ────────────────────────────────────────────────────
   - name: tests
@@ -96,7 +96,7 @@ jobs:
           methodName: execute
           inputs:
             run: "deno task test"
-            workingDir: "/tmp/swamp-verify-build-${{ inputs.commit }}"
+            workingDir: "/tmp/swamp-verify-build-${{ run.id }}"
 
   # ── Dependency Audit ─────────────────────────────────────────
   - name: deps-audit
@@ -114,7 +114,7 @@ jobs:
           methodName: execute
           inputs:
             run: "deno task audit"
-            workingDir: "/tmp/swamp-verify-build-${{ inputs.commit }}"
+            workingDir: "/tmp/swamp-verify-build-${{ run.id }}"
 
   # ── Compile + Binary Check ────────────────────────────────────
   - name: compile
@@ -135,7 +135,7 @@ jobs:
           methodName: execute
           inputs:
             run: "deno task compile"
-            workingDir: "/tmp/swamp-verify-build-${{ inputs.commit }}"
+            workingDir: "/tmp/swamp-verify-build-${{ run.id }}"
 
       - name: binary-check
         dependsOn:
@@ -149,7 +149,7 @@ jobs:
           methodName: execute
           inputs:
             run: "ls -la swamp && chmod +x swamp && ./swamp --version"
-            workingDir: "/tmp/swamp-verify-build-${{ inputs.commit }}"
+            workingDir: "/tmp/swamp-verify-build-${{ run.id }}"
 
   # ── Cleanup ──────────────────────────────────────────────────
   - name: cleanup
@@ -170,7 +170,7 @@ jobs:
           methodName: execute
           inputs:
             run: |
-              CHECKOUT_DIR="/tmp/swamp-verify-build-${{ inputs.commit }}"
+              CHECKOUT_DIR="/tmp/swamp-verify-build-${{ run.id }}"
               git worktree remove --force "$CHECKOUT_DIR" 2>/dev/null || true
               git worktree prune
             ignoreExitCode: true

--- a/verification/workflow-verify-build.yaml
+++ b/verification/workflow-verify-build.yaml
@@ -2,7 +2,8 @@ id: 7c2f8a31-4e19-4d6b-b8a0-1f3d5e7c9b2a
 name: verify-build
 description: |
   Build verification: lint, format check, type check, tests, dependency audit,
-  compile, and binary smoke test. Runs on the host from a fresh checkout.
+  compile, and binary smoke test. Runs on the host in a fresh git worktree
+  checked out at the verified commit.
 version: 1
 
 tags:
@@ -23,9 +24,31 @@ inputs:
 concurrency: 4
 
 jobs:
+  # ── Fresh Checkout ──────────────────────────────────────────
+  - name: setup
+    description: Create a clean worktree at the verified commit.
+    steps:
+      - name: checkout
+        task:
+          type: model_method
+          modelType: "command/shell"
+          modelName: build-setup
+          methodName: execute
+          inputs:
+            run: |
+              set -e
+              CHECKOUT_DIR="/tmp/swamp-verify-build-${{ inputs.commit }}"
+              rm -rf "$CHECKOUT_DIR"
+              git worktree prune
+              git worktree add --detach "$CHECKOUT_DIR" "${{ inputs.commit }}"
+
   # ── Static Analysis ──────────────────────────────────────────
   - name: static-analysis
     description: Lint, format check, and type check.
+    dependsOn:
+      - job: setup
+        condition:
+          type: succeeded
     steps:
       - name: lint
         task:
@@ -35,6 +58,7 @@ jobs:
           methodName: execute
           inputs:
             run: "deno lint"
+            workingDir: "/tmp/swamp-verify-build-${{ inputs.commit }}"
 
       - name: fmt-check
         task:
@@ -44,6 +68,7 @@ jobs:
           methodName: execute
           inputs:
             run: "deno fmt --check"
+            workingDir: "/tmp/swamp-verify-build-${{ inputs.commit }}"
 
       - name: type-check
         task:
@@ -53,10 +78,15 @@ jobs:
           methodName: execute
           inputs:
             run: "deno task check"
+            workingDir: "/tmp/swamp-verify-build-${{ inputs.commit }}"
 
   # ── Tests ────────────────────────────────────────────────────
   - name: tests
     description: Run the full test suite.
+    dependsOn:
+      - job: setup
+        condition:
+          type: succeeded
     steps:
       - name: run-tests
         task:
@@ -66,10 +96,15 @@ jobs:
           methodName: execute
           inputs:
             run: "deno task test"
+            workingDir: "/tmp/swamp-verify-build-${{ inputs.commit }}"
 
   # ── Dependency Audit ─────────────────────────────────────────
   - name: deps-audit
     description: Scan dependencies for known vulnerabilities.
+    dependsOn:
+      - job: setup
+        condition:
+          type: succeeded
     steps:
       - name: vuln-scan
         task:
@@ -79,6 +114,7 @@ jobs:
           methodName: execute
           inputs:
             run: "deno task audit"
+            workingDir: "/tmp/swamp-verify-build-${{ inputs.commit }}"
 
   # ── Compile + Binary Check ────────────────────────────────────
   - name: compile
@@ -99,6 +135,7 @@ jobs:
           methodName: execute
           inputs:
             run: "deno task compile"
+            workingDir: "/tmp/swamp-verify-build-${{ inputs.commit }}"
 
       - name: binary-check
         dependsOn:
@@ -112,3 +149,28 @@ jobs:
           methodName: execute
           inputs:
             run: "ls -la swamp && chmod +x swamp && ./swamp --version"
+            workingDir: "/tmp/swamp-verify-build-${{ inputs.commit }}"
+
+  # ── Cleanup ──────────────────────────────────────────────────
+  - name: cleanup
+    description: Remove the temporary worktree.
+    dependsOn:
+      - job: compile
+        condition:
+          type: always
+      - job: deps-audit
+        condition:
+          type: always
+    steps:
+      - name: remove-worktree
+        task:
+          type: model_method
+          modelType: "command/shell"
+          modelName: build-cleanup
+          methodName: execute
+          inputs:
+            run: |
+              CHECKOUT_DIR="/tmp/swamp-verify-build-${{ inputs.commit }}"
+              git worktree remove --force "$CHECKOUT_DIR" 2>/dev/null || true
+              git worktree prune
+            ignoreExitCode: true

--- a/verification/workflow-verify-reviews.yaml
+++ b/verification/workflow-verify-reviews.yaml
@@ -38,7 +38,7 @@ jobs:
           inputs:
             run: |
               set -e
-              CHECKOUT_DIR="/tmp/swamp-verify-reviews-${{ inputs.commit }}"
+              CHECKOUT_DIR="/tmp/swamp-verify-reviews-${{ run.id }}"
               rm -rf "$CHECKOUT_DIR"
               git worktree prune
               git worktree add --detach "$CHECKOUT_DIR" "${{ inputs.commit }}"
@@ -107,7 +107,7 @@ jobs:
                 echo "::error::Code review did not pass (verdict: ${VERDICT:-missing})"
                 exit 1
               fi
-            workingDir: "/tmp/swamp-verify-reviews-${{ inputs.commit }}"
+            workingDir: "/tmp/swamp-verify-reviews-${{ run.id }}"
 
       - name: adversarial-review
         guard: "${{ data.latest('repo', 'diff').attributes.files.filter(f, f.startsWith('src/domain/') || f.startsWith('src/infrastructure/') || f.startsWith('src/libswamp/') || f.startsWith('src/serve/') || f.startsWith('src/worker/')).size() == 0 }}"
@@ -135,7 +135,7 @@ jobs:
                 echo "::error::Adversarial review did not pass (verdict: ${VERDICT:-missing})"
                 exit 1
               fi
-            workingDir: "/tmp/swamp-verify-reviews-${{ inputs.commit }}"
+            workingDir: "/tmp/swamp-verify-reviews-${{ run.id }}"
 
       - name: ux-review
         guard: "${{ data.latest('repo', 'diff').attributes.files.filter(f, f.startsWith('src/cli/commands/') || f.startsWith('src/presentation/') || f == 'src/domain/errors.ts' || f.startsWith('src/libswamp/')).size() == 0 }}"
@@ -163,7 +163,7 @@ jobs:
                 echo "::error::UX review did not pass (verdict: ${VERDICT:-missing})"
                 exit 1
               fi
-            workingDir: "/tmp/swamp-verify-reviews-${{ inputs.commit }}"
+            workingDir: "/tmp/swamp-verify-reviews-${{ run.id }}"
 
       - name: ci-security-review
         guard: "${{ data.latest('repo', 'diff').attributes.files.filter(f, f.startsWith('.github/workflows/')).size() == 0 }}"
@@ -191,7 +191,7 @@ jobs:
                 echo "::error::CI security review did not pass (verdict: ${VERDICT:-missing})"
                 exit 1
               fi
-            workingDir: "/tmp/swamp-verify-reviews-${{ inputs.commit }}"
+            workingDir: "/tmp/swamp-verify-reviews-${{ run.id }}"
 
   # ── Cleanup ──────────────────────────────────────────────────
   - name: cleanup
@@ -209,7 +209,7 @@ jobs:
           methodName: execute
           inputs:
             run: |
-              CHECKOUT_DIR="/tmp/swamp-verify-reviews-${{ inputs.commit }}"
+              CHECKOUT_DIR="/tmp/swamp-verify-reviews-${{ run.id }}"
               git worktree remove --force "$CHECKOUT_DIR" 2>/dev/null || true
               git worktree prune
             ignoreExitCode: true

--- a/verification/workflow-verify-reviews.yaml
+++ b/verification/workflow-verify-reviews.yaml
@@ -3,8 +3,8 @@ name: verify-reviews
 description: |
   Agent code reviews using claude CLI directly. Detects changed files,
   constructs review prompts with the diff inlined, and runs claude -p
-  for each review type in parallel. Runs on the host (not in a container)
-  so CLAUDE.md and skills are available as project context.
+  for each review type in parallel. Runs on the host in a fresh git
+  worktree so CLAUDE.md, skills, and file reads reflect the verified commit.
 version: 1
 
 tags:
@@ -25,9 +25,31 @@ inputs:
 concurrency: 4
 
 jobs:
+  # ── Fresh Checkout ──────────────────────────────────────────
+  - name: setup
+    description: Create a clean worktree at the verified commit.
+    steps:
+      - name: checkout
+        task:
+          type: model_method
+          modelType: "command/shell"
+          modelName: review-setup
+          methodName: execute
+          inputs:
+            run: |
+              set -e
+              CHECKOUT_DIR="/tmp/swamp-verify-reviews-${{ inputs.commit }}"
+              rm -rf "$CHECKOUT_DIR"
+              git worktree prune
+              git worktree add --detach "$CHECKOUT_DIR" "${{ inputs.commit }}"
+
   # ── Detect Changed Files ──────────────────────────────────────
   - name: detect-changes
     description: Compute the merge-base diff and changed file list.
+    dependsOn:
+      - job: setup
+        condition:
+          type: succeeded
     steps:
       - name: diff
         task:
@@ -85,6 +107,7 @@ jobs:
                 echo "::error::Code review did not pass (verdict: ${VERDICT:-missing})"
                 exit 1
               fi
+            workingDir: "/tmp/swamp-verify-reviews-${{ inputs.commit }}"
 
       - name: adversarial-review
         guard: "${{ data.latest('repo', 'diff').attributes.files.filter(f, f.startsWith('src/domain/') || f.startsWith('src/infrastructure/') || f.startsWith('src/libswamp/') || f.startsWith('src/serve/') || f.startsWith('src/worker/')).size() == 0 }}"
@@ -112,6 +135,7 @@ jobs:
                 echo "::error::Adversarial review did not pass (verdict: ${VERDICT:-missing})"
                 exit 1
               fi
+            workingDir: "/tmp/swamp-verify-reviews-${{ inputs.commit }}"
 
       - name: ux-review
         guard: "${{ data.latest('repo', 'diff').attributes.files.filter(f, f.startsWith('src/cli/commands/') || f.startsWith('src/presentation/') || f == 'src/domain/errors.ts' || f.startsWith('src/libswamp/')).size() == 0 }}"
@@ -139,6 +163,7 @@ jobs:
                 echo "::error::UX review did not pass (verdict: ${VERDICT:-missing})"
                 exit 1
               fi
+            workingDir: "/tmp/swamp-verify-reviews-${{ inputs.commit }}"
 
       - name: ci-security-review
         guard: "${{ data.latest('repo', 'diff').attributes.files.filter(f, f.startsWith('.github/workflows/')).size() == 0 }}"
@@ -166,3 +191,25 @@ jobs:
                 echo "::error::CI security review did not pass (verdict: ${VERDICT:-missing})"
                 exit 1
               fi
+            workingDir: "/tmp/swamp-verify-reviews-${{ inputs.commit }}"
+
+  # ── Cleanup ──────────────────────────────────────────────────
+  - name: cleanup
+    description: Remove the temporary worktree.
+    dependsOn:
+      - job: reviews
+        condition:
+          type: always
+    steps:
+      - name: remove-worktree
+        task:
+          type: model_method
+          modelType: "command/shell"
+          modelName: review-cleanup
+          methodName: execute
+          inputs:
+            run: |
+              CHECKOUT_DIR="/tmp/swamp-verify-reviews-${{ inputs.commit }}"
+              git worktree remove --force "$CHECKOUT_DIR" 2>/dev/null || true
+              git worktree prune
+            ignoreExitCode: true


### PR DESCRIPTION
## Summary

- Both verification workflows (build + reviews) were running in the caller's working directory after the container-based approach was removed, meaning uncommitted changes could leak into builds and review agents could read untracked files via Read/Glob/Grep
- Add setup/cleanup jobs that create a temporary `git worktree --detach` at the verified commit in `/tmp/swamp-verify-{build|reviews}-<commit>`
- All build and review steps now run with `workingDir` pointing at the clean checkout
- Cleanup uses the `always` condition so the worktree is removed regardless of pass/fail
- Updated verification-conventions.md to document the isolation mechanism

## Test Plan

- Ran `verify-build` workflow end-to-end against HEAD — all 9 steps passed (setup, lint, fmt, type-check, tests, audit, compile, binary-check, cleanup), worktree created and cleaned up
- Ran `verify-reviews` workflow end-to-end — setup, detect-changes, guarded review skips, code-review pass, and cleanup all succeeded; `always` condition fired correctly
- Confirmed `/tmp` directory and `git worktree list` are clean after both runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)