### PR TITLE
fix(serve): remove http2:false error masking from WebSocket clients, add --ca-cert to worker connect (swamp-club#1843)

### DIFF
--- a/src/cli/commands/worker_connect.ts
+++ b/src/cli/commands/worker_connect.ts
@@ -34,6 +34,7 @@ import { VERSION } from "./version.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 import { parseTimeout } from "../duration_parser.ts";
 import { resolveExtraHeaders } from "../../domain/auth/extra_headers.ts";
+import { getEnvCaCerts } from "../remote_run.ts";
 
 // Import models barrel so built-in models resolve from the worker's own
 // registry when a `builtin:` bundle fingerprint is dispatched.
@@ -133,6 +134,10 @@ export const workerConnectCommand = new Command()
   .option(
     "--concurrency <n:string>",
     'Number of concurrent dispatch slots ("auto" = CPU count, min 1). Default: 1 (env: SWAMP_WORKER_CONCURRENCY)',
+  )
+  .option(
+    "--ca-cert <path:string>",
+    "Path to PEM-encoded CA certificate to trust for TLS connections to the orchestrator (env: SWAMP_CA_CERT)",
   )
   .action(async function (options: AnyOptions, urlArg?: string) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -243,6 +248,7 @@ export const workerConnectCommand = new Command()
         dataPlaneUrl: options.dataPlaneUrl,
         cacheDir,
         headers: extraHeaders,
+        caCerts: getEnvCaCerts(),
         reconnect: options.reconnect !== false,
         maxDispatches: maxDispatchesRaw,
         idleTimeoutMs,

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -238,30 +238,11 @@ export function requestServerResponse<T>(
       if (!settled) {
         settled = true;
         cleanup();
-
-        const errorMsg = connectErrorDetail;
-        if (errorMsg.includes(H2_MASKED_ERROR)) {
-          diagnoseTlsError(baseUrl).then((diagnosis) => {
-            const detail = diagnosis ? `: ${diagnosis}` : connectErrorDetail;
-            reject(
-              new UserError(
-                `Could not connect to ${baseUrl}${detail}`,
-              ),
-            );
-          }).catch(() => {
-            reject(
-              new UserError(
-                `Could not connect to ${baseUrl}${connectErrorDetail}`,
-              ),
-            );
-          });
-        } else {
-          reject(
-            new UserError(
-              `Could not connect to ${baseUrl}${connectErrorDetail}`,
-            ),
-          );
-        }
+        reject(
+          new UserError(
+            `Could not connect to ${baseUrl}${connectErrorDetail}`,
+          ),
+        );
       }
     };
 
@@ -407,29 +388,15 @@ async function classifyConnectionError(
       return `Authentication failed — run: swamp auth server-login --server ${wsUrl}`;
     }
   }
-  if (originalMessage.includes(H2_MASKED_ERROR)) {
-    try {
-      const diagnosis = await diagnoseTlsError(wsUrl);
-      if (diagnosis) return diagnosis;
-    } catch { /* fall through to other checks */ }
-  }
+  const tlsGuidance = diagnoseTlsMessage(originalMessage);
+  if (tlsGuidance) return tlsGuidance;
   if (await probeServerHealth(wsUrl)) {
     return `Authentication failed — run: swamp auth server-login --server ${wsUrl}`;
   }
   return originalMessage;
 }
 
-// Force HTTP/1.1 ALPN for wss:// connections so WebSocket upgrades succeed
-// through HTTP/2-capable reverse proxies (Caddy, Traefik, nginx). Without
-// this, Deno's default client advertises h2 ALPN, the proxy selects h2, and
-// the HTTP/1.1 WebSocket Upgrade is invalid over HTTP/2.
-// See: https://github.com/denoland/deno/issues/16923
-//
-// Caveat: this flag causes Deno to mask all TLS errors (UnknownIssuer,
-// CaUsedAsEndEntity, expired, etc.) as "HTTP/2 not supported by this
-// client" in the WebSocket code path. diagnoseTlsError() below works
-// around this by probing with fetch() when that message appears.
-const wsHttpClient = Deno.createHttpClient({ http2: false });
+const wsHttpClient = Deno.createHttpClient({});
 
 let resolvedEnvCaCerts: string[] | undefined;
 
