### PR TITLE
fix(telemetry): redact sensitive content from errorMessage before export

### DIFF
--- a/src/domain/telemetry/error_message_redaction.ts
+++ b/src/domain/telemetry/error_message_redaction.ts
@@ -1,0 +1,40 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// See also: sanitizeErrorForClient in src/serve/handlers/shared.ts, which
+// solves the same class of problem for WebSocket error frames with a
+// destructive strategy (replaces the entire message). Telemetry preserves
+// diagnostic structure by normalizing in-place instead.
+
+const HOME_PATH_RE =
+  /(\/Users\/|\/home\/|C:\\Users\\|C:\/Users\/)([^\s/\\]+)/g;
+
+const INTERNAL_HOST_RE =
+  /\b[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.(?:internal|local|lan|corp|intranet|private|home)\b/g;
+
+export function redactErrorMessage(message: string): string {
+  let result = message.replace(
+    HOME_PATH_RE,
+    (_match, prefix: string, _username: string) => `${prefix}<REDACTED>`,
+  );
+
+  result = result.replace(INTERNAL_HOST_RE, "<REDACTED-HOST>");
+
+  return result;
+}

--- a/src/domain/telemetry/error_message_redaction.ts
+++ b/src/domain/telemetry/error_message_redaction.ts
@@ -22,8 +22,7 @@
 // destructive strategy (replaces the entire message). Telemetry preserves
 // diagnostic structure by normalizing in-place instead.
 
-const HOME_PATH_RE =
-  /(\/Users\/|\/home\/|C:\\Users\\|C:\/Users\/)([^\s/\\]+)/g;
+const HOME_PATH_RE = /(\/Users\/|\/home\/|C:\\Users\\|C:\/Users\/)([^\s/\\]+)/g;
 
 const INTERNAL_HOST_RE =
   /\b[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.(?:internal|local|lan|corp|intranet|private|home)\b/g;

--- a/src/domain/telemetry/error_message_redaction_test.ts
+++ b/src/domain/telemetry/error_message_redaction_test.ts
@@ -1,0 +1,121 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { redactErrorMessage } from "./error_message_redaction.ts";
+
+Deno.test("redactErrorMessage: redacts macOS home directory path", () => {
+  const result = redactErrorMessage(
+    "Not a swamp repository: /Users/johndoe/projects/myapp. Run 'swamp repo init'.",
+  );
+  assertEquals(
+    result,
+    "Not a swamp repository: /Users/<REDACTED>/projects/myapp. Run 'swamp repo init'.",
+  );
+});
+
+Deno.test("redactErrorMessage: redacts Linux home directory path", () => {
+  const result = redactErrorMessage(
+    "File not found: /home/alice/workspace/models/test.yaml",
+  );
+  assertEquals(
+    result,
+    "File not found: /home/<REDACTED>/workspace/models/test.yaml",
+  );
+});
+
+Deno.test("redactErrorMessage: redacts Windows backslash path", () => {
+  const result = redactErrorMessage(
+    "Cannot read file: C:\\Users\\bob\\Documents\\swamp\\model.yaml",
+  );
+  assertEquals(
+    result,
+    "Cannot read file: C:\\Users\\<REDACTED>\\Documents\\swamp\\model.yaml",
+  );
+});
+
+Deno.test("redactErrorMessage: redacts Windows forward-slash path", () => {
+  const result = redactErrorMessage(
+    "Cannot read file: C:/Users/bob/Documents/swamp/model.yaml",
+  );
+  assertEquals(
+    result,
+    "Cannot read file: C:/Users/<REDACTED>/Documents/swamp/model.yaml",
+  );
+});
+
+Deno.test("redactErrorMessage: redacts multiple home paths in one message", () => {
+  const result = redactErrorMessage(
+    "Cannot copy /Users/alice/src to /Users/alice/dest",
+  );
+  assertEquals(
+    result,
+    "Cannot copy /Users/<REDACTED>/src to /Users/<REDACTED>/dest",
+  );
+});
+
+Deno.test("redactErrorMessage: redacts internal hostnames", () => {
+  const result = redactErrorMessage(
+    "Connection refused: db-primary.internal:5432",
+  );
+  assertEquals(result, "Connection refused: <REDACTED-HOST>:5432");
+});
+
+Deno.test("redactErrorMessage: redacts .local hostnames", () => {
+  const result = redactErrorMessage(
+    "Cannot reach build-server.local",
+  );
+  assertEquals(result, "Cannot reach <REDACTED-HOST>");
+});
+
+Deno.test("redactErrorMessage: redacts .corp hostnames", () => {
+  const result = redactErrorMessage(
+    "Timeout connecting to api.corp",
+  );
+  assertEquals(result, "Timeout connecting to <REDACTED-HOST>");
+});
+
+Deno.test("redactErrorMessage: passes through safe error messages", () => {
+  const message = "Model not found: my-model";
+  assertEquals(redactErrorMessage(message), message);
+});
+
+Deno.test("redactErrorMessage: passes through error codes and types", () => {
+  const message = "UserError: Invalid CEL expression in query";
+  assertEquals(redactErrorMessage(message), message);
+});
+
+Deno.test("redactErrorMessage: passes through swamp-club.com domain", () => {
+  const message = "Authentication failed: https://swamp-club.com/api/v1/auth";
+  assertEquals(redactErrorMessage(message), message);
+});
+
+Deno.test("redactErrorMessage: passes through empty string", () => {
+  assertEquals(redactErrorMessage(""), "");
+});
+
+Deno.test("redactErrorMessage: handles combined path and hostname", () => {
+  const result = redactErrorMessage(
+    "Failed syncing /home/deploy/repo to cache.internal",
+  );
+  assertEquals(
+    result,
+    "Failed syncing /home/<REDACTED>/repo to <REDACTED-HOST>",
+  );
+});

--- a/src/domain/telemetry/invocation_result.ts
+++ b/src/domain/telemetry/invocation_result.ts
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { redactErrorMessage } from "./error_message_redaction.ts";
+
 /**
  * Status of a command invocation.
  */
@@ -63,13 +65,12 @@ export function createErrorResult(
   error: Error,
   isUserError: boolean = false,
 ): InvocationResult {
-  // Get first line of error message only (sanitize)
   const firstLine = error.message.split("\n")[0];
 
   return {
     status: isUserError ? "user_error" : "error",
     errorType: error.constructor.name,
-    errorMessage: firstLine,
+    errorMessage: redactErrorMessage(firstLine),
     exitCode: 1,
   };
 }

--- a/src/domain/telemetry/invocation_result_test.ts
+++ b/src/domain/telemetry/invocation_result_test.ts
@@ -1,0 +1,66 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { createErrorResult, createSuccessResult } from "./invocation_result.ts";
+
+Deno.test("createSuccessResult: returns success status", () => {
+  const result = createSuccessResult();
+  assertEquals(result.status, "success");
+  assertEquals(result.exitCode, 0);
+  assertEquals(result.errorType, undefined);
+  assertEquals(result.errorMessage, undefined);
+});
+
+Deno.test("createErrorResult: redacts home directory paths in errorMessage", () => {
+  const error = new Error(
+    "Not a swamp repository: /Users/johndoe/projects/myapp",
+  );
+  const result = createErrorResult(error);
+  assertEquals(result.status, "error");
+  assertEquals(
+    result.errorMessage,
+    "Not a swamp repository: /Users/<REDACTED>/projects/myapp",
+  );
+});
+
+Deno.test("createErrorResult: marks user errors correctly", () => {
+  const error = new Error("Invalid argument");
+  const result = createErrorResult(error, true);
+  assertEquals(result.status, "user_error");
+  assertEquals(result.exitCode, 1);
+});
+
+Deno.test("createErrorResult: takes only first line of multi-line error", () => {
+  const error = new Error("First line\nSecond line\nThird line");
+  const result = createErrorResult(error);
+  assertEquals(result.errorMessage, "First line");
+});
+
+Deno.test("createErrorResult: captures error constructor name as errorType", () => {
+  class CustomError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "CustomError";
+    }
+  }
+  const error = new CustomError("something failed");
+  const result = createErrorResult(error);
+  assertEquals(result.errorType, "CustomError");
+});

