### PR TITLE
fix(workflows): aggregate forEach expanded step statuses for dependsOn evaluation

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -2462,6 +2462,7 @@ export class WorkflowExecutionService {
           const expanded = expandedStepsMap.get(step.name);
           const names = expanded ? expanded.map((e) => e.expandedName) : [];
           jobRun.replaceExpandedSteps(step.name, names);
+          jobRun.registerForEachExpansion(step.name, names);
         }
       }
 

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -372,6 +372,8 @@ export class StepRun {
  * JobRun tracks the execution state of a job and its steps.
  */
 export class JobRun implements TriggerEvaluationContext {
+  private _forEachMappings = new Map<string, readonly string[]>();
+
   constructor(
     readonly jobName: string,
     private _status: RunStatus,
@@ -421,9 +423,37 @@ export class JobRun implements TriggerEvaluationContext {
 
   /**
    * Gets the status of a step by name (for TriggerEvaluationContext).
+   *
+   * When `ref` is a forEach template name, aggregates the expanded steps'
+   * statuses: failed if any failed, succeeded if all succeeded, skipped if
+   * all skipped, running if any still in progress.
    */
   getStatus(ref: string): RunStatus | undefined {
-    return this._steps.find((s) => s.stepName === ref)?.status;
+    const direct = this._steps.find((s) => s.stepName === ref)?.status;
+    if (direct !== undefined) return direct;
+
+    const expandedNames = this._forEachMappings.get(ref);
+    if (!expandedNames || expandedNames.length === 0) return undefined;
+
+    const statuses: RunStatus[] = [];
+    for (const name of expandedNames) {
+      const status = this._steps.find((s) => s.stepName === name)?.status;
+      if (status === undefined) return undefined;
+      statuses.push(status);
+    }
+
+    if (statuses.some((s) => s === "failed")) return "failed";
+    if (
+      statuses.some((s) =>
+        s === "pending" || s === "running" || s === "waiting_approval"
+      )
+    ) {
+      return "running";
+    }
+    if (statuses.every((s) => s === "succeeded")) return "succeeded";
+    if (statuses.every((s) => s === "skipped")) return "skipped";
+    // Mix of succeeded and skipped (no failures, all terminal)
+    return "succeeded";
   }
 
   /**
@@ -474,6 +504,19 @@ export class JobRun implements TriggerEvaluationContext {
       }
     }
     this._steps.splice(templateIndex, 1, ...insertions);
+  }
+
+  /**
+   * Records the mapping from a forEach template step name to its expanded
+   * step names so {@link getStatus} can aggregate their statuses. Called
+   * by the execution service after forEach expansion on every run
+   * (including resume), so the mapping does not need to be persisted.
+   */
+  registerForEachExpansion(
+    templateName: string,
+    expandedNames: readonly string[],
+  ): void {
+    this._forEachMappings.set(templateName, expandedNames);
   }
 
   resetToPending(): void {

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -442,7 +442,6 @@ export class JobRun implements TriggerEvaluationContext {
       statuses.push(status);
     }
 
-    if (statuses.some((s) => s === "failed")) return "failed";
     if (
       statuses.some((s) =>
         s === "pending" || s === "running" || s === "waiting_approval"
@@ -450,6 +449,7 @@ export class JobRun implements TriggerEvaluationContext {
     ) {
       return "running";
     }
+    if (statuses.some((s) => s === "failed")) return "failed";
     if (statuses.every((s) => s === "succeeded")) return "succeeded";
     if (statuses.every((s) => s === "skipped")) return "skipped";
     // Mix of succeeded and skipped (no failures, all terminal)

--- a/src/domain/workflows/workflow_run_test.ts
+++ b/src/domain/workflows/workflow_run_test.ts
@@ -1362,6 +1362,27 @@ Deno.test("JobRun.getStatus: aggregates forEach expanded steps — any still run
   assertEquals(jobRun.getStatus("deploy"), "running");
 });
 
+Deno.test("JobRun.getStatus: aggregates forEach expanded steps — failed with sibling still running", () => {
+  const jobRun = JobRun.pending("main", ["deploy"]);
+  jobRun.replaceExpandedSteps("deploy", [
+    "deploy-dev",
+    "deploy-qa",
+    "deploy-staging",
+  ]);
+  jobRun.registerForEachExpansion("deploy", [
+    "deploy-dev",
+    "deploy-qa",
+    "deploy-staging",
+  ]);
+
+  jobRun.getStep("deploy-dev")!.start();
+  jobRun.getStep("deploy-dev")!.fail("timeout");
+  jobRun.getStep("deploy-qa")!.start();
+  // deploy-staging still pending
+
+  assertEquals(jobRun.getStatus("deploy"), "running");
+});
+
 Deno.test("JobRun.getStatus: empty forEach expansion returns undefined", () => {
   const jobRun = JobRun.pending("main", ["deploy"]);
   jobRun.replaceExpandedSteps("deploy", []);

--- a/src/domain/workflows/workflow_run_test.ts
+++ b/src/domain/workflows/workflow_run_test.ts
@@ -1298,3 +1298,148 @@ Deno.test("WorkflowRun.toData: stepProgress counts failed steps as completed", (
   const data = run.toData();
   assertEquals(data.stepProgress, { completed: 2, total: 3 });
 });
+
+// --- forEach getStatus aggregation (swamp-club#1780) ---
+
+Deno.test("JobRun.getStatus: aggregates forEach expanded steps — all succeeded", () => {
+  const jobRun = JobRun.pending("main", ["deploy"]);
+  jobRun.replaceExpandedSteps("deploy", ["deploy-dev", "deploy-qa"]);
+  jobRun.registerForEachExpansion("deploy", ["deploy-dev", "deploy-qa"]);
+
+  jobRun.getStep("deploy-dev")!.start();
+  jobRun.getStep("deploy-dev")!.succeed();
+  jobRun.getStep("deploy-qa")!.start();
+  jobRun.getStep("deploy-qa")!.succeed();
+
+  assertEquals(jobRun.getStatus("deploy"), "succeeded");
+});
+
+Deno.test("JobRun.getStatus: aggregates forEach expanded steps — any failed", () => {
+  const jobRun = JobRun.pending("main", ["deploy"]);
+  jobRun.replaceExpandedSteps("deploy", ["deploy-dev", "deploy-qa"]);
+  jobRun.registerForEachExpansion("deploy", ["deploy-dev", "deploy-qa"]);
+
+  jobRun.getStep("deploy-dev")!.start();
+  jobRun.getStep("deploy-dev")!.succeed();
+  jobRun.getStep("deploy-qa")!.start();
+  jobRun.getStep("deploy-qa")!.fail("connection timeout");
+
+  assertEquals(jobRun.getStatus("deploy"), "failed");
+});
+
+Deno.test("JobRun.getStatus: aggregates forEach expanded steps — all skipped", () => {
+  const jobRun = JobRun.pending("main", ["deploy"]);
+  jobRun.replaceExpandedSteps("deploy", ["deploy-dev", "deploy-qa"]);
+  jobRun.registerForEachExpansion("deploy", ["deploy-dev", "deploy-qa"]);
+
+  jobRun.getStep("deploy-dev")!.skip();
+  jobRun.getStep("deploy-qa")!.skip();
+
+  assertEquals(jobRun.getStatus("deploy"), "skipped");
+});
+
+Deno.test("JobRun.getStatus: aggregates forEach expanded steps — mixed succeeded and skipped", () => {
+  const jobRun = JobRun.pending("main", ["deploy"]);
+  jobRun.replaceExpandedSteps("deploy", ["deploy-dev", "deploy-qa"]);
+  jobRun.registerForEachExpansion("deploy", ["deploy-dev", "deploy-qa"]);
+
+  jobRun.getStep("deploy-dev")!.start();
+  jobRun.getStep("deploy-dev")!.succeed();
+  jobRun.getStep("deploy-qa")!.skip();
+
+  assertEquals(jobRun.getStatus("deploy"), "succeeded");
+});
+
+Deno.test("JobRun.getStatus: aggregates forEach expanded steps — any still running", () => {
+  const jobRun = JobRun.pending("main", ["deploy"]);
+  jobRun.replaceExpandedSteps("deploy", ["deploy-dev", "deploy-qa"]);
+  jobRun.registerForEachExpansion("deploy", ["deploy-dev", "deploy-qa"]);
+
+  jobRun.getStep("deploy-dev")!.start();
+  jobRun.getStep("deploy-dev")!.succeed();
+  // deploy-qa still pending
+
+  assertEquals(jobRun.getStatus("deploy"), "running");
+});
+
+Deno.test("JobRun.getStatus: empty forEach expansion returns undefined", () => {
+  const jobRun = JobRun.pending("main", ["deploy"]);
+  jobRun.replaceExpandedSteps("deploy", []);
+  jobRun.registerForEachExpansion("deploy", []);
+
+  assertEquals(jobRun.getStatus("deploy"), undefined);
+});
+
+Deno.test("JobRun.getStatus: unknown template returns undefined (no regression)", () => {
+  const jobRun = JobRun.pending("main", ["step1"]);
+
+  assertEquals(jobRun.getStatus("nonexistent"), undefined);
+});
+
+Deno.test("JobRun.getStatus: direct match takes priority over forEach mapping", () => {
+  const jobRun = JobRun.pending("main", ["step1", "deploy"]);
+  jobRun.registerForEachExpansion("deploy", ["deploy-dev"]);
+
+  jobRun.getStep("deploy")!.start();
+  jobRun.getStep("deploy")!.fail("error");
+
+  assertEquals(jobRun.getStatus("deploy"), "failed");
+});
+
+Deno.test("JobRun.getStatus: forEach aggregation works with trigger conditions", () => {
+  const jobRun = JobRun.pending("main", ["deploy", "after"]);
+  jobRun.replaceExpandedSteps("deploy", ["deploy-dev", "deploy-qa"]);
+  jobRun.registerForEachExpansion("deploy", ["deploy-dev", "deploy-qa"]);
+
+  jobRun.getStep("deploy-dev")!.start();
+  jobRun.getStep("deploy-dev")!.succeed();
+  jobRun.getStep("deploy-qa")!.start();
+  jobRun.getStep("deploy-qa")!.succeed();
+
+  const succeeded = TriggerCondition.succeeded();
+  assertEquals(succeeded.evaluate(jobRun, "deploy"), true);
+
+  const failed = TriggerCondition.failed();
+  assertEquals(failed.evaluate(jobRun, "deploy"), false);
+
+  const completed = TriggerCondition.completed();
+  assertEquals(completed.evaluate(jobRun, "deploy"), true);
+
+  const skipped = TriggerCondition.skipped();
+  assertEquals(skipped.evaluate(jobRun, "deploy"), false);
+});
+
+Deno.test("JobRun.getStatus: forEach aggregation with failed iteration triggers conditions correctly", () => {
+  const jobRun = JobRun.pending("main", ["deploy", "cleanup"]);
+  jobRun.replaceExpandedSteps("deploy", ["deploy-dev", "deploy-qa"]);
+  jobRun.registerForEachExpansion("deploy", ["deploy-dev", "deploy-qa"]);
+
+  jobRun.getStep("deploy-dev")!.start();
+  jobRun.getStep("deploy-dev")!.succeed();
+  jobRun.getStep("deploy-qa")!.start();
+  jobRun.getStep("deploy-qa")!.fail("timeout");
+
+  const succeeded = TriggerCondition.succeeded();
+  assertEquals(succeeded.evaluate(jobRun, "deploy"), false);
+
+  const failed = TriggerCondition.failed();
+  assertEquals(failed.evaluate(jobRun, "deploy"), true);
+
+  const completed = TriggerCondition.completed();
+  assertEquals(completed.evaluate(jobRun, "deploy"), true);
+});
+
+Deno.test("JobRun.getStatus: registerForEachExpansion is idempotent on re-registration", () => {
+  const jobRun = JobRun.pending("main", ["deploy"]);
+  jobRun.replaceExpandedSteps("deploy", ["deploy-dev", "deploy-qa"]);
+  jobRun.registerForEachExpansion("deploy", ["deploy-dev", "deploy-qa"]);
+  // Re-register (simulates resume path)
+  jobRun.registerForEachExpansion("deploy", ["deploy-dev", "deploy-qa"]);
+
+  jobRun.getStep("deploy-dev")!.start();
+  jobRun.getStep("deploy-dev")!.succeed();
+  jobRun.getStep("deploy-qa")!.start();
+  jobRun.getStep("deploy-qa")!.succeed();
+
+  assertEquals(jobRun.getStatus("deploy"), "succeeded");
+});


### PR DESCRIPTION
## Summary

Fixes swamp-club#1780 — a step whose `dependsOn` references a `forEach` step in the same job was always skipped (except with `condition: always`), even when every iteration succeeded.

- **Root cause**: `JobRun.getStatus()` does an exact `stepName` match, but `replaceExpandedSteps()` removes the template step (e.g. `deploy`) and replaces it with expanded entries (`deploy-dev`, `deploy-qa`). The lookup returned `undefined`, so all leaf conditions evaluated to `false`.
- **Fix**: Add forEach template-to-expanded-name tracking in `JobRun` via `registerForEachExpansion()`, and aggregate expanded step statuses in `getStatus()` — failed if any failed, succeeded if all succeeded, skipped if all skipped, running if any still in progress. In-progress check comes before failed so a mix of failed + still-running returns `running`.
- **12 unit tests** covering all aggregation scenarios, trigger condition integration, edge cases (empty expansion, mixed statuses, idempotent re-registration).

## Test Plan

- [x] 629 workflow domain tests pass (0 failures)
- [x] Reproduction confirmed: `after` step now runs after forEach iterations succeed (was previously skipped)
- [x] Verification workflow passed (lint, fmt, type-check, tests, compile, code review, adversarial review, UX review)

Co-authored-by: Randy Bias <randybias@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)