### PR TITLE
fix(serve): disable stale-row filtering for remote datastores (swamp-club#1828)

### DIFF
--- a/design/data-query.md
+++ b/design/data-query.md
@@ -369,6 +369,19 @@ materialized on demand. Under the previous destructive replace semantics, a
 walk gap was data loss in the catalog; under additive upsert, a walk gap is a
 no-op for the rows it misses.
 
+### Stale-Row Filtering
+
+`DataQueryService` accepts a `filterStaleRows` option. When enabled, the
+query hydration loop calls `Deno.statSync` on each row's `raw` content file
+and drops rows where the file is absent. This catches catalog rows orphaned
+by a model retype (type field changed, UUID kept), where data moves to a new
+type directory path and the old catalog row becomes stale.
+
+`filterStaleRows` must be **disabled** for remote datastores (S3/GCS) where
+content may not yet be hydrated into the local cache. A missing `raw` file in
+that context means "not yet downloaded", not "stale". The repo-context
+composition root sets `filterStaleRows: !isCustomDatastoreConfig(...)`.
+
 The trade-off is that the catalog can accumulate orphaned rows for data that
 was genuinely deleted or renamed outside the write-through path (e.g. manual
 file deletion). Write-through handles normal deletes and renames, and

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -465,6 +465,7 @@ export async function requireInitializedRepoReadOnly(
     namespace: datastoreConfig.namespace,
     hydrateFile: hydrateFileHook,
     autoGc: marker?.autoGc === true,
+    filterStaleRows: !isCustomDatastoreConfig(datastoreConfig),
     ...factoryConfig,
   });
 
@@ -684,6 +685,7 @@ export function requireInitializedRepo(
         : undefined,
       namespace: datastoreConfig.namespace,
       autoGc: marker?.autoGc === true,
+      filterStaleRows: !isCustomDatastoreConfig(datastoreConfig),
       ...factoryConfig,
     });
 
@@ -837,6 +839,7 @@ export async function requireInitializedRepoUnlocked(
       : undefined,
     namespace: datastoreConfig.namespace,
     autoGc: marker?.autoGc === true,
+    filterStaleRows: !isCustomDatastoreConfig(datastoreConfig),
     ...factoryConfig,
   });
 

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -1709,6 +1709,40 @@ Deno.test("DataQueryService: skips stale catalog rows with missing backing files
   catalog.close();
 });
 
