### PR TITLE
feat(ci): add non-blocking attestation validator

### DIFF
--- a/.claude/skills/issue-lifecycle/references/verification.md
+++ b/.claude/skills/issue-lifecycle/references/verification.md
@@ -73,8 +73,7 @@ failed" below.
 
 1. Construct the combined attestation JSON including the `configIntegrity`
    checksums (see `agent-constraints/verification-conventions.md` for the full
-   schema). The attestation is posted to swamp-club as part of the
-   `verification_passed` call so the team has a permanent, shared record.
+   schema).
 
 2. Call `verification_passed` with the attestation data:
 
@@ -90,16 +89,29 @@ failed" below.
    with its actual status (succeeded, failed, or skipped).
 
 3. **Present the full verification checklist to the user and wait for their
-   approval before opening the PR.** The checklist must show every step from
-   both the build and review workflows — status, model, duration, and for
-   reviews the VERDICT and finding count. Include the workflow run file paths so
-   the user can inspect the raw data. See
-   `agent-constraints/verification-conventions.md` for the checklist format.
+   confirmation to proceed.** The checklist must show every step from both the
+   build and review workflows — status, model, duration, and for reviews the
+   VERDICT and finding count. Include the workflow run file paths so the user
+   can inspect the raw data. See `agent-constraints/verification-conventions.md`
+   for the checklist format.
 
-   Do NOT proceed to open a PR until the user has seen the checklist and
-   confirmed they are happy with the results.
+   **Stop here and wait.** Do NOT post the attestation or open a PR until the
+   user has seen the checklist and explicitly said they are ready to open the
+   PR.
 
-4. Then proceed to open a PR — read the "Create a PR" section in
+4. **After the user confirms**, post the attestation to swamp-club. This is a
+   **hard block** — the PR MUST NOT open until the attestation has been
+   successfully posted. See `agent-constraints/verification-conventions.md` step
+   7 for the exact command and failure handling.
+
+   The user's confirmation is what triggers the attestation push. Do not post it
+   automatically after verification passes — the user decides when to ship.
+
+   If the POST fails, report the error to the user and fix the issue (auth,
+   connectivity) before retrying. Without a stored attestation, the CI
+   `validate-attestation` check will report "no attestation found."
+
+5. Then proceed to open a PR — read the "Create a PR" section in
    [implementation.md](implementation.md).
 
 ### Any step failed
@@ -121,10 +133,21 @@ This transitions back to `implementing`. Fix the failing code:
 
 After fixing, return to step 1 and re-verify. Repeat until all steps pass.
 
-## 5. Do NOT Open a PR Without Verification
+## 5. Do NOT Open a PR Without Verification and Attestation
 
 The `link_pr` method requires a passing verification result. If you skip
 verification and try to link a PR directly, it will be missing the
 `verificationResult` data that the lifecycle checks for.
 
-The loop is: implement → conformance review → verify → fix → re-verify → PR.
+**Two hard gates before a PR opens:**
+
+1. **Verification passes** — `gate.allPassed` is true
+2. **Attestation posted** — the attestation JSON has been successfully stored in
+   swamp-club via `POST /api/v1/admin/attestations`
+
+If either gate fails, do NOT open a PR. The CI `validate-attestation` job reads
+the attestation from swamp-club and validates commit match, config integrity,
+and freshness. A missing attestation will be flagged.
+
+The loop is: implement → conformance review → verify → fix → re-verify → present
+checklist → user confirms → post attestation → PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -746,32 +746,32 @@ jobs:
 
           if [ "$http_code" != "200" ] || [ ! -s attestation.json ]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
