### PR TITLE
fix(extensions): lazy cold-start indexing to prevent OOM on large repos (swamp-club#1684)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -1726,8 +1726,13 @@ model registry is wired up initially.
      unchanged) and retried when they mismatch (source changed) — warm-start and
      reconcile operate on orthogonal axes.
 
-   - If not populated (first run or DB deleted): falls back to the existing
-     full-import path, then populates the catalog from the loaded registry
+   - If not populated (first run or DB deleted): bundles all source files
+     without importing them into V8 (`load()` with `indexOnly: true`), then
+     populates the catalog from source extraction and registers lazy entries.
+     This avoids OOM on repos with thousands of model definitions — bundles
+     stay on disk and are imported on demand via `ensureTypeLoaded()`. Schema
+     validation errors are deferred to first type access, matching the
+     warm-start behavior.
 
 2. `types()` returns both fully loaded and lazy type names — commands like
    `model type search` work without importing any bundles.
@@ -1746,9 +1751,11 @@ model registry is wired up initially.
 
 ### Self-Healing
 
-The catalog self-heals: deleting `_extension_catalog.db` triggers a full import
-on next access (same behavior as before lazy loading was added). The `populated`
-flag follows the same pattern as the data catalog's backfill mechanism.
+The catalog self-heals: deleting `_extension_catalog.db` triggers a cold-start
+rebuild on next access — source files are bundled (without importing into V8)
+and the catalog is repopulated from source extraction. Types are then available
+as lazy entries and imported on demand. The `populated` flag follows the same
+pattern as the data catalog's backfill mechanism.
 
 ### Roadmap
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1488,8 +1488,8 @@ export const serveCommand = new Command()
       dataPlane.releaseDispatch(dispatchId)
     );
 