+Deno.test("DataQueryService: filterStaleRows disabled preserves rows with missing backing files (remote datastore)", () => {
+  const dir = Deno.makeTempDirSync({ prefix: "swamp-query-no-stale-" });
+  const dbPath = join(dir, ".swamp", "data", "_catalog.db");
+  const catalog = new CatalogStore(dbPath);
+  catalog.markPopulated();
+  const dataRepo = new FileSystemUnifiedDataRepository(dir, undefined, catalog);
+  const service = new DataQueryService(catalog, dataRepo, {
+    filterStaleRows: false,
+  });
+
+  catalog.upsert(makeRow({
+    model_name: "remote-model",
+    data_name: "state-main",
+    type_normalized: "test/remote-type",
+    model_id: "remote-model-id",
+    version: 1,
+    is_latest: 1,
+    id: "00000000-0000-1000-8000-000000000077",
+  }));
+
+  const results = service.querySync(
+    'modelName == "remote-model"',
+  ) as DataRecord[];
+
+  assertEquals(
+    results.length,
+    1,
+    "rows with missing backing files must be kept when filterStaleRows is disabled",
+  );
+  assertEquals(results[0].modelId, "remote-model-id");
+
+  catalog.close();
+});
+
 Deno.test("DataQueryService: filterStaleRows skips foreign namespace rows (no local backing file expected)", () => {
   const dir = Deno.makeTempDirSync({ prefix: "swamp-query-foreign-stale-" });
   const dbPath = join(dir, ".swamp", "data", "_catalog.db");

--- a/src/infrastructure/persistence/repository_factory.ts
+++ b/src/infrastructure/persistence/repository_factory.ts
@@ -328,6 +328,15 @@ export interface RepositoryFactoryConfig {
    */
   namespace?: string;
   autoGc?: boolean;
+  /**
+   * When true, catalog query hydration drops rows whose backing `raw` file
+   * is absent on local disk. Correct for filesystem datastores where a
+   * missing file means the catalog row is stale (e.g. model retype moved
+   * data to a different type path). Must be false for remote datastores
+   * where content may not yet be hydrated into the local cache.
+   * Defaults to true for backward compatibility.
+   */
+  filterStaleRows?: boolean;
 }
 
 /**
@@ -448,7 +457,7 @@ export function createRepositoryContext(
   // never need to reach into the repo to rebuild it. This keeps the
   // catalog handle as an infrastructure detail of the composition root.
   const dataQueryService = new DataQueryService(catalogStore, unifiedDataRepo, {
-    filterStaleRows: true,
+    filterStaleRows: config.filterStaleRows ?? true,
   });
   const outputRepo = new YamlOutputRepository(
     repoDir,

--- a/src/serve/boot_reconciliation.ts
+++ b/src/serve/boot_reconciliation.ts
@@ -92,8 +92,10 @@ export async function hydrateLocalCache(
       ...(deps.namespace ? { namespace: deps.namespace } : {}),
     });
     const count = typeof pulled === "number" ? pulled : 0;
-    if (count > 0) {
-      logger.info`Pulled ${count} file(s) from remote datastore`;
+    if (pulled !== 0) {
+      if (count > 0) {
+        logger.info`Pulled ${count} file(s) from remote datastore`;
+      }
       deps.catalogInvalidate();
     }
     return { pulled: count };

--- a/src/serve/boot_reconciliation.ts
+++ b/src/serve/boot_reconciliation.ts
@@ -94,8 +94,8 @@ export async function hydrateLocalCache(
     const count = typeof pulled === "number" ? pulled : 0;
     if (count > 0) {
       logger.info`Pulled ${count} file(s) from remote datastore`;
+      deps.catalogInvalidate();
     }
-    deps.catalogInvalidate();
     return { pulled: count };
   } catch (err: unknown) {
     logger.warn(

--- a/src/serve/boot_reconciliation_test.ts
+++ b/src/serve/boot_reconciliation_test.ts
@@ -1266,11 +1266,11 @@ Deno.test("hydrateLocalCache: invalidates catalog after successful pull", async 
   assertEquals(h.invalidated.length, 1);
 });
 
-Deno.test("hydrateLocalCache: handles void return from pullChanged without invalidating", async () => {
+Deno.test("hydrateLocalCache: invalidates on void return (unknown count = be safe)", async () => {
   const h = createHydrateDeps({ pullResult: undefined });
   const result = await hydrateLocalCache(h.deps);
   assertEquals(result.pulled, 0);
-  assertEquals(h.invalidated.length, 0);
+  assertEquals(h.invalidated.length, 1);
 });
 
 Deno.test("hydrateLocalCache: does not invalidate catalog when zero files pulled", async () => {

--- a/src/serve/boot_reconciliation_test.ts
+++ b/src/serve/boot_reconciliation_test.ts
@@ -1266,11 +1266,17 @@ Deno.test("hydrateLocalCache: invalidates catalog after successful pull", async 
   assertEquals(h.invalidated.length, 1);
 });
 
-Deno.test("hydrateLocalCache: handles void return from pullChanged", async () => {
+Deno.test("hydrateLocalCache: handles void return from pullChanged without invalidating", async () => {
   const h = createHydrateDeps({ pullResult: undefined });
   const result = await hydrateLocalCache(h.deps);
   assertEquals(result.pulled, 0);
-  assertEquals(h.invalidated.length, 1);
+  assertEquals(h.invalidated.length, 0);
+});
+
+Deno.test("hydrateLocalCache: does not invalidate catalog when zero files pulled", async () => {
+  const h = createHydrateDeps({ pullResult: 0 });
+  await hydrateLocalCache(h.deps);
+  assertEquals(h.invalidated.length, 0);
 });
 
 Deno.test("hydrateLocalCache: catches pull failure and returns zero", async () => {


### PR DESCRIPTION
## Summary

- Disable `filterStaleRows` for remote datastores (S3/GCS) where missing
  `raw` content files mean "not yet hydrated", not "stale catalog row"
- Add `filterStaleRows` to `RepositoryFactoryConfig` (default `true` for
  backward compat); all three `createRepositoryContext` call sites in
  `repo_context.ts` pass `!isCustomDatastoreConfig(datastoreConfig)`
- Gate `hydrateLocalCache` catalog invalidation: `pulled !== 0` (treats
  `undefined`/void as "unknown count, invalidate to be safe"; explicit `0`
  skips invalidation)

**Root cause**: PR #2218 (Aug 23) introduced `filterStaleRows: true`
unconditionally in `createRepositoryContext`. During query hydration, it calls
`Deno.statSync` on each catalog row's `raw` file and silently drops rows where
the file is absent. Correct for filesystem datastores (stale row from model
retype), but wrong for serve with remote datastores where content may not yet
be in the local cache. The commit message said "defaults off for remote/lazy
scenarios" but the conditional was never implemented.

**Reproduction**: S3 datastore (MinIO), data written by CLI, serve boots →
`data query 'true'` returns 0 results instead of 8. `data versions` (direct
filesystem, no stale filter) returns correct results.

Closes swamp-club#1828

## Test plan

- [x] Unit: `filterStaleRows: false` preserves rows with missing backing
  files (remote datastore scenario)
- [x] Unit: `filterStaleRows: true` still drops stale rows (#1737 retype
  regression preserved)
- [x] Unit: foreign namespace rows skip stale check regardless of setting
- [x] Unit: `hydrateLocalCache` does not invalidate on explicit zero pull
- [x] Unit: `hydrateLocalCache` invalidates on void return (unknown count)
- [x] E2E: patched binary + MinIO + deleted raw files → 8 results (was 4)
- [x] Build verification: 9/9 passed (lint, fmt, check, test, compile)
- [x] Reviews: code-review pass, adversarial-review pass, ux-review pass

Co-authored-by: Sean Escriva <webframp@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)