-            {
-              echo "## Attestation Validation"
-              echo ""
-              echo "⚠️ No verification attestation found for \`${head_sha:0:8}\`."
-              echo ""
-              echo "Run local verification before opening the PR:"
-              echo '```bash'
-              echo 'SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-build \'
-              echo '  --input commit=$(git rev-parse HEAD) \'
-              echo '  --input branch=$(git branch --show-current)'
-              echo ''
-              echo 'SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-reviews \'
-              echo '  --input commit=$(git rev-parse HEAD) \'
-              echo '  --input branch=$(git branch --show-current)'
-              echo '```'
-            } >> "$GITHUB_STEP_SUMMARY"
+            cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## Attestation Validation
+
+          ⚠️ No verification attestation found for \`${head_sha:0:8}\`.
+
+          Run local verification before opening the PR:
+          \`\`\`bash
+          SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-build \\
+            --input commit=\$(git rev-parse HEAD) \\
+            --input branch=\$(git branch --show-current)
+
+          SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-reviews \\
+            --input commit=\$(git rev-parse HEAD) \\
+            --input branch=\$(git branch --show-current)
+          \`\`\`
+          EOF
             exit 0
           fi
 
           if ! jq . attestation.json > /dev/null 2>&1; then
             echo "found=false" >> "$GITHUB_OUTPUT"
-            {
-              echo "## Attestation Validation"
-              echo ""
-              echo "❌ Attestation response is not valid JSON."
-            } >> "$GITHUB_STEP_SUMMARY"
+            cat >> "$GITHUB_STEP_SUMMARY" << 'EOF'
+          ## Attestation Validation
+
+          ❌ Attestation response is not valid JSON.
+          EOF
             exit 1
           fi
 
@@ -846,9 +846,11 @@ jobs:
           fi
 
           # -- 5. Config integrity checksums --
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "### Config Integrity" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo ""
+            echo "### Config Integrity"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
 
           check_hash() {
             local label="$1" jq_path="$2" file="$3"
@@ -882,31 +884,37 @@ jobs:
           check_hash "verify-reviews workflow" '.configIntegrity.workflows."verify-reviews"' "verification/workflow-verify-reviews.yaml"
 
           # -- 6. Steps summary table --
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "### Steps" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Job | Step | Status | Duration | Verdict |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-----|------|--------|----------|---------|" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo ""
+            echo "### Steps"
+            echo ""
+            echo "| Job | Step | Status | Duration | Verdict |"
+            echo "|-----|------|--------|----------|---------|"
+          } >> "$GITHUB_STEP_SUMMARY"
           jq -r '.steps // [] | .[] | "| \(.job) | \(.step) | \(.status) | \(if .durationMs then "\(.durationMs / 1000)s" else "—" end) | \(.verdict // .reason // "—") |"' attestation.json >> "$GITHUB_STEP_SUMMARY" || true
 
           # -- 7. Review config --
           if jq -e '.reviewConfig' attestation.json > /dev/null 2>&1; then
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "### Reviews" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "| Review | Model | Ran |" >> "$GITHUB_STEP_SUMMARY"
-            echo "|--------|-------|-----|" >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo ""
+              echo "### Reviews"
+              echo ""
+              echo "| Review | Model | Ran |"
+              echo "|--------|-------|-----|"
+            } >> "$GITHUB_STEP_SUMMARY"
             jq -r '.reviewConfig | to_entries[] | "| \(.key) | \(.value.model) | \(if .value.ran then "✅" else "⏭️ \(.value.reason // "skipped")" end) |"' attestation.json >> "$GITHUB_STEP_SUMMARY" || true
           fi
 
           # -- Result --
-          echo "" >> "$GITHUB_STEP_SUMMARY"
           total_duration=$(jq -r '.timing.totalDurationMs // 0' attestation.json)
           total_secs=$((total_duration / 1000))
           total_mins=$((total_secs / 60))
           remaining_secs=$((total_secs % 60))
-          echo "**Verification ran in ${total_mins}m ${remaining_secs}s**" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo ""
+            echo "**Verification ran in ${total_mins}m ${remaining_secs}s**"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$errors" -gt 0 ]; then
             echo "### ❌ Validation Failed ($errors errors, $warnings warnings)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -722,6 +722,201 @@ jobs:
             exit 1
           fi
 
+  validate-attestation:
+    name: Validate Attestation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Informational only — not a merge gate. Validates that local verification
+    # ran on this commit and that config integrity checksums match.
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Fetch attestation from swamp-club
+        id: find
+        run: |
+          head_sha="${{ github.event.pull_request.head.sha }}"
+
+          http_code=$(curl -s -w '%{http_code}' -o attestation.json \
+            "https://swamp.club/api/v1/admin/attestations?commit=${head_sha}" \
+            2>/dev/null) || true
+
+          if [ "$http_code" != "200" ] || [ ! -s attestation.json ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Attestation Validation"
+              echo ""
+              echo "⚠️ No verification attestation found for \`${head_sha:0:8}\`."
+              echo ""
+              echo "Run local verification before opening the PR:"
+              echo '```bash'
+              echo 'SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-build \'
+              echo '  --input commit=$(git rev-parse HEAD) \'
+              echo '  --input branch=$(git branch --show-current)'
+              echo ''
+              echo 'SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-reviews \'
+              echo '  --input commit=$(git rev-parse HEAD) \'
+              echo '  --input branch=$(git branch --show-current)'
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if ! jq . attestation.json > /dev/null 2>&1; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Attestation Validation"
+              echo ""
+              echo "❌ Attestation response is not valid JSON."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "found=true" >> "$GITHUB_OUTPUT"
+
+      - name: Validate attestation
+        if: steps.find.outputs.found == 'true'
+        run: |
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          errors=0
+          warnings=0
+
+          {
+            echo "## Attestation Validation"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # -- 1. Schema version --
+          version=$(jq -r '.version // empty' attestation.json)
+          if [ "$version" != "1" ]; then
+            echo "::error::Unknown attestation version: $version"
+            echo "❌ Unknown attestation version: \`$version\`" >> "$GITHUB_STEP_SUMMARY"
+            errors=$((errors + 1))
+          fi
+
+          # -- 2. Commit match --
+          att_commit=$(jq -r '.subject.commit // empty' attestation.json)
+          if [ "$att_commit" != "$head_sha" ]; then
+            echo "::error::Commit mismatch: attestation=${att_commit:0:8} PR=${head_sha:0:8}"
+            echo "❌ Commit mismatch: attestation \`${att_commit:0:8}\` ≠ PR \`${head_sha:0:8}\`" >> "$GITHUB_STEP_SUMMARY"
+            errors=$((errors + 1))
+          else
+            echo "✅ Commit: \`${head_sha:0:8}\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # -- 3. Gate --
+          all_passed=$(jq -r '.gate.allPassed // false' attestation.json)
+          steps_completed=$(jq -r '.gate.stepsCompleted // 0' attestation.json)
+          steps_total=$(jq -r '.gate.stepsTotal // 0' attestation.json)
+          steps_skipped=$(jq -r '.gate.stepsSkipped // 0' attestation.json)
+          if [ "$all_passed" != "true" ]; then
+            echo "::error::Gate failed: allPassed=$all_passed ($steps_completed/$steps_total)"
+            echo "❌ Gate: **failed** ($steps_completed/$steps_total completed, $steps_skipped skipped)" >> "$GITHUB_STEP_SUMMARY"
+            errors=$((errors + 1))
+          else
+            echo "✅ Gate: $steps_completed/$steps_total passed, $steps_skipped skipped" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # -- 4. Freshness (24h window) --
+          completed_at=$(jq -r '.timing.completedAt // empty' attestation.json)
+          if [ -n "$completed_at" ]; then
+            att_epoch=$(date -d "$completed_at" +%s 2>/dev/null || echo "0")
+            now_epoch=$(date +%s)
+            if [ "$att_epoch" -gt 0 ]; then
+              age_secs=$((now_epoch - att_epoch))
+              age_hours=$((age_secs / 3600))
+              age_mins=$(( (age_secs % 3600) / 60 ))
+              if [ "$age_secs" -gt 86400 ]; then
+                echo "::warning::Attestation is ${age_hours}h ${age_mins}m old (max 24h)"
+                echo "⚠️ Freshness: ${age_hours}h ${age_mins}m old (exceeds 24h)" >> "$GITHUB_STEP_SUMMARY"
+                warnings=$((warnings + 1))
+              else
+                echo "✅ Freshness: ${age_hours}h ${age_mins}m old" >> "$GITHUB_STEP_SUMMARY"
+              fi
+            else
+              echo "⚠️ Freshness: could not parse timestamp" >> "$GITHUB_STEP_SUMMARY"
+              warnings=$((warnings + 1))
+            fi
+          else
+            echo "⚠️ Freshness: no timestamp in attestation" >> "$GITHUB_STEP_SUMMARY"
+            warnings=$((warnings + 1))
+          fi
+
+          # -- 5. Config integrity checksums --
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Config Integrity" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          check_hash() {
+            local label="$1" jq_path="$2" file="$3"
+            local att_hash actual_hash
+            att_hash=$(jq -r "$jq_path // empty" attestation.json)
+            if [ -z "$att_hash" ]; then
+              echo "⚠️ \`$label\`: not in attestation" >> "$GITHUB_STEP_SUMMARY"
+              warnings=$((warnings + 1))
+              return
+            fi
+            if [ ! -f "$file" ]; then
+              echo "⚠️ \`$label\`: file not found at commit" >> "$GITHUB_STEP_SUMMARY"
+              warnings=$((warnings + 1))
+              return
+            fi
+            actual_hash=$(sha256sum "$file" | awk '{print $1}')
+            if [ "$att_hash" = "$actual_hash" ]; then
+              echo "✅ \`$label\`" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "❌ \`$label\`: checksum mismatch" >> "$GITHUB_STEP_SUMMARY"
+              errors=$((errors + 1))
+            fi
+          }
+
+          check_hash "CLAUDE.md" '.configIntegrity.claudeMd' "CLAUDE.md"
+          check_hash "code-review prompt" '.configIntegrity.prompts."code-review"' "verification/review-prompts/code-review.md"
+          check_hash "adversarial-review prompt" '.configIntegrity.prompts."adversarial-review"' "verification/review-prompts/adversarial-review.md"
+          check_hash "ux-review prompt" '.configIntegrity.prompts."ux-review"' "verification/review-prompts/ux-review.md"
+          check_hash "ci-security-review prompt" '.configIntegrity.prompts."ci-security-review"' "verification/review-prompts/ci-security-review.md"
+          check_hash "verify-build workflow" '.configIntegrity.workflows."verify-build"' "verification/workflow-verify-build.yaml"
+          check_hash "verify-reviews workflow" '.configIntegrity.workflows."verify-reviews"' "verification/workflow-verify-reviews.yaml"
+
+          # -- 6. Steps summary table --
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Steps" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Job | Step | Status | Duration | Verdict |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-----|------|--------|----------|---------|" >> "$GITHUB_STEP_SUMMARY"
+          jq -r '.steps // [] | .[] | "| \(.job) | \(.step) | \(.status) | \(if .durationMs then "\(.durationMs / 1000)s" else "—" end) | \(.verdict // .reason // "—") |"' attestation.json >> "$GITHUB_STEP_SUMMARY" || true
+
+          # -- 7. Review config --
+          if jq -e '.reviewConfig' attestation.json > /dev/null 2>&1; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "### Reviews" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Review | Model | Ran |" >> "$GITHUB_STEP_SUMMARY"
+            echo "|--------|-------|-----|" >> "$GITHUB_STEP_SUMMARY"
+            jq -r '.reviewConfig | to_entries[] | "| \(.key) | \(.value.model) | \(if .value.ran then "✅" else "⏭️ \(.value.reason // "skipped")" end) |"' attestation.json >> "$GITHUB_STEP_SUMMARY" || true
+          fi
+
+          # -- Result --
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          total_duration=$(jq -r '.timing.totalDurationMs // 0' attestation.json)
+          total_secs=$((total_duration / 1000))
+          total_mins=$((total_secs / 60))
+          remaining_secs=$((total_secs % 60))
+          echo "**Verification ran in ${total_mins}m ${remaining_secs}s**" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$errors" -gt 0 ]; then
+            echo "### ❌ Validation Failed ($errors errors, $warnings warnings)" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          elif [ "$warnings" -gt 0 ]; then
+            echo "### ⚠️ Passed with Warnings ($warnings warnings)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### ✅ Validation Passed" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   auto-merge:
     name: Auto-merge PR
     needs:

--- a/agent-constraints/verification-conventions.md
+++ b/agent-constraints/verification-conventions.md
@@ -258,9 +258,43 @@ To construct this checklist:
    If any step failed, call `verification_failed` instead. Do not treat a
    partial pass as success.
 
-   - **All pass** → post the attestation JSON to swamp-club as part of the
-     `verification_passed` call so the team has a permanent, shared record
+   - **All pass** → present checklist to user, wait for confirmation
    - **Any fail** → call `verification_failed`, fix the issues, re-verify
+
+7. **Wait for the user to confirm they are ready to open the PR.** Present
+   the full verification checklist and stop. Do NOT post the attestation or
+   open a PR until the user explicitly says to proceed. The user's
+   confirmation is the trigger for the attestation push.
+
+8. **After the user confirms, post the attestation to swamp-club.** This is
+   a **hard requirement** — the PR MUST NOT open until the attestation has
+   been successfully posted.
+
+   ```bash
+   curl -sf -X POST \
+     -H "Content-Type: application/json" \
+     -H "Cookie: $(cat ~/.config/swamp/session-cookie)" \
+     -d @attestation.json \
+     "https://swamp.club/api/v1/admin/attestations"
+   ```
+
+   The endpoint requires swamp admin authentication. The attestation JSON is
+   the same object constructed in step 4.
+
+   **If the POST fails, do NOT open a PR.** Report the failure to the user
+   and fix the auth or connectivity issue before retrying. The attestation
+   record in swamp-club is what CI validates — without it, the
+   `validate-attestation` CI check will report "no attestation found."
+
+   **If the POST succeeds**, the response includes the server-stamped
+   `postedBy` and `postedAt` fields. Log these so the user can confirm
+   attribution.
+
+   Verify the attestation was stored correctly:
+
+   ```bash
+   curl -sf "https://swamp.club/api/v1/admin/attestations?commit=<SHA>" | jq .
+   ```
 
 ## Handling Failures
 
