### PR TITLE
fix(data): skip specName ambiguity check on exact data name lookups (swamp-club#1838)

### DIFF
--- a/design/data-query.md
+++ b/design/data-query.md
@@ -50,11 +50,12 @@ Results from any shortcut are structurally identical to the equivalent
 `data.query()` call — same `DataRecord[]` type, same fields, same semantics.
 
 **specName ambiguity detection:** `data.latest()` throws a `UserError` when the
-matched data item's `specName` tag is shared by other data items under the same
-model. This prevents silent resolution to a single item when multiple items
-share the same spec. Use the specific data name or `data.findBySpec()` to
-explicitly query by specName. The raw `data.query()` equivalent does not perform
-this check.
+lookup argument matches a `specName` tag that is shared by multiple data items
+under the same model. This fires only when the argument equals the specName —
+callers who pass an exact data name that differs from the specName are not
+affected, even when sibling items share the same spec. Use `data.findBySpec()`
+to explicitly query by specName. The raw `data.query()` equivalent does not
+perform this check.
 
 ### Null-safe access (.?)
 

--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -201,7 +201,9 @@ export class DataQueryService {
     const row = this.catalogStore.findLatestRow(modelName, dataName, namespace);
     if (row) {
       if (populated) {
-        this.checkSpecNameAmbiguity(row.spec_name, modelName, namespace);
+        if (dataName === row.spec_name) {
+          this.checkSpecNameAmbiguity(row.spec_name, modelName, namespace);
+        }
         return this.buildRecordFromRow(modelName, dataName, namespace, row);
       }
       // Catalog not populated — verify the data still exists on disk to

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -17,7 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertNotEquals, assertThrows } from "@std/assert";
+import {
+  assertEquals,
+  assertNotEquals,
+  assertRejects,
+  assertThrows,
+} from "@std/assert";
 import { join } from "@std/path";
 import { ensureDirSync } from "@std/fs";
 import { stringify as stringifyYaml } from "@std/yaml";
@@ -1248,6 +1253,70 @@ Deno.test("getLatestRecord: namespace filtering works in scoped path", async () 
 
   catalog.close();
   Deno.removeSync(dir, { recursive: true });
+});
+
+Deno.test("getLatestRecord: exact data name skips specName ambiguity check (swamp-club#1838)", async () => {
+  const { catalog, service } = setupTest();
+
+  // Two data items with different names but the same specName "state"
+  catalog.upsert(
+    makeRow({
+      data_name: "hs",
+      spec_name: "state",
+      id: "00000000-0000-1000-8000-000000001838",
+      tags:
+        '{"type":"resource","specName":"state","modelName":"ingest"}',
+    }),
+  );
+  catalog.upsert(
+    makeRow({
+      data_name: "learning",
+      spec_name: "state",
+      id: "00000000-0000-1000-8000-000000001839",
+      tags:
+        '{"type":"resource","specName":"state","modelName":"ingest"}',
+    }),
+  );
+
+  // Calling with exact data name "hs" must NOT throw — the caller is
+  // unambiguously requesting a specific data item, not a specName.
+  const record = await service.getLatestRecord("ingest", "hs");
+  assertNotEquals(record, null);
+  assertEquals(record!.name, "hs");
+
+  catalog.close();
+});
+
+Deno.test("getLatestRecord: dataName matching specName still throws on ambiguity", async () => {
+  const { catalog, service } = setupTest();
+
+  // Data name "state" matches its own specName "state" — ambiguity check fires
+  catalog.upsert(
+    makeRow({
+      data_name: "state",
+      spec_name: "state",
+      id: "00000000-0000-1000-8000-000000001840",
+      tags:
+        '{"type":"resource","specName":"state","modelName":"ingest"}',
+    }),
+  );
+  catalog.upsert(
+    makeRow({
+      data_name: "learning",
+      spec_name: "state",
+      id: "00000000-0000-1000-8000-000000001841",
+      tags:
+        '{"type":"resource","specName":"state","modelName":"ingest"}',
+    }),
+  );
+
+  await assertRejects(
+    () => service.getLatestRecord("ingest", "state"),
+    Error,
+    "Ambiguous data.latest() match",
+  );
+
+  catalog.close();
 });
 
 // ---------------------------------------------------------------------------

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -1264,8 +1264,7 @@ Deno.test("getLatestRecord: exact data name skips specName ambiguity check (swam
       data_name: "hs",
       spec_name: "state",
       id: "00000000-0000-1000-8000-000000001838",
-      tags:
-        '{"type":"resource","specName":"state","modelName":"ingest"}',
+      tags: '{"type":"resource","specName":"state","modelName":"ingest"}',
     }),
   );
   catalog.upsert(
@@ -1273,8 +1272,7 @@ Deno.test("getLatestRecord: exact data name skips specName ambiguity check (swam
       data_name: "learning",
       spec_name: "state",
       id: "00000000-0000-1000-8000-000000001839",
-      tags:
-        '{"type":"resource","specName":"state","modelName":"ingest"}',
+      tags: '{"type":"resource","specName":"state","modelName":"ingest"}',
     }),
   );
 
