### PR TITLE
feat(definitions): preserve YAML comments and add description field

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -55,7 +55,8 @@
     "@opentelemetry/context-async-hooks": "npm:@opentelemetry/context-async-hooks@^1.30.1",
     "@opentelemetry/resources": "npm:@opentelemetry/resources@^1.30.1",
     "@opentelemetry/semantic-conventions": "npm:@opentelemetry/semantic-conventions@^1.40.0",
-    "@vercel/beautiful-mermaid": "npm:@vercel/beautiful-mermaid@^0.1.5"
+    "@vercel/beautiful-mermaid": "npm:@vercel/beautiful-mermaid@^0.1.5",
+    "yaml": "npm:yaml@^2.7.1"
   },
   "compilerOptions": {
     "jsx": "react",

--- a/deno.json
+++ b/deno.json
@@ -56,7 +56,7 @@
     "@opentelemetry/resources": "npm:@opentelemetry/resources@^1.30.1",
     "@opentelemetry/semantic-conventions": "npm:@opentelemetry/semantic-conventions@^1.40.0",
     "@vercel/beautiful-mermaid": "npm:@vercel/beautiful-mermaid@^0.1.5",
-    "yaml": "npm:yaml@^2.7.1"
+    "yaml": "npm:yaml@^2.9.0"
   },
   "compilerOptions": {
     "jsx": "react",

--- a/deno.lock
+++ b/deno.lock
@@ -38,13 +38,13 @@
     "npm:@opentelemetry/sdk-logs@~0.57.2": "0.57.2_@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/sdk-trace-base@^1.30.1": "1.30.1_@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/semantic-conventions@^1.40.0": "1.40.0",
-    "npm:@tailwindcss/vite@^4.3.3": "4.3.3_vite@6.4.3__@types+node@24.0.7",
+    "npm:@tailwindcss/vite@^4.3.3": "4.3.3_vite@6.4.3__@types+node@24.0.7__yaml@2.7.1_yaml@2.7.1",
     "npm:@types/js-yaml@^4.0.9": "4.0.9",
     "npm:@types/node@24.0.7": "24.0.7",
     "npm:@types/react-dom@^19.2.4": "19.2.4_@types+react@19.2.14",
     "npm:@types/react@^19.2.14": "19.2.14",
     "npm:@vercel/beautiful-mermaid@~0.1.5": "0.1.5",
-    "npm:@vitejs/plugin-react@^4.5.2": "4.7.0_vite@6.4.3__@types+node@24.0.7_@types+node@24.0.7",
+    "npm:@vitejs/plugin-react@^4.5.2": "4.7.0_vite@6.4.3__@types+node@24.0.7__yaml@2.7.1_yaml@2.7.1",
     "npm:croner@^9.1.0": "9.1.0",
     "npm:fast-check@^3.23.2": "3.23.2",
     "npm:fast-json-patch@^3.1.1": "3.1.1",
@@ -58,7 +58,9 @@
     "npm:react@^19.2.5": "19.2.7",
     "npm:tailwindcss@^4.3.3": "4.3.3",
     "npm:typescript@^5.8.3": "5.9.3",
-    "npm:vite@^6.3.5": "6.4.3_@types+node@24.0.7",
+    "npm:vite@^6.3.5": "6.4.3_@types+node@24.0.7_yaml@2.7.1",
+    "npm:yaml@2.7.1": "2.7.1",
+    "npm:yaml@^2.7.1": "2.7.1",
     "npm:zod@3.24.4": "3.24.4",
     "npm:zod@^4.3.6": "4.4.3",
     "npm:zod@^4.4.3": "4.4.3"
@@ -1573,7 +1575,7 @@
         "@tailwindcss/oxide-win32-x64-msvc"
       ]
     },
