### PR TITLE
fix(serve): push workflow run terminal status to shared datastore after completion

### DIFF
--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -462,6 +462,16 @@ export const workflowResumeCommand = withRemoteOptions(
     try {
       await consumeStream(resumeGenerator(), renderer.handlers());
     } finally {
+      if (unlocked.syncService) {
+        try {
+          await unlocked.syncService.pushChanged();
+        } catch (pushErr) {
+          cliCtx.logger
+            .warn`Post-resume push failed; terminal status may be delayed: ${
+            pushErr instanceof Error ? pushErr.message : String(pushErr)
+          }`;
+        }
+      }
       shutdownHandle.dispose();
       ephemeral.dispose();
     }

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -560,6 +560,16 @@ export const workflowRunCommand = new Command()
       const message = error instanceof Error ? error.message : String(error);
       throw new UserError(`Workflow execution failed: ${message}`);
     } finally {
+      if (unlocked.syncService) {
+        try {
+          await unlocked.syncService.pushChanged();
+        } catch (pushErr) {
+          ctx.logger
+            .warn`Post-run push failed; terminal status may be delayed: ${
+            pushErr instanceof Error ? pushErr.message : String(pushErr)
+          }`;
+        }
+      }
       shutdownHandle?.dispose();
       exitSuppress.dispose();
     }

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -430,28 +430,43 @@ export async function executeWorkflowWithLocks(
     }
   };
 
-  if (!runTelemetry) {
-    await runTraced();
-    return;
-  }
-
-  // Record the run's own parent entry however it ends. Telemetry must never
-  // be able to fail a workflow run, so `finish` is isolated from the run's
-  // own error and the original error always propagates.
   try {
-    await runTraced();
-  } catch (error) {
-    await finishRunTelemetry(
-      runTelemetry,
-      error instanceof Error ? error : new Error(String(error)),
-    );
-    throw error;
-  }
+    if (!runTelemetry) {
+      await runTraced();
+      return;
+    }
 