@@ -491,7 +458,6 @@ function createSocket(
   if (effectiveCaCerts?.length) {
     if (!cachedCaCertClient) {
       cachedCaCertClient = Deno.createHttpClient({
-        http2: false,
         caCerts: effectiveCaCerts,
       });
     }
@@ -506,72 +472,49 @@ function createSocket(
   return new WebSocket(url, opts);
 }
 
-const H2_MASKED_ERROR = "HTTP/2 not supported by this client";
-
 /**
- * When `createHttpClient({ http2: false })` is used, Deno's WebSocket
- * masks every TLS validation error — and also HTTP error codes like 401
- * — as "HTTP/2 not supported by this client". Probe with `fetch()` to
- * surface the real error. Uses the CA cert from `--ca-cert` /
- * `SWAMP_CA_CERT` when available so the probe reflects the same trust
- * configuration as the WebSocket connection; without this, a server
- * that rejects an unauthenticated upgrade (401) is misdiagnosed as a
- * TLS failure because the bare probe fails on an untrusted issuer.
- * Returns a more helpful message or `undefined` if the probe succeeds
- * (meaning the WebSocket failure has a different cause).
+ * Matches known TLS error patterns in the WebSocket error message and
+ * returns user-friendly guidance. Returns `undefined` when the message
+ * does not look like a TLS error.
  */
-export async function diagnoseTlsError(
-  wsUrl: string,
-): Promise<string | undefined> {
-  let parsed: URL;
-  try {
-    parsed = new URL(wsUrl);
-  } catch {
-    return undefined;
+export function diagnoseTlsMessage(
+  message: string,
+): string | undefined {
+  if (message.includes("CaUsedAsEndEntity")) {
+    return (
+      `TLS certificate rejected: the server certificate has ` +
+      `basicConstraints CA:TRUE, which is invalid for a server ` +
+      `(end-entity) certificate. Regenerate with ` +
+      `"basicConstraints=critical,CA:FALSE" — restart swamp serve ` +
+      `to see the exact openssl command`
+    );
   }
-  if (parsed.protocol !== "wss:") return undefined;
 
-  parsed.protocol = "https:";
-  const fetchClient = getCaCertFetchClient();
-  const fetchOpts: Record<string, unknown> = {
-    signal: AbortSignal.timeout(3_000),
-  };
-  if (fetchClient) fetchOpts.client = fetchClient;
-  try {
-    const resp = await fetch(parsed.href, fetchOpts);
-    await resp.body?.cancel();
-    return undefined;
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-
-    if (msg.includes("CaUsedAsEndEntity")) {
-      return (
-        `TLS certificate rejected: the server certificate has ` +
-        `basicConstraints CA:TRUE, which is invalid for a server ` +
-        `(end-entity) certificate. Regenerate with ` +
-        `"basicConstraints=critical,CA:FALSE" — restart swamp serve ` +
-        `to see the exact openssl command`
-      );
-    }
-
-    if (msg.includes("UnknownIssuer")) {
-      return (
-        `TLS certificate rejected: the server's certificate issuer is ` +
-        `not trusted. If using a self-signed certificate, pass it with ` +
-        `--ca-cert /path/to/cert.pem or set SWAMP_CA_CERT=/path/to/cert.pem`
-      );
-    }
-
-    if (msg.includes("expired") || msg.includes("NotValidYet")) {
-      return `TLS certificate rejected: ${msg}`;
-    }
-
-    if (msg.includes("AbortError") || msg.includes("timed out")) {
-      return undefined;
-    }
-
-    return `TLS connection failed: ${msg}`;
+  if (message.includes("UnknownIssuer")) {
+    return (
+      `TLS certificate rejected: the server's certificate issuer is ` +
+      `not trusted. If using a self-signed certificate, pass it with ` +
+      `--ca-cert /path/to/cert.pem or set SWAMP_CA_CERT=/path/to/cert.pem`
+    );
   }
+
+  if (message.includes("not valid for name")) {
+    return (
+      `TLS certificate rejected: the server's certificate does not ` +
+      `match the hostname you connected to. Check that the URL matches ` +
+      `the certificate's subject or SAN entries`
+    );
+  }
+
+  if (message.includes("expired") || message.includes("NotValidYet")) {
+    return `TLS certificate rejected: ${message}`;
+  }
+
+  if (message.includes("invalid peer certificate")) {
+    return `TLS certificate rejected: ${message}`;
+  }
+
+  return undefined;
 }
 
 interface OutboundRequest {

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -25,7 +25,7 @@ import {
 } from "@std/assert";
 import { UserError } from "../domain/errors.ts";
 import {
-  diagnoseTlsError,
+  diagnoseTlsMessage,
   normalizeServerUrl,
   probeServerHealth,
   requestServerResponse,
@@ -1236,22 +1236,39 @@ Deno.test({
   },
 });
 
-// ── diagnoseTlsError tests ────────────────────────────────────────────
+// ── diagnoseTlsMessage tests ──────────────────────────────────────────
 
-Deno.test({
-  name: "diagnoseTlsError: returns undefined for non-wss URLs",
-  sanitizeOps: false,
-  sanitizeResources: false,
-  fn: async () => {
-    assertEquals(await diagnoseTlsError("ws://127.0.0.1:9999"), undefined);
-  },
+Deno.test("diagnoseTlsMessage: returns guidance for CaUsedAsEndEntity", () => {
+  const result = diagnoseTlsMessage(
+    "invalid peer certificate: Other(OtherError(CaUsedAsEndEntity))",
+  );
+  assertStringIncludes(result!, "CA:TRUE");
+  assertStringIncludes(result!, "CA:FALSE");
 });
 
-Deno.test({
-  name: "diagnoseTlsError: returns undefined for invalid URL",
-  sanitizeOps: false,
-  sanitizeResources: false,
-  fn: async () => {
-    assertEquals(await diagnoseTlsError("not-a-url"), undefined);
-  },
+Deno.test("diagnoseTlsMessage: returns guidance for UnknownIssuer", () => {
+  const result = diagnoseTlsMessage(
+    "invalid peer certificate: UnknownIssuer",
+  );
+  assertStringIncludes(result!, "--ca-cert");
+  assertStringIncludes(result!, "SWAMP_CA_CERT");
+});
+
+Deno.test("diagnoseTlsMessage: returns guidance for hostname mismatch", () => {
+  const result = diagnoseTlsMessage(
+    'certificate not valid for name "localhost"; certificate is only valid for DnsName("external.example.com")',
+  );
+  assertStringIncludes(result!, "does not match the hostname");
+});
+
+Deno.test("diagnoseTlsMessage: returns message for expired cert", () => {
+  const result = diagnoseTlsMessage(
+    "invalid peer certificate: expired",
+  );
+  assertStringIncludes(result!, "TLS certificate rejected");
+});
+
+Deno.test("diagnoseTlsMessage: returns undefined for non-TLS errors", () => {
+  assertEquals(diagnoseTlsMessage("connection refused"), undefined);
+  assertEquals(diagnoseTlsMessage("DNS lookup failed"), undefined);
 });

--- a/src/worker/connect.ts
+++ b/src/worker/connect.ts
@@ -45,18 +45,11 @@ import {
   type WorkerDispatchEvent,
 } from "./dispatch_handler.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+import { diagnoseTlsMessage } from "../cli/remote_run.ts";
 
 const logger = getSwampLogger(["worker", "connect"]);
 
-// Force HTTP/1.1 ALPN for wss:// so WebSocket upgrades succeed through
-// HTTP/2-capable reverse proxies. See: https://github.com/denoland/deno/issues/16923
-//
-// Caveat: this flag causes Deno to mask all TLS errors as "HTTP/2 not
-// supported by this client" in the WebSocket code path. The CLI side
-// (remote_run.ts) diagnoses the real error; here we log it as-is since
-// the worker connect loop retries and the serve-side startup warning
-// catches the most common cert issue (CA:TRUE).
-const wsHttpClient = Deno.createHttpClient({ http2: false });
+const defaultHttpClient = Deno.createHttpClient({});
 
 /** Refresh the session credential when 2/3 of its lifetime has elapsed. */
 const REFRESH_FRACTION = 2 / 3;
@@ -120,6 +113,8 @@ export interface RunWorkerOptions {
   onDrainAvailable?: (requestDrain: (reason: WorkerExitReason) => void) => void;
   /** Extra headers for proxy/tunnel pass-through (env: SWAMP_SERVE_EXTRA_HEADERS). */
   headers?: Record<string, string>;
+  /** PEM-encoded CA certificates to trust for TLS connections. */
+  caCerts?: string[];
   /** Test seam: WebSocket factory. */
   createSocket?: (url: string, headers?: Record<string, string>) => WebSocket;
   /** Test seam: override the runner command for the dispatch child process. */
@@ -146,6 +141,9 @@ export async function runWorker(
   const cacheDir = options.cacheDir ??
     await Deno.makeTempDir({ prefix: "swamp-worker-cache-" });
   const machineId = await loadOrCreateMachineId(cacheDir);
+  const httpClient = options.caCerts?.length
+    ? Deno.createHttpClient({ caCerts: options.caCerts })
+    : defaultHttpClient;
 
   const concurrency = options.concurrency ?? 1;
   let drainReason: WorkerExitReason | null = null;
@@ -213,6 +211,7 @@ export async function runWorker(
     try {
       const outcome = await connectOnce({
         options,
+        httpClient,
         instanceUuid,
         machineId,
         session,
@@ -250,11 +249,12 @@ export async function runWorker(
       options.onStatus?.({ kind: "disconnected", reason: outcome });
       delayMs = RECONNECT_BASE_DELAY_MS;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      if (isPermanentEnrollmentFailure(message)) {
-        options.onStatus?.({ kind: "stopped", reason: message });
+      const raw = error instanceof Error ? error.message : String(error);
+      if (isPermanentEnrollmentFailure(raw)) {
+        options.onStatus?.({ kind: "stopped", reason: raw });
         throw error;
       }
+      const message = diagnoseTlsMessage(raw) ?? raw;
       consecutivePreEnrollFailures++;
       if (consecutivePreEnrollFailures >= MAX_PRE_ENROLL_FAILURES) {
         const reason =
@@ -338,6 +338,7 @@ function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
 
 interface ConnectOnceArgs {
   options: RunWorkerOptions;
+  httpClient: Deno.HttpClient;
   instanceUuid: string;
   machineId: string;
   session: SessionState;
@@ -358,7 +359,7 @@ function connectOnce(args: ConnectOnceArgs): Promise<string> {
   const { options, instanceUuid, machineId, session } = args;
   return new Promise<string>((resolve, reject) => {
     const defaultCreate = (url: string, headers?: Record<string, string>) => {
-      const opts: Record<string, unknown> = { client: wsHttpClient };
+      const opts: Record<string, unknown> = { client: args.httpClient };
       if (headers && Object.keys(headers).length > 0) {
         opts.headers = headers;
       }


### PR DESCRIPTION
## Summary

- Remove the harmful `Deno.createHttpClient({ http2: false })` flag from both WebSocket client paths — Deno's WebSocket always negotiates HTTP/1.1 in TLS ALPN regardless of this flag; its only effect was masking all TLS validation errors as the misleading "HTTP/2 not supported by this client" message
- Replace the async `diagnoseTlsError()` fetch probe with synchronous `diagnoseTlsMessage()` pattern matcher — real TLS errors now surface directly with actionable guidance (UnknownIssuer → `--ca-cert` guidance, hostname mismatch → SAN guidance, CaUsedAsEndEntity → regenerate guidance)
- Add `--ca-cert` / `SWAMP_CA_CERT` to `swamp worker connect`, matching existing `--server` command support

Fixes swamp-club#1843.

## Root cause

PR #1941 added `http2: false` to WebSocket HTTP clients based on [denoland/deno#16923](https://github.com/denoland/deno/issues/16923), but that Deno issue and its fix ([denoland/deno#19303](https://github.com/denoland/deno/pull/19303)) only affected `fetch()` ALPN — WebSocket has always negotiated HTTP/1.1 independently. The flag was a no-op for WebSocket ALPN but introduced a Deno side-effect that masks all TLS errors behind a confusing h2 message. PR #2209's `diagnoseTlsError()` was a workaround for this self-inflicted masking.

Verified on Deno 2.8.3: WebSocket connects identically with and without the flag when certs are valid. The flag only changes error messages — removing it surfaces real TLS errors instead of "HTTP/2 not supported".

## Test plan

- [x] 42 remote_run tests passed (including 5 new `diagnoseTlsMessage` tests)
- [x] 8 worker connect tests passed
- [x] 6 worker connect command tests passed
- [x] 10/10 end-to-end binary tests against compiled binary:
  - Untrusted issuer (--server) → shows real "issuer is not trusted" with `--ca-cert` guidance
  - Hostname mismatch (--server) → shows "does not match the hostname"
  - Valid cert + --ca-cert (--server) → connects successfully
  - Worker connect + untrusted issuer → shows real cert error with guidance
  - Worker connect + valid cert + --ca-cert → connects successfully
  - Zero occurrences of "HTTP/2 not supported" in any test
- [x] Verification workflow: lint, fmt, type-check, test, compile, code review, adversarial review, UX review — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Blake Irvin <blakeirvin@me.com>