--- a/src/domain/telemetry/mod.ts
+++ b/src/domain/telemetry/mod.ts
@@ -59,6 +59,8 @@ export {
   RELEVANT_ENV_VARS,
 } from "./agent_harness_detection.ts";
 
+export { redactErrorMessage } from "./error_message_redaction.ts";
+
 export {
   createErrorResult,
   createSuccessResult,


### PR DESCRIPTION
## Summary

- Add `redactErrorMessage()` to normalize home directory paths and internal hostnames in CLI telemetry error messages before they are exported
- Wire redaction into `createErrorResult()` so all telemetry `errorMessage` fields pass through the same protection that `invocation.args` already have
- Export the new function from the telemetry barrel (`mod.ts`)

Closes swamp-club#1824

## Context

CLI telemetry properly redacts `invocation.args` via `ARG_SCHEMAS`, but `result.errorMessage` was sent verbatim. Error messages routinely contain absolute file paths with usernames (e.g. `/Users/johndoe/projects/...`), which is exactly the class of value the args redaction exists to protect.

The fix normalizes paths in-place (`/Users/johndoe/...` → `/Users/<REDACTED>/...`) rather than replacing the entire message, preserving diagnostic value while removing user-identifiable content. This is deliberately separate from `sanitizeErrorForClient` in `src/serve/handlers/shared.ts`, which uses a destructive strategy (replaces the whole message) appropriate for WebSocket error frames but too aggressive for telemetry.

## Test Plan

- 13 unit tests for `redactErrorMessage()` covering macOS, Linux, and Windows paths, internal hostnames (`.internal`, `.local`, `.corp`), safe content passthrough, and combined scenarios
- 5 unit tests for `createErrorResult()` verifying redaction is applied, user error classification, multi-line truncation, and error type capture
- All 92 telemetry domain tests pass
- Full verification workflow passed (lint, fmt, type-check, 10628 tests, compile, code review, adversarial review)