### PR TITLE
fix(verification): default method field and forbid post-attestation amends

### DIFF
--- a/.claude/skills/issue-lifecycle/references/implementation.md
+++ b/.claude/skills/issue-lifecycle/references/implementation.md
@@ -59,6 +59,13 @@ opening a PR.** If you have not yet posted the attestation via
 [verification.md](verification.md) step 4 and complete the attestation flow
 first. Do NOT skip this step. Do NOT open a PR without a posted attestation.
 
+**DO NOT amend, rebase, or modify the verified commit after the attestation has
+been posted.** The attestation is bound to the commit SHA — amending (even just
+to add a co-author line) changes the SHA and invalidates the attestation. The
+co-author trailer must be included in the ORIGINAL commit, not added via amend
+afterwards. If the commit has already been amended, you must re-run verification
+and post a new attestation for the new SHA.
+
 **Always ask the human before opening a PR.** Do not create the PR automatically
 — present a summary of the changes and ask if they are ready to open it. Only
 proceed after explicit confirmation.

--- a/.claude/skills/issue-lifecycle/references/verification.md
+++ b/.claude/skills/issue-lifecycle/references/verification.md
@@ -124,6 +124,13 @@ failed" below.
    `validate-attestation` check will fail if no attestation exists for the
    commit.
 
+   **NEVER amend, rebase, or modify the commit after posting the attestation.**
+   The attestation is bound to a specific commit SHA. If you amend the commit
+   (e.g., to add a co-author, fix a typo, or reword the message), the SHA
+   changes and the attestation becomes invalid — CI will report a commit
+   mismatch. If you need to change the commit after posting, you must re-run
+   verification on the new SHA and post a new attestation.
+
 5. **Only after `post_attestation` succeeds**, proceed to open a PR — read the
    "Create a PR" section in [implementation.md](implementation.md). If you
    skipped step 4, implementation.md will send you back here.

--- a/.claude/skills/issue-lifecycle/references/verification.md
+++ b/.claude/skills/issue-lifecycle/references/verification.md
@@ -104,10 +104,17 @@ failed" below.
    what triggers the attestation push. Do not post it automatically after
    verification passes — the user decides when to ship.
 
+   Write the attestation JSON to a file first, then pass it as a stringified
+   JSON value:
+
    ```
    swamp model @swamp/issue-lifecycle method run post_attestation issue-<N> \
-     --input attestation='<attestation JSON string>'
+     --input attestation="$(cat <path-to-attestation.json>)" \
+     --repo-dir <repo-root>
    ```
+
+   The `attestation` input must be the full attestation JSON as a single string
+   — use `$(cat file)` to inline it from the file you wrote in step 1.
 
    The method posts the attestation to swamp-club using the CLI's existing auth
    credentials. It throws on failure — if it fails, fix the auth or connectivity

--- a/extensions/models/issue_lifecycle.ts
+++ b/extensions/models/issue_lifecycle.ts
@@ -1769,7 +1769,7 @@ export const model = {
           job: z.string(),
           step: z.string(),
           model: z.string(),
-          method: z.string(),
+          method: z.string().default("execute"),
           status: z.enum(["succeeded", "failed", "skipped"]),
         })),
       }),


### PR DESCRIPTION
## Summary

- Default `method` to `"execute"` in `verification_passed` steps schema — the field was required but not in the attestation format, causing validation failures on live runs
- Add explicit warnings in both `verification.md` and `implementation.md`: **never amend/rebase the commit after posting the attestation** — it changes the SHA and invalidates the attestation binding, causing CI to report a commit mismatch
- Clarify `post_attestation` docs to use `$(cat file)` for stringifying the attestation JSON

## Context

Found during live testing: the agent posted the attestation, then amended the commit to add a co-author line, changing the SHA. CI correctly flagged the mismatch but the agent shouldn't have amended in the first place.

## Test plan

- [x] `verification_passed` accepts steps without `method` field (defaults to "execute")
- [x] Docs clearly state the no-amend rule in both files the agent reads before opening a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEUofYG1ehMUVSfmEsjmMt