### PR TITLE
fix(workflows): strip step output content from WorkflowRun to prevent OOM

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -3130,12 +3130,7 @@ export class WorkflowExecutionService {
         }
       }
 
-      // Store a lightweight copy of the output on the step run — strip
-      // content and attributes from DataRecords to avoid accumulating
-      // gigabytes of parsed data in the WorkflowRun aggregate. The full
-      // content is already persisted in the datastore and available via
-      // `swamp data get`. The expression context (updated above) retains
-      // the original references for downstream CEL evaluation.
+      // Strip heavy payload from the run record (see stripResourceContent).
       const lightOutput = step.task.isModelMethod() && output &&
           typeof output === "object"
         ? stripResourceContent(output as Record<string, unknown>)
@@ -3754,7 +3749,7 @@ function stripResourceContent(
   if (dataHandles) {
     result.dataHandles = dataHandles.map((handle) => {
       if (!handle.attributes) return handle;
-      return { ...handle, attributes: undefined };
+      return { ...handle, attributes: null };
     });
   }
 

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -3130,7 +3130,17 @@ export class WorkflowExecutionService {
         }
       }
 
-      stepRun.succeed(output);
+      // Store a lightweight copy of the output on the step run — strip
+      // content and attributes from DataRecords to avoid accumulating
+      // gigabytes of parsed data in the WorkflowRun aggregate. The full
+      // content is already persisted in the datastore and available via
+      // `swamp data get`. The expression context (updated above) retains
+      // the original references for downstream CEL evaluation.
+      const lightOutput = step.task.isModelMethod() && output &&
+          typeof output === "object"
+        ? stripResourceContent(output as Record<string, unknown>)
+        : output;
+      stepRun.succeed(lightOutput);
       stepSpan.setStatus({ code: SpanStatusCode.OK });
       const executor = output && typeof output === "object" &&
           "executor" in output
@@ -3697,6 +3707,58 @@ export class WorkflowExecutionService {
       evalSpan.end();
     }
   }
+}
+
+/**
+ * Create a lightweight copy of step output, stripping heavy payload fields
+ * from DataRecords (`resources`) and DataHandles (`dataHandles`). The full
+ * data is already persisted in the datastore; keeping it on the WorkflowRun
+ * causes the run aggregate to grow proportionally to cumulative step
+ * output, which triggers OOM on large workflows (swamp-club#1673).
+ */
+function stripResourceContent(
+  output: Record<string, unknown>,
+): Record<string, unknown> {
+  const result = { ...output };
+
+  const resources = output.resources as
+    | Record<string, Record<string, DataRecord>>
+    | undefined;
+  if (resources) {
+    const lightResources: Record<
+      string,
+      Record<
+        string,
+        Omit<DataRecord, "content" | "attributes"> & {
+          content: null;
+          attributes: null;
+        }
+      >
+    > = {};
+    for (const [specName, instances] of Object.entries(resources)) {
+      lightResources[specName] = {};
+      for (const [instanceName, record] of Object.entries(instances)) {
+        lightResources[specName][instanceName] = {
+          ...record,
+          content: null,
+          attributes: null,
+        };
+      }
+    }
+    result.resources = lightResources;
+  }
+
+  const dataHandles = output.dataHandles as
+    | Array<{ attributes?: Record<string, unknown>; [key: string]: unknown }>
+    | undefined;
+  if (dataHandles) {
+    result.dataHandles = dataHandles.map((handle) => {
+      if (!handle.attributes) return handle;
+      return { ...handle, attributes: undefined };
+    });
+  }
+
+  return result;
 }
 
 function readGlobalConcurrencyLimit(): number | undefined {

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -5015,3 +5015,157 @@ Deno.test("suspend: sibling step failure is recorded during drain", async () => 
     assertEquals(cleanupJob.getStep("gc")!.status, "failed");
   });
 });