-    "@tailwindcss/vite@4.3.3_vite@6.4.3__@types+node@24.0.7": {
+    "@tailwindcss/vite@4.3.3_vite@6.4.3__@types+node@24.0.7__yaml@2.7.1_yaml@2.7.1": {
       "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
       "dependencies": [
         "@tailwindcss/node",
@@ -1641,7 +1643,7 @@
         "@dagrejs/dagre"
       ]
     },
-    "@vitejs/plugin-react@4.7.0_vite@6.4.3__@types+node@24.0.7_@types+node@24.0.7": {
+    "@vitejs/plugin-react@4.7.0_vite@6.4.3__@types+node@24.0.7__yaml@2.7.1_yaml@2.7.1": {
       "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
       "dependencies": [
         "@babel/core",
@@ -2409,7 +2411,7 @@
       ],
       "bin": true
     },
-    "vite@6.4.3_@types+node@24.0.7": {
+    "vite@6.4.3_@types+node@24.0.7_yaml@2.7.1": {
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dependencies": [
         "@types/node",
@@ -2418,13 +2420,15 @@
         "picomatch",
         "postcss",
         "rollup",
-        "tinyglobby"
+        "tinyglobby",
+        "yaml"
       ],
       "optionalDependencies": [
         "fsevents"
       ],
       "optionalPeers": [
-        "@types/node"
+        "@types/node",
+        "yaml"
       ],
       "bin": true
     },
@@ -2458,6 +2462,10 @@
     },
     "yallist@3.1.1": {
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+    },
+    "yaml@2.7.1": {
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "bin": true
     },
     "yargs-parser@20.2.9": {
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
@@ -2680,6 +2688,7 @@
       "npm:marked-terminal@^7.3.0",
       "npm:marked@^14.1.4",
       "npm:react@^19.2.5",
+      "npm:yaml@^2.7.1",
       "npm:zod@^4.4.3"
     ],
     "members": {

--- a/deno.lock
+++ b/deno.lock
@@ -38,13 +38,13 @@
     "npm:@opentelemetry/sdk-logs@~0.57.2": "0.57.2_@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/sdk-trace-base@^1.30.1": "1.30.1_@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/semantic-conventions@^1.40.0": "1.40.0",
-    "npm:@tailwindcss/vite@^4.3.3": "4.3.3_vite@6.4.3__@types+node@24.0.7__yaml@2.7.1_yaml@2.7.1",
+    "npm:@tailwindcss/vite@^4.3.3": "4.3.3_vite@6.4.3__@types+node@24.0.7__yaml@2.9.0_yaml@2.9.0",
     "npm:@types/js-yaml@^4.0.9": "4.0.9",
     "npm:@types/node@24.0.7": "24.0.7",
     "npm:@types/react-dom@^19.2.4": "19.2.4_@types+react@19.2.14",
     "npm:@types/react@^19.2.14": "19.2.14",
     "npm:@vercel/beautiful-mermaid@~0.1.5": "0.1.5",
-    "npm:@vitejs/plugin-react@^4.5.2": "4.7.0_vite@6.4.3__@types+node@24.0.7__yaml@2.7.1_yaml@2.7.1",
+    "npm:@vitejs/plugin-react@^4.5.2": "4.7.0_vite@6.4.3__@types+node@24.0.7__yaml@2.9.0_yaml@2.9.0",
     "npm:croner@^9.1.0": "9.1.0",
     "npm:fast-check@^3.23.2": "3.23.2",
     "npm:fast-json-patch@^3.1.1": "3.1.1",
@@ -58,9 +58,8 @@
     "npm:react@^19.2.5": "19.2.7",
     "npm:tailwindcss@^4.3.3": "4.3.3",
     "npm:typescript@^5.8.3": "5.9.3",
-    "npm:vite@^6.3.5": "6.4.3_@types+node@24.0.7_yaml@2.7.1",
-    "npm:yaml@2.7.1": "2.7.1",
-    "npm:yaml@^2.7.1": "2.7.1",
+    "npm:vite@^6.3.5": "6.4.3_@types+node@24.0.7_yaml@2.9.0",
+    "npm:yaml@^2.9.0": "2.9.0",
     "npm:zod@3.24.4": "3.24.4",
     "npm:zod@^4.3.6": "4.4.3",
     "npm:zod@^4.4.3": "4.4.3"
@@ -1575,7 +1574,7 @@
         "@tailwindcss/oxide-win32-x64-msvc"
       ]
     },
