### PR TITLE
fix(install): skip interactive prompt in CI environments

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -103,7 +103,8 @@ main() {
   echo
 
   # Prompt to connect to SWAMP CLUB when running interactively
-  if [ -e /dev/tty ] && [ -t 1 ]; then
+  # Skip in CI environments or when explicitly requested via SWAMP_NONINTERACTIVE
+  if [ -z "${CI:-}" ] && [ -z "${SWAMP_NONINTERACTIVE:-}" ] && [ -e /dev/tty ] && [ -t 1 ]; then
     echo
     section "Swamp is better with SWAMP CLUB (swamp-club.com)"
     info ""


### PR DESCRIPTION
## Summary

- The TTY detection (`[ -e /dev/tty ] && [ -t 1 ]`) in `install.sh` is unreliable in CI — `/dev/tty` often exists as a device node even when no terminal is attached, causing the SWAMP CLUB login prompt to intermittently hang
- Added checks for `CI` and `SWAMP_NONINTERACTIVE` env vars before TTY detection — `CI` is set automatically by GitHub Actions, GitLab CI, and most CI systems; `SWAMP_NONINTERACTIVE` is an explicit escape hatch for other non-interactive contexts (Dockerfiles, provisioning scripts)
- This lets consumers (like `setup-swamp`) drop workarounds like `rm -f /dev/tty`

## Test plan

- [ ] Verify `curl ... | sh` still shows the interactive prompt on a real terminal
- [ ] Verify `CI=true curl ... | sh` skips the prompt
- [ ] Verify `SWAMP_NONINTERACTIVE=1 curl ... | sh` skips the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)