+
+Deno.test("step output stored on WorkflowRun has stripped content and attributes (swamp-club#1673)", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new ModelMethodMockExecutor();
+
+    // Use the real nested structure: specName → instanceName → DataRecord
+    // The executor spreads output into the returned object, so we bypass
+    // the mock's type constraint with a direct set on the execute method.
+    const largePayload = "x".repeat(10000);
+    const originalExecute = executor.execute.bind(executor);
+    executor.execute = (step: Step, ctx: StepExecutionContext) => {
+      if (step.name === "step1") {
+        executor.executedSteps.push(`${ctx.jobName}/${ctx.stepName}`);
+        if (ctx.expressionContext) {
+          executor.capturedContexts.set(
+            ctx.stepName,
+            JSON.parse(JSON.stringify(ctx.expressionContext.model)),
+          );
+        }
+        return Promise.resolve({
+          type: "model_method",
+          method: "generate",
+          model: "data-model",
+          resources: {
+            result: {
+              "default": {
+                id: "data-123",
+                name: "result",
+                version: 1,
+                createdAt: "2024-01-01T00:00:00Z",
+                attributes: { largePayload },
+                content: { largePayload },
+                tags: { type: "resource" },
+                modelName: "data-model",
+                modelId: "model-id-1",
+                modelType: "data-generator",
+                specName: "result",
+                dataType: "resource",
+                contentType: "application/json",
+                lifetime: "infinite",
+                ownerType: "model-method",
+                streaming: false,
+                size: 10000,
+                isLatest: true,
+                namespace: "",
+                ownerRef: "",
+                workflowRunId: "",
+                workflowName: "",
+                jobName: "",
+                stepName: "",
+                source: "",
+              },
+            },
+          },
+        });
+      }
+      if (step.name === "step2") {
+        executor.executedSteps.push(`${ctx.jobName}/${ctx.stepName}`);
+        if (ctx.expressionContext) {
+          executor.capturedContexts.set(
+            ctx.stepName,
+            JSON.parse(JSON.stringify(ctx.expressionContext.model)),
+          );
+        }
+        return Promise.resolve({ executed: true, step: step.name });
+      }
+      return originalExecute(step, ctx);
+    };
+
+    const workflow = Workflow.create({
+      name: "strip-content-test",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "step1",
+              task: StepTask.model("data-model", "generate"),
+            }),
+            Step.create({
+              name: "step2",
+              task: StepTask.model("consumer-model", "consume"),
+              dependsOn: [
+                { step: "step1", condition: TriggerCondition.succeeded() },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const run = await service.execute(workflow.name);
+    assertEquals(run.status, "succeeded");
+
+    // Expression context should still have full content for downstream steps
+    const step2Context = executor.capturedContexts.get("step2");
+    const dataModel = step2Context?.["data-model"] as {
+      resource?: Record<
+        string,
+        Record<string, { attributes: Record<string, unknown> }>
+      >;
+    };
+    assertEquals(
+      dataModel?.resource?.["result"]?.["default"]?.attributes?.largePayload,
+      "x".repeat(10000),
+    );
+
+    // Step run output should have stripped content and attributes
+    const step1Run = run.getJob("job1")!.getStep("step1")!;
+    const step1Output = step1Run.toData().output as {
+      resources?: Record<
+        string,
+        Record<
+          string,
+          {
+            content: unknown;
+            attributes: unknown;
+            id: string;
+            name: string;
+            version: number;
+          }
+        >
+      >;
+    };
+    assertEquals(
+      step1Output?.resources?.["result"]?.["default"]?.content,
+      null,
+    );
+    assertEquals(
+      step1Output?.resources?.["result"]?.["default"]?.attributes,
+      null,
+    );
+
+    // Metadata should still be present
+    const record = step1Output?.resources?.["result"]?.["default"];
+    assertEquals(record?.id, "data-123");
+    assertEquals(record?.name, "result");
+    assertEquals(record?.version, 1);
+  });
+});

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -5071,6 +5071,19 @@ Deno.test("step output stored on WorkflowRun has stripped content and attributes
               },
             },
           },
+          dataHandles: [
+            {
+              name: "default",
+              specName: "result",
+              kind: "resource",
+              dataId: "data-123",
+              version: 1,
+              size: 10000,
+              tags: { type: "resource" },
+              metadata: {},
+              attributes: { largePayload },
+            },
+          ],
         });
       }
       if (step.name === "step2") {
@@ -5167,5 +5180,14 @@ Deno.test("step output stored on WorkflowRun has stripped content and attributes
     assertEquals(record?.id, "data-123");
     assertEquals(record?.name, "result");
     assertEquals(record?.version, 1);
+
+    // DataHandle attributes should also be stripped
+    const step1Handles = (step1Run.toData().output as {
+      dataHandles?: Array<{ attributes: unknown; name: string }>;
+    })?.dataHandles;
+    assert(step1Handles);
+    assertEquals(step1Handles.length, 1);
+    assertEquals(step1Handles[0].name, "default");
+    assertEquals(step1Handles[0].attributes, null);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1673.

`stepRun.succeed(output)` stored full DataRecord content (parsed JSON) on the
WorkflowRun aggregate. `saveRun()` then serialized the entire growing aggregate
to YAML after each DAG level. For workflows with many steps producing large
data, this caused the run object and its serialization to accumulate gigabytes
of redundant data — the same content already persisted in the datastore.

- Strip `content` and `attributes` from DataRecords in `resources` before
  storing on the step run
- Strip `attributes` from `dataHandles` before storing on the step run
- The expression context (used by downstream CEL evaluation) reads from the
  original output before stripping — inter-step data references are unaffected
- The full data remains accessible via `swamp data get`

Measured on a 10-step workflow producing ~10MB per step:
- `saveRun` heap spike: **1649MB → 5MB**
- Run YAML on disk: **155MB → 56KB**
- Process peak memory: **1922MB → 198MB**

## Audited consumers

Every consumer of `StepRun.output` was audited — reports, workflow history,
data provenance, serve dispatch — none reads `content` or `attributes` from the
stored DataRecords. The `resources` content in the run record was redundant
ballast.

## Test Plan

- New unit test verifying stripped content/attributes are null, metadata
  preserved, expression context retains full content, and dataHandles
  attributes are stripped
- 629 workflow domain tests pass
- 168 libswamp workflow tests pass
- 3 workflow integration tests pass
- Verification workflow passed (lint, format, test, compile, deps audit,
  code review, UX review, adversarial review)
- Manual verification: `swamp data get`, `swamp report get`,
  `swamp workflow history`, `swamp data query` all return correct results

Co-authored-by: Jesse Robbins <jesserobbins@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvU45xNj9nB6jDtAwHNfqb