### PR TITLE
fix(workflows): drain parallel sibling steps before persisting suspension

### DIFF
--- a/design/workflow.md
+++ b/design/workflow.md
@@ -135,8 +135,12 @@ steps:
 **Lifecycle: suspend → approve → resume**
 
 1. `swamp workflow run` executes until hitting a `manual_approval` step. The step
-   is marked `waiting_approval`, the run is saved as `suspended`, and the CLI
-   exits.
+   is marked `waiting_approval` and the run status is set to `suspended`.
+   Parallel sibling steps that are already in-flight continue executing until
+   they reach a terminal state (succeeded, failed, or skipped) — the executor
+   drains all generators at the current level before persisting. The saved run
+   record is a consistent checkpoint: every step is either completed or has not
+   started. The CLI then exits.
 2. `swamp workflow approve <workflow> <step>` marks the step as succeeded in the
    persisted run record. Lightweight — no execution, any authorized user.
 3. `swamp workflow resume <workflow>` re-enters the executor, skips completed

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1895,27 +1895,35 @@ export class WorkflowExecutionService {
         }
         await this.saveRun(workflow.id, run);
 
-        // If a manual_approval step suspended the run during parallel
-        // execution, merge() swallows the WorkflowSuspendedError. Detect
-        // this by checking the run status and re-throwing so the outer
-        // catch handler yields the suspended terminal event.
         if (run.status === "suspended") {
-          const waiting = run.findWaitingApprovalStep();
-          if (waiting) {
-            const wfStep = workflow.jobs
-              .find((j) => j.name === waiting.jobName)?.steps
-              .find((s) => s.name === waiting.stepName);
-            const taskData = wfStep?.task.data;
-            throw new WorkflowSuspendedError(
-              waiting.jobName,
-              waiting.stepName,
-              taskData?.type === "manual_approval" ? taskData.prompt : "",
-              taskData?.type === "manual_approval"
-                ? taskData.timeout
-                : undefined,
-            );
-          }
+          break;
         }
+      }
+
+      // Handle suspension: all parallel siblings at the current level have
+      // drained, so the persisted run is a consistent checkpoint.
+      if (run.status === "suspended") {
+        if (wfHeartbeatInterval) clearInterval(wfHeartbeatInterval);
+        if (this.runTracker) this.runTracker.complete(run.id, "suspended");
+        const waiting = run.findWaitingApprovalStep();
+        if (waiting) {
+          const wfStep = workflow.jobs
+            .find((j) => j.name === waiting.jobName)?.steps
+            .find((s) => s.name === waiting.stepName);
+          const taskData = wfStep?.task.data;
+          yield {
+            kind: "suspended" as const,
+            run,
+            jobId: waiting.jobName,
+            stepId: waiting.stepName,
+            prompt: taskData?.type === "manual_approval" ? taskData.prompt : "",
+            timeout: taskData?.type === "manual_approval"
+              ? taskData.timeout
+              : undefined,
+          };
+        }
+        runSpan.setStatus({ code: SpanStatusCode.OK });
+        return;
       }
 
       // Check if the run was cancelled via abort signal