@@ -330,8 +364,10 @@ Repeat steps 1–4 until all build steps pass and all reviews return
 `VERDICT: pass`. Present the full verification checklist to the user after
 each run.
 
-Do NOT open a PR until the user has seen a fully green checklist and
-confirmed they want to proceed.
+Do NOT open a PR until the user has seen a fully green checklist,
+confirmed they want to proceed, and the attestation has been posted to
+swamp-club (step 8). The user's confirmation triggers the attestation
+push — do not post it automatically.
 
 ## Review Prompts
 


### PR DESCRIPTION
## Summary

- Adds a `validate-attestation` CI job that fetches verification attestations from the swamp-club API (`GET /api/v1/admin/attestations?commit=<sha>`) and validates commit match, gate status, freshness (24h window), and config integrity checksums against the files at the PR head
- The job runs in parallel with all existing checks and is **not** in auto-merge's dependency list — informational only until we iterate
- Updates verification conventions to require posting the attestation to swamp-club **after** the user confirms the checklist (user confirmation triggers the push, not automatic)
- Updates issue lifecycle to enforce two hard gates before a PR opens: verification passes + attestation stored

## Test plan

- [x] Tested validation script against a valid attestation — all checks pass, summary renders correctly
- [x] Tested against a bad attestation (wrong commit, failed gate, tampered CLAUDE.md checksum) — all three failures caught
- [x] Verified all jq expressions produce correct output against the attestation schema
- [x] Confirmed `check_hash` function correctly modifies outer error/warning counters
- [x] Verified curl handles 404 (no attestation) and connection failures gracefully
- [x] YAML validates cleanly
- [x] Zero lines removed from existing CI jobs — pure addition
- [ ] Validate-attestation job will report "no attestation found" on this PR (expected — no attestation has been posted for this commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEUofYG1ehMUVSfmEsjmMt