### PR TITLE
fix(verification): use run-scoped model names to prevent lock contention

### DIFF
--- a/verification/workflow-verify-build.yaml
+++ b/verification/workflow-verify-build.yaml
@@ -32,7 +32,7 @@ jobs:
         task:
           type: model_method
           modelType: "command/shell"
-          modelName: build-setup
+          modelName: build-setup-${{ run.id }}
           methodName: execute
           inputs:
             run: |
@@ -54,7 +54,7 @@ jobs:
         task:
           type: model_method
           modelType: "command/shell"
-          modelName: build-lint
+          modelName: build-lint-${{ run.id }}
           methodName: execute
           inputs:
             run: "deno lint"
@@ -64,7 +64,7 @@ jobs:
         task:
           type: model_method
           modelType: "command/shell"
-          modelName: build-fmt
+          modelName: build-fmt-${{ run.id }}
           methodName: execute
           inputs:
             run: "deno fmt --check"
@@ -74,7 +74,7 @@ jobs:
         task:
           type: model_method
           modelType: "command/shell"
-          modelName: build-check
+          modelName: build-check-${{ run.id }}
           methodName: execute
           inputs:
             run: "deno task check"
@@ -92,7 +92,7 @@ jobs:
         task:
           type: model_method
           modelType: "command/shell"
-          modelName: build-tests
+          modelName: build-tests-${{ run.id }}
           methodName: execute
           inputs:
             run: "deno task test"
@@ -110,7 +110,7 @@ jobs:
         task:
           type: model_method
           modelType: "command/shell"
-          modelName: build-audit
+          modelName: build-audit-${{ run.id }}
           methodName: execute
           inputs:
             run: "deno task audit"
@@ -131,7 +131,7 @@ jobs:
         task:
           type: model_method
           modelType: "command/shell"
-          modelName: build-compile
+          modelName: build-compile-${{ run.id }}
           methodName: execute
           inputs:
             run: "deno task compile"
@@ -145,7 +145,7 @@ jobs:
         task:
           type: model_method
           modelType: "command/shell"
-          modelName: build-smoke
+          modelName: build-smoke-${{ run.id }}
           methodName: execute
           inputs:
             run: "ls -la swamp && chmod +x swamp && ./swamp --version"
@@ -166,11 +166,14 @@ jobs:
         task:
           type: model_method
           modelType: "command/shell"
-          modelName: build-cleanup
+          modelName: build-cleanup-${{ run.id }}
           methodName: execute
           inputs:
             run: |
               CHECKOUT_DIR="/tmp/swamp-verify-build-${{ run.id }}"
               git worktree remove --force "$CHECKOUT_DIR" 2>/dev/null || true
               git worktree prune
+              # Remove ephemeral auto-definitions created for this run
+              REPO_ROOT="$(git rev-parse --git-common-dir)/.."
+              find "$REPO_ROOT/.swamp/auto-definitions" -name "*-${{ run.id }}.yaml" -delete 2>/dev/null || true
             ignoreExitCode: true

--- a/verification/workflow-verify-reviews.yaml
+++ b/verification/workflow-verify-reviews.yaml
@@ -33,7 +33,7 @@ jobs:
         task:
           type: model_method
           modelType: "command/shell"
-          modelName: review-setup
+          modelName: review-setup-${{ run.id }}
           methodName: execute
           inputs:
             run: |
@@ -86,7 +86,7 @@ jobs:
         task:
           type: model_method
           modelType: "command/shell"
-          modelName: review-code
+          modelName: review-code-${{ run.id }}
           methodName: execute
           inputs:
             run: |
@@ -114,7 +114,7 @@ jobs:
         task:
           type: model_method
           modelType: "command/shell"
-          modelName: review-adversarial
+          modelName: review-adversarial-${{ run.id }}
           methodName: execute
           inputs:
             run: |
@@ -142,7 +142,7 @@ jobs:
         task:
           type: model_method
           modelType: "command/shell"
-          modelName: review-ux
+          modelName: review-ux-${{ run.id }}
           methodName: execute
           inputs:
             run: |
@@ -170,7 +170,7 @@ jobs:
         task:
           type: model_method
           modelType: "command/shell"
-          modelName: review-ci-security
+          modelName: review-ci-security-${{ run.id }}
           methodName: execute
           inputs:
             run: |
@@ -205,11 +205,14 @@ jobs:
         task:
           type: model_method
           modelType: "command/shell"
-          modelName: review-cleanup
+          modelName: review-cleanup-${{ run.id }}
           methodName: execute
           inputs:
             run: |
               CHECKOUT_DIR="/tmp/swamp-verify-reviews-${{ run.id }}"
               git worktree remove --force "$CHECKOUT_DIR" 2>/dev/null || true
               git worktree prune
+              # Remove ephemeral auto-definitions created for this run
+              REPO_ROOT="$(git rev-parse --git-common-dir)/.."
+              find "$REPO_ROOT/.swamp/auto-definitions" -name "*-${{ run.id }}.yaml" -delete 2>/dev/null || true
             ignoreExitCode: true


### PR DESCRIPTION
## Summary

- Appends `${{ run.id }}` to every `command/shell` `modelName` in both `workflow-verify-reviews.yaml` and `workflow-verify-build.yaml` so each workflow run creates its own auto-definition and data directory, eliminating lock contention when running concurrently from different worktrees.
- Adds cleanup of ephemeral auto-definition files in both cleanup jobs, using `git rev-parse --git-common-dir` to locate the repo root reliably from worktrees.

## Test Plan

- [x] `swamp workflow validate` passes for both workflows
- [x] Single run confirms `${{ run.id }}` interpolation in `modelName` (e.g., `review-code-b3f053fb-...`)
- [x] Two concurrent `verify-reviews` runs complete without lock timeout
- [x] Auto-definition files are cleaned up after each run (verified via `git rev-parse --git-common-dir`)
- [x] Real branch (worktree-1770, commit 8edf7f5c) exercises code-review + adversarial-review in parallel with no lock errors
- [x] Compared original vs modified workflow against same commit — identical results, no regression