### PR TITLE
fix(release): build dashboard before compile so assets are included in binary (swamp-club#1818)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,12 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Version: $VERSION"
 
+      - name: Build dashboard
+        working-directory: packages/dashboard
+        run: |
+          npm ci
+          npm run build
+
       - name: Build binaries
         run: |
           mkdir -p dist

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -3798,7 +3798,7 @@ export const serveCommand = new Command()
             const indexResponse = await serveDashboardFile("index.html");
             if (indexResponse) return indexResponse;
             return new Response(
-              "Dashboard not built. Run: cd packages/dashboard && npm run build",
+              "Dashboard assets not available in this build",
               { status: 404, headers: { "content-type": "text/plain" } },
             );
           }


### PR DESCRIPTION
## Summary

- Add dashboard build step (`npm ci && npm run build`) to the release workflow before `deno compile`, mirroring the existing CI pattern — dashboard assets were never included in release binaries because the dist directory didn't exist at compile time
- Replace the misleading 404 message ("Run: cd packages/dashboard && npm run build") with a generic fallback — binary users don't have that directory

Fixes swamp-club#1818

## Test Plan

- [x] Verification workflow passed (build: 9/9, reviews: 10/11 with 1 skipped by guard)
- [x] Code review: pass
- [x] CI security review: pass (validates the release.yml change)
- [x] UX review: pass
- [x] Binary compiles and boots successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)