### PR TITLE
fix(remote): auto-refresh dispatch credentials to remove 15-minute execution ceiling

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -673,10 +673,14 @@ tracks N active dispatches per worker keyed by `(workerName, dispatchId)`.
 **Per-dispatch credentials**: each runner receives its own credential from
 `SessionCredentialService.issueForDispatch(workerId, dispatchId)`. This
 credential is independent of the control-channel credential — session refreshes
-do not invalidate in-flight runners. Credentials are revoked when the dispatch
-completes. The capability bridge overrides `dispatchId` in every RPC verb so
-the `CapabilityService` can resolve the correct dispatch for model-type scope
-isolation.
+do not invalidate in-flight runners. The service auto-refreshes dispatch
+credentials internally: a periodic timer slides the credential's expiry forward
+every 2/3 TTL, so the credential remains valid for the entire lifetime of the
+dispatch regardless of duration. The credential string stays the same (the
+runner does not need to be notified of the refresh). Credentials are revoked
+when the dispatch completes. The capability bridge overrides `dispatchId` in
+every RPC verb so the `CapabilityService` can resolve the correct dispatch for
+model-type scope isolation.
 
 **Idle semantics**: a worker is "idle" when `activeDispatchIds.length === 0`.
 The idle timeout starts only when all slots are empty. `maxDispatches` counts

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -3965,6 +3965,7 @@ export const serveCommand = new Command()
       if (heartbeatService) {
         await heartbeatService.stop();
       }
+      workerGateway.dispose();
       if (collectiveRefreshService) {
         await collectiveRefreshService.dispose();
       }

--- a/src/domain/remote/session_credential.ts
+++ b/src/domain/remote/session_credential.ts
@@ -24,6 +24,10 @@
  * worker presents it on every data-plane HTTP request and refreshes it over
  * the control socket before expiry, so the window slides forward (see
  * design/remote-execution.md, "Authenticating the data plane").