@@ -2296,22 +2304,33 @@ export class WorkflowExecutionService {
         await this.saveRun(workflow.id, existingRun);
 
         if (existingRun.status === "suspended") {
-          const waiting = existingRun.findWaitingApprovalStep();
-          if (waiting) {
-            const wfStep = resolvedWorkflow.jobs
-              .find((j) => j.name === waiting.jobName)?.steps
-              .find((s) => s.name === waiting.stepName);
-            const taskData = wfStep?.task.data;
-            throw new WorkflowSuspendedError(
-              waiting.jobName,
-              waiting.stepName,
-              taskData?.type === "manual_approval" ? taskData.prompt : "",
-              taskData?.type === "manual_approval"
-                ? taskData.timeout
-                : undefined,
-            );
-          }
+          break;
         }
+      }
+
+      if (existingRun.status === "suspended") {
+        if (resumeHeartbeatInterval) clearInterval(resumeHeartbeatInterval);
+        if (this.runTracker) {
+          this.runTracker.complete(existingRun.id, "suspended");
+        }
+        const waiting = existingRun.findWaitingApprovalStep();
+        if (waiting) {
+          const wfStep = resolvedWorkflow.jobs
+            .find((j) => j.name === waiting.jobName)?.steps
+            .find((s) => s.name === waiting.stepName);
+          const taskData = wfStep?.task.data;
+          yield {
+            kind: "suspended" as const,
+            run: existingRun,
+            jobId: waiting.jobName,
+            stepId: waiting.stepName,
+            prompt: taskData?.type === "manual_approval" ? taskData.prompt : "",
+            timeout: taskData?.type === "manual_approval"
+              ? taskData.timeout
+              : undefined,
+          };
+        }
+        return;
       }
 
       if (options?.signal?.aborted) {
@@ -2563,42 +2582,36 @@ export class WorkflowExecutionService {
         }
 
         if (run.status === "suspended") {
-          const waiting = run.findWaitingApprovalStep();
-          if (waiting) {
-            const wfStep = workflow.jobs
-              .find((j) => j.name === job.name)?.steps
-              .find((s) => s.name === waiting.stepName);
-            const taskData = wfStep?.task.data;
-            throw new WorkflowSuspendedError(
-              job.name,
-              waiting.stepName,
-              taskData?.type === "manual_approval" ? taskData.prompt : "",
-              taskData?.type === "manual_approval"
-                ? taskData.timeout
-                : undefined,
-            );
-          }
+          break;
         }
       }
 
-      // Complete job
-      if (jobFailed) {
-        jobRun.fail();
-        jobSpan.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: "Job failed",
-        });
+      // When the run is suspended and this job still has non-terminal steps
+      // (pending or waiting_approval), leave the job running so resume picks
+      // it up. In all other cases — normal completion, normal failure (where
+      // pending steps remain because jobFailed broke early) — complete the job.
+      const suspendedWithPendingSteps = run.status === "suspended" &&
+        jobRun.steps.some((s) =>
+          s.status !== "succeeded" && s.status !== "failed" &&
+          s.status !== "skipped"
+        );
+      if (suspendedWithPendingSteps) {
+        jobSpan.setStatus({ code: SpanStatusCode.OK });
       } else {
-        jobRun.succeed();
-        jobSpan.setStatus({ code: SpanStatusCode.OK });
+        if (jobFailed) {
+          jobRun.fail();
+          jobSpan.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: "Job failed",
+          });
+        } else {
+          jobRun.succeed();
+          jobSpan.setStatus({ code: SpanStatusCode.OK });
+        }
+        jobSpan.setAttribute("job.status", jobRun.status);
+        yield { kind: "job_completed", jobId: jobName, status: jobRun.status };
       }
