### PR TITLE
fix(cancel): skip serve-owned runs in local workflow cancel

### DIFF
--- a/src/cli/commands/workflow_cancel.ts
+++ b/src/cli/commands/workflow_cancel.ts
@@ -47,6 +47,10 @@ type AnyOptions = any;
 
 const TERMINAL_STATUSES = new Set(["succeeded", "failed", "cancelled"]);
 
+export function isServeOwnedRun(run: WorkflowRun): boolean {
+  return run.instanceId !== undefined;
+}
+
 async function cancelRun(run: WorkflowRun, reason: string): Promise<void> {
   if (run.pid && run.pid !== Deno.pid) {
     await killProcessTree(run.pid);
@@ -221,19 +225,22 @@ export const workflowCancelCommand = withRemoteOptions(
       const activeRuns = await findAllActiveRuns(workflowRepo, runRepo);
       if (activeRuns.length === 0) {
         if (cliCtx.outputMode === "json") {
-          console.log(JSON.stringify({ cancelled: [] }));
+          console.log(JSON.stringify({ cancelled: [], skipped: [] }));
         } else {
           cliCtx.logger.info("No active workflow runs found to cancel.");
         }
         return;
       }
 
+      const localRuns = activeRuns.filter(({ run }) => !isServeOwnedRun(run));
+      const serveRuns = activeRuns.filter(({ run }) => isServeOwnedRun(run));
+
       const cancelled: {
         runId: string;
         workflowName: string;
         previousStatus: string;
       }[] = [];
-      for (const { run, workflowId, workflowName } of activeRuns) {
+      for (const { run, workflowId, workflowName } of localRuns) {
         const previousStatus = run.status;
         await cancelRun(run, reason);
         await runRepo.save(workflowId, run);
@@ -244,18 +251,38 @@ export const workflowCancelCommand = withRemoteOptions(
         });
       }
 
+      const skipped = serveRuns.map(({ run, workflowName }) => ({
+        runId: run.id,
+        workflowName,
+        status: run.status,
+      }));
+
       if (cliCtx.outputMode === "json") {
         console.log(JSON.stringify({
           cancelled,
+          skipped,
           count: cancelled.length,
           reason,
         }));
       } else {
-        cliCtx.logger
-          .info`Cancelled ${cancelled.length} workflow run(s)`;
-        for (const entry of cancelled) {
+        if (cancelled.length > 0) {
           cliCtx.logger
-            .info`  ${entry.workflowName} (${entry.runId}): ${entry.previousStatus} -> cancelled`;
+            .info`Cancelled ${cancelled.length} workflow run(s)`;
+          for (const entry of cancelled) {
+            cliCtx.logger
+              .info`  ${entry.workflowName} (${entry.runId}): ${entry.previousStatus} -> cancelled`;
+          }
+        }
+        if (skipped.length > 0) {
+          cliCtx.logger
+            .warn`Skipped ${skipped.length} serve-owned run(s) — cancel these individually via --server --run <id>`;
+          for (const entry of skipped) {
+            cliCtx.logger
+              .warn`  ${entry.workflowName} (${entry.runId}): ${entry.status}`;
+          }
+        }
+        if (cancelled.length === 0 && skipped.length === 0) {
+          cliCtx.logger.info("No active workflow runs found to cancel.");
         }
       }
       return;
@@ -302,6 +329,13 @@ export const workflowCancelCommand = withRemoteOptions(
     if (TERMINAL_STATUSES.has(run.status)) {
       throw new UserError(
         `Run ${run.id} is already in a terminal state (status: ${run.status})`,
+      );
+    }
+
+    if (isServeOwnedRun(run)) {
+      throw new UserError(
+        `Run ${run.id} belongs to a serve instance and cannot be cancelled locally. ` +
+          `Use --server to cancel it: swamp workflow cancel --run ${run.id} --server <url>`,
       );
     }
 

--- a/src/cli/commands/workflow_cancel_test.ts
+++ b/src/cli/commands/workflow_cancel_test.ts
@@ -1,0 +1,90 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
+import { isServeOwnedRun } from "./workflow_cancel.ts";
+
+// Import models barrel to trigger self-registration
+import "../../domain/models/models.ts";
+
+await initializeLogging({});
+
+const WORKFLOW_ID = "a0000000-0000-4000-8000-000000000001";
+
+function makeRun(
+  overrides: {
+    status?:
+      | "pending"
+      | "running"
+      | "suspended"
+      | "succeeded"
+      | "failed"
+      | "cancelled";
+    pid?: number;
+    instanceId?: string;
+  } = {},
+): WorkflowRun {
+  return WorkflowRun.fromData({
+    id: crypto.randomUUID(),
+    workflowId: WORKFLOW_ID,
+    workflowName: "test-workflow",
+    status: overrides.status ?? "running",
+    startedAt: "2026-07-20T20:00:00.000Z",
+    pid: overrides.pid,
+    instanceId: overrides.instanceId,
+    jobs: [{
+      jobName: "main",
+      status: "running",
+      startedAt: "2026-07-20T20:00:00.000Z",
+      steps: [{
+        stepName: "step1",
+        status: "running",
+        startedAt: "2026-07-20T20:00:00.000Z",
+      }],
+    }],
+    tags: {},
+  });
+}
+
+Deno.test("isServeOwnedRun: returns true when instanceId is set", () => {
+  const run = makeRun({ instanceId: crypto.randomUUID() });
+  assertEquals(isServeOwnedRun(run), true);
+});
+
+Deno.test("isServeOwnedRun: returns false when instanceId is undefined", () => {
+  const run = makeRun();
+  assertEquals(isServeOwnedRun(run), false);
+});
+
+Deno.test("isServeOwnedRun: returns false for CLI-started run with pid", () => {
+  const run = makeRun({ pid: 12345 });
+  assertEquals(isServeOwnedRun(run), false);
+});
+
+Deno.test("isServeOwnedRun: returns true for serve run with both pid and instanceId", () => {
+  const run = makeRun({ pid: 12345, instanceId: crypto.randomUUID() });
+  assertEquals(isServeOwnedRun(run), true);
+});
+
+Deno.test("workflowCancelCommand module loads", async () => {
+  const { workflowCancelCommand } = await import("./workflow_cancel.ts");
+  assertEquals(workflowCancelCommand.getName(), "cancel");
+});


### PR DESCRIPTION
## Summary

- Local `swamp workflow cancel --all` was sending SIGTERM to the serve process
  because serve-owned runs share the serve PID. Added a guard checking
  `run.instanceId` — runs with an instanceId belong to a serve instance and are
  now skipped instead of killed.
- `--all` filters out serve-owned runs and warns the user to cancel them
  individually via `--server --run <id>`
- Single-cancel path rejects serve-owned runs with a `UserError`
- JSON output gains a `skipped` array alongside `cancelled`

Closes swamp-club#1769
Docs follow-up: swamp-club#1803

## Test plan

- [x] Unit tests: `isServeOwnedRun` returns true/false based on `instanceId`
- [x] Reproduction: started serve, submitted a workflow run, ran `cancel --all`
  — serve stayed alive, run was reported as skipped
- [x] Reproduction: single cancel of serve-owned run rejected with `UserError`
- [x] JSON output: `skipped` array populated, `cancelled` empty
- [x] Verification workflow: lint, fmt, type-check, tests, compile, code review,
  UX review all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)