### PR TITLE
fix(data): cross-demote is_latest between model-method and workflow step writes (swamp-club#1802)

### DIFF
--- a/design/data-query.md
+++ b/design/data-query.md
@@ -200,12 +200,21 @@ All data access functions (`data.findBySpec()`, `data.findByTag()`,
 `context.queryData()`) return unscoped results by default. The predicate
 string is the contract — if it doesn't say it, it isn't happening.
 
-**Step-scoped versioning:** The `is_latest` flag is scoped per
-`(data_name, step_name)`. When different workflow steps write to the same
-data name, each step maintains its own version chain. Collection helpers
-(`findBySpec`, `findByTag`) return the latest version per step, so multiple
-records may be returned for the same data name. `data.latest()` returns the
-single most-recently-written record regardless of step.
+**Step-aware versioning:** The `is_latest` flag follows asymmetric
+demotion rules based on `step_name`:
+
+- **Model-method writes** (`step_name = ""`) demote ALL prior latest rows
+  for the same `(model, data)`, regardless of their `step_name`. A
+  model-method write always produces exactly one latest.
+- **Workflow-step writes** (`step_name != ""`) demote prior rows with the
+  same `step_name` AND prior model-method rows (`step_name = ""`), but
+  leave other steps' latest rows untouched. Different workflow steps
+  writing to the same data name maintain independent version chains.
+
+Collection helpers (`findBySpec`, `findByTag`) return the latest version
+per step, so multiple records may be returned for the same data name when
+produced by different workflow steps. `data.latest()` returns the single
+most-recently-written record regardless of step.
 
 **Vault resolution:** JSON attributes containing `vault.get(...)` references
 are resolved automatically in async data access paths (extension methods,

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -455,8 +455,9 @@ want to scope to the current run.
 
 When the same model is invoked by different workflow steps that produce data
 with the same spec/instance name, each step's output is treated as a distinct
-record. The version chain is scoped per step: step A's latest version and step
-B's latest version are both returned.
+record. Each step maintains its own latest version, so step A's latest and
+step B's latest are both returned. A standalone model-method write to the
+same data name demotes all prior step outputs.
 
 ### data.findByTag(tagKey, tagValue)
 

--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -45,24 +45,60 @@ import { resolveVaultRefsInData } from "../models/data_writer.ts";
 const logger = getLogger(["swamp", "domain", "data", "query"]);
 
 /**
- * Sets `is_latest` on each row so that the highest version per
- * (model_id, data_name, step_name) group is marked latest.
- * Different workflow steps writing to the same data name keep
- * independent latest markers; non-workflow data (step_name = "")
- * collapses as before.
+ * Sets `is_latest` on each row to match the demotion semantics of
+ * `CatalogStore.upsertNewVersion`:
+ *
+ * - Model-method rows (step_name = "") are demoted by ANY later write
+ *   (model-method or workflow-step), so they keep is_latest only when
+ *   they are the absolute highest version in the group.
+ * - Workflow-step rows (step_name != "") are demoted by later writes
+ *   with the same step_name or by later model-method writes. Above
+ *   the highest model-method version, each step_name gets its own
+ *   latest.
  */
-function markLatestPerStep(rows: CatalogRow[]): void {
-  const maxVersions = new Map<string, number>();
+export function computeLatestFlags(rows: CatalogRow[]): void {
+  const groups = new Map<string, CatalogRow[]>();
   for (const row of rows) {
-    const key = `${row.model_id}\0${row.data_name}\0${row.step_name}`;
-    const cur = maxVersions.get(key);
-    if (cur === undefined || row.version > cur) {
-      maxVersions.set(key, row.version);
+    const key = `${row.model_id}\0${row.data_name}`;
+    let group = groups.get(key);
+    if (!group) {
+      group = [];
+      groups.set(key, group);
     }
+    group.push(row);
   }
-  for (const row of rows) {
-    const key = `${row.model_id}\0${row.data_name}\0${row.step_name}`;
-    row.is_latest = row.version === maxVersions.get(key) ? 1 : 0;
+
+  for (const group of groups.values()) {
+    let overallMax = -1;
+    let globalMax = -1;
+    for (const row of group) {
+      if (row.version > overallMax) overallMax = row.version;
+      if (row.step_name === "" && row.version > globalMax) {
+        globalMax = row.version;
+      }
+    }
+
+    const maxVersionPerStep = new Map<string, number>();
+    for (const row of group) {
+      if (row.step_name !== "" && row.version < globalMax) continue;
+      if (row.step_name !== "") {
+        const cur = maxVersionPerStep.get(row.step_name);
+        if (cur === undefined || row.version > cur) {
+          maxVersionPerStep.set(row.step_name, row.version);
+        }
+      }
+    }
+
+    for (const row of group) {
+      if (row.step_name === "") {
+        row.is_latest = row.version === overallMax ? 1 : 0;
+      } else if (row.version < globalMax) {
+        row.is_latest = 0;
+      } else {
+        const maxForStep = maxVersionPerStep.get(row.step_name);
+        row.is_latest = row.version === maxForStep ? 1 : 0;
+      }
+    }
   }
 }
 
@@ -594,10 +630,7 @@ export class DataQueryService {
       await new Promise<void>((resolve) => setTimeout(resolve, 0));
     }
 
-    // Compute is_latest per (data_name, step_name) group so different
-    // workflow steps writing to the same name keep independent latest
-    // markers.
-    markLatestPerStep(rows);
+    computeLatestFlags(rows);
 
     this.catalogStore.bulkUpsert(rows);
     this.catalogStore.markPopulated();
@@ -659,7 +692,7 @@ export class DataQueryService {
         }
       }
     }
-    markLatestPerStep(rows);
+    computeLatestFlags(rows);
     this.catalogStore.bulkUpsert(rows);
     this.catalogStore.markPopulated();
   }

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -26,7 +26,7 @@ import {
   CatalogStore,
 } from "../../infrastructure/persistence/catalog_store.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
-import { DataQueryService } from "./data_query_service.ts";
+import { computeLatestFlags, DataQueryService } from "./data_query_service.ts";
 import type { DataRecord } from "./data_record.ts";
 import { createNamespace } from "./namespace.ts";
 import { UserError } from "../errors.ts";
@@ -1746,4 +1746,74 @@ Deno.test("DataQueryService: filterStaleRows skips foreign namespace rows (no lo
   assertEquals(results[0].modelId, "foreign-model-id");
 
   catalog.close();
+});
+
+// --- computeLatestFlags tests ---
+
+Deno.test("computeLatestFlags: model-method write demotes all prior step outputs", () => {
+  const rows: CatalogRow[] = [
+    makeRow({ version: 1, step_name: "step-a" }),
+    makeRow({ version: 2, step_name: "step-b" }),
+    makeRow({ version: 3, step_name: "" }),
+  ];
+  computeLatestFlags(rows);
+
+  assertEquals(rows[0].is_latest, 0);
+  assertEquals(rows[1].is_latest, 0);
+  assertEquals(rows[2].is_latest, 1);
+});
+
+Deno.test("computeLatestFlags: different workflow steps keep independent latests above watermark", () => {
+  const rows: CatalogRow[] = [
+    makeRow({ version: 1, step_name: "" }),
+    makeRow({ version: 2, step_name: "step-a" }),
+    makeRow({ version: 3, step_name: "step-b" }),
+  ];
+  computeLatestFlags(rows);
+
+  assertEquals(rows[0].is_latest, 0);
+  assertEquals(rows[1].is_latest, 1);
+  assertEquals(rows[2].is_latest, 1);
+});
+
+Deno.test("computeLatestFlags: rows below global watermark are demoted", () => {
+  const rows: CatalogRow[] = [
+    makeRow({ version: 1, step_name: "" }),
+    makeRow({ version: 2, step_name: "step-a" }),
+    makeRow({ version: 3, step_name: "" }),
+    makeRow({ version: 4, step_name: "step-b" }),
+  ];
+  computeLatestFlags(rows);
+
+  assertEquals(rows[0].is_latest, 0);
+  assertEquals(rows[1].is_latest, 0);
+  assertEquals(rows[2].is_latest, 0);
+  assertEquals(rows[3].is_latest, 1);
+});
+
+Deno.test("computeLatestFlags: no model-method rows means each step gets own latest", () => {
+  const rows: CatalogRow[] = [
+    makeRow({ version: 1, step_name: "step-a" }),
+    makeRow({ version: 2, step_name: "step-a" }),
+    makeRow({ version: 3, step_name: "step-b" }),
+  ];
+  computeLatestFlags(rows);
+
+  assertEquals(rows[0].is_latest, 0);
+  assertEquals(rows[1].is_latest, 1);
+  assertEquals(rows[2].is_latest, 1);
+});
+
+Deno.test("computeLatestFlags: model-method as latest version demotes everything", () => {
+  const rows: CatalogRow[] = [
+    makeRow({ version: 1, step_name: "step-a" }),
+    makeRow({ version: 2, step_name: "step-b" }),
+    makeRow({ version: 3, step_name: "" }),
+  ];
+  computeLatestFlags(rows);
+
+  const latestRows = rows.filter((r) => r.is_latest === 1);
+  assertEquals(latestRows.length, 1);
+  assertEquals(latestRows[0].version, 3);
+  assertEquals(latestRows[0].step_name, "");
 });

--- a/src/infrastructure/persistence/catalog_store.ts
+++ b/src/infrastructure/persistence/catalog_store.ts
@@ -278,13 +278,16 @@ export class CatalogStore {
 
   /**
    * Inserts a row as the new latest version for (type, model, name), clearing
-   * `is_latest` on any prior rows for that quadruple including step_name.
-   * The `is_latest` field on the supplied row is ignored — this method
-   * always writes `1`.
+   * `is_latest` on prior rows. The `is_latest` field on the supplied row is
+   * ignored — this method always writes `1`.
    *
-   * Step-name scoping ensures that different workflow steps writing to the
-   * same data name maintain independent version chains.  Non-workflow data
-   * has step_name = "" and collapses as before.
+   * Demotion scope depends on the incoming step_name:
+   * - Model-method writes (step_name = "") demote ALL prior latest rows
+   *   regardless of their step_name.
+   * - Workflow-step writes (step_name != "") demote rows with the same
+   *   step_name AND rows with step_name = "" (model-method rows), but
+   *   leave other steps' latest rows untouched so different workflow
+   *   steps maintain independent version chains.
    *
    * Runs in an IMMEDIATE transaction so concurrent writers serialize
    * through SQLite's reserved lock rather than racing on the flag.
@@ -295,13 +298,14 @@ export class CatalogStore {
       this.db.prepare(
         `UPDATE catalog SET is_latest = 0
          WHERE namespace = ? AND type_normalized = ? AND model_id = ? AND data_name = ?
-           AND step_name = ?
+           AND (step_name = ? OR ? = '' OR step_name = '')
            AND is_latest = 1`,
       ).run(
         row.namespace,
         row.type_normalized,
         row.model_id,
         row.data_name,
+        row.step_name,
         row.step_name,
       );
       this.upsert({ ...row, is_latest: 1 });

--- a/src/infrastructure/persistence/catalog_store_test.ts
+++ b/src/infrastructure/persistence/catalog_store_test.ts
@@ -163,7 +163,7 @@ Deno.test("CatalogStore: upsertNewVersion does not touch unrelated data names", 
   store.close();
 });
 
-Deno.test("CatalogStore: upsertNewVersion scopes is_latest by step_name", () => {
+Deno.test("CatalogStore: upsertNewVersion keeps independent latests for different workflow steps", () => {
   const dbPath = makeTempDbPath();
   const store = new CatalogStore(dbPath);
 
@@ -201,6 +201,97 @@ Deno.test("CatalogStore: upsertNewVersion clears is_latest within same step_name
   const latestRows = rows.filter((r) => r.is_latest === 1);
   assertEquals(latestRows.length, 1);
   assertEquals(latestRows[0].version, 2);
+  store.close();
+});
+
+Deno.test("CatalogStore: upsertNewVersion model-method demotes all step_names", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  store.upsertNewVersion(
+    makeRow({ version: 1, step_name: "step-a" }),
+  );
+  store.upsertNewVersion(
+    makeRow({ version: 2, step_name: "step-b" }),
+  );
+  store.upsertNewVersion(
+    makeRow({ version: 3, step_name: "" }),
+  );
+
+  const rows = [...store.iterate()];
+  assertEquals(rows.length, 3);
+  const latestRows = rows.filter((r) => r.is_latest === 1);
+  assertEquals(latestRows.length, 1);
+  assertEquals(latestRows[0].version, 3);
+  assertEquals(latestRows[0].step_name, "");
+  store.close();
+});
+
+Deno.test("CatalogStore: upsertNewVersion workflow step demotes model-method rows", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  store.upsertNewVersion(
+    makeRow({ version: 1, step_name: "" }),
+  );
+  store.upsertNewVersion(
+    makeRow({ version: 2, step_name: "approve" }),
+  );
+
+  const rows = [...store.iterate()];
+  assertEquals(rows.length, 2);
+  const latestRows = rows.filter((r) => r.is_latest === 1);
+  assertEquals(latestRows.length, 1);
+  assertEquals(latestRows[0].version, 2);
+  assertEquals(latestRows[0].step_name, "approve");
+  store.close();
+});
+
+Deno.test("CatalogStore: upsertNewVersion workflow step does not demote other steps", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  store.upsertNewVersion(
+    makeRow({ version: 1, step_name: "step-a" }),
+  );
+  store.upsertNewVersion(
+    makeRow({ version: 2, step_name: "step-b" }),
+  );
+
+  const rows = [...store.iterate()];
+  assertEquals(rows.length, 2);
+  const latestRows = rows.filter((r) => r.is_latest === 1);
+  assertEquals(latestRows.length, 2);
+  assertEquals(latestRows.map((r) => r.step_name).sort(), [
+    "step-a",
+    "step-b",
+  ]);
+  store.close();
+});
+
+Deno.test("CatalogStore: upsertNewVersion model-method after workflow steps demotes all", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  store.upsertNewVersion(
+    makeRow({ version: 1, step_name: "" }),
+  );
+  store.upsertNewVersion(
+    makeRow({ version: 2, step_name: "step-a" }),
+  );
+  store.upsertNewVersion(
+    makeRow({ version: 3, step_name: "step-b" }),
+  );
+  store.upsertNewVersion(
+    makeRow({ version: 4, step_name: "" }),
+  );
+
+  const rows = [...store.iterate()];
+  assertEquals(rows.length, 4);
+  const latestRows = rows.filter((r) => r.is_latest === 1);
+  assertEquals(latestRows.length, 1);
+  assertEquals(latestRows[0].version, 4);
+  assertEquals(latestRows[0].step_name, "");
   store.close();
 });
 


### PR DESCRIPTION
## Summary

- Fixes regression from PR #2202 (swamp-club#1761) where `is_latest` demotion in `CatalogStore.upsertNewVersion` was scoped by `step_name`, preventing cross-demotion between model-method writes (`step_name=""`) and workflow step-output writes (`step_name!=""`)
- Changes the demotion to use asymmetric rules: model-method writes demote ALL prior latest rows; workflow step writes demote same-step and model-method rows but leave other steps independent (preserving #1761)
- Renames `markLatestPerStep` to `computeLatestFlags` with matching watermark-based semantics for catalog backfill
- Updates design docs (`data-query.md`, `expressions.md`) to document the corrected step-aware versioning behavior

## Test plan

- [x] 4 new catalog store tests for cross-demotion scenarios (model-method demotes all, workflow step demotes model-method, workflow step preserves other steps, model-method after workflow steps demotes all)
- [x] 5 new `computeLatestFlags` tests for backfill consistency
- [x] Existing model resolver `findBySpec` multi-step tests pass (22/22)
- [x] Full test suite: all passing
- [x] Reproduced bug in scratch repo at `/tmp/swamp-repro-issue-1802`
- [x] Build verification: 9/9 steps passed (lint, fmt, type-check, tests, deps audit, compile, binary check)
- [x] Code review: passed
- [x] Adversarial review: "The code is solid. No findings." (verdict: missing due to harness format issue)

Fixes swamp-club#1802

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FR6yvoejiAomU6HVfSCE6e