-    // Eagerly load extension registries so failures surface at startup
-    // rather than silently on first scheduled/webhook execution.
+    // Index extension registries so types are discoverable at startup.
+    // Bundles are imported on demand when workflow steps target them.
     await Promise.all([
       modelRegistry.ensureLoaded(),
       vaultTypeRegistry.ensureLoaded(),

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -661,7 +661,7 @@ async function loadUserModels(
 
     // Build the index: reads catalog + mtime scan for freshness.
     // If catalog is populated, only rebundles changed files.
-    // If not populated (first run), does a full import to bootstrap.
+    // If not populated (first run), bundles without importing (indexOnly).
     // Always scans for staleness so users never see stale data.
     // Load order: local > sources > pulled (sources override pulled).
     // pulledDirs is one entry per installed extension — the loader walks
@@ -671,6 +671,7 @@ async function loadUserModels(
       absoluteModelsDir,
       {
         additionalDirs: [...sourceDirs, ...pulledDirs],
+        indexOnly: true,
       },
     );
 
@@ -754,6 +755,7 @@ async function loadUserVaults(
 
       const result = await loader.buildIndex(absoluteVaultsDir, {
         additionalDirs: [...sourceDirs, ...pulledDirs],
+        indexOnly: true,
       });
 
       throwOnTransientLoadFailures(result.failed, "vault");
@@ -838,6 +840,7 @@ async function loadUserDatastores(
         absoluteDatastoresDir,
         {
           additionalDirs: [...sourceDirs, ...pulledDirs],
+          indexOnly: true,
         },
       );
 
@@ -923,6 +926,7 @@ async function loadUserReports(
 
       const result = await loader.buildIndex(absoluteReportsDir, {
         additionalDirs: [...sourceDirs, ...pulledDirs],
+        indexOnly: true,
       });
 
       throwOnTransientLoadFailures(result.failed, "report");

--- a/src/domain/extensions/extension_loader.ts
+++ b/src/domain/extensions/extension_loader.ts
@@ -395,7 +395,7 @@ export class ExtensionLoader {
 
   async buildIndex(
     dir: string,
-    options?: { additionalDirs?: string[] },
+    options?: { additionalDirs?: string[]; indexOnly?: boolean },
   ): Promise<ExtensionLoadResult> {
     const repository = this.requireRepository("buildIndex");
     const catalog = repository.getCatalogStore();
@@ -522,14 +522,10 @@ export class ExtensionLoader {
       return result;
     }
 
-    // Cold start: bundle all source files without importing them into V8.
-    // This avoids OOM on repos with thousands of model definitions by
-    // keeping bundles on disk only. Types are registered as lazy catalog
-    // entries and imported on demand via ensureTypeLoaded()/loadSingleType().
     const fullResult = await this.load(dir, {
       additionalDirs: options?.additionalDirs,
       skipAlreadyRegistered: true,
-      indexOnly: true,
+      indexOnly: options?.indexOnly,
     });
 
     if (fullResult.failed.length > 0 && this.repoDir) {
@@ -612,7 +608,9 @@ export class ExtensionLoader {
     if (this.repoDir) {
       catalog.resolveOriginConflicts(this.repoDir);
     }
-    this.registerLazyFromCatalog(catalog);
+    if (options?.indexOnly) {
+      this.registerLazyFromCatalog(catalog);
+    }
     catalog.markPopulated(this.adapter.kind);
     catalog.setLayoutVersion(BUNDLE_LAYOUT_VERSION);
     catalog.setDatastoreBasePath(currentBasePath, this.adapter.kind);

--- a/src/domain/extensions/extension_loader.ts
+++ b/src/domain/extensions/extension_loader.ts
@@ -176,6 +176,7 @@ export class ExtensionLoader {
     options?: {
       skipAlreadyRegistered?: boolean;
       additionalDirs?: string[];
+      indexOnly?: boolean;
     },
   ): Promise<ExtensionLoadResult> {
     const result: ExtensionLoadResult = {
@@ -203,6 +204,41 @@ export class ExtensionLoader {
       for (const file of files) {
         allFiles.push({ file, baseDir: d });
       }
+    }
+
+    if (options?.indexOnly) {
+      for (const { file, baseDir } of allFiles) {
+        try {
+          const absolutePath = resolve(baseDir, file);
+          const source = await Deno.readTextFile(absolutePath);
+          if (!this.adapter.exportRegex.test(source)) {
+            this.logger
+              .debug`Skipping ${file} (no ${this.adapter.kind} export found)`;
+            continue;
+          }
+
+          const { fromCache } = await this.bundleWithCache(
+            absolutePath,
+            file,
+            denoPath,
+            baseDir,
+            { trustPulledCache: true },
+          );
+          if (fromCache) {
+            this.logger
+              .warn`Using cached bundle for ${file} — source may have changed but bundle could not be regenerated`;
+          }
+          result.loaded.push(file);
+        } catch (error) {
+          result.failed.push({
+            file,
+            error: String(error),
+            originalError: error,
+            baseDir,
+          });
+        }
+      }
+      return result;
     }
 
     const primaryFiles: Array<{
@@ -486,9 +522,14 @@ export class ExtensionLoader {
       return result;
     }
 
+    // Cold start: bundle all source files without importing them into V8.
+    // This avoids OOM on repos with thousands of model definitions by
+    // keeping bundles on disk only. Types are registered as lazy catalog
+    // entries and imported on demand via ensureTypeLoaded()/loadSingleType().
     const fullResult = await this.load(dir, {
       additionalDirs: options?.additionalDirs,
       skipAlreadyRegistered: true,
+      indexOnly: true,
     });
 
     if (fullResult.failed.length > 0 && this.repoDir) {
@@ -571,6 +612,7 @@ export class ExtensionLoader {
     if (this.repoDir) {
       catalog.resolveOriginConflicts(this.repoDir);
     }
+    this.registerLazyFromCatalog(catalog);
     catalog.markPopulated(this.adapter.kind);
     catalog.setLayoutVersion(BUNDLE_LAYOUT_VERSION);
     catalog.setDatastoreBasePath(currentBasePath, this.adapter.kind);

--- a/src/domain/extensions/extension_loader_test.ts
+++ b/src/domain/extensions/extension_loader_test.ts
@@ -437,6 +437,197 @@ const stubDenoRuntime: DenoRuntime = {
   getDenoEnv: () => Deno.env.toObject(),
 };
 
+// -- load() indexOnly (swamp-club#1684) -----------------------------------
+
+Deno.test("load: indexOnly bundles files without importing or registering types", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "swamp_1684_" });
+  try {
+    // Set up a pulled-extensions directory structure so bundleWithCache
+    // takes the trustPulledCache fast path (no Deno subprocess).
+    const pulledDir = join(dir, ".swamp", "pulled-extensions", "@test", "ext");
+    const modelsDir = join(pulledDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const sourcePath = join(modelsDir, "my_type.ts");
+    await Deno.writeTextFile(
+      sourcePath,
+      'export const model = { type: "@test/my-type", name: "my-type" };\n',
+    );
+
+    // Pre-create the bundle at the expected path so bundleWithCache
+    // returns it from cache without shelling out to Deno.
+    const { bundleNamespace: bn } = await import(
+      "../../infrastructure/persistence/paths.ts"
+    );
+    const ns = bn(modelsDir, dir);
+    const bundleDir = join(dir, ".swamp", "bundles", ns);
+    await Deno.mkdir(bundleDir, { recursive: true });
+    const bundlePath = join(bundleDir, "my_type.js");
+    await Deno.writeTextFile(
+      bundlePath,
+      'export const model = { type: "@test/my-type", name: "my-type" };\n',
+    );
+
+    const registered = new Set<string>();
+    const adapter = makeStubAdapter(registered);
+
+    const loader = new ExtensionLoader(
+      stubDenoRuntime,
+      adapter,
+      dir,
+      undefined,
+      undefined,
+    );
+
+    const result = await loader.load(modelsDir, { indexOnly: true });
+
+    assertEquals(
+      result.loaded.length > 0,
+      true,
+      "indexOnly should report files as loaded (bundled)",
+    );
+    assertEquals(
+      registered.size,
+      0,
+      "indexOnly must not register any types — they should stay lazy",
+    );
+    assertEquals(
+      result.extended.length,
+      0,
+      "indexOnly must not process secondary exports",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("load: without indexOnly imports and registers types normally", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "swamp_1684_eager_" });
+  try {
+    const pulledDir = join(dir, ".swamp", "pulled-extensions", "@test", "ext");
+    const modelsDir = join(pulledDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const sourcePath = join(modelsDir, "eager_type.ts");
+    await Deno.writeTextFile(
+      sourcePath,
+      'export const model = { type: "@test/eager", name: "eager" };\n',
+    );
+
+    const { bundleNamespace: bn } = await import(
+      "../../infrastructure/persistence/paths.ts"
+    );
+    const ns = bn(modelsDir, dir);
+    const bundleDir = join(dir, ".swamp", "bundles", ns);
+    await Deno.mkdir(bundleDir, { recursive: true });
+    const bundlePath = join(bundleDir, "eager_type.js");
+    await Deno.writeTextFile(
+      bundlePath,
+      'export const model = { type: "@test/eager", name: "eager" };\n',
+    );
+
+    const registered = new Set<string>();
+    const adapter: KindAdapter = {
+      kind: "model",
+      bundleSubdir: "bundles",
+      catalogKinds: ["model"],
+      primaryExportKey: "model",
+      exportRegex: /export\s+const\s+model\s*[=:]/,
+      useResolver: false,
+      validatePrimaryExport() {
+        return { success: true, data: { type: "@test/eager" } };
+      },
+      formatValidationError() {
+        return "validation error";
+      },
+      normalizeType(validated: Record<string, unknown>) {
+        return String(validated.type ?? "");
+      },
+      extractTypeFromSource() {
+        return null;
+      },
+      register(type: string) {
+        registered.add(type);
+      },
+      registerLazy() {},
+      promoteFromLazy() {},
+      hasType(type) {
+        return registered.has(type);
+      },
+      isFullyLoaded(type) {
+        return registered.has(type);
+      },
+    };
+
+    const loader = new ExtensionLoader(
+      stubDenoRuntime,
+      adapter,
+      dir,
+      undefined,
+      undefined,
+    );
+
+    const result = await loader.load(modelsDir, {
+      skipAlreadyRegistered: true,
+    });
+
+    assertEquals(
+      result.loaded.length > 0,
+      true,
+      "eager load should report files as loaded",
+    );
+    assertEquals(
+      registered.has("@test/eager"),
+      true,
+      "eager load must register the type",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("load: indexOnly records bundling failures", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "swamp_1684_fail_" });
+  try {
+    const modelsDir = join(dir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    // Source file that matches exportRegex but has no pre-existing bundle
+    // and no real Deno to bundle it — bundleWithCache will fail.
+    const sourcePath = join(modelsDir, "broken.ts");
+    await Deno.writeTextFile(
+      sourcePath,
+      'export const model = { type: "@test/broken" };\n',
+    );
+
+    const registered = new Set<string>();
+    const adapter = makeStubAdapter(registered);
+
+    const loader = new ExtensionLoader(
+      stubDenoRuntime,
+      adapter,
+      dir,
+      undefined,
+      undefined,
+    );
+
+    const result = await loader.load(modelsDir, { indexOnly: true });
+
+    assertEquals(
+      result.failed.length > 0,
+      true,
+      "bundling failure should be recorded",
+    );
+    assertEquals(
+      registered.size,
+      0,
+      "failed bundles must not register types",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
 Deno.test("loadSingleType: skips bundle without primary export and removes catalog entry", async () => {
   const dir = await Deno.makeTempDir({ prefix: "swamp_1018_" });
   try {


### PR DESCRIPTION
## Summary

- Add `indexOnly` option to `ExtensionLoader.load()` that discovers and bundles source files without importing them into V8
- `buildIndex()` cold-start path now accepts `indexOnly` — when true, bundles files to disk, populates the catalog from source extraction, and registers lazy entries without importing
- All four production `loadUser*()` functions (`loadUserModels`, `loadUserVaults`, `loadUserDatastores`, `loadUserReports`) pass `indexOnly: true` to `buildIndex()`
- Types are imported on demand via the existing `ensureTypeLoaded()`/`loadSingleType()` mechanism — the same path warm-start already uses

On repos with 2000+ model definitions, the previous eager cold-start path imported every extension bundle into V8 simultaneously, exhausting the ~4GB heap limit and crashing `swamp serve` at boot. With this change, cold start behaves like warm start: catalog the extensions, load them on demand.

`indexOnly` defaults to `false` for backward compatibility — tests and other callers keep existing eager behavior.

Closes swamp-club#1684

## Test Plan

- 3 new unit tests: `indexOnly` bundles without importing/registering, non-indexOnly regression, failure recording
- All 10,554+ existing tests pass (including `user_model_loader_test.ts` `buildIndex`/`attachPendingExtensionsForType` tests)
- Full verification workflow green: lint, fmt, type-check, vuln-scan, tests, compile, binary-check (9/9 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)