### PR TITLE
feat(serve): add --dashboard flag to daemon enable command

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -501,6 +501,9 @@ export function collectServeExtraArgs(options: AnyOptions): string[] {
   if (options.enableInternalApi) {
     args.push("--enable-internal-api");
   }
+  if (options.dashboard) {
+    args.push("--dashboard");
+  }
   return args;
 }
 
@@ -762,6 +765,11 @@ const daemonEnableCommand = new Command()
     "--enable-internal-api",
     "Enable the /internal/runs endpoint for full run history access " +
       "(env: SWAMP_ENABLE_INTERNAL_API)",
+  )
+  .option(
+    "--dashboard",
+    "Enable the web dashboard at /dashboard " +
+      "(env: SWAMP_DASHBOARD)",
   )
   .example("Enable daemon", "swamp serve daemon enable")
   .example(

--- a/src/cli/commands/serve_daemon_test.ts
+++ b/src/cli/commands/serve_daemon_test.ts
@@ -144,6 +144,16 @@ Deno.test("collectServeExtraArgs: skips --grants-file when not set", () => {
   assertEquals(args, []);
 });
 
+Deno.test("collectServeExtraArgs: forwards --dashboard", () => {
+  const args = collectServeExtraArgs({ dashboard: true });
+  assertEquals(args, ["--dashboard"]);
+});
+
+Deno.test("collectServeExtraArgs: omits --dashboard when false", () => {
+  const args = collectServeExtraArgs({ dashboard: false });
+  assertEquals(args, []);
+});
+
 Deno.test("collectServeExtraArgs: combines multiple flags", () => {
   const args = collectServeExtraArgs({
     schedule: false,


### PR DESCRIPTION
## Summary

- Add `--dashboard` flag to `swamp serve daemon enable`, matching the flag
  already available on `swamp serve` (shipped in PR #2208)
- Add dashboard forwarding to `collectServeExtraArgs` so the flag is passed
  through to the generated service definition
- Add unit tests for the new flag forwarding

Closes #1793

## Test Plan

- [x] `collectServeExtraArgs` forwards `--dashboard` when `dashboard: true`
- [x] `collectServeExtraArgs` omits `--dashboard` when `dashboard: false`
- [x] All existing `collectServeExtraArgs` tests still pass (21/21)
- [x] Verification workflow: lint, fmt, type-check, test, compile, code review all pass

## Verification

```
Gate: 10/13 passed, 3 skipped (guard)
Build:   ff95d1f1-008b-4ded-bbf1-bc7b30d6c16f
Reviews: efa59675-541e-476d-9ae4-1b5b5a9b4896
```