### PR TITLE
feat(serve): add jira webhook signature verification scheme

### DIFF
--- a/.claude/skills/swamp/references/workflow/reference.md
+++ b/.claude/skills/swamp/references/workflow/reference.md
@@ -161,10 +161,10 @@ override inputs are merged on top of built-in inputs.
 The signature scheme is set per endpoint on `swamp serve`'s `--webhook` flag:
 `<route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]`, where `scheme`
 is `github` (default), `jira`, `linear`, `stripe`, `slack`, or `generic`
-(requires header; optional prefix). Omitting the scheme preserves the original behavior.
-The secret field supports indirection to avoid exposing secrets in argv:
-`@env=VAR_NAME` reads from an environment variable, `@file=/path` reads from a
-file (trailing newline trimmed). Plain strings are literal secrets.
+(requires header; optional prefix). Omitting the scheme preserves the original
+behavior. The secret field supports indirection to avoid exposing secrets in
+argv: `@env=VAR_NAME` reads from an environment variable, `@file=/path` reads
+from a file (trailing newline trimmed). Plain strings are literal secrets.
 
 ## Edit a Workflow
 

--- a/.claude/skills/swamp/references/workflow/reference.md
+++ b/.claude/skills/swamp/references/workflow/reference.md
@@ -160,8 +160,8 @@ override inputs are merged on top of built-in inputs.
 
 The signature scheme is set per endpoint on `swamp serve`'s `--webhook` flag:
 `<route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]`, where `scheme`
-is `github` (default), `linear`, `stripe`, `slack`, or `generic` (requires
-header; optional prefix). Omitting the scheme preserves the original behavior.
+is `github` (default), `jira`, `linear`, `stripe`, `slack`, or `generic`
+(requires header; optional prefix). Omitting the scheme preserves the original behavior.
 The secret field supports indirection to avoid exposing secrets in argv:
 `@env=VAR_NAME` reads from an environment variable, `@file=/path` reads from a
 file (trailing newline trimmed). Plain strings are literal secrets.

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -620,8 +620,9 @@ The `webhook` namespace exposes:
 
 The signature scheme is selected per endpoint on the `--webhook` flag:
 `<route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]`. `scheme` is one
-of `github` (the default, `X-Hub-Signature-256`), `linear`, `stripe`, `slack`,
-or `generic` (which requires a header name and accepts an optional value prefix). When no
+of `github` (the default, `X-Hub-Signature-256`), `jira` (`X-Hub-Signature`),
+`linear`, `stripe`, `slack`, or `generic` (which requires a header name and
+accepts an optional value prefix). When no
 scheme is given the flag behaves exactly as before, so the secret may still
 contain colons; a scheme is recognized only when the fourth field is a known
 scheme keyword.

