### PR TITLE
perf(data): route data search through catalog index (swamp-club#1827)

### DIFF
--- a/design/data-query.md
+++ b/design/data-query.md
@@ -353,10 +353,13 @@ The catalog builds up incrementally:
    and the row is missing (or stale), it runs a scoped filesystem walk for just
    the requested `(modelName, dataName)` pair, upserts matching rows, and
    retries. The `populated` flag is not set by scoped backfill.
-3. **Full backfill on first query** — on the first call to
-   `DataQueryService.query()`, if the catalog is not marked as populated, a
-   one-time `findAllGlobal()` runs, commits every row it found, and sets a
-   `populated` flag in the `catalog_meta` table.
+3. **Full backfill on first query or search** — on the first call to
+   `DataQueryService.query()` or `ensurePopulated()` (used by `data search`),
+   if the catalog is not marked as populated, a one-time `findAllGlobal()` runs,
+   commits every row it found, and sets a `populated` flag in the
+   `catalog_meta` table. Both `data search` and `data query` use the catalog
+   after backfill — `data search` iterates `is_latest` rows directly rather
+   than re-walking the filesystem.
 4. **Self-healing** — if `_catalog.db` is deleted or corrupted, the next query
    triggers a backfill automatically.
 

--- a/src/cli/commands/data_search.ts
+++ b/src/cli/commands/data_search.ts
@@ -52,55 +52,10 @@ import type { OutputMode } from "../../presentation/output/output.ts";
 import { UserError } from "../../domain/errors.ts";
 import { toRelativePath } from "../../infrastructure/persistence/paths.ts";
 import type { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
-import type { DataQueryService } from "../../domain/data/data_query_service.ts";
-import type {
-  CatalogRow,
-  CatalogStore,
-} from "../../infrastructure/persistence/catalog_store.ts";
+import { findLatestItemsFromCatalog } from "../../infrastructure/persistence/catalog_search_adapter.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
-
-function catalogRowToSearchItem(row: CatalogRow): DataSearchItem {
-  let tags: Record<string, string> = {};
-  try {
-    tags = JSON.parse(row.tags) as Record<string, string>;
-  } catch {
-    // Invalid tags JSON, use empty
-  }
-  return {
-    id: row.id,
-    name: row.data_name,
-    version: row.version,
-    contentType: row.content_type,
-    type: row.data_type,
-    lifetime: row.lifetime,
-    ownerType: row.owner_type,
-    ownerRef: row.owner_ref,
-    modelId: row.model_id,
-    modelName: row.model_name,
-    modelType: row.type_normalized,
-    streaming: row.streaming === 1,
-    size: row.size,
-    createdAt: row.created_at,
-    tags,
-    workflowTag: tags.workflow,
-    jobTag: tags.job,
-    stepTag: tags.step,
-  };
-}
-
-async function findLatestItemsFromCatalog(
-  dataQueryService: DataQueryService,
-  catalogStore: CatalogStore,
-): Promise<DataSearchItem[]> {
-  await dataQueryService.ensurePopulated();
-  const items: DataSearchItem[] = [];
-  for (const row of catalogStore.iterateFiltered("is_latest = ?", [1])) {
-    items.push(catalogRowToSearchItem(row));
-  }
-  return items;
-}
 
 /**
  * Creates a fetchPreview closure for the data search picker.

--- a/src/cli/commands/data_search.ts
+++ b/src/cli/commands/data_search.ts
@@ -47,15 +47,60 @@ import {
 } from "../remote_run.ts";
 import type { DataSearchResponse } from "../../serve/protocol.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
-import { createDefinitionId } from "../../domain/definitions/definition.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import type { OutputMode } from "../../presentation/output/output.ts";
 import { UserError } from "../../domain/errors.ts";
 import { toRelativePath } from "../../infrastructure/persistence/paths.ts";
 import type { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import type { DataQueryService } from "../../domain/data/data_query_service.ts";
+import type {
+  CatalogRow,
+  CatalogStore,
+} from "../../infrastructure/persistence/catalog_store.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
+
+function catalogRowToSearchItem(row: CatalogRow): DataSearchItem {
+  let tags: Record<string, string> = {};
+  try {
+    tags = JSON.parse(row.tags) as Record<string, string>;
+  } catch {
+    // Invalid tags JSON, use empty
+  }
+  return {
+    id: row.id,
+    name: row.data_name,
+    version: row.version,
+    contentType: row.content_type,
+    type: row.data_type,
+    lifetime: row.lifetime,
+    ownerType: row.owner_type,
+    ownerRef: row.owner_ref,
+    modelId: row.model_id,
+    modelName: row.model_name,
+    modelType: row.type_normalized,
+    streaming: row.streaming === 1,
+    size: row.size,
+    createdAt: row.created_at,
+    tags,
+    workflowTag: tags.workflow,
+    jobTag: tags.job,
+    stepTag: tags.step,
+  };
+}
+
+async function findLatestItemsFromCatalog(
+  dataQueryService: DataQueryService,
+  catalogStore: CatalogStore,
+): Promise<DataSearchItem[]> {
+  await dataQueryService.ensurePopulated();
+  const items: DataSearchItem[] = [];
+  for (const row of catalogStore.iterateFiltered("is_latest = ?", [1])) {
+    items.push(catalogRowToSearchItem(row));
+  }
+  return items;
+}
 
 /**
  * Creates a fetchPreview closure for the data search picker.
@@ -278,6 +323,8 @@ export const dataSearchCommand = withRemoteOptions(
   });
   const definitionRepo = repoContext.definitionRepo;
   const dataRepo = repoContext.unifiedDataRepo;
+  const dataQueryService = repoContext.dataQueryService;
+  const catalogStore = repoContext.catalogStore;
 
   // Parse --tag values into Record<string, string>
   const parsedTags = options.tag
@@ -285,12 +332,8 @@ export const dataSearchCommand = withRemoteOptions(
     : undefined;
 
   const deps: DataSearchDeps = {
-    findAllGlobal: () => dataRepo.findAllGlobal(),
-    findDefinitionById: (type, defId) =>
-      definitionRepo.findById(
-        ModelType.create(type.normalized),
-        createDefinitionId(defId),
-      ),
+    findLatestItems: () =>
+      findLatestItemsFromCatalog(dataQueryService, catalogStore),
     findDefinitionByIdOrName: (idOrName) =>
       findDefinitionByIdOrName(definitionRepo, idOrName),
   };

--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -306,6 +306,25 @@ export class DataQueryService {
   }
 
   /**
+   * Ensures the catalog is populated, triggering a backfill if needed.
+   * Reuses the same backfill-coalescing logic as query().
+   */
+  async ensurePopulated(): Promise<void> {
+    if (this.catalogStore.isPopulated()) return;
+    if (this.backfillPromise) {
+      await this.backfillPromise;
+      return;
+    }
+    const promise = this.backfillAsync();
+    this.backfillPromise = promise;
+    try {
+      await promise;
+    } finally {
+      this.backfillPromise = null;
+    }
+  }
+
+  /**
    * Queries data artifacts matching a CEL predicate.
    * Triggers backfill if the catalog is not yet populated.
    * Vault references in JSON attributes are resolved when a VaultService
@@ -315,19 +334,7 @@ export class DataQueryService {
     predicate: string,
     options?: DataQueryOptions,
   ): Promise<DataRecord[] | unknown[]> {
-    if (!this.catalogStore.isPopulated()) {
-      if (this.backfillPromise) {
-        await this.backfillPromise;
-      } else {
-        const promise = this.backfillAsync();
-        this.backfillPromise = promise;
-        try {
-          await promise;
-        } finally {
-          this.backfillPromise = null;
-        }
-      }
-    }
+    await this.ensurePopulated();
     const results = this.executeQuery(predicate, options);
 
     // Hydrate foreign namespace records whose content isn't available locally.

--- a/src/infrastructure/persistence/catalog_search_adapter.ts
+++ b/src/infrastructure/persistence/catalog_search_adapter.ts
@@ -1,0 +1,63 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { CatalogRow, CatalogStore } from "./catalog_store.ts";
+import type { DataSearchItem } from "../../libswamp/mod.ts";
+import type { DataQueryService } from "../../domain/data/data_query_service.ts";
+
+function catalogRowToSearchItem(row: CatalogRow): DataSearchItem {
+  let tags: Record<string, string> = {};
+  try {
+    tags = JSON.parse(row.tags) as Record<string, string>;
+  } catch {
+    // empty
+  }
+  return {
+    id: row.id,
+    name: row.data_name,
+    version: row.version,
+    contentType: row.content_type,
+    type: row.data_type,
+    lifetime: row.lifetime,
+    ownerType: row.owner_type,
+    ownerRef: row.owner_ref,
+    modelId: row.model_id,
+    modelName: row.model_name,
+    modelType: row.type_normalized,
+    streaming: row.streaming === 1,
+    size: row.size,
+    createdAt: row.created_at,
+    tags,
+    workflowTag: tags.workflow,
+    jobTag: tags.job,
+    stepTag: tags.step,
+  };
+}
+
+export async function findLatestItemsFromCatalog(
+  dataQueryService: DataQueryService,
+  catalogStore: CatalogStore,
+): Promise<DataSearchItem[]> {
+  await dataQueryService.ensurePopulated();
+  const items: DataSearchItem[] = [];
+  for (const row of catalogStore.iterateFiltered("is_latest = ?", [1])) {
+    items.push(catalogRowToSearchItem(row));
+  }
+  return items;
+}

--- a/src/libswamp/data/search.ts
+++ b/src/libswamp/data/search.ts
@@ -67,29 +67,7 @@ export type DataSearchEvent =
  * Dependencies for the data search generator.
  */
 export interface DataSearchDeps {
-  findAllGlobal(): Promise<
-    Array<{
-      data: {
-        id: string;
-        name: string;
-        version: number;
-        contentType: string;
-        type: string;
-        lifetime: string;
-        ownerDefinition: { ownerType: string; ownerRef: string };
-        streaming: boolean;
-        size?: number;
-        createdAt: Date;
-        tags: Record<string, string>;
-      };
-      modelType: { normalized: string };
-      modelId: string;
-    }>
-  >;
-  findDefinitionById(
-    type: { normalized: string },
-    defId: string,
-  ): Promise<{ name: string } | null>;
+  findLatestItems(): Promise<DataSearchItem[]>;
   findDefinitionByIdOrName(
     idOrName: string,
   ): Promise<{ definition: { name: string } } | null>;
@@ -276,38 +254,8 @@ export async function* dataSearch(
         }
       }
 
-      // Fetch and convert all data
-      const allResults = await deps.findAllGlobal();
-      const items: DataSearchItem[] = [];
-
-      for (const { data, modelType, modelId } of allResults) {
-        let modelName = modelId;
-        const definition = await deps.findDefinitionById(modelType, modelId);
-        if (definition) {
-          modelName = definition.name;
-        }
-
-        items.push({
-          id: data.id,
-          name: data.name,
-          version: data.version,
-          contentType: data.contentType,
-          type: data.type,
-          lifetime: data.lifetime,
-          ownerType: data.ownerDefinition.ownerType,
-          ownerRef: data.ownerDefinition.ownerRef,
-          modelId,
-          modelName,
-          modelType: modelType.normalized,
-          streaming: data.streaming,
-          size: data.size ?? 0,
-          createdAt: data.createdAt.toISOString(),
-          tags: data.tags,
-          workflowTag: data.tags.workflow,
-          jobTag: data.tags.job,
-          stepTag: data.tags.step,
-        });
-      }
+      // Fetch latest items from the catalog index
+      const items = await deps.findLatestItems();
 
       // Apply filters
       const filtered = filterData(items, input);

--- a/src/libswamp/data/search_test.ts
+++ b/src/libswamp/data/search_test.ts
@@ -24,42 +24,45 @@ import {
   dataSearch,
   type DataSearchDeps,
   type DataSearchEvent,
+  type DataSearchItem,
   parseDuration,
   parseTags,
 } from "./search.ts";
 import { UserError } from "../../domain/errors.ts";
 
-function makeDataItem(overrides: Record<string, unknown> = {}) {
+function makeSearchItem(
+  overrides: Record<string, unknown> = {},
+): DataSearchItem {
+  const tags = (overrides.tags as Record<string, string>) ?? {};
   return {
-    data: {
-      id: (overrides.id as string) ?? "d1",
-      name: (overrides.name as string) ?? "output",
-      version: (overrides.version as number) ?? 1,
-      contentType: (overrides.contentType as string) ?? "application/json",
-      type: (overrides.type as string) ?? "data",
-      lifetime: (overrides.lifetime as string) ?? "persistent",
-      ownerDefinition: {
-        ownerType: (overrides.ownerType as string) ?? "model",
-        ownerRef: (overrides.ownerRef as string) ?? "ref-1",
-      },
-      streaming: (overrides.streaming as boolean) ?? false,
-      size: (overrides.size as number) ?? 100,
-      createdAt: (overrides.createdAt as Date) ?? new Date("2026-01-15"),
-      tags: (overrides.tags as Record<string, string>) ?? {},
-    },
-    modelType: { normalized: (overrides.modelType as string) ?? "aws/ec2" },
+    id: (overrides.id as string) ?? "d1",
+    name: (overrides.name as string) ?? "output",
+    version: (overrides.version as number) ?? 1,
+    contentType: (overrides.contentType as string) ?? "application/json",
+    type: (overrides.type as string) ?? "data",
+    lifetime: (overrides.lifetime as string) ?? "persistent",
+    ownerType: (overrides.ownerType as string) ?? "model",
+    ownerRef: (overrides.ownerRef as string) ?? "ref-1",
     modelId: (overrides.modelId as string) ?? "model-1",
+    modelName: (overrides.modelName as string) ?? "my-model",
+    modelType: (overrides.modelType as string) ?? "aws/ec2",
+    streaming: (overrides.streaming as boolean) ?? false,
+    size: (overrides.size as number) ?? 100,
+    createdAt: (overrides.createdAt as string) ??
+      new Date("2026-01-15").toISOString(),
+    tags,
+    workflowTag: tags.workflow,
+    jobTag: tags.job,
+    stepTag: tags.step,
   };
 }
 
 function makeDeps(
-  items: ReturnType<typeof makeDataItem>[] = [],
+  items: DataSearchItem[] = [],
   overrides?: Partial<DataSearchDeps>,
 ): DataSearchDeps {
   return {
-    findAllGlobal: () => Promise.resolve(items),
-    findDefinitionById: (_type, defId) =>
-      Promise.resolve({ name: `name-${defId}` }),
+    findLatestItems: () => Promise.resolve(items),
     findDefinitionByIdOrName: () =>
       Promise.resolve({ definition: { name: "my-model" } }),
     ...overrides,
@@ -68,8 +71,8 @@ function makeDeps(
 
 Deno.test("dataSearch: returns all data items with no query or filters", async () => {
   const items = [
-    makeDataItem({ id: "d1", name: "alpha" }),
-    makeDataItem({ id: "d2", name: "beta" }),
+    makeSearchItem({ id: "d1", name: "alpha" }),
+    makeSearchItem({ id: "d2", name: "beta" }),
   ];
   const deps = makeDeps(items);
   const events = await collect<DataSearchEvent>(
@@ -89,9 +92,9 @@ Deno.test("dataSearch: returns all data items with no query or filters", async (
 
 Deno.test("dataSearch: filters by type", async () => {
   const items = [
-    makeDataItem({ id: "d1", type: "data" }),
-    makeDataItem({ id: "d2", type: "log" }),
-    makeDataItem({ id: "d3", type: "data" }),
+    makeSearchItem({ id: "d1", type: "data" }),
+    makeSearchItem({ id: "d2", type: "log" }),
+    makeSearchItem({ id: "d3", type: "data" }),
   ];
   const deps = makeDeps(items);
   const events = await collect<DataSearchEvent>(
@@ -112,8 +115,8 @@ Deno.test("dataSearch: filters by since duration", async () => {
   const recent = new Date(now.getTime() - 1 * 60 * 60 * 1000); // 1 hour ago
   const old = new Date(now.getTime() - 48 * 60 * 60 * 1000); // 48 hours ago
   const items = [
-    makeDataItem({ id: "d1", createdAt: recent }),
-    makeDataItem({ id: "d2", createdAt: old }),
+    makeSearchItem({ id: "d1", createdAt: recent.toISOString() }),
+    makeSearchItem({ id: "d2", createdAt: old.toISOString() }),
   ];
   const deps = makeDeps(items);
   const events = await collect<DataSearchEvent>(
@@ -130,15 +133,15 @@ Deno.test("dataSearch: filters by since duration", async () => {
 
 Deno.test("dataSearch: filters by tags with AND logic", async () => {
   const items = [
-    makeDataItem({
+    makeSearchItem({
       id: "d1",
       tags: { env: "prod", team: "infra" },
     }),
-    makeDataItem({
+    makeSearchItem({
       id: "d2",
       tags: { env: "prod", team: "app" },
     }),
-    makeDataItem({
+    makeSearchItem({
       id: "d3",
       tags: { env: "staging" },
     }),
@@ -160,7 +163,7 @@ Deno.test("dataSearch: filters by tags with AND logic", async () => {
 
 Deno.test("dataSearch: surfaces workflowTag/jobTag/stepTag from data tags", async () => {
   const items = [
-    makeDataItem({
+    makeSearchItem({
       id: "d1",
       tags: { workflow: "my-wf", job: "my-job", step: "my-step" },
     }),
@@ -182,7 +185,7 @@ Deno.test("dataSearch: surfaces workflowTag/jobTag/stepTag from data tags", asyn
 
 Deno.test("dataSearch: jobTag is undefined when data has no job tag", async () => {
   const items = [
-    makeDataItem({ id: "d1", tags: {} }),
+    makeSearchItem({ id: "d1", tags: {} }),
   ];
   const deps = makeDeps(items);
   const events = await collect<DataSearchEvent>(
@@ -213,9 +216,9 @@ Deno.test("dataSearch: yields error when model not found", async () => {
 
 Deno.test("dataSearch: applies limit and reports total/limited correctly", async () => {
   const items = [
-    makeDataItem({ id: "d1" }),
-    makeDataItem({ id: "d2" }),
-    makeDataItem({ id: "d3" }),
+    makeSearchItem({ id: "d1" }),
+    makeSearchItem({ id: "d2" }),
+    makeSearchItem({ id: "d3" }),
   ];
   const deps = makeDeps(items);
   const events = await collect<DataSearchEvent>(
@@ -233,9 +236,18 @@ Deno.test("dataSearch: applies limit and reports total/limited correctly", async
 
 Deno.test("dataSearch: sorts results by createdAt descending", async () => {
   const items = [
-    makeDataItem({ id: "d1", createdAt: new Date("2026-01-01") }),
-    makeDataItem({ id: "d2", createdAt: new Date("2026-03-01") }),
-    makeDataItem({ id: "d3", createdAt: new Date("2026-02-01") }),
+    makeSearchItem({
+      id: "d1",
+      createdAt: new Date("2026-01-01").toISOString(),
+    }),
+    makeSearchItem({
+      id: "d2",
+      createdAt: new Date("2026-03-01").toISOString(),
+    }),
+    makeSearchItem({
+      id: "d3",
+      createdAt: new Date("2026-02-01").toISOString(),
+    }),
   ];
   const deps = makeDeps(items);
   const events = await collect<DataSearchEvent>(

--- a/src/serve/handlers/data_handlers.ts
+++ b/src/serve/handlers/data_handlers.ts
@@ -43,6 +43,7 @@ import {
   dataRename,
   dataSearch,
   type DataSearchDeps,
+  type DataSearchItem,
   dataVersions,
   DEFAULT_WORKFLOW_RUN_RETENTION_DAYS,
   parseDuration,
@@ -63,8 +64,11 @@ import type {
   SummarisePayload,
 } from "../protocol.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
-import { createDefinitionId } from "../../domain/definitions/definition.ts";
-import { ModelType } from "../../domain/models/model_type.ts";
+import type { DataQueryService } from "../../domain/data/data_query_service.ts";
+import type {
+  CatalogRow,
+  CatalogStore,
+} from "../../infrastructure/persistence/catalog_store.ts";
 import type { Principal } from "../../domain/access/principal.ts";
 import {
   authorizeOrReject,
@@ -75,6 +79,47 @@ import {
   send,
   sendError,
 } from "./shared.ts";
+
+function catalogRowToSearchItem(row: CatalogRow): DataSearchItem {
+  let tags: Record<string, string> = {};
+  try {
+    tags = JSON.parse(row.tags) as Record<string, string>;
+  } catch {
+    // Invalid tags JSON, use empty
+  }
+  return {
+    id: row.id,
+    name: row.data_name,
+    version: row.version,
+    contentType: row.content_type,
+    type: row.data_type,
+    lifetime: row.lifetime,
+    ownerType: row.owner_type,
+    ownerRef: row.owner_ref,
+    modelId: row.model_id,
+    modelName: row.model_name,
+    modelType: row.type_normalized,
+    streaming: row.streaming === 1,
+    size: row.size,
+    createdAt: row.created_at,
+    tags,
+    workflowTag: tags.workflow,
+    jobTag: tags.job,
+    stepTag: tags.step,
+  };
+}
+
+async function findLatestItemsFromCatalog(
+  dataQueryService: DataQueryService,
+  catalogStore: CatalogStore,
+): Promise<DataSearchItem[]> {
+  await dataQueryService.ensurePopulated();
+  const items: DataSearchItem[] = [];
+  for (const row of catalogStore.iterateFiltered("is_latest = ?", [1])) {
+    items.push(catalogRowToSearchItem(row));
+  }
+  return items;
+}
 
 export async function handleDataGet(
   socket: WebSocket,
@@ -299,15 +344,12 @@ export async function handleDataSearch(
   try {
     const libCtx = createLibSwampContext();
     const definitionRepo = ctx.repoContext.definitionRepo;
-    const dataRepo = ctx.repoContext.unifiedDataRepo;
+    const dataQueryService = ctx.repoContext.dataQueryService;
+    const catalogStore = ctx.repoContext.catalogStore;
 
     const deps: DataSearchDeps = {
-      findAllGlobal: () => dataRepo.findAllGlobal(),
-      findDefinitionById: (type, defId) =>
-        definitionRepo.findById(
-          ModelType.create(type.normalized),
-          createDefinitionId(defId),
-        ),
+      findLatestItems: () =>
+        findLatestItemsFromCatalog(dataQueryService, catalogStore),
       findDefinitionByIdOrName: (idOrName) =>
         findDefinitionByIdOrName(definitionRepo, idOrName),
     };

--- a/src/serve/handlers/data_handlers.ts
+++ b/src/serve/handlers/data_handlers.ts
@@ -43,7 +43,6 @@ import {
   dataRename,
   dataSearch,
   type DataSearchDeps,
-  type DataSearchItem,
   dataVersions,
   DEFAULT_WORKFLOW_RUN_RETENTION_DAYS,
   parseDuration,
@@ -64,11 +63,7 @@ import type {
   SummarisePayload,
 } from "../protocol.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
-import type { DataQueryService } from "../../domain/data/data_query_service.ts";
-import type {
-  CatalogRow,
-  CatalogStore,
-} from "../../infrastructure/persistence/catalog_store.ts";
+import { findLatestItemsFromCatalog } from "../../infrastructure/persistence/catalog_search_adapter.ts";
 import type { Principal } from "../../domain/access/principal.ts";
 import {
   authorizeOrReject,
@@ -79,47 +74,6 @@ import {
   send,
   sendError,
 } from "./shared.ts";
-
-function catalogRowToSearchItem(row: CatalogRow): DataSearchItem {
-  let tags: Record<string, string> = {};
-  try {
-    tags = JSON.parse(row.tags) as Record<string, string>;
-  } catch {
-    // Invalid tags JSON, use empty
-  }
-  return {
-    id: row.id,
-    name: row.data_name,
-    version: row.version,
-    contentType: row.content_type,
-    type: row.data_type,
-    lifetime: row.lifetime,
-    ownerType: row.owner_type,
-    ownerRef: row.owner_ref,
-    modelId: row.model_id,
-    modelName: row.model_name,
-    modelType: row.type_normalized,
-    streaming: row.streaming === 1,
-    size: row.size,
-    createdAt: row.created_at,
-    tags,
-    workflowTag: tags.workflow,
-    jobTag: tags.job,
-    stepTag: tags.step,
-  };
-}
-
-async function findLatestItemsFromCatalog(
-  dataQueryService: DataQueryService,
-  catalogStore: CatalogStore,
-): Promise<DataSearchItem[]> {
-  await dataQueryService.ensurePopulated();
-  const items: DataSearchItem[] = [];
-  for (const row of catalogStore.iterateFiltered("is_latest = ?", [1])) {
-    items.push(catalogRowToSearchItem(row));
-  }
-  return items;
-}
 
 export async function handleDataGet(
   socket: WebSocket,


### PR DESCRIPTION
## Summary

- Route `data search` through the SQLite catalog index instead of walking the entire `.swamp/data/` filesystem tree on every call
- On large repos (234k+ metadata files), reduces per-call latency from ~21s to sub-second
- Add `ensurePopulated()` to `DataQueryService` to trigger catalog backfill without CEL evaluation overhead
- Extract shared `catalogRowToSearchItem` adapter to avoid duplication between CLI and serve handlers

Fixes swamp-club#1827

## Test plan

- [x] All 11 `search_test.ts` unit tests pass with updated `DataSearchItem`-based mocks
- [x] All 54 `data_query_service_test.ts` tests pass (ensurePopulated refactor)
- [x] All 15 `data_search_test.ts` CLI command tests pass
- [x] Compiled binary verified against scratch repo: catalog created by search, correct results returned
- [x] Verification workflow: 10/11 steps passed, 1 skipped (CI security guard)
- [x] Code review: pass | Adversarial review: pass | UX review: pass

Co-authored-by: Sean Escriva <webframp@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8Pg9gVJirzKLfNobSpumd