-      jobSpan.setAttribute("job.status", jobRun.status);
-      yield { kind: "job_completed", jobId: jobName, status: jobRun.status };
     } catch (error) {
-      if (error instanceof WorkflowSuspendedError) {
-        jobSpan.setStatus({ code: SpanStatusCode.OK });
-        throw error;
-      }
       jobSpan.setStatus({
         code: SpanStatusCode.ERROR,
         message: error instanceof Error ? error.message : String(error),
@@ -2818,14 +2831,13 @@ export class WorkflowExecutionService {
         // resolve `inputs.*` once the run is resumed. This is the manual_approval
         // branch, which runs before any step-level input augmentation, so
         // `inputs` here is the clean workflow-level set.
+        //
+        // Return instead of throwing WorkflowSuspendedError so that merge()
+        // continues draining parallel sibling generators to completion. The
+        // post-level save in run()/resume() captures the consistent state.
         run.suspend(stepExprContext?.inputs);
-        await this.saveRun(workflow.id, run);
-        throw new WorkflowSuspendedError(
-          job.name,
-          stepName,
-          task.prompt,
-          task.timeout,
-        );
+        stepSpan.end();
+        return;
       }
 
       // Handle assert tasks — evaluate CEL predicate, record pass/fail

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -4764,3 +4764,254 @@ Deno.test("assert: model.method() in expr fails when method returns falsy", asyn
     assertEquals(events[0].message, "Instance check failed");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Drain-before-suspend: parallel sibling steps complete before suspension
+// ---------------------------------------------------------------------------
+
+Deno.test("suspend: parallel sibling steps complete before suspension is persisted", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new ConcurrencyTrackingExecutor(50);
+
+    // deploy → (gate + cleanup) where gate is manual_approval and cleanup
+    // is a model_method. Both depend on deploy (same level, parallel).
+    const workflow = Workflow.create({
+      name: "drain-suspend",
+      jobs: [
+        Job.create({
+          name: "deploy",
+          steps: [
+            Step.create({
+              name: "build",
+              task: StepTask.model("test-model", "run"),
+            }),
+          ],
+        }),
+        Job.create({
+          name: "gate",
+          steps: [
+            Step.create({
+              name: "production-gate",
+              task: StepTask.manualApproval("Approve?"),
+            }),
+          ],
+          dependsOn: [
+            { job: "deploy", condition: TriggerCondition.succeeded() },
+          ],
+        }),
+        Job.create({
+          name: "cleanup",
+          steps: [
+            Step.create({
+              name: "gc",
+              task: StepTask.model("test-model", "run"),
+            }),
+          ],
+          dependsOn: [
+            { job: "deploy", condition: TriggerCondition.completed() },
+          ],
+        }),
+      ],
+    });
+
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const suspended = await service.execute(workflow.name);
+
+    assertEquals(suspended.status, "suspended");
+
+    // The cleanup job's step must be succeeded — not stuck at running.
+    const cleanupJob = suspended.getJob("cleanup")!;
+    assertEquals(cleanupJob.status, "succeeded");
+    assertEquals(cleanupJob.getStep("gc")!.status, "succeeded");
+
+    // The gate job stays running with the approval step waiting.
+    const gateJob = suspended.getJob("gate")!;
+    assertEquals(gateJob.status, "running");
+    assertEquals(
+      gateJob.getStep("production-gate")!.status,
+      "waiting_approval",
+    );
+
+    // The deploy job completed normally.
+    assertEquals(suspended.getJob("deploy")!.status, "succeeded");
+
+    // The executor ran the deploy step and the cleanup step (not the gate).
+    assert(executor.executedSteps.includes("deploy/build"));
+    assert(executor.executedSteps.includes("cleanup/gc"));
+  });
+});
+
+Deno.test("suspend: resumed run skips completed sibling steps", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+
+    const workflow = Workflow.create({
+      name: "resume-skip",
+      jobs: [
+        Job.create({
+          name: "deploy",
+          steps: [
+            Step.create({
+              name: "build",
+              task: StepTask.model("test-model", "run"),
+            }),
+          ],
+        }),
+        Job.create({
+          name: "gate",
+          steps: [
+            Step.create({
+              name: "approval",
+              task: StepTask.manualApproval("Go?"),
+            }),
+          ],
+          dependsOn: [
+            { job: "deploy", condition: TriggerCondition.succeeded() },
+          ],
+        }),
+        Job.create({
+          name: "cleanup",
+          steps: [
+            Step.create({
+              name: "gc",
+              task: StepTask.model("test-model", "run"),
+            }),
+          ],
+          dependsOn: [
+            { job: "deploy", condition: TriggerCondition.completed() },
+          ],
+        }),
+        Job.create({
+          name: "post-gate",
+          steps: [
+            Step.create({
+              name: "release",
+              task: StepTask.model("test-model", "run"),
+            }),
+          ],
+          dependsOn: [
+            { job: "gate", condition: TriggerCondition.succeeded() },
+            { job: "cleanup", condition: TriggerCondition.succeeded() },
+          ],
+        }),
+      ],
+    });
+
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const suspended = await service.execute(workflow.name);
+    assertEquals(suspended.status, "suspended");
+
+    // Approve the gate step.
+    const toApprove = await runRepo.findById(workflow.id, suspended.id);
+    toApprove!.getJob("gate")!.getStep("approval")!.succeed();
+    await runRepo.save(workflow.id, toApprove!);
+
+    // Clear executor tracking and resume.
+    executor.executedSteps = [];
+
+    let resumedRun: WorkflowRun | undefined;
+    for await (const event of service.resume(workflow.name, suspended.id)) {
+      if (event.kind === "completed") resumedRun = event.run;
+    }
+
+    assertEquals(resumedRun?.status, "succeeded");
+
+    // Only post-gate/release should execute on resume — cleanup/gc was
+    // already completed during the initial run and must NOT re-execute.
+    assertEquals(executor.executedSteps, ["post-gate/release"]);
+  });
+});
+
+Deno.test("suspend: sibling step failure is recorded during drain", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+    executor.shouldFail.add("gc");
+
+    const workflow = Workflow.create({
+      name: "drain-fail",
+      jobs: [
+        Job.create({
+          name: "deploy",
+          steps: [
+            Step.create({
+              name: "build",
+              task: StepTask.model("test-model", "run"),
+            }),
+          ],
+        }),
+        Job.create({
+          name: "gate",
+          steps: [
+            Step.create({
+              name: "approval",
+              task: StepTask.manualApproval("Ready?"),
+            }),
+          ],
+          dependsOn: [
+            { job: "deploy", condition: TriggerCondition.succeeded() },
+          ],
+        }),
+        Job.create({
+          name: "cleanup",
+          steps: [
+            Step.create({
+              name: "gc",
+              task: StepTask.model("test-model", "run"),
+            }),
+          ],
+          dependsOn: [
+            { job: "deploy", condition: TriggerCondition.completed() },
+          ],
+        }),
+      ],
+    });
+
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const suspended = await service.execute(workflow.name);
+    assertEquals(suspended.status, "suspended");
+
+    // The cleanup job's step failed — properly recorded, not stuck running.
+    const cleanupJob = suspended.getJob("cleanup")!;
+    assertEquals(cleanupJob.status, "failed");
+    assertEquals(cleanupJob.getStep("gc")!.status, "failed");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes swamp-club#1782.

When a `manual_approval` step suspends the workflow, in-flight parallel sibling steps are now drained to completion before the suspended run record is persisted. Previously, suspension threw `WorkflowSuspendedError` immediately, which tore down sibling generators via `AsyncQueue` closure — leaving their steps stuck at `status: running` in the persisted run. On resume, those steps would re-execute, causing double side effects for non-idempotent work.

**What changed in `execution_service.ts`:**
- `runStep()`: manual_approval handler returns instead of throwing, letting `merge()` continue draining siblings
- `runJob()`: replaces throw-on-suspended with break; guards job completion so suspended jobs with non-terminal steps stay running while completed siblings are marked succeeded/failed
- `run()` and `resume()`: replaces throw-on-suspended with break + inline suspension handling after all generators at the current level drain

The persisted run record is now a consistent checkpoint: every step is either completed or has not started.

## Test Plan

- Added 3 unit tests in `execution_service_test.ts`:
  - Parallel sibling steps reach terminal states before suspension is persisted
  - Resumed run skips completed sibling steps (no double execution)
  - Sibling step failure is properly recorded during drain
- All 75 existing tests pass (no regressions)
- Reproduced the bug in a scratch repo, verified the fix produces `cleanup.gc: succeeded` instead of `cleanup.gc: running`
- Verification workflow passed: lint, fmt, type-check, tests, compile, code-review, adversarial-review, ux-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)