+ *
+ * Per-dispatch credentials are auto-refreshed internally by the service for
+ * the lifetime of the dispatch — the credential string stays the same but
+ * its expiry slides forward every 2/3 TTL until explicitly revoked.
  */
 
 export interface SessionCredentialRecord {
@@ -38,6 +42,9 @@ export interface SessionCredentialRecord {
 /** Default credential lifetime: 15 minutes, refreshed well before expiry. */
 export const DEFAULT_SESSION_TTL_MS = 15 * 60 * 1000;
 
+/** Refresh at 2/3 of the TTL — matches the worker-side refresh fraction. */
+const REFRESH_FRACTION = 2 / 3;
+
 /**
  * Generate a 256-bit opaque bearer token, hex-encoded. Used for both
  * data-plane session credentials and enrollment-token secrets.
@@ -46,6 +53,13 @@ export function generateOpaqueToken(): string {
   const bytes = new Uint8Array(32);
   crypto.getRandomValues(bytes);
   return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export interface SessionCredentialServiceOptions {
+  ttlMs?: number;
+  now?: () => number;
+  setInterval?: (cb: () => void, ms: number) => number;
+  clearInterval?: (id: number) => void;
 }
 
 /**
@@ -59,12 +73,20 @@ export class SessionCredentialService {
   #byWorker = new Map<string, string>();
   #byDispatch = new Map<string, string>();
   #credentialsByWorker = new Map<string, Set<string>>();
+  #refreshTimers = new Map<string, number>();
   readonly #ttlMs: number;
   readonly #now: () => number;
+  readonly #setInterval: (cb: () => void, ms: number) => number;
+  readonly #clearInterval: (id: number) => void;
 
-  constructor(options?: { ttlMs?: number; now?: () => number }) {
+  constructor(options?: SessionCredentialServiceOptions) {
     this.#ttlMs = options?.ttlMs ?? DEFAULT_SESSION_TTL_MS;
     this.#now = options?.now ?? Date.now;
+    this.#setInterval = options?.setInterval ??
+      ((cb: () => void, ms: number) =>
+        globalThis.setInterval(cb, ms) as unknown as number);
+    this.#clearInterval = options?.clearInterval ??
+      ((id: number) => globalThis.clearInterval(id));
   }
 
   /**
@@ -91,9 +113,10 @@ export class SessionCredentialService {
   }
 
   /**
-   * Issue a per-dispatch credential. These are independent of the
-   * control-channel credential and are not revoked by `issue()` or
-   * `refresh()`. They are revoked explicitly via `revokeDispatch()`.
+   * Issue a per-dispatch credential with auto-refresh. The credential's
+   * expiry slides forward every 2/3 TTL until explicitly revoked via
+   * revokeDispatch() or revokeAllForWorker(). The credential string stays
+   * the same — the runner process does not need to be notified.
    */
   issueForDispatch(
     workerId: string,
@@ -113,6 +136,7 @@ export class SessionCredentialService {
       this.#credentialsByWorker.set(workerId, workerCreds);
     }
     workerCreds.add(record.credential);
+    this.#startRefreshTimer(dispatchId, record);
     return record;
   }
 
@@ -139,7 +163,8 @@ export class SessionCredentialService {
 
   /**
    * Slide the window forward: re-issue against a currently valid
-   * control-channel credential. Does not affect dispatch credentials.
+   * control-channel credential. Does not affect dispatch credentials
+   * (those are auto-refreshed internally).
    */
   refresh(credential: string): SessionCredentialRecord | null {
     const result = this.verify(credential);
@@ -152,6 +177,37 @@ export class SessionCredentialService {
     return this.issue(result.workerId);
   }
 
+  /** Clean up all refresh timers. Call on orchestrator shutdown. */
+  dispose(): void {
+    for (const timerId of this.#refreshTimers.values()) {
+      this.#clearInterval(timerId);
+    }
+    this.#refreshTimers.clear();
+  }
+
+  #startRefreshTimer(
+    dispatchId: string,
+    record: SessionCredentialRecord,
+  ): void {
+    const intervalMs = Math.max(1_000, this.#ttlMs * REFRESH_FRACTION);
+    const timerId = this.#setInterval(() => {
+      if (!this.#byCredential.has(record.credential)) {
+        this.#stopRefreshTimer(dispatchId);
+        return;
+      }
+      record.expiresAtMs = this.#now() + this.#ttlMs;
+    }, intervalMs);
+    this.#refreshTimers.set(dispatchId, timerId);
+  }
+
+  #stopRefreshTimer(dispatchId: string): void {
+    const timerId = this.#refreshTimers.get(dispatchId);
+    if (timerId !== undefined) {
+      this.#clearInterval(timerId);
+      this.#refreshTimers.delete(dispatchId);
+    }
+  }
+
   #deleteCredential(record: SessionCredentialRecord): void {
     this.#byCredential.delete(record.credential);
     if (this.#byWorker.get(record.workerId) === record.credential) {
@@ -159,6 +215,7 @@ export class SessionCredentialService {
     }
     if (record.dispatchId) {
       this.#byDispatch.delete(record.dispatchId);
+      this.#stopRefreshTimer(record.dispatchId);
     }
     this.#credentialsByWorker.get(record.workerId)?.delete(record.credential);
   }
@@ -182,6 +239,7 @@ export class SessionCredentialService {
         const record = this.#byCredential.get(cred);
         if (record?.dispatchId) {
           this.#byDispatch.delete(record.dispatchId);
+          this.#stopRefreshTimer(record.dispatchId);
         }
         this.#byCredential.delete(cred);
       }

--- a/src/domain/remote/session_credential_test.ts
+++ b/src/domain/remote/session_credential_test.ts
@@ -20,13 +20,38 @@
 import { assertEquals, assertNotEquals } from "@std/assert";
 import { SessionCredentialService } from "./session_credential.ts";
 
+interface FakeInterval {
+  id: number;
+  cb: () => void;
+  ms: number;
+}
+
 function serviceAt(clock: { nowMs: number }, ttlMs = 1000) {
-  return new SessionCredentialService({ ttlMs, now: () => clock.nowMs });
+  const intervals: FakeInterval[] = [];
+  let nextId = 1;
+  const service = new SessionCredentialService({
+    ttlMs,
+    now: () => clock.nowMs,
+    setInterval: (cb: () => void, ms: number) => {
+      const id = nextId++;
+      intervals.push({ id, cb, ms });
+      return id;
+    },
+    clearInterval: (id: number) => {
+      const idx = intervals.findIndex((i) => i.id === id);
+      if (idx !== -1) intervals.splice(idx, 1);
+    },
+  });
+  return { service, intervals };
+}
+
+function serviceAtSimple(clock: { nowMs: number }, ttlMs = 1000) {
+  return serviceAt(clock, ttlMs).service;
 }
 
 Deno.test("SessionCredentialService: issue then verify returns the worker id", () => {
   const clock = { nowMs: 0 };
-  const service = serviceAt(clock);
+  const service = serviceAtSimple(clock);
   const record = service.issue("worker-1");
   assertEquals(service.verify(record.credential), {
     workerId: "worker-1",
@@ -36,13 +61,13 @@ Deno.test("SessionCredentialService: issue then verify returns the worker id", (
 });
 
 Deno.test("SessionCredentialService: verify rejects unknown credentials", () => {
-  const service = serviceAt({ nowMs: 0 });
+  const service = serviceAtSimple({ nowMs: 0 });
   assertEquals(service.verify("not-a-credential"), null);
 });
 
 Deno.test("SessionCredentialService: verify rejects expired credentials", () => {
   const clock = { nowMs: 0 };
-  const service = serviceAt(clock, 1000);
+  const service = serviceAtSimple(clock, 1000);
   const record = service.issue("worker-1");
   clock.nowMs = 1000;
   assertEquals(service.verify(record.credential), null);
@@ -50,7 +75,7 @@ Deno.test("SessionCredentialService: verify rejects expired credentials", () => 
 
 Deno.test("SessionCredentialService: refresh slides the window with a new credential", () => {
   const clock = { nowMs: 0 };
-  const service = serviceAt(clock, 1000);
+  const service = serviceAtSimple(clock, 1000);
   const first = service.issue("worker-1");
   clock.nowMs = 900;
   const second = service.refresh(first.credential);
@@ -64,7 +89,7 @@ Deno.test("SessionCredentialService: refresh slides the window with a new creden
 
 Deno.test("SessionCredentialService: refresh of an expired credential fails", () => {
   const clock = { nowMs: 0 };
-  const service = serviceAt(clock, 1000);
+  const service = serviceAtSimple(clock, 1000);
   const record = service.issue("worker-1");
   clock.nowMs = 2000;
   assertEquals(service.refresh(record.credential), null);
@@ -72,7 +97,7 @@ Deno.test("SessionCredentialService: refresh of an expired credential fails", ()
 
 Deno.test("SessionCredentialService: issue revokes the worker's prior credential", () => {
   const clock = { nowMs: 0 };
-  const service = serviceAt(clock);
+  const service = serviceAtSimple(clock);
   const first = service.issue("worker-1");
   const second = service.issue("worker-1");
   assertEquals(service.verify(first.credential), null);
@@ -81,7 +106,7 @@ Deno.test("SessionCredentialService: issue revokes the worker's prior credential
 
 Deno.test("SessionCredentialService: revokeForWorker invalidates the credential", () => {
   const clock = { nowMs: 0 };
-  const service = serviceAt(clock);
+  const service = serviceAtSimple(clock);
   const record = service.issue("worker-1");
   service.revokeForWorker("worker-1");
   assertEquals(service.verify(record.credential), null);
@@ -89,7 +114,7 @@ Deno.test("SessionCredentialService: revokeForWorker invalidates the credential"
 
 Deno.test("SessionCredentialService: credentials are distinct per worker", () => {
   const clock = { nowMs: 0 };
-  const service = serviceAt(clock);
+  const service = serviceAtSimple(clock);
   const a = service.issue("worker-a");
   const b = service.issue("worker-b");
   assertNotEquals(a.credential, b.credential);
@@ -99,7 +124,7 @@ Deno.test("SessionCredentialService: credentials are distinct per worker", () =>
 
 Deno.test("SessionCredentialService: issueForDispatch creates a credential with workerId and dispatchId", () => {
   const clock = { nowMs: 0 };
-  const service = serviceAt(clock);
+  const service = serviceAtSimple(clock);
   const record = service.issueForDispatch("worker-1", "dispatch-42");
   assertEquals(service.verify(record.credential), {
     workerId: "worker-1",
@@ -109,7 +134,7 @@ Deno.test("SessionCredentialService: issueForDispatch creates a credential with 
 
 Deno.test("SessionCredentialService: revokeDispatch revokes only the targeted dispatch credential", () => {
   const clock = { nowMs: 0 };
-  const service = serviceAt(clock);
+  const service = serviceAtSimple(clock);
   const control = service.issue("worker-1");
   const d1 = service.issueForDispatch("worker-1", "dispatch-1");
   const d2 = service.issueForDispatch("worker-1", "dispatch-2");
@@ -123,7 +148,7 @@ Deno.test("SessionCredentialService: revokeDispatch revokes only the targeted di
 
 Deno.test("SessionCredentialService: revokeAllForWorker revokes control and dispatch credentials", () => {
   const clock = { nowMs: 0 };
-  const service = serviceAt(clock);
+  const service = serviceAtSimple(clock);
   const control = service.issue("worker-1");
   const d1 = service.issueForDispatch("worker-1", "dispatch-1");
   const d2 = service.issueForDispatch("worker-1", "dispatch-2");
@@ -139,7 +164,7 @@ Deno.test("SessionCredentialService: revokeAllForWorker revokes control and disp
 
 Deno.test("SessionCredentialService: refresh returns null for dispatch credentials", () => {
   const clock = { nowMs: 0 };
-  const service = serviceAt(clock);
+  const service = serviceAtSimple(clock);
   const dispatch = service.issueForDispatch("worker-1", "dispatch-1");
   assertEquals(service.refresh(dispatch.credential), null);
   assertEquals(
@@ -150,7 +175,7 @@ Deno.test("SessionCredentialService: refresh returns null for dispatch credentia
 
 Deno.test("SessionCredentialService: control-channel issue does not revoke dispatch credentials", () => {
   const clock = { nowMs: 0 };
-  const service = serviceAt(clock);
+  const service = serviceAtSimple(clock);
   const d1 = service.issueForDispatch("worker-1", "dispatch-1");
   const first = service.issue("worker-1");
   const second = service.issue("worker-1");
@@ -162,7 +187,7 @@ Deno.test("SessionCredentialService: control-channel issue does not revoke dispa
 
 Deno.test("SessionCredentialService: revokeDispatch ignores mismatched workerId", () => {
   const clock = { nowMs: 0 };
-  const service = serviceAt(clock);
+  const service = serviceAtSimple(clock);
   const d1 = service.issueForDispatch("worker-1", "dispatch-1");
 
   service.revokeDispatch("worker-2", "dispatch-1");
@@ -172,7 +197,7 @@ Deno.test("SessionCredentialService: revokeDispatch ignores mismatched workerId"
 
 Deno.test("SessionCredentialService: expired dispatch credential cleans up secondary indexes", () => {
   const clock = { nowMs: 0 };
-  const service = serviceAt(clock, 1000);
+  const service = serviceAtSimple(clock, 1000);
   const d1 = service.issueForDispatch("worker-1", "dispatch-1");
   clock.nowMs = 1000;
 
@@ -184,7 +209,7 @@ Deno.test("SessionCredentialService: expired dispatch credential cleans up secon
 
 Deno.test("SessionCredentialService: revokeAllForWorker then issueForDispatch reuses dispatchId cleanly", () => {
   const clock = { nowMs: 0 };
-  const service = serviceAt(clock);
+  const service = serviceAtSimple(clock);
   service.issueForDispatch("worker-1", "dispatch-1");
   service.issueForDispatch("worker-1", "dispatch-2");
   service.issue("worker-1");
@@ -197,7 +222,7 @@ Deno.test("SessionCredentialService: revokeAllForWorker then issueForDispatch re
 
 Deno.test("SessionCredentialService: interleaved issue and revoke maintains index consistency", () => {
   const clock = { nowMs: 0 };
-  const service = serviceAt(clock);
+  const service = serviceAtSimple(clock);
 
   const c1 = service.issue("worker-1");
   const d1 = service.issueForDispatch("worker-1", "dispatch-1");
@@ -216,4 +241,145 @@ Deno.test("SessionCredentialService: interleaved issue and revoke maintains inde
 
   assertEquals(service.verify(c2.credential)?.workerId, "worker-2");
   assertEquals(service.verify(d3.credential)?.dispatchId, "dispatch-3");
+});
+
+// ── Auto-refresh tests ───────────────────────────────────────────────────
+
+Deno.test("SessionCredentialService: dispatch credential auto-refreshes past original TTL", () => {
+  const clock = { nowMs: 0 };
+  const { service, intervals } = serviceAt(clock, 1000);
+  const record = service.issueForDispatch("worker-1", "dispatch-1");
+
+  assertEquals(intervals.length, 1);
+  assertEquals(record.expiresAtMs, 1000);
+
+  // Advance past the original TTL and fire the refresh callback
+  clock.nowMs = 900;
+  intervals[0].cb();
+  assertEquals(record.expiresAtMs, 1900);
+
+  // Credential still verifies past the original expiry
+  clock.nowMs = 1500;
+  assertEquals(service.verify(record.credential)?.dispatchId, "dispatch-1");
+
+  service.dispose();
+});
+
+Deno.test("SessionCredentialService: dispatch credential refresh interval matches 2/3 TTL", () => {
+  const clock = { nowMs: 0 };
+  const { service, intervals } = serviceAt(clock, 3000);
+  service.issueForDispatch("worker-1", "dispatch-1");
+
+  assertEquals(intervals.length, 1);
+  assertEquals(intervals[0].ms, 2000); // 3000 * 2/3
+
+  service.dispose();
+});
+
+Deno.test("SessionCredentialService: revokeDispatch clears the refresh interval", () => {
+  const clock = { nowMs: 0 };
+  const { service, intervals } = serviceAt(clock, 1000);
+  service.issueForDispatch("worker-1", "dispatch-1");
+
+  assertEquals(intervals.length, 1);
+  service.revokeDispatch("worker-1", "dispatch-1");
+  assertEquals(intervals.length, 0);
+
+  service.dispose();
+});
+
+Deno.test("SessionCredentialService: revokeAllForWorker clears all dispatch refresh intervals", () => {
+  const clock = { nowMs: 0 };
+  const { service, intervals } = serviceAt(clock, 1000);
+  service.issueForDispatch("worker-1", "dispatch-1");
+  service.issueForDispatch("worker-1", "dispatch-2");
+  service.issueForDispatch("worker-2", "dispatch-3");
+
+  assertEquals(intervals.length, 3);
+  service.revokeAllForWorker("worker-1");
+  assertEquals(intervals.length, 1);
+  assertEquals(intervals[0].id, 3); // only dispatch-3 remains
+
+  service.dispose();
+});
+
+Deno.test("SessionCredentialService: dispose clears all refresh intervals", () => {
+  const clock = { nowMs: 0 };
+  const { service, intervals } = serviceAt(clock, 1000);
+  service.issueForDispatch("worker-1", "dispatch-1");
+  service.issueForDispatch("worker-2", "dispatch-2");
+
+  assertEquals(intervals.length, 2);
+  service.dispose();
+  assertEquals(intervals.length, 0);
+});
+
+Deno.test("SessionCredentialService: refresh callback guards against deleted record", () => {
+  const clock = { nowMs: 0 };
+  const { service, intervals } = serviceAt(clock, 1000);
+  const record = service.issueForDispatch("worker-1", "dispatch-1");
+
+  // Force-expire and verify (which deletes the record)
+  clock.nowMs = 1000;
+  assertEquals(service.verify(record.credential), null);
+
+  // The interval was cleared by #deleteCredential via verify
+  assertEquals(intervals.length, 0);
+
+  service.dispose();
+});
+
+Deno.test("SessionCredentialService: concurrent dispatches have independent refresh cycles", () => {
+  const clock = { nowMs: 0 };
+  const { service, intervals } = serviceAt(clock, 1000);
+  const d1 = service.issueForDispatch("worker-1", "dispatch-1");
+  const d2 = service.issueForDispatch("worker-1", "dispatch-2");
+
+  assertEquals(intervals.length, 2);
+
+  // Fire only dispatch-1's refresh
+  clock.nowMs = 800;
+  intervals[0].cb();
+  assertEquals(d1.expiresAtMs, 1800);
+  assertEquals(d2.expiresAtMs, 1000); // unchanged
+
+  // Revoke dispatch-1, dispatch-2 still has its interval
+  service.revokeDispatch("worker-1", "dispatch-1");
+  assertEquals(intervals.length, 1);
+
+  // Fire dispatch-2's refresh
+  intervals[0].cb();
+  assertEquals(d2.expiresAtMs, 1800);
+
+  service.dispose();
+});
+
+Deno.test("SessionCredentialService: refresh callback no-ops after revocation race", () => {
+  const clock = { nowMs: 0 };
+  const { service, intervals } = serviceAt(clock, 1000);
+  const record = service.issueForDispatch("worker-1", "dispatch-1");
+
+  // Capture the callback before revocation clears the interval
+  const cb = intervals[0].cb;
+
+  // Simulate: revocation happened but callback was already scheduled
+  service.revokeDispatch("worker-1", "dispatch-1");
+
+  // Manually fire the callback — should not crash
+  cb();
+
+  // Credential is still revoked
+  assertEquals(service.verify(record.credential), null);
+
+  service.dispose();
+});
+
+Deno.test("SessionCredentialService: control-channel credentials do not get refresh intervals", () => {
+  const clock = { nowMs: 0 };
+  const { service, intervals } = serviceAt(clock, 1000);
+  service.issue("worker-1");
+
+  assertEquals(intervals.length, 0);
+
+  service.dispose();
 });

--- a/src/serve/worker_gateway.ts
+++ b/src/serve/worker_gateway.ts
@@ -235,6 +235,11 @@ export class WorkerGateway {
     return this.#sessions;
   }
 
+  /** Clean up internal timers (dispatch credential refresh). */
+  dispose(): void {
+    this.#sessions.dispose();
+  }
+
   /**
    * Attach a control socket. Returns the per-socket state whose channel
    * consumes RPC frames; the caller feeds raw messages to `feed()` and must


### PR DESCRIPTION
## Summary

- Dispatch credentials were minted with a fixed 15-minute TTL and explicitly excluded from the control-channel refresh mechanism, causing steps running longer than 15 minutes to fail with a 401 on data-plane writes — after the work had already succeeded on the worker
- `SessionCredentialService` now auto-refreshes dispatch credentials internally: `issueForDispatch()` starts a periodic timer that slides `expiresAtMs` forward every 2/3 TTL until explicitly revoked
- The credential string stays the same (the runner process cannot receive updated credentials mid-execution), so no protocol or wire-format changes are needed

## Test Plan

- 9 new unit tests covering the auto-refresh lifecycle: credential stays valid past original TTL, interval matches 2/3 TTL, revocation clears interval, `revokeAllForWorker` clears all, `dispose()` clears everything, callback guards deleted record, concurrent dispatches independent, race condition no-op, control-channel credentials unaffected
- All 26 session credential tests pass
- All 31 worker gateway tests pass (no regressions)
- Full verification pipeline green: lint, fmt, type-check, compile, test suite, and 3 agent reviews (code, adversarial, UX) all pass

Closes swamp-club#1750