--- a/integration/webhook_signature_schemes_test.ts
+++ b/integration/webhook_signature_schemes_test.ts
@@ -130,6 +130,49 @@ function post(route: string, headers: HeadersInit, body: string): Request {
 }
 
 Deno.test({
+  name: "webhook scheme: a valid jira signature is accepted",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withService(
+      "/hooks/jira:jira-wf:shhh:jira",
+      "jira-wf",
+      async (service) => {
+        const body = '{"webhookEvent":"jira:issue_updated"}';
+        const sig = await hmacSha256Hex(new TextEncoder().encode(body), SECRET);
+        const res = await service.handleRequest(
+          post("/hooks/jira", { "x-hub-signature": `sha256=${sig}` }, body),
+        );
+        assertEquals(res?.status, 200);
+        assertEquals((await res!.json()).status, "queued");
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "webhook scheme: a forged jira signature is rejected with 401",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withService(
+      "/hooks/jira:jira-wf:shhh:jira",
+      "jira-wf",
+      async (service) => {
+        const res = await service.handleRequest(
+          post(
+            "/hooks/jira",
+            { "x-hub-signature": `sha256=${"00".repeat(32)}` },
+            '{"webhookEvent":"jira:issue_updated"}',
+          ),
+        );
+        assertEquals(res?.status, 401);
+      },
+    );
+  },
+});
+
+Deno.test({
   name: "webhook scheme: a valid linear signature is accepted",
   sanitizeOps: false,
   sanitizeResources: false,

--- a/src/serve/webhook_verifiers.ts
+++ b/src/serve/webhook_verifiers.ts
@@ -37,6 +37,7 @@ const TIMESTAMP_TOLERANCE_SECONDS = 300;
 /** The closed set of supported verification schemes. */
 export type WebhookScheme =
   | "github"
+  | "jira"
   | "linear"
   | "stripe"
   | "slack"
@@ -45,6 +46,7 @@ export type WebhookScheme =
 /** Schemes selectable on the --webhook flag, in stable order. */
 export const WEBHOOK_SCHEMES: readonly WebhookScheme[] = [
   "github",
+  "jira",
   "linear",
   "stripe",
   "slack",
@@ -57,7 +59,7 @@ export const WEBHOOK_SCHEMES: readonly WebhookScheme[] = [
  * strip); the named schemes are fully determined by their scheme tag.
  */
 export type VerifierConfig =
-  | { readonly scheme: "github" | "linear" | "stripe" | "slack" }
+  | { readonly scheme: "github" | "jira" | "linear" | "stripe" | "slack" }
   | {
     readonly scheme: "generic";
     readonly header: string;
@@ -251,6 +253,8 @@ export function createVerifier(config: VerifierConfig): WebhookVerifier {
   switch (config.scheme) {
     case "github":
       return prefixedBodyVerifier("x-hub-signature-256", "sha256=");
+    case "jira":
+      return prefixedBodyVerifier("x-hub-signature", "sha256=");
     case "linear":
       return prefixedBodyVerifier("linear-signature", "");
     case "stripe":

--- a/src/serve/webhook_verifiers.ts
+++ b/src/serve/webhook_verifiers.ts
@@ -23,8 +23,8 @@
  * Every supported provider authenticates with the same primitive — an
  * HMAC-SHA256 digest of a provider-specific message — and differs only in the
  * header it uses, how the digest is encoded in that header, and what bytes are
- * signed. This module hosts a closed, hardcoded set of schemes (github, linear,
- * stripe, slack, generic) over shared HMAC and constant-time-comparison
+ * signed. This module hosts a closed, hardcoded set of schemes (github, jira,
+ * linear, stripe, slack, generic) over shared HMAC and constant-time-comparison
  * primitives. Each verifier is a stateless function of (body, headers, secret).
  *
  * Generalizing this into a data-driven/templated engine so new providers need

--- a/src/serve/webhook_verifiers_test.ts
+++ b/src/serve/webhook_verifiers_test.ts
@@ -91,6 +91,45 @@ Deno.test("github verifier: requiredHeaders contains only the signature header",
   assertEquals(verifier.requiredHeaders, ["x-hub-signature-256"]);
 });
 
+// ── jira ───────────────────────────────────────────────────────────────
+
+Deno.test("jira verifier: accepts a valid signature", async () => {
+  const verifier = createVerifier({ scheme: "jira" });
+  const body = '{"webhookEvent":"jira:issue_updated"}';
+  const headers = new Headers({
+    "x-hub-signature": `sha256=${await sign(body)}`,
+  });
+  assertEquals(await verifier.verify(enc(body), headers, SECRET), true);
+});
+
+Deno.test("jira verifier: rejects a wrong secret", async () => {
+  const verifier = createVerifier({ scheme: "jira" });
+  const body = "payload";
+  const headers = new Headers({
+    "x-hub-signature": `sha256=${await sign(body, "other")}`,
+  });
+  assertEquals(await verifier.verify(enc(body), headers, SECRET), false);
+});
+
+Deno.test("jira verifier: rejects a missing header", async () => {
+  const verifier = createVerifier({ scheme: "jira" });
+  assertEquals(await verifier.verify(enc("x"), new Headers(), SECRET), false);
+});
+
+Deno.test("jira verifier: rejects a missing sha256= prefix", async () => {
+  const verifier = createVerifier({ scheme: "jira" });
+  const headers = new Headers({
+    "x-hub-signature": await sign("body"),
+  });
+  assertEquals(await verifier.verify(enc("body"), headers, SECRET), false);
+});
+
+Deno.test("jira verifier: uses x-hub-signature header (not x-hub-signature-256)", () => {
+  const verifier = createVerifier({ scheme: "jira" });
+  assertEquals(verifier.signatureHeader, "x-hub-signature");
+  assertEquals(verifier.requiredHeaders, ["x-hub-signature"]);
+});
+
 // ── linear ──────────────────────────────────────────────────────────────
 
 Deno.test("linear verifier: accepts a valid bare-hex signature", async () => {
@@ -253,6 +292,7 @@ Deno.test("slack verifier: requiredHeaders includes both signature and timestamp
 
 Deno.test("isWebhookScheme: recognizes known schemes", () => {
   assertEquals(isWebhookScheme("github"), true);
+  assertEquals(isWebhookScheme("jira"), true);
   assertEquals(isWebhookScheme("generic"), true);
 });
 


### PR DESCRIPTION
## Summary

Adds a first-class `jira` webhook verification scheme to the pluggable signature verification system, alongside the existing `github`, `linear`, `stripe`, `slack`, and `generic` schemes.

Jira webhooks use the `X-Hub-Signature` header with `sha256=` prefix for HMAC-SHA256 payload verification — identical mechanics to GitHub's `X-Hub-Signature-256` but with a different header name. The implementation reuses the existing `prefixedBodyVerifier()` function.

- Added `"jira"` to `WebhookScheme` union, `WEBHOOK_SCHEMES` array, and `VerifierConfig`
- Added `case "jira"` to `createVerifier()` switch
- Added 5 unit tests and 2 integration tests
- Updated design docs and skill references

Closes swamp-club#1777

Co-authored-by: Simon Helson <shelson@users.noreply.github.com>

## Test Plan

- [x] Unit tests: valid signature, wrong secret, missing header, missing prefix, header name assertion
- [x] Integration tests: valid jira signature accepted (200), forged signature rejected (401)
- [x] `isWebhookScheme("jira")` returns true
- [x] Full verification workflow passed (lint, fmt, type-check, tests, compile, code review, adversarial review)