@@ -1296,8 +1294,7 @@ Deno.test("getLatestRecord: dataName matching specName still throws on ambiguity
       data_name: "state",
       spec_name: "state",
       id: "00000000-0000-1000-8000-000000001840",
-      tags:
-        '{"type":"resource","specName":"state","modelName":"ingest"}',
+      tags: '{"type":"resource","specName":"state","modelName":"ingest"}',
     }),
   );
   catalog.upsert(
@@ -1305,8 +1302,7 @@ Deno.test("getLatestRecord: dataName matching specName still throws on ambiguity
       data_name: "learning",
       spec_name: "state",
       id: "00000000-0000-1000-8000-000000001841",
-      tags:
-        '{"type":"resource","specName":"state","modelName":"ingest"}',
+      tags: '{"type":"resource","specName":"state","modelName":"ingest"}',
     }),
   );
 

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -813,7 +813,9 @@ export class ModelResolver {
               );
               if (data) {
                 if (
-                  data.tags["specName"] && this.dataQueryService
+                  data.tags["specName"] &&
+                  dataName === data.tags["specName"] &&
+                  this.dataQueryService
                 ) {
                   const targetNs = ns.namespacePredicate
                     ? ns.namespacePredicate.match(
@@ -877,7 +879,7 @@ export class ModelResolver {
         checkWildcardAmbiguity(results, rawModelName);
         if (results.length > 0) {
           const specName = results[0].specName;
-          if (specName) {
+          if (specName && dataName === specName) {
             this.dataQueryService.checkSpecNameAmbiguity(
               specName,
               ns.modelName,

--- a/src/domain/expressions/model_resolver_test.ts
+++ b/src/domain/expressions/model_resolver_test.ts
@@ -1721,7 +1721,11 @@ Deno.test("data.latest() with exact data name skips specName ambiguity check (sw
       contentType: "application/json",
       lifetime: "infinite",
       garbageCollection: 10,
-      tags: { type: "resource", specName: "state", modelName: "node-provisioner" },
+      tags: {
+        type: "resource",
+        specName: "state",
+        modelName: "node-provisioner",
+      },
       ownerDefinition: owner,
     });
     await dataRepo.save(
@@ -1736,7 +1740,11 @@ Deno.test("data.latest() with exact data name skips specName ambiguity check (sw
       contentType: "application/json",
       lifetime: "infinite",
       garbageCollection: 10,
-      tags: { type: "resource", specName: "state", modelName: "node-provisioner" },
+      tags: {
+        type: "resource",
+        specName: "state",
+        modelName: "node-provisioner",
+      },
       ownerDefinition: owner,
     });
     await dataRepo.save(

--- a/src/domain/expressions/model_resolver_test.ts
+++ b/src/domain/expressions/model_resolver_test.ts
@@ -1697,3 +1697,69 @@ Deno.test("data.latest() passes when specName is unique", async () => {
     catalog.close();
   });
 });
+
+Deno.test("data.latest() with exact data name skips specName ambiguity check (swamp-club#1838)", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalog,
+    );
+    const type = ModelType.create("test/model");
+
+    const model = Definition.create({
+      name: "node-provisioner",
+      globalArguments: {},
+    });
+    await defRepo.save(type, model);
+
+    const data1 = Data.create({
+      name: "hs",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", specName: "state", modelName: "node-provisioner" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      data1,
+      new TextEncoder().encode(JSON.stringify({ ipv4: "10.0.0.1" })),
+    );
+
+    const data2 = Data.create({
+      name: "learning",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", specName: "state", modelName: "node-provisioner" },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      type,
+      model.id,
+      data2,
+      new TextEncoder().encode(JSON.stringify({ ipv4: "10.0.0.2" })),
+    );
+
+    const dqs = new DataQueryService(catalog, dataRepo);
+    await dqs.query('name == ""');
+
+    const resolver = new ModelResolver(defRepo, {
+      repoDir,
+      dataRepo,
+      dataQueryService: dqs,
+    });
+    const ctx = await resolver.buildContext();
+
+    assertExists(ctx.data);
+    const result = await ctx.data.latest("node-provisioner", "hs");
+    assertExists(result);
+    assertEquals(result.attributes.ipv4, "10.0.0.1");
+    catalog.close();
+  });
+});


### PR DESCRIPTION
## Summary

- The specName ambiguity guard from #1816 fired unconditionally after every `data.latest()` lookup, even when the caller passed an exact, unique data name — breaking factory/fan-out models where one spec produces multiple named data items
- Now the check only fires when the lookup argument equals the specName (the case where the caller might have intended a specName-based lookup)
- Added guard at all three call sites: `getLatestRecord`, model resolver `findByName` path, and model resolver wildcard/query path

Fixes swamp-club#1838

## Test plan

- [x] Unit test: exact data name with shared specName does NOT throw
- [x] Unit test: dataName matching specName still throws on ambiguity
- [x] Model resolver e2e test: `data.latest()` with exact data name succeeds with shared-specName siblings
- [x] Existing ambiguity test continues to pass (dataName === specName case)
- [x] Full test suite: 10,641 passed, 0 failed
- [x] Verification workflow: build (lint, fmt, test, compile, deps-audit) and agent reviews all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)