-    "@tailwindcss/vite@4.3.3_vite@6.4.3__@types+node@24.0.7__yaml@2.7.1_yaml@2.7.1": {
+    "@tailwindcss/vite@4.3.3_vite@6.4.3__@types+node@24.0.7__yaml@2.9.0_yaml@2.9.0": {
       "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
       "dependencies": [
         "@tailwindcss/node",
@@ -1643,7 +1642,7 @@
         "@dagrejs/dagre"
       ]
     },
-    "@vitejs/plugin-react@4.7.0_vite@6.4.3__@types+node@24.0.7__yaml@2.7.1_yaml@2.7.1": {
+    "@vitejs/plugin-react@4.7.0_vite@6.4.3__@types+node@24.0.7__yaml@2.9.0_yaml@2.9.0": {
       "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
       "dependencies": [
         "@babel/core",
@@ -2411,7 +2410,7 @@
       ],
       "bin": true
     },
-    "vite@6.4.3_@types+node@24.0.7_yaml@2.7.1": {
+    "vite@6.4.3_@types+node@24.0.7_yaml@2.9.0": {
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dependencies": [
         "@types/node",
@@ -2463,8 +2462,8 @@
     "yallist@3.1.1": {
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
-    "yaml@2.7.1": {
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+    "yaml@2.9.0": {
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "bin": true
     },
     "yargs-parser@20.2.9": {
@@ -2688,7 +2687,7 @@
       "npm:marked-terminal@^7.3.0",
       "npm:marked@^14.1.4",
       "npm:react@^19.2.5",
-      "npm:yaml@^2.7.1",
+      "npm:yaml@^2.9.0",
       "npm:zod@^4.4.3"
     ],
     "members": {

--- a/src/domain/definitions/definition.ts
+++ b/src/domain/definitions/definition.ts
@@ -207,6 +207,7 @@ const DefinitionObjectSchema = z.object({
   ),
   id: z.string().uuid(),
   name: definitionNameBase,
+  description: z.string().optional(),
   version: z.number().int().positive(),
   tags: z.record(z.string(), z.string()).default({}),
   globalArguments: z.record(z.string(), z.unknown()).default({}),
@@ -225,6 +226,7 @@ const DefinitionStrictObjectSchema = z.object({
   ),
   id: z.string().uuid(),
   name: definitionNameStrict,
+  description: z.string().optional(),
   version: z.number().int().positive(),
   tags: z.record(z.string(), z.string()).default({}),
   globalArguments: z.record(z.string(), z.unknown()).default({}),
@@ -274,6 +276,7 @@ export interface CreateDefinitionProps {
   typeVersion?: string;
   id?: string;
   name: string;
+  description?: string;
   version?: number;
   tags?: Record<string, string>;
   globalArguments?: Record<string, unknown>;
@@ -299,6 +302,7 @@ export class Definition {
     readonly typeVersion: string | undefined,
     readonly id: DefinitionId,
     readonly name: string,
+    readonly description: string | undefined,
     readonly version: number,
     private _tags: Record<string, string>,
     private _globalArguments: Record<string, unknown>,
@@ -324,6 +328,7 @@ export class Definition {
       typeVersion: props.typeVersion,
       id,
       name: props.name,
+      description: props.description,
       version,
       tags: props.tags ?? {},
       globalArguments: props.globalArguments ?? {},
@@ -339,6 +344,7 @@ export class Definition {
       validated.typeVersion,
       createDefinitionId(validated.id),
       validated.name,
+      validated.description,
       validated.version,
       validated.tags,
       validated.globalArguments,
@@ -363,6 +369,7 @@ export class Definition {
       validated.typeVersion,
       createDefinitionId(validated.id),
       validated.name,
+      validated.description,
       validated.version,
       validated.tags,
       validated.globalArguments,
@@ -393,6 +400,7 @@ export class Definition {
       newTypeVersion,
       original.id,
       original.name,
+      original.description,
       original.version,
       { ...original._tags },
       structuredClone(newGlobalArguments),
@@ -527,6 +535,7 @@ export class Definition {
       typeVersion: this.typeVersion,
       id: this.id,
       name: this.name,
+      description: this.description,
       version: this.version,
       tags: { ...this._tags },
       globalArguments: structuredClone(this._globalArguments),
@@ -543,7 +552,12 @@ export class Definition {
    * This hash uniquely identifies the definition configuration.
    */
   async computeHash(): Promise<string> {
-    const { type: _type, typeVersion: _tv, ...contentData } = this.toData();
+    const {
+      type: _type,
+      typeVersion: _tv,
+      description: _desc,
+      ...contentData
+    } = this.toData();
     // Recursively sort keys for consistent hashing
     const sortedData = JSON.stringify(contentData, (_key, value) => {
       if (

--- a/src/domain/definitions/definition_test.ts
+++ b/src/domain/definitions/definition_test.ts
@@ -327,6 +327,7 @@ Deno.test("Definition.toData returns correct structure", () => {
     typeVersion: undefined,
     id: "550e8400-e29b-41d4-a716-446655440000",
     name: "test-definition",
+    description: undefined,
     version: 2,
     tags: { env: "prod" },
     globalArguments: { message: "hello" },
@@ -681,4 +682,78 @@ Deno.test("Definition.parse: resources without vaultName remain backwards compat
   const definition = Definition.fromData(data);
   assertEquals(definition.resources?.result?.vaultName, undefined);
   assertEquals(definition.resources?.result?.lifetime, "infinite");
+});
+
+// --- Description field tests ---
+
+Deno.test("Definition.create: accepts description", () => {
+  const def = Definition.create({
+    name: "with-desc",
+    description: "EC2 instance for ML workloads",
+  });
+  assertEquals(def.description, "EC2 instance for ML workloads");
+});
+
+Deno.test("Definition.create: description is optional", () => {
+  const def = Definition.create({ name: "no-desc" });
+  assertEquals(def.description, undefined);
+});
+
+Deno.test("Definition.fromData: round-trips description", () => {
+  const original = Definition.create({
+    name: "round-trip-desc",
+    description: "Important context about this definition",
+  });
+  const data = original.toData();
+  assertEquals(data.description, "Important context about this definition");
+
+  const restored = Definition.fromData(data);
+  assertEquals(restored.description, "Important context about this definition");
+});
+
+Deno.test("Definition.fromData: parses without description (backwards compatible)", () => {
+  const data = {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "legacy-def",
+    version: 1,
+    tags: {},
+    globalArguments: {},
+    methods: {},
+  };
+  const def = Definition.fromData(data as DefinitionData);
+  assertEquals(def.description, undefined);
+  assertEquals(def.name, "legacy-def");
+});
+
+Deno.test("Definition.computeHash: excludes description", async () => {
+  const defA = Definition.create({
+    name: "hash-test",
+    description: "First description",
+    globalArguments: { key: "value" },
+  });
+  const defB = Definition.create({
+    id: defA.id,
+    name: "hash-test",
+    description: "Different description",
+    globalArguments: { key: "value" },
+  });
+
+  const hashA = await defA.computeHash();
+  const hashB = await defB.computeHash();
+  assertEquals(hashA, hashB, "description should not affect computeHash");
+});
+
+Deno.test("Definition.withUpgradedGlobalArguments: preserves description", () => {
+  const original = Definition.create({
+    name: "upgrade-desc",
+    description: "Preserved across upgrades",
+    globalArguments: { old: "value" },
+  });
+  const upgraded = Definition.withUpgradedGlobalArguments(
+    original,
+    { new: "value" },
+    "2026.1.0",
+  );
+  assertEquals(upgraded.description, "Preserved across upgrades");
+  assertEquals(upgraded.globalArguments.new, "value");
 });

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -537,6 +537,11 @@ export class YamlDefinitionRepository implements DefinitionRepository {
       }
 
       if (await this.exists(targetPath)) {
+        await this.cleanupOldPaths(
+          targetPath,
+          previousPath,
+          legacyPath,
+        );
         this.idToActualPath.set(definition.id, targetPath);
         if (this.eventBus) {
           await this.eventBus.publish(
@@ -554,40 +559,7 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     const content = stringifyYaml(cleanData);
     await atomicWriteTextFile(targetPath, content);
 
-    // Clean up old file if we wrote to a different path
-    if (previousPath && previousPath !== targetPath) {
-      try {
-        await Deno.remove(previousPath);
-        logger.debug`Migrated definition file from ${
-          basename(previousPath)
-        } to ${basename(targetPath)}`;
-      } catch (error) {
-        if (!(error instanceof Deno.errors.NotFound)) {
-          logger.warn`Failed to remove old definition file ${previousPath}: ${
-            error instanceof Error ? error.message : String(error)
-          }`;
-        }
-      }
-    }
-
-    // Also check the legacy UUID path if it wasn't the previousPath
-    if (
-      targetPath !== legacyPath && previousPath !== legacyPath &&
-      await this.exists(legacyPath)
-    ) {
-      try {
-        await Deno.remove(legacyPath);
-        logger.debug`Migrated definition file from ${basename(legacyPath)} to ${
-          basename(targetPath)
-        }`;
-      } catch (error) {
-        if (!(error instanceof Deno.errors.NotFound)) {
-          logger.warn`Failed to remove legacy definition file ${legacyPath}: ${
-            error instanceof Error ? error.message : String(error)
-          }`;
-        }
-      }
-    }
+    await this.cleanupOldPaths(targetPath, previousPath, legacyPath);
 
     this.idToActualPath.set(definition.id, targetPath);
 
@@ -671,6 +643,45 @@ export class YamlDefinitionRepository implements DefinitionRepository {
 
   getPath(type: ModelType, id: DefinitionId): string {
     return this.idToActualPath.get(id) ?? this.getLegacyPath(type, id);
+  }
+
+  private async cleanupOldPaths(
+    targetPath: string,
+    previousPath: string | undefined,
+    legacyPath: string,
+  ): Promise<void> {
+    if (previousPath && previousPath !== targetPath) {
+      try {
+        await Deno.remove(previousPath);
+        logger.debug`Migrated definition file from ${
+          basename(previousPath)
+        } to ${basename(targetPath)}`;
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          logger.warn`Failed to remove old definition file ${previousPath}: ${
+            error instanceof Error ? error.message : String(error)
+          }`;
+        }
+      }
+    }
+
+    if (
+      targetPath !== legacyPath && previousPath !== legacyPath &&
+      await this.exists(legacyPath)
+    ) {
+      try {
+        await Deno.remove(legacyPath);
+        logger.debug`Migrated definition file from ${basename(legacyPath)} to ${
+          basename(targetPath)
+        }`;
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          logger.warn`Failed to remove legacy definition file ${legacyPath}: ${
+            error instanceof Error ? error.message : String(error)
+          }`;
+        }
+      }
+    }
   }
 
   private resolveWritePath(

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -24,6 +24,13 @@ import { atomicWriteTextFile } from "./atomic_write.ts";
 import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { isIoError } from "./io_errors.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import {
+  type Document as YamlDocument,
+  isMap,
+  isSeq,
+  parseDocument,
+  type YAMLMap,
+} from "yaml";
 import { assertSafePath } from "./safe_path.ts";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
@@ -486,8 +493,65 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     }
 
     // Remove undefined values since YAML can't stringify them
-    const cleanData = JSON.parse(JSON.stringify(data));
-    const content = stringifyYaml(cleanData as Record<string, unknown>);
+    const cleanData = JSON.parse(JSON.stringify(data)) as Record<
+      string,
+      unknown
+    >;
+
+    // When the file already exists at the target path, check whether the
+    // definition data has actually changed. If it hasn't, skip the write
+    // entirely to avoid destroying YAML comments and producing git noise.
+    // When the data HAS changed, use npm:yaml's Document API to merge the
+    // new values onto the existing AST so that comments on unchanged nodes
+    // are preserved.
+    if (!isNew && await this.exists(targetPath)) {
+      try {
+        const existingRaw = await Deno.readTextFile(targetPath);
+        const existingParsed = parseYaml(existingRaw) as Record<
+          string,
+          unknown
+        >;
+        const normalizedExisting = JSON.parse(
+          JSON.stringify(existingParsed),
+        ) as Record<string, unknown>;
+
+        if (
+          canonicalJson(cleanData) === canonicalJson(normalizedExisting)
+        ) {
+          this.idToActualPath.set(definition.id, targetPath);
+          logger.debug`Definition ${definition.name} unchanged, skipping write`;
+          return;
+        }
+
+        // Data changed — merge onto existing document to preserve comments
+        const doc = parseDocument(existingRaw);
+        mergeIntoDocument(doc, cleanData);
+        await atomicWriteTextFile(targetPath, doc.toString());
+      } catch (error) {
+        if (error instanceof Deno.errors.NotFound) {
+          // File disappeared between exists() and read — fall through to
+          // fresh write below.
+        } else {
+          throw error;
+        }
+      }
+
+      if (await this.exists(targetPath)) {
+        this.idToActualPath.set(definition.id, targetPath);
+        if (this.eventBus) {
+          await this.eventBus.publish(
+            createDefinitionUpdated(
+              type.normalized,
+              definition.id,
+              definition.name,
+            ),
+          );
+        }
+        return;
+      }
+    }
+
+    const content = stringifyYaml(cleanData);
     await atomicWriteTextFile(targetPath, content);
 
     // Clean up old file if we wrote to a different path
@@ -629,5 +693,75 @@ export class YamlDefinitionRepository implements DefinitionRepository {
 
   private getTypeDir(type: ModelType): string {
     return join(this.baseDir, type.toDirectoryPath());
+  }
+}
+
+function canonicalJson(data: Record<string, unknown>): string {
+  return JSON.stringify(data, (_key, value) => {
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      const sorted: Record<string, unknown> = {};
+      for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+        sorted[k] = (value as Record<string, unknown>)[k];
+      }
+      return sorted;
+    }
+    return value;
+  });
+}
+
+function mergeIntoDocument(
+  doc: YamlDocument,
+  newData: Record<string, unknown>,
+): void {
+  const root = doc.contents;
+  if (!isMap(root)) {
+    doc.contents = doc.createNode(newData);
+    return;
+  }
+  mergeMap(doc, root, newData);
+
+  // Remove keys from the document that are no longer in the new data
+  for (let i = root.items.length - 1; i >= 0; i--) {
+    const key = String(root.items[i].key);
+    if (!(key in newData)) {
+      root.items.splice(i, 1);
+    }
+  }
+}
+
+function mergeMap(
+  doc: YamlDocument,
+  map: YAMLMap,
+  data: Record<string, unknown>,
+): void {
+  for (const [key, newValue] of Object.entries(data)) {
+    const existing = map.get(key, true);
+
+    if (
+      existing !== undefined && isMap(existing) &&
+      newValue !== null && typeof newValue === "object" &&
+      !Array.isArray(newValue)
+    ) {
+      // Both sides are objects — recurse to preserve nested comments
+      mergeMap(doc, existing, newValue as Record<string, unknown>);
+
+      // Remove keys from the map that are no longer in the new data
+      for (let i = existing.items.length - 1; i >= 0; i--) {
+        const childKey = String(existing.items[i].key);
+        if (!(childKey in (newValue as Record<string, unknown>))) {
+          existing.items.splice(i, 1);
+        }
+      }
+    } else if (
+      existing !== undefined && isSeq(existing) && Array.isArray(newValue)
+    ) {
+      // Replace arrays wholesale — element-level merge would lose ordering semantics
+      map.set(key, doc.createNode(newValue));
+    } else {
+      const existingScalar = map.get(key);
+      if (existingScalar === undefined || existingScalar !== newValue) {
+        map.set(key, doc.createNode(newValue));
+      }
+    }
   }
 }

--- a/src/infrastructure/persistence/yaml_definition_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository_test.ts
@@ -926,3 +926,149 @@ Deno.test("YamlDefinitionRepository.findAllGlobal throws UserError on EACCES", a
     }
   });
 });
+
+// --- Skip-write and comment-preservation tests ---
+
+Deno.test("YamlDefinitionRepository.save: skips write when data is unchanged", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = createTestDefinition("unchanged-def");
+
+    await repo.save(testType, definition);
+
+    const typeDir = join(dir, "models", testType.toDirectoryPath());
+    const filePath = join(typeDir, "unchanged-def.yaml");
+
+    // Advance mtime so we can detect a rewrite
+    await Deno.utime(filePath, new Date(), new Date(0));
+    const statAfterUtime = await Deno.stat(filePath);
+    assertEquals(statAfterUtime.mtime?.getTime(), 0);
+
+    // Save again with the same data
+    await repo.save(testType, definition);
+
+    const statAfterSave = await Deno.stat(filePath);
+    // mtime should still be 0 — file was not rewritten
+    assertEquals(
+      statAfterSave.mtime?.getTime(),
+      0,
+      "File was rewritten despite unchanged data",
+    );
+
+    // Content should still be readable and correct
+    const loaded = await repo.findById(testType, definition.id);
+    assertEquals(loaded!.name, "unchanged-def");
+  });
+});
+
+Deno.test("YamlDefinitionRepository.save: writes when data has changed", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = createTestDefinition("changed-def");
+
+    await repo.save(testType, definition);
+
+    const typeDir = join(dir, "models", testType.toDirectoryPath());
+    const filePath = join(typeDir, "changed-def.yaml");
+
+    // Set mtime to epoch so we can detect a rewrite
+    await Deno.utime(filePath, new Date(), new Date(0));
+
+    // Mutate the definition and save again
+    definition.setGlobalArgument("newKey", "newValue");
+    await repo.save(testType, definition);
+
+    const statAfterSave = await Deno.stat(filePath);
+    assertNotEquals(
+      statAfterSave.mtime?.getTime(),
+      0,
+      "File was not rewritten despite changed data",
+    );
+
+    const loaded = await repo.findById(testType, definition.id);
+    assertEquals(loaded!.globalArguments.newKey, "newValue");
+  });
+});
+
+Deno.test("YamlDefinitionRepository.save: preserves YAML comments when data changes", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = createTestDefinition("commented-def");
+
+    await repo.save(testType, definition);
+
+    const typeDir = join(dir, "models", testType.toDirectoryPath());
+    const filePath = join(typeDir, "commented-def.yaml");
+
+    // Manually add comments to the saved file
+    const original = await Deno.readTextFile(filePath);
+    const withComments = "# This is an important header comment\n" + original
+      .replace(
+        "globalArguments:",
+        "globalArguments: # inline comment on globalArguments",
+      );
+    await Deno.writeTextFile(filePath, withComments);
+
+    // Change a tag (not globalArguments) and save
+    definition.setTag("env", "prod");
+    await repo.save(testType, definition);
+
+    const saved = await Deno.readTextFile(filePath);
+    assertStringIncludes(saved, "# This is an important header comment");
+    assertStringIncludes(saved, "# inline comment on globalArguments");
+    assertStringIncludes(saved, "env: prod");
+  });
+});
+
+Deno.test("YamlDefinitionRepository.save: preserves comments inside globalArguments on unchanged keys", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = Definition.create({
+      name: "deep-comments",
+      globalArguments: {
+        rootVolume: 64,
+        instanceType: "m5.large",
+      },
+    });
+
+    await repo.save(testType, definition);
+
+    const typeDir = join(dir, "models", testType.toDirectoryPath());
+    const filePath = join(typeDir, "deep-comments.yaml");
+
+    // Add a comment inside globalArguments explaining a sizing decision
+    const original = await Deno.readTextFile(filePath);
+    const withComment = original.replace(
+      "rootVolume: 64",
+      "# 64GB needed for the ML model cache — do not reduce\n  rootVolume: 64",
+    );
+    await Deno.writeTextFile(filePath, withComment);
+
+    // Change instanceType but NOT rootVolume
+    definition.setGlobalArgument("instanceType", "m5.xlarge");
+    await repo.save(testType, definition);
+
+    const saved = await Deno.readTextFile(filePath);
+    assertStringIncludes(
+      saved,
+      "# 64GB needed for the ML model cache",
+      "Comment inside globalArguments was lost",
+    );
+    assertStringIncludes(saved, "rootVolume: 64");
+    assertStringIncludes(saved, "m5.xlarge");
+  });
+});
+
+Deno.test("YamlDefinitionRepository.save: new definitions always write", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = createTestDefinition("brand-new");
+
+    await repo.save(testType, definition);
+
+    const typeDir = join(dir, "models", testType.toDirectoryPath());
+    const filePath = join(typeDir, "brand-new.yaml");
+    const content = await Deno.readTextFile(filePath);
+    assertStringIncludes(content, "brand-new");
+  });
+});


### PR DESCRIPTION
## Summary

- Skip unnecessary definition file writes when data is unchanged — prevents stripping YAML comments and avoids git noise
- Use `npm:yaml` Document API to merge changed values onto the existing YAML AST, preserving comments on unchanged nodes when definitions genuinely change
- Add optional `description` field to `DefinitionData` for structured definition-level reasoning that survives serialization

Closes swamp-club#1842

## Test Plan

- Unit tests verify skip-write when data unchanged (mtime check), write when data changed, comment preservation at top-level and inside nested `globalArguments`, new definitions always write
- Definition tests verify `description` round-trips through `toData`/`fromData`, is excluded from `computeHash`, is backwards-compatible (existing definitions parse without it), and is preserved across `withUpgradedGlobalArguments`
- End-to-end reproduction test verified all three asks from the issue: skip-write, comment preservation, and description field
- Verification workflow passed: lint, fmt, type-check, deps-audit, 10643 tests, compile, code-review, adversarial-review, ux-review