### PR TITLE
fix(serve): seed WebSocket Origin allowlist from trustedHosts (swamp-club#1840)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -336,6 +336,13 @@ export function validateWebSocketOrigin(
     if (tlsEnabled) {
       TRUSTED_ORIGINS.add(`https://${bindHost.toLowerCase()}`);
     }
+    if (trustedHosts) {
+      for (const h of trustedHosts) {
+        const lh = h.toLowerCase();
+        TRUSTED_ORIGINS.add(`http://${lh}`);
+        TRUSTED_ORIGINS.add(`https://${lh}`);
+      }
+    }
 
     let originBase: string;
     try {

--- a/src/cli/commands/serve_test.ts
+++ b/src/cli/commands/serve_test.ts
@@ -351,16 +351,69 @@ Deno.test("validateWebSocketOrigin: multiple trusted hosts", () => {
   assertEquals(result2.allowed, true);
 });
 
-Deno.test("validateWebSocketOrigin: trusted hosts do not affect origin validation", () => {
+Deno.test("validateWebSocketOrigin: trusted hosts seed origin allowlist with https", () => {
   const result = validateWebSocketOrigin(
-    "http://host.docker.internal",
-    "host.docker.internal:9090",
+    "https://swamp.k3s-dev.example.com",
+    "swamp.k3s-dev.example.com:9090",
     "0.0.0.0",
     true,
-    ["host.docker.internal"],
+    ["swamp.k3s-dev.example.com"],
+  );
+  assertEquals(result.allowed, true);
+});
+
+Deno.test("validateWebSocketOrigin: trusted hosts seed origin allowlist with http", () => {
+  const result = validateWebSocketOrigin(
+    "http://swamp.k3s-dev.example.com",
+    "swamp.k3s-dev.example.com:9090",
+    "0.0.0.0",
+    false,
+    ["swamp.k3s-dev.example.com"],
+  );
+  assertEquals(result.allowed, true);
+});
+
+Deno.test("validateWebSocketOrigin: untrusted origin still rejected with trusted hosts set", () => {
+  const result = validateWebSocketOrigin(
+    "https://evil.com",
+    "swamp.k3s-dev.example.com:9090",
+    "0.0.0.0",
+    true,
+    ["swamp.k3s-dev.example.com"],
   );
   assertEquals(result.allowed, false);
   assertStringIncludes(result.reason!, "untrusted origin");
+});
+
+Deno.test("validateWebSocketOrigin: multiple trusted hosts seed origin allowlist", () => {
+  const result1 = validateWebSocketOrigin(
+    "https://host-a.example.com",
+    "host-a.example.com:9090",
+    "0.0.0.0",
+    true,
+    ["host-a.example.com", "host-b.example.com"],
+  );
+  assertEquals(result1.allowed, true);
+
+  const result2 = validateWebSocketOrigin(
+    "https://host-b.example.com",
+    "host-b.example.com:9090",
+    "0.0.0.0",
+    true,
+    ["host-a.example.com", "host-b.example.com"],
+  );
+  assertEquals(result2.allowed, true);
+});
+
+Deno.test("validateWebSocketOrigin: trusted hosts origin check is case-insensitive", () => {
+  const result = validateWebSocketOrigin(
+    "https://Swamp.K3S-Dev.Example.Com",
+    "swamp.k3s-dev.example.com:9090",
+    "0.0.0.0",
+    true,
+    ["swamp.k3s-dev.example.com"],
+  );
+  assertEquals(result.allowed, true);
 });
 
 Deno.test("validateWebSocketOrigin: empty trusted hosts array has no effect", () => {


### PR DESCRIPTION
## Summary

- **Bug**: `validateWebSocketOrigin` used `trustedHosts` for the Host header
  check but not for the Origin check, making the dashboard WebSocket unusable
  behind an ingress even when all other config (auth, TLS, `trustedHosts`) was
  correct
- **Fix**: Seed `TRUSTED_ORIGINS` from `trustedHosts` with both `http://` and
  `https://` variants so the Origin check honors the same hostnames the operator
  declared safe
- Replaced the old test asserting trusted hosts did *not* affect origin
  validation with 5 new tests covering the corrected behavior

## Test Plan

- [x] `deno run test src/cli/commands/serve_test.ts` — all 65 tests pass
- [x] Verification workflow (build + reviews) passed — attestation posted
- [x] New tests cover: HTTPS origin via trustedHosts, HTTP origin via
  trustedHosts, untrusted origin still rejected, multiple trustedHosts entries,
  case-insensitivity