### PR TITLE
feat(cli): add --workflow filter to workflow history search

### DIFF
--- a/packages/client/protocol.ts
+++ b/packages/client/protocol.ts
@@ -213,6 +213,7 @@ export interface WorkflowHistoryLogsPayload {
 
 export interface WorkflowHistorySearchPayload {
   query?: string;
+  workflow?: string;
   inputs?: Record<string, string>;
 }
 

--- a/src/cli/commands/workflow_history_search.ts
+++ b/src/cli/commands/workflow_history_search.ts
@@ -150,7 +150,11 @@ export async function workflowHistorySearchAction(
       { server, token },
       {
         type: "workflow.history.search",
-        payload: { query, inputs: parsedInputs },
+        payload: {
+          query,
+          workflow: options.workflow as string | undefined,
+          inputs: parsedInputs,
+        },
       },
     );
     const renderer = createWorkflowHistorySearchRenderer(effectiveMode);
@@ -207,7 +211,11 @@ export async function workflowHistorySearchAction(
   };
 
   await consumeStream(
-    workflowHistorySearch(libCtx, deps, { query, inputs: parsedInputs }),
+    workflowHistorySearch(libCtx, deps, {
+      query,
+      workflow: options.workflow as string | undefined,
+      inputs: parsedInputs,
+    }),
     handlers,
   );
 
@@ -259,6 +267,10 @@ export const workflowHistorySearchCommand = withRemoteOptions(
     .option(
       "--repo-dir <dir:string>",
       "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option(
+      "--workflow <name:string>",
+      "Filter by workflow name",
     )
     .option(
       "--input <input:string>",

--- a/src/libswamp/workflows/history_search.ts
+++ b/src/libswamp/workflows/history_search.ts
@@ -71,6 +71,7 @@ export interface WorkflowHistorySearchDeps {
  */
 export interface WorkflowHistorySearchInput {
   query?: string;
+  workflow?: string;
   inputs?: Record<string, string>;
 }
 
@@ -140,6 +141,13 @@ export async function* workflowHistorySearch(
           stepProgress: run.stepProgress,
         };
       });
+
+      if (input.workflow) {
+        const name = input.workflow.toLowerCase();
+        results = results.filter(
+          (r) => r.workflowName.toLowerCase() === name,
+        );
+      }
 
       if (input.inputs) {
         const inputEntries = Object.entries(input.inputs);

--- a/src/libswamp/workflows/history_search_test.ts
+++ b/src/libswamp/workflows/history_search_test.ts
@@ -163,6 +163,118 @@ Deno.test("workflowHistorySearch: filters by inputs", async () => {
   assertEquals(completed.data.results[0].runId, "run-match");
 });
 
+Deno.test("workflowHistorySearch: filters by workflow name", async () => {
+  const deps = makeDeps();
+  const events = await collect<WorkflowHistorySearchEvent>(
+    workflowHistorySearch(createLibSwampContext(), deps, {
+      workflow: "deploy",
+    }),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowHistorySearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 1);
+  assertEquals(completed.data.results[0].workflowName, "deploy");
+});
+
+Deno.test("workflowHistorySearch: workflow filter is case-insensitive", async () => {
+  const deps = makeDeps();
+  const events = await collect<WorkflowHistorySearchEvent>(
+    workflowHistorySearch(createLibSwampContext(), deps, {
+      workflow: "DEPLOY",
+    }),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowHistorySearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 1);
+  assertEquals(completed.data.results[0].workflowName, "deploy");
+});
+
+Deno.test("workflowHistorySearch: workflow filter combined with inputs filter", async () => {
+  const deps = makeDeps({
+    findAllWorkflows: () =>
+      Promise.resolve([
+        { id: "wf-1", name: "deploy" },
+        { id: "wf-2", name: "test" },
+      ]),
+    findAllRunsByWorkflowId: (id: string) => {
+      if (id === "wf-1") {
+        return Promise.resolve([
+          {
+            id: "run-match",
+            workflowId: "wf-1",
+            workflowName: "deploy",
+            status: "succeeded",
+            startedAt: new Date(now - 1000),
+            completedAt: new Date(now),
+            tags: {},
+            inputs: { env: "prod" },
+          },
+          {
+            id: "run-no-input-match",
+            workflowId: "wf-1",
+            workflowName: "deploy",
+            status: "succeeded",
+            startedAt: new Date(now - 2000),
+            completedAt: new Date(now - 1000),
+            tags: {},
+            inputs: { env: "staging" },
+          },
+        ]);
+      }
+      if (id === "wf-2") {
+        return Promise.resolve([
+          {
+            id: "run-wrong-workflow",
+            workflowId: "wf-2",
+            workflowName: "test",
+            status: "succeeded",
+            startedAt: new Date(now - 500),
+            completedAt: new Date(now),
+            tags: {},
+            inputs: { env: "prod" },
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    },
+  });
+
+  const events = await collect<WorkflowHistorySearchEvent>(
+    workflowHistorySearch(createLibSwampContext(), deps, {
+      workflow: "deploy",
+      inputs: { env: "prod" },
+    }),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowHistorySearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 1);
+  assertEquals(completed.data.results[0].runId, "run-match");
+});
+
+Deno.test("workflowHistorySearch: workflow filter with no matches returns empty", async () => {
+  const deps = makeDeps();
+  const events = await collect<WorkflowHistorySearchEvent>(
+    workflowHistorySearch(createLibSwampContext(), deps, {
+      workflow: "nonexistent",
+    }),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowHistorySearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 0);
+});
+
 Deno.test("workflowHistorySearch: returns empty results when no runs exist", async () => {
   const deps = makeDeps({
     findAllWorkflows: () => Promise.resolve([{ id: "wf-1", name: "deploy" }]),

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -624,6 +624,7 @@ const WorkflowHistorySearchRequestSchema = z.object({
   id: z.string().min(1).max(256),
   payload: z.object({
     query: z.string().optional(),
+    workflow: z.string().optional(),
     inputs: z.record(z.string(), z.string()).optional(),
   }).optional(),
 });

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -693,6 +693,7 @@ export async function handleWorkflowHistorySearch(
     await consumeStream(
       workflowHistorySearch(libCtx, deps, {
         query: payload?.query,
+        workflow: payload?.workflow,
         inputs: payload?.inputs,
       }),
       {

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -294,6 +294,7 @@ export interface WorkflowHistoryLogsPayload {
 
 export interface WorkflowHistorySearchPayload {
   query?: string;
+  workflow?: string;
   inputs?: Record<string, string>;
 }
 


### PR DESCRIPTION
## Summary

- Adds `--workflow <name>` flag to `swamp workflow history search`, consistent with the existing `--workflow` filter in `workflow run search` and `data list`
- Uses case-insensitive exact matching on `workflowName`, mirroring the `run_search.ts` pattern
- Wires the flag through local CLI, remote serve protocol (payload, Zod schema, handler), and client package

Closes swamp-club#1826

## Test plan

- [x] Unit tests: 4 new tests covering workflow filter, case-insensitive matching, combined with `--input` filter, and no-match scenario
- [x] Type check: all 7 changed files pass `deno check`
- [x] Manual E2E: compiled binary tested in scratch repo with two workflows — `--workflow deploy` returns only deploy runs, `--workflow DEPLOY` matches case-insensitively, `--workflow nonexistent` returns empty
- [x] Build verification: lint, fmt, type-check, test, deps-audit, compile all pass
- [x] Agent reviews: code review, adversarial review, UX review all pass with no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)