### PR TITLE
feat(auth): replace localhost callback with OAuth device flow for remote login (#1560)

### DIFF
--- a/src/libswamp/auth/login.ts
+++ b/src/libswamp/auth/login.ts
@@ -23,16 +23,17 @@ import {
   SwampClubClient,
 } from "../../infrastructure/http/swamp_club_client.ts";
 import type { ClientIdentity } from "../../infrastructure/http/client_identity.ts";
-import { startCallbackServer } from "../../infrastructure/http/callback_server.ts";
 import { openBrowser } from "../../infrastructure/process/browser.ts";
 import { UserError } from "../../domain/errors.ts";
 import { readSecretFromTty } from "../../infrastructure/io/stdin_reader.ts";
-import { generateDeviceCode } from "../../domain/auth/device_code.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { validationFailed } from "../errors.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export const CLI_CLIENT_ID = "swamp-cli";
+
 /** Data returned on successful authentication. */
 export interface AuthLoginData {
   username: string;
@@ -46,8 +47,13 @@ export interface AuthLoginData {
 export type AuthLoginEvent =
   | { kind: "opening_browser" }
   | { kind: "browser_open_failed"; message: string }
-  | { kind: "device_verification"; deviceCode: string }
-  | { kind: "waiting_for_auth" }
+  | {
+    kind: "device_verification";
+    userCode: string;
+    verificationUri: string;
+    verificationUriComplete?: string;
+  }
+  | { kind: "polling" }
   | { kind: "securing_session" }
   | { kind: "completed"; data: AuthLoginData }
   | { kind: "error"; error: SwampError };
@@ -60,22 +66,48 @@ export interface AuthLoginInput {
   password?: string;
 }
 
-/** Handle returned by the callback server dependency. */
-export interface CallbackServerHandle {
-  port: number;
-  token: Promise<string>;
-  shutdown: () => Promise<void>;
+/** Device authorization response from swamp-club. */
+export interface DeviceAuthResponse {
+  readonly deviceCode: string;
+  readonly userCode: string;
+  readonly verificationUri: string;
+  readonly verificationUriComplete?: string;
+  readonly expiresIn: number;
+  readonly interval: number;
+}
+
+/** Token response from a device code poll. */
+export interface DeviceTokenResponse {
+  readonly accessToken: string;
+}
+
+/** Error thrown when the device token poll receives a pending response. */
+export class DeviceAuthPendingError extends Error {
+  readonly slowDown: boolean;
+  constructor(slowDown = false) {
+    super(slowDown ? "slow_down" : "authorization_pending");
+    this.name = "DeviceAuthPendingError";
+    this.slowDown = slowDown;
+  }
 }
 
 /** Dependencies for the auth login operation, injected for testability. */
 export interface AuthLoginDeps {
-  /** Try to open a URL in the browser. Returns error message if it fails, null on success. */
-  openBrowser: (url: string) => Promise<string | null>;
-  /** Start callback server, returns port, token promise, and shutdown function. */
-  startCallbackServer: (
-    state: string,
+  /** Try to open a URL in the browser. Returns true on success, false on failure. */
+  openBrowser: (url: string) => Promise<boolean>;
+  /** Start device authorization, returns device code and verification URI. */
+  startDeviceAuth: (
     serverUrl: string,
-  ) => CallbackServerHandle;
+    clientId: string,
+    signal: AbortSignal,
+  ) => Promise<DeviceAuthResponse>;
+  /** Poll for device token approval. Throws DeviceAuthPendingError while pending. */
+  pollDeviceToken: (
+    serverUrl: string,
+    deviceCode: string,
+    clientId: string,
+    signal: AbortSignal,
+  ) => Promise<DeviceTokenResponse>;
   /** Sign in with username/password, returns session token and username. */
   signIn: (
     serverUrl: string,
@@ -111,8 +143,6 @@ export interface AuthLoginDeps {
     username: string;
     collectives?: string[];
   }) => Promise<void>;
-  /** Generate a device verification code. */
-  generateDeviceCode: () => string;
   /** Get hostname for API key naming. */
   getHostname: () => string;
 }
@@ -147,6 +177,25 @@ async function readPassword(prompt: string): Promise<string> {
   }
 }
 
+/** Delay helper that respects AbortSignal. */
+function delay(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 /**
  * Wires real infrastructure into AuthLoginDeps.
  *
@@ -160,20 +209,99 @@ export function createAuthLoginDeps(
 ): AuthLoginDeps {
   const repo = new AuthRepository();
   return {
-    openBrowser: async (url: string): Promise<string | null> => {
+    openBrowser: async (url: string): Promise<boolean> => {
       try {
         await openBrowser(url);
-        return null;
-      } catch (err) {
-        if (err instanceof UserError) {
-          return err.message;
-        }
-        const message = err instanceof Error ? err.message : String(err);
-        return `Failed to open browser: ${message}`;
+        return true;
+      } catch {
+        return false;
       }
     },
-    startCallbackServer: (state: string, serverUrl: string) =>
-      startCallbackServer(state, serverUrl),
+    startDeviceAuth: async (
+      serverUrl: string,
+      clientId: string,
+      signal: AbortSignal,
+    ): Promise<DeviceAuthResponse> => {
+      const resp = await fetch(`${serverUrl}/api/auth/device/code`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ client_id: clientId }),
+        signal,
+      });
+      const body = await resp.text();
+      if (!resp.ok) {
+        throw new UserError(
+          `Failed to start device authorization: ${resp.status} ${body}`,
+        );
+      }
+      let data: Record<string, unknown>;
+      try {
+        data = JSON.parse(body);
+      } catch {
+        throw new UserError(
+          `Failed to start device authorization: server returned invalid JSON`,
+        );
+      }
+      return {
+        deviceCode: data.device_code as string,
+        userCode: data.user_code as string,
+        verificationUri: data.verification_uri as string,
+        verificationUriComplete: data.verification_uri_complete as
+          | string
+          | undefined,
+        expiresIn: data.expires_in as number,
+        interval: data.interval as number,
+      };
+    },
+    pollDeviceToken: async (
+      serverUrl: string,
+      deviceCode: string,
+      clientId: string,
+      signal: AbortSignal,
+    ): Promise<DeviceTokenResponse> => {
+      const resp = await fetch(`${serverUrl}/api/auth/device/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          device_code: deviceCode,
+          client_id: clientId,
+        }),
+        signal,
+      });
+      if (resp.status === 403 || resp.status === 410) {
+        const body = await resp.text();
+        throw new UserError(
+          `Device authorization failed: ${body || resp.statusText}`,
+        );
+      }
+      const body = await resp.text();
+      let data: Record<string, unknown>;
+      try {
+        data = JSON.parse(body);
+      } catch {
+        throw new UserError(
+          `Failed to poll device token: ${resp.status} ${body}`,
+        );
+      }
+      if (data.error === "authorization_pending") {
+        throw new DeviceAuthPendingError(false);
+      }
+      if (data.error === "slow_down") {
+        throw new DeviceAuthPendingError(true);
+      }
+      if (!resp.ok) {
+        throw new UserError(
+          `Failed to poll device token: ${resp.status} ${body}`,
+        );
+      }
+      if (typeof data.access_token !== "string" || !data.access_token) {
+        throw new UserError(
+          `Server returned 200 but no access_token in response`,
+        );
+      }
+      return { accessToken: data.access_token };
+    },
     signIn: async (serverUrl: string, username: string, password: string) => {
       const client = new SwampClubClient(serverUrl, identity);
       const result = await client.signIn(username, password);
@@ -205,12 +333,11 @@ export function createAuthLoginDeps(
       };
     },
     saveCredentials: (credentials) => repo.save(credentials),
-    generateDeviceCode,
     getHostname: () => Deno.hostname?.() ?? "unknown",
   };
 }
 
-/** Authenticates with a swamp-club server via browser or stdin flow. */
+/** Authenticates with a swamp-club server via device flow or stdin flow. */
 export async function* authLogin(
   ctx: LibSwampContext,
   deps: AuthLoginDeps,
@@ -226,32 +353,87 @@ export async function* authLogin(
       let knownUsername: string | undefined;
 
       if (input.useBrowserFlow) {
-        // Browser flow
-        const state = crypto.randomUUID();
-        const deviceCode = deps.generateDeviceCode();
-        const server = deps.startCallbackServer(state, input.serverUrl);
+        const deviceAuth = await deps.startDeviceAuth(
+          input.serverUrl,
+          CLI_CLIENT_ID,
+          AbortSignal.timeout(10_000),
+        );
 
-        const callbackUrl = `http://localhost:${server.port}/callback`;
-        const loginUrl = `${input.serverUrl}/login?cli_callback=${
-          encodeURIComponent(callbackUrl)
-        }&state=${encodeURIComponent(state)}&device_code=${
-          encodeURIComponent(deviceCode)
-        }`;
+        const expiryMs = deviceAuth.expiresIn * 1000;
+        const signal = AbortSignal.timeout(Math.max(expiryMs, 60_000));
 
+        yield {
+          kind: "device_verification",
+          userCode: deviceAuth.userCode,
+          verificationUri: deviceAuth.verificationUri,
+          verificationUriComplete: deviceAuth.verificationUriComplete,
+        };
+
+        const urlToOpen = deviceAuth.verificationUriComplete ??
+          deviceAuth.verificationUri;
         yield { kind: "opening_browser" };
-        const browserError = await deps.openBrowser(loginUrl);
-        if (browserError) {
-          yield { kind: "browser_open_failed", message: browserError };
+        const opened = await deps.openBrowser(urlToOpen);
+        if (!opened) {
+          yield {
+            kind: "browser_open_failed",
+            message:
+              `Could not open browser automatically. Please visit the URL above.`,
+          };
         }
 
-        yield { kind: "device_verification", deviceCode };
-        yield { kind: "waiting_for_auth" };
+        let intervalMs = (deviceAuth.interval > 0 ? deviceAuth.interval : 5) *
+          1000;
+        const deadline = Date.now() + expiryMs;
 
-        try {
-          sessionToken = await server.token;
-        } finally {
-          await server.shutdown();
+        let token: string | undefined;
+        while (Date.now() < deadline) {
+          yield { kind: "polling" };
+          try {
+            const result = await deps.pollDeviceToken(
+              input.serverUrl,
+              deviceAuth.deviceCode,
+              CLI_CLIENT_ID,
+              signal,
+            );
+            token = result.accessToken;
+            break;
+          } catch (err) {
+            if (err instanceof DeviceAuthPendingError) {
+              if (err.slowDown) {
+                intervalMs += 5000;
+              }
+              try {
+                await delay(intervalMs, signal);
+              } catch {
+                break;
+              }
+              continue;
+            }
+            yield {
+              kind: "error",
+              error: err instanceof UserError
+                ? { code: "user_error", message: err.message }
+                : {
+                  code: "unknown",
+                  message: err instanceof Error ? err.message : String(err),
+                },
+            };
+            return;
+          }
         }
+
+        if (!token) {
+          yield {
+            kind: "error",
+            error: {
+              code: "user_error",
+              message: "Device authorization timed out",
+            },
+          };
+          return;
+        }
+
+        sessionToken = token;
       } else {
         // Stdin flow
         let username = input.username;

--- a/src/libswamp/auth/login_test.ts
+++ b/src/libswamp/auth/login_test.ts
@@ -25,16 +25,24 @@ import {
   type AuthLoginDeps,
   type AuthLoginEvent,
   type AuthLoginInput,
+  DeviceAuthPendingError,
 } from "./login.ts";
 
 function makeDeps(overrides: Partial<AuthLoginDeps> = {}): AuthLoginDeps {
   return {
-    openBrowser: () => Promise.resolve(null),
-    startCallbackServer: (_state: string, _serverUrl: string) => ({
-      port: 9999,
-      token: Promise.resolve("session-token-abc"),
-      shutdown: () => Promise.resolve(),
-    }),
+    openBrowser: () => Promise.resolve(true),
+    startDeviceAuth: () =>
+      Promise.resolve({
+        deviceCode: "device-abc-123",
+        userCode: "ABCD-1234",
+        verificationUri: "https://swamp-club.com/device",
+        verificationUriComplete:
+          "https://swamp-club.com/device?user_code=ABCD-1234",
+        expiresIn: 900,
+        interval: 0.001,
+      }),
+    pollDeviceToken: () =>
+      Promise.resolve({ accessToken: "session-token-abc" }),
     signIn: (_serverUrl: string, _username: string, _password: string) =>
       Promise.resolve({ token: "session-token-abc", username: "testuser" }),
     readCredentials: (_prefilled) =>
@@ -52,7 +60,6 @@ function makeDeps(overrides: Partial<AuthLoginDeps> = {}): AuthLoginDeps {
         collectives: ["org1"],
       }),
     saveCredentials: () => Promise.resolve(),
-    generateDeviceCode: () => "ABCD-1234",
     getHostname: () => "testhost",
     ...overrides,
   };
@@ -66,7 +73,7 @@ function makeInput(overrides: Partial<AuthLoginInput> = {}): AuthLoginInput {
   };
 }
 
-Deno.test("authLogin: successful browser flow emits correct event sequence", async () => {
+Deno.test("authLogin: successful device flow emits correct event sequence", async () => {
   let savedCreds: Record<string, unknown> = {};
   const deps = makeDeps({
     saveCredentials: (creds) => {
@@ -82,18 +89,26 @@ Deno.test("authLogin: successful browser flow emits correct event sequence", asy
 
   const kinds = events.map((e) => e.kind);
   assertEquals(kinds, [
-    "opening_browser",
     "device_verification",
-    "waiting_for_auth",
+    "opening_browser",
+    "polling",
     "securing_session",
     "completed",
   ]);
 
-  const deviceEvent = events[1] as Extract<
+  const deviceEvent = events[0] as Extract<
     AuthLoginEvent,
     { kind: "device_verification" }
   >;
-  assertEquals(deviceEvent.deviceCode, "ABCD-1234");
+  assertEquals(deviceEvent.userCode, "ABCD-1234");
+  assertEquals(
+    deviceEvent.verificationUri,
+    "https://swamp-club.com/device",
+  );
+  assertEquals(
+    deviceEvent.verificationUriComplete,
+    "https://swamp-club.com/device?user_code=ABCD-1234",
+  );
 
   const completed = events[4] as Extract<
     AuthLoginEvent,
@@ -108,11 +123,71 @@ Deno.test("authLogin: successful browser flow emits correct event sequence", asy
   assertEquals(savedCreds.apiKey, "swamp_testapikey123456");
 });
 
-Deno.test("authLogin: browser open failure emits browser_open_failed event", async () => {
+Deno.test("authLogin: browser open failure emits browser_open_failed but completes", async () => {
   const deps = makeDeps({
-    openBrowser: () =>
-      Promise.resolve(
-        "Could not open a browser. Please open this URL manually:\n  https://example.com",
+    openBrowser: () => Promise.resolve(false),
+  });
+  const input = makeInput({ useBrowserFlow: true });
+
+  const events = await collect<AuthLoginEvent>(
+    authLogin(createLibSwampContext(), deps, input),
+  );
+
+  const kinds = events.map((e) => e.kind);
+  assertEquals(kinds, [
+    "device_verification",
+    "opening_browser",
+    "browser_open_failed",
+    "polling",
+    "securing_session",
+    "completed",
+  ]);
+
+  const failedEvent = events[2] as Extract<
+    AuthLoginEvent,
+    { kind: "browser_open_failed" }
+  >;
+  assertEquals(
+    failedEvent.message.includes("Could not open browser"),
+    true,
+  );
+});
+
+Deno.test("authLogin: retries polling on pending status", async () => {
+  let pollCount = 0;
+  const deps = makeDeps({
+    pollDeviceToken: () => {
+      pollCount++;
+      if (pollCount < 3) {
+        return Promise.reject(new DeviceAuthPendingError());
+      }
+      return Promise.resolve({ accessToken: "session-token-abc" });
+    },
+  });
+  const input = makeInput({ useBrowserFlow: true });
+
+  const events = await collect<AuthLoginEvent>(
+    authLogin(createLibSwampContext(), deps, input),
+  );
+
+  const kinds = events.map((e) => e.kind);
+  assertEquals(kinds, [
+    "device_verification",
+    "opening_browser",
+    "polling",
+    "polling",
+    "polling",
+    "securing_session",
+    "completed",
+  ]);
+  assertEquals(pollCount, 3);
+});
+
+Deno.test("authLogin: yields error on poll failure", async () => {
+  const deps = makeDeps({
+    pollDeviceToken: () =>
+      Promise.reject(
+        new Error("Device authorization failed: access_denied"),
       ),
   });
   const input = makeInput({ useBrowserFlow: true });
@@ -123,20 +198,18 @@ Deno.test("authLogin: browser open failure emits browser_open_failed event", asy
 
   const kinds = events.map((e) => e.kind);
   assertEquals(kinds, [
-    "opening_browser",
-    "browser_open_failed",
     "device_verification",
-    "waiting_for_auth",
-    "securing_session",
-    "completed",
+    "opening_browser",
+    "polling",
+    "error",
   ]);
 
-  const failedEvent = events[1] as Extract<
+  const errorEvent = events[3] as Extract<
     AuthLoginEvent,
-    { kind: "browser_open_failed" }
+    { kind: "error" }
   >;
   assertEquals(
-    failedEvent.message.includes("Could not open a browser"),
+    errorEvent.error.message.includes("Device authorization failed"),
     true,
   );
 });
@@ -298,23 +371,93 @@ Deno.test("authLogin: stdin flow with both --username and --password skips all p
   assertEquals(kinds, ["securing_session", "completed"]);
 });
 
-Deno.test("authLogin: callback server is shut down after browser flow", async () => {
-  let shutdownCalled = false;
+Deno.test("authLogin: device flow passes correct client_id and server URL", async () => {
+  let capturedServerUrl = "";
+  let capturedClientId = "";
   const deps = makeDeps({
-    startCallbackServer: (_state: string, _serverUrl: string) => ({
-      port: 8888,
-      token: Promise.resolve("tok"),
-      shutdown: () => {
-        shutdownCalled = true;
-        return Promise.resolve();
-      },
-    }),
+    startDeviceAuth: (serverUrl, clientId) => {
+      capturedServerUrl = serverUrl;
+      capturedClientId = clientId;
+      return Promise.resolve({
+        deviceCode: "device-abc-123",
+        userCode: "WXYZ-5678",
+        verificationUri: "https://swamp-club.com/device",
+        expiresIn: 900,
+        interval: 0.001,
+      });
+    },
   });
-  const input = makeInput({ useBrowserFlow: true });
+  const input = makeInput({
+    useBrowserFlow: true,
+    serverUrl: "https://custom-server.example.com",
+  });
 
   await collect<AuthLoginEvent>(
     authLogin(createLibSwampContext(), deps, input),
   );
 
-  assertEquals(shutdownCalled, true);
+  assertEquals(capturedServerUrl, "https://custom-server.example.com");
+  assertEquals(capturedClientId, "swamp-cli");
+});
+
+Deno.test("authLogin: device flow times out when expiresIn elapses", async () => {
+  const deps = makeDeps({
+    startDeviceAuth: () =>
+      Promise.resolve({
+        deviceCode: "device-abc-123",
+        userCode: "ABCD-1234",
+        verificationUri: "https://swamp-club.com/device",
+        expiresIn: 0.001,
+        interval: 0.001,
+      }),
+    pollDeviceToken: () => Promise.reject(new DeviceAuthPendingError()),
+  });
+  const input = makeInput({ useBrowserFlow: true });
+
+  const events = await collect<AuthLoginEvent>(
+    authLogin(createLibSwampContext(), deps, input),
+  );
+
+  const last = events[events.length - 1];
+  assertEquals(last.kind, "error");
+  if (last.kind === "error") {
+    assertEquals(last.error.message, "Device authorization timed out");
+  }
+});
+
+Deno.test("authLogin: slow_down increases polling interval", async () => {
+  let pollCount = 0;
+  const deps = makeDeps({
+    startDeviceAuth: () =>
+      Promise.resolve({
+        deviceCode: "device-abc-123",
+        userCode: "ABCD-1234",
+        verificationUri: "https://swamp-club.com/device",
+        expiresIn: 900,
+        interval: 0.001,
+      }),
+    pollDeviceToken: () => {
+      pollCount++;
+      if (pollCount === 1) {
+        return Promise.reject(new DeviceAuthPendingError(true));
+      }
+      return Promise.resolve({ accessToken: "session-token-abc" });
+    },
+  });
+  const input = makeInput({ useBrowserFlow: true });
+
+  const events = await collect<AuthLoginEvent>(
+    authLogin(createLibSwampContext(), deps, input),
+  );
+
+  const kinds = events.map((e) => e.kind);
+  assertEquals(kinds, [
+    "device_verification",
+    "opening_browser",
+    "polling",
+    "polling",
+    "securing_session",
+    "completed",
+  ]);
+  assertEquals(pollCount, 2);
 });

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1271,7 +1271,7 @@ export {
   type AuthLoginDeps,
   type AuthLoginEvent,
   type AuthLoginInput,
-  type CallbackServerHandle,
+  CLI_CLIENT_ID,
   createAuthLoginDeps,
 } from "./auth/login.ts";
 

--- a/src/presentation/renderers/auth_login.ts
+++ b/src/presentation/renderers/auth_login.ts
@@ -44,8 +44,8 @@ function stripAnsi(str: string): string {
 
 /** Mask an API key, showing prefix and last 4 chars. */
 function maskApiKey(key: string): string {
-  if (key.length <= 16) return key.slice(0, 8) + dim("\u2022\u2022\u2022");
-  return key.slice(0, 12) + dim("\u2022\u2022\u2022") + key.slice(-4);
+  if (key.length <= 16) return key.slice(0, 8) + dim("•••");
+  return key.slice(0, 12) + dim("•••") + key.slice(-4);
 }
 
 /**
@@ -69,23 +69,23 @@ function renderCard(
   const lines: string[] = [];
 
   // Top border
-  lines.push(green(`  \u2554${"\u2550".repeat(contentWidth)}\u2557`));
+  lines.push(green(`  ╔${"═".repeat(contentWidth)}╗`));
 
   // Header
   const headerPad = " ".repeat(contentWidth - headerTextWidth - 2);
   lines.push(
-    green("  \u2551") + `  ${header}${headerPad}` + green("\u2551"),
+    green("  ║") + `  ${header}${headerPad}` + green("║"),
   );
 
   // Divider
-  lines.push(green(`  \u2560${"\u2550".repeat(contentWidth)}\u2563`));
+  lines.push(green(`  ╠${"═".repeat(contentWidth)}╣`));
 
   // Body groups
   for (let gi = 0; gi < groups.length; gi++) {
     const group = groups[gi];
 
     // Spacer before each group
-    lines.push(green("  \u2551") + " ".repeat(contentWidth) + green("\u2551"));
+    lines.push(green("  ║") + " ".repeat(contentWidth) + green("║"));
 
     for (const row of group) {
       const paddedLabel = row.label.padEnd(labelWidth);
@@ -93,34 +93,42 @@ function renderCard(
       const valuePad = " ".repeat(rawValueWidth - visibleValueLen);
       const extraPad = " ".repeat(contentWidth - rowInnerWidth);
       lines.push(
-        green("  \u2551") + "  " + bold(cyan(paddedLabel)) + "   " +
+        green("  ║") + "  " + bold(cyan(paddedLabel)) + "   " +
           row.value +
-          valuePad + extraPad + "  " + green("\u2551"),
+          valuePad + extraPad + "  " + green("║"),
       );
     }
 
     // Spacer after last group
     if (gi === groups.length - 1) {
       lines.push(
-        green("  \u2551") + " ".repeat(contentWidth) + green("\u2551"),
+        green("  ║") + " ".repeat(contentWidth) + green("║"),
       );
     }
   }
 
   // Bottom border
-  lines.push(green(`  \u255a${"\u2550".repeat(contentWidth)}\u255d`));
+  lines.push(green(`  ╚${"═".repeat(contentWidth)}╝`));
 
   return lines;
 }
 
-function renderDeviceVerification(deviceCode: string): void {
+function renderDeviceVerification(
+  userCode: string,
+  verificationUri: string,
+  verificationUriComplete?: string,
+): void {
+  const url = verificationUriComplete ?? verificationUri;
   const lines = renderCard(
     bold("Verify your device"),
-    [[{ label: "Code", value: bold(yellow(deviceCode)) }]],
+    [[
+      { label: "Code", value: bold(yellow(userCode)) },
+      { label: "URL", value: url },
+    ]],
   );
   lines.push("");
   lines.push(
-    "  Confirm this code matches in your browser before signing in.",
+    "  Open the URL above and enter the code to sign in.",
   );
 
   writeOutput(lines.join("\n"));
@@ -145,7 +153,7 @@ function renderAuthLoginSuccess(data: AuthLoginData): void {
   ];
 
   const lines = renderCard(
-    `${green("\u2714")} ${bold("Authenticated")}`,
+    `${green("✔")} ${bold("Authenticated")}`,
     [identity, session],
   );
 
@@ -156,36 +164,31 @@ function renderAuthLoginSuccess(data: AuthLoginData): void {
 
 class LogAuthLoginRenderer implements Renderer<AuthLoginEvent> {
   private spinner: Spinner | null = null;
+  private pollingSpinnerStarted = false;
 
   constructor(private showSpinner: boolean) {}
 
   handlers(): EventHandlers<AuthLoginEvent> {
     return {
-      opening_browser: () => {
-        if (this.showSpinner) {
-          this.spinner = new Spinner();
-          this.spinner.start("Opening browser...");
-        }
-      },
-      browser_open_failed: (e) => {
-        this.spinner?.stop();
-        console.log(e.message);
-        if (this.showSpinner) {
-          this.spinner = new Spinner();
-          this.spinner.start("Waiting for authentication...");
-        }
-      },
       device_verification: (e) => {
         this.spinner?.stop();
-        renderDeviceVerification(e.deviceCode);
+        renderDeviceVerification(
+          e.userCode,
+          e.verificationUri,
+          e.verificationUriComplete,
+        );
         console.log();
-        if (this.showSpinner) {
+      },
+      opening_browser: () => {},
+      browser_open_failed: (e) => {
+        console.log(yellow(e.message));
+      },
+      polling: () => {
+        if (this.showSpinner && !this.pollingSpinnerStarted) {
+          this.pollingSpinnerStarted = true;
           this.spinner = new Spinner();
           this.spinner.start("Waiting for authentication...");
         }
-      },
-      waiting_for_auth: () => {
-        // Spinner already started in device_verification handler
       },
       securing_session: () => {
         if (this.spinner) {
@@ -209,8 +212,15 @@ class JsonAuthLoginRenderer implements Renderer<AuthLoginEvent> {
     return {
       opening_browser: () => {},
       browser_open_failed: () => {},
-      device_verification: () => {},
-      waiting_for_auth: () => {},
+      device_verification: (e) => {
+        console.log(JSON.stringify({
+          status: "device_verification",
+          userCode: e.userCode,
+          verificationUri: e.verificationUri,
+          verificationUriComplete: e.verificationUriComplete,
+        }));
+      },
+      polling: () => {},
       securing_session: () => {},
       completed: (e) => {
         console.log(JSON.stringify(


### PR DESCRIPTION
## Summary

- Replace the localhost callback server in `swamp auth login` with OAuth device code flow (RFC 8628) polling against swamp-club.com
- The CLI now requests a device code, displays the verification URL and user code, and polls for token approval — works from any environment (SSH, Docker, IDE remoting) without port forwarding
- Once approved, the session token is exchanged for an API key using the existing `createApiKey` flow — credentials are stored identically to before

Depends on swamp-club/swamp-club server-side change that registers `swamp-cli` as a trusted OAuth client.

## Test Plan

- Unit tests (13 cases): device flow happy path, polling retries on `authorization_pending`, `slow_down` interval backoff, browser failure non-blocking, timeout on expiry, poll error handling, stdin flow unchanged, client_id verification
- Manual testing: authenticated successfully via `./swamp auth login` on macOS (local browser opens)
- Manual testing: authenticated from inside a Docker container (no browser, copy URL, approve remotely)
- Verified `auth.json` credentials match previous format

Closes swamp-club#1560

Co-authored-by: Sven Dowideit <SvenDowideit@home.org.au>