-  const failure = finalStatus === "succeeded" ? null : new Error(
-    streamError ?? `workflow run ${finalStatus ?? "did not complete"}`,
-  );
-  await finishRunTelemetry(runTelemetry, failure);
+    // Record the run's own parent entry however it ends. Telemetry must never
+    // be able to fail a workflow run, so `finish` is isolated from the run's
+    // own error and the original error always propagates.
+    try {
+      await runTraced();
+    } catch (error) {
+      await finishRunTelemetry(
+        runTelemetry,
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      throw error;
+    }
+
+    const failure = finalStatus === "succeeded" ? null : new Error(
+      streamError ?? `workflow run ${finalStatus ?? "did not complete"}`,
+    );
+    await finishRunTelemetry(runTelemetry, failure);
+  } finally {
+    if (syncService) {
+      try {
+        await syncService.pushChanged();
+      } catch (pushErr) {
+        logger.warn(
+          "Post-run push failed; terminal status may be delayed: {error}",
+          {
+            error: pushErr instanceof Error ? pushErr.message : String(pushErr),
+          },
+        );
+      }
+    }
+  }
 }
 
 /**

--- a/src/serve/deps_test.ts
+++ b/src/serve/deps_test.ts
@@ -18,9 +18,10 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { createWorkflowRunDeps } from "./deps.ts";
+import { createWorkflowRunDeps, executeWorkflowWithLocks } from "./deps.ts";
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
 import type { DatastoreConfig } from "../domain/datastore/datastore_config.ts";
+import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
 import type { WorkflowTelemetrySink } from "../libswamp/mod.ts";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 
@@ -78,4 +79,90 @@ Deno.test("createWorkflowRunDeps: leaves telemetrySink undefined by default", as
   );
 
   assertEquals(deps.telemetrySink, undefined);
+});
+
+function stubSyncService(): DatastoreSyncService & { pushCalledCount: number } {
+  const svc = {
+    pushCalledCount: 0,
+    pullChanged: () => Promise.resolve(),
+    pushChanged: () => {
+      svc.pushCalledCount++;
+      return Promise.resolve();
+    },
+    markDirty: () => Promise.resolve(),
+  };
+  return svc;
+}
+
+function stubRepoContextWithRepos(): RepositoryContext {
+  return {
+    workflowRepo: {
+      findByName: () => Promise.resolve(null),
+      findById: () => Promise.resolve(null),
+      findAll: () => Promise.resolve([]),
+    },
+    workflowRunRepo: {},
+    catalogStore: { invalidate: () => {} },
+    unifiedDataRepo: { namespace: "test" },
+    definitionRepo: {},
+    autoDefinitionsDir: "/tmp/auto-definitions",
+    markDirty: () => {},
+    eventBus: {},
+  } as unknown as RepositoryContext;
+}
+
+Deno.test("executeWorkflowWithLocks: calls pushChanged after run completes", async () => {
+  const syncService = stubSyncService();
+  const ctx = stubRepoContextWithRepos();
+
+  await executeWorkflowWithLocks(
+    "/tmp/repo",
+    ctx,
+    datastoreConfig,
+    { workflowIdOrName: "nonexistent" },
+    new AbortController().signal,
+    () => {},
+    syncService,
+  );
+
+  assertEquals(syncService.pushCalledCount, 1);
+});
+
+Deno.test("executeWorkflowWithLocks: calls pushChanged even when onEvent throws", async () => {
+  const syncService = stubSyncService();
+  const ctx = stubRepoContextWithRepos();
+
+  let threw = false;
+  try {
+    await executeWorkflowWithLocks(
+      "/tmp/repo",
+      ctx,
+      datastoreConfig,
+      { workflowIdOrName: "nonexistent" },
+      new AbortController().signal,
+      () => {
+        throw new Error("deliberate onEvent failure");
+      },
+      syncService,
+    );
+  } catch {
+    threw = true;
+  }
+
+  assertEquals(threw, true);
+  assertEquals(syncService.pushCalledCount, 1);
+});
+
+Deno.test("executeWorkflowWithLocks: skips pushChanged when no syncService", async () => {
+  const ctx = stubRepoContextWithRepos();
+
+  await executeWorkflowWithLocks(
+    "/tmp/repo",
+    ctx,
+    datastoreConfig,
+    { workflowIdOrName: "nonexistent" },
+    new AbortController().signal,
+    () => {},
+    undefined,
+  );
 });

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -1104,6 +1104,21 @@ export async function handleWorkflowResume(
         const message = sanitizeErrorForClient(error);
         sendError(socket, requestId, "workflow_resume_failed", message);
       }
+    } finally {
+      if (ctx.syncService) {
+        try {
+          await ctx.syncService.pushChanged();
+        } catch (pushErr) {
+          logger.warn(
+            "Post-resume push failed; terminal status may be delayed: {error}",
+            {
+              error: pushErr instanceof Error
+                ? pushErr.message
+                : String(pushErr),
+            },
+          );
+        }
+      }
     }
     return;
   }
@@ -1265,6 +1280,20 @@ export async function handleWorkflowResume(
         });
       }
     } finally {
+      if (ctx.syncService) {
+        try {
+          await ctx.syncService.pushChanged();
+        } catch (pushErr) {
+          logger.warn(
+            "Post-resume push failed; terminal status may be delayed: {error}",
+            {
+              error: pushErr instanceof Error
+                ? pushErr.message
+                : String(pushErr),
+            },
+          );
+        }
+      }
       try {
         ephemeral?.dispose();
       } catch (disposeErr) {


### PR DESCRIPTION
## Summary

Fixes swamp-club#1770 — a workflow run's terminal status (`succeeded`/`failed`/`completedAt`) was written to the local cache but never pushed to the shared datastore. The per-step lock flush pushes during step execution, but `saveRun()` writes the terminal status *after* the last step's flush — no subsequent push catches it. The last run is always stranded at `status: running` in the remote.

- Add `pushChanged()` in `executeWorkflowWithLocks()` (`src/serve/deps.ts`) via a `try/finally` wrapping the run/telemetry block — covers all serve-mode execution paths (API inline, API detached, webhook, scheduled)
- Add `pushChanged()` in serve `handleWorkflowResume` (`src/serve/handlers/workflow_handlers.ts`) for both inline and detached resume paths
- Add `pushChanged()` in the CLI `workflow run` command (`src/cli/commands/workflow_run.ts`)
- Add `pushChanged()` in the CLI `workflow resume` command (`src/cli/commands/workflow_resume.ts`)
- Add 3 unit tests verifying `pushChanged` is called after completion, called on error, and skipped when no sync service

All push calls are guarded by `if (syncService)` and wrapped in try/catch so a transient S3 failure cannot fail the workflow run itself.

## Test Plan

- [x] Reproduced with MinIO as S3-compatible datastore: before fix, bucket shows `status: running` with no `completedAt`; after fix, bucket immediately shows `status: succeeded` with `completedAt`
- [x] Unit tests pass: `deno run test src/serve/deps_test.ts` (5/5)
- [x] Type check passes on all modified files
- [x] Full verification workflow: build 7/7 passed, reviews VERDICT: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)