### PR TITLE
feat(workflow): add --filter flag to workflow history search

### DIFF
--- a/.claude/skills/swamp/references/workflow/guide.md
+++ b/.claude/skills/swamp/references/workflow/guide.md
@@ -28,32 +28,33 @@ skill.
 
 ## Quick Reference
 
-| Task               | Command                                                       |
-| ------------------ | ------------------------------------------------------------- |
-| Get schema         | `swamp workflow schema get --json`                            |
-| Search workflows   | `swamp workflow search [query] --json`                        |
-| Get a workflow     | `swamp workflow get <id_or_name> --json`                      |
-| Create a workflow  | `swamp workflow create <name> --json`                         |
-| Edit a workflow    | `swamp workflow edit [id_or_name]`                            |
-| Delete a workflow  | `swamp workflow delete <id_or_name> --json`                   |
-| Validate workflow  | `swamp workflow validate [id_or_name] --json`                 |
-| Evaluate workflow  | `swamp workflow evaluate <id_or_name> --json`                 |
-| Run a workflow     | `swamp workflow run <id_or_name>`                             |
-| Run with inputs    | `swamp workflow run <id_or_name> --input key=value`           |
-| Run from stdin     | `echo '{"k":"v"}' \| swamp workflow run <id_or_name> --stdin` |
-| Approve step       | `swamp workflow approve <workflow> <step>`                    |
-| Reject step        | `swamp workflow reject <workflow> <step>`                     |
-| Resume workflow    | `swamp workflow resume <workflow> [--input k=v]`              |
-| Resume from step   | `swamp workflow resume <wf> --from <step>`                    |
-| List approvals     | `swamp workflow approvals`                                    |
-| Active runs        | `swamp run history --active`                                  |
-| Recent runs        | `swamp run history`                                           |
-| View run history   | `swamp workflow history search --json`                        |
-| Get latest run     | `swamp workflow history get <workflow> --json`                |
-| View run logs      | `swamp workflow history logs <run_or_workflow> --json`        |
-| List workflow data | `swamp data list --workflow <name> --json`                    |
-| Query wf data      | `swamp data query 'tags.workflow == "<name>"'`                |
-| Get workflow data  | `swamp data get --workflow <name> <data_name> --json`         |
+| Task               | Command                                                                  |
+| ------------------ | ------------------------------------------------------------------------ |
+| Get schema         | `swamp workflow schema get --json`                                       |
+| Search workflows   | `swamp workflow search [query] --json`                                   |
+| Get a workflow     | `swamp workflow get <id_or_name> --json`                                 |
+| Create a workflow  | `swamp workflow create <name> --json`                                    |
+| Edit a workflow    | `swamp workflow edit [id_or_name]`                                       |
+| Delete a workflow  | `swamp workflow delete <id_or_name> --json`                              |
+| Validate workflow  | `swamp workflow validate [id_or_name] --json`                            |
+| Evaluate workflow  | `swamp workflow evaluate <id_or_name> --json`                            |
+| Run a workflow     | `swamp workflow run <id_or_name>`                                        |
+| Run with inputs    | `swamp workflow run <id_or_name> --input key=value`                      |
+| Run from stdin     | `echo '{"k":"v"}' \| swamp workflow run <id_or_name> --stdin`            |
+| Approve step       | `swamp workflow approve <workflow> <step>`                               |
+| Reject step        | `swamp workflow reject <workflow> <step>`                                |
+| Resume workflow    | `swamp workflow resume <workflow> [--input k=v]`                         |
+| Resume from step   | `swamp workflow resume <wf> --from <step>`                               |
+| List approvals     | `swamp workflow approvals`                                               |
+| Active runs        | `swamp run history --active`                                             |
+| Recent runs        | `swamp run history`                                                      |
+| View run history   | `swamp workflow history search --json`                                   |
+| Filter run history | `swamp workflow history search --filter 'inputs.commit == "abc"' --json` |
+| Get latest run     | `swamp workflow history get <workflow> --json`                           |
+| View run logs      | `swamp workflow history logs <run_or_workflow> --json`                   |
+| List workflow data | `swamp data list --workflow <name> --json`                               |
+| Query wf data      | `swamp data query 'tags.workflow == "<name>"'`                           |
+| Get workflow data  | `swamp data get --workflow <name> <data_name> --json`                    |
 
 ## Repository Structure
 

--- a/.claude/skills/swamp/references/workflow/reference.md
+++ b/.claude/skills/swamp/references/workflow/reference.md
@@ -310,6 +310,11 @@ stdin item.
 ```bash
 swamp workflow history search --json
 swamp workflow history search "deploy" --json
+
+# Filter with a CEL expression over run metadata
+swamp workflow history search --filter 'inputs.commit == "b3ff3a8a"' --json
+swamp workflow history search --filter 'status == "failed"' --json
+swamp workflow history search verify-reviews --filter 'inputs.branch == "main"' --json
 ```
 
 **Output shape:**

--- a/packages/client/protocol.ts
+++ b/packages/client/protocol.ts
@@ -215,6 +215,7 @@ export interface WorkflowHistorySearchPayload {
   query?: string;
   workflow?: string;
   inputs?: Record<string, string>;
+  filter?: string;
 }
 
 export interface WorkflowRunSearchPayload {

--- a/src/cli/commands/workflow_history_search.ts
+++ b/src/cli/commands/workflow_history_search.ts
@@ -154,6 +154,7 @@ export async function workflowHistorySearchAction(
           query,
           workflow: options.workflow as string | undefined,
           inputs: parsedInputs,
+          filter: options.filter as string | undefined,
         },
       },
     );
@@ -215,6 +216,7 @@ export async function workflowHistorySearchAction(
       query,
       workflow: options.workflow as string | undefined,
       inputs: parsedInputs,
+      filter: options.filter as string | undefined,
     }),
     handlers,
   );
@@ -263,6 +265,14 @@ export const workflowHistorySearchCommand = withRemoteOptions(
     .description("Search workflow run history")
     .example("Browse run history", "swamp workflow history search")
     .example("Search runs", "swamp workflow history search deploy")
+    .example(
+      "Filter by commit",
+      "swamp workflow history search --filter 'inputs.commit == \"b3ff3a8a\"'",
+    )
+    .example(
+      "Filter failed runs",
+      "swamp workflow history search --filter 'status == \"failed\"'",
+    )
     .arguments("[query:string]")
     .option(
       "--repo-dir <dir:string>",
@@ -276,5 +286,9 @@ export const workflowHistorySearchCommand = withRemoteOptions(
       "--input <input:string>",
       "Filter by workflow input (KEY=VALUE), can be repeated",
       { collect: true },
+    )
+    .option(
+      "--filter <expression:string>",
+      "Filter results with a CEL expression over run metadata (inputs, tags, status, timing)",
     ),
 ).action(workflowHistorySearchAction);

--- a/src/infrastructure/cel/workflow_run_filter.ts
+++ b/src/infrastructure/cel/workflow_run_filter.ts
@@ -258,7 +258,7 @@ export function validateWorkflowRunFilter(
     return {
       valid: false,
       error:
-        `Filter exceeds maximum length of ${MAX_FILTER_LENGTH} bytes (got ${filter.length})`,
+        `Filter exceeds maximum length of ${MAX_FILTER_LENGTH} characters (got ${filter.length})`,
     };
   }
 
@@ -357,6 +357,10 @@ export function evaluateWorkflowRunFilter(
     failureReason: run.failureReason ?? "",
   };
 
-  const result = env.evaluate(filter, context);
-  return result === true;
+  try {
+    const result = env.evaluate(filter, context);
+    return result === true;
+  } catch {
+    return false;
+  }
 }

--- a/src/infrastructure/cel/workflow_run_filter.ts
+++ b/src/infrastructure/cel/workflow_run_filter.ts
@@ -1,0 +1,362 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Environment } from "cel-js";
+import { registerArithmeticOverloads } from "./cel_evaluator.ts";
+
+export const MAX_FILTER_LENGTH = 1024;
+export const MAX_AST_DEPTH = 24;
+export const MAX_COMPREHENSION_NESTING = 2;
+export const MAX_FILTER_COST = 500;
+
+export interface WorkflowRunFilterValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+interface ASTNode {
+  op: string;
+  args: unknown;
+}
+
+interface MatchesCallInfo {
+  isLiteral: boolean;
+  pattern?: string;
+}
+
+interface ASTMetrics {
+  maxDepth: number;
+  maxComprehensionNesting: number;
+  nodeCount: number;
+  weightedCost: number;
+  matchesCalls: MatchesCallInfo[];
+}
+
+const COMPREHENSION_MACROS = new Set([
+  "all",
+  "exists",
+  "exists_one",
+  "map",
+  "filter",
+]);
+
+const COMPREHENSION_COST_WEIGHT = 10;
+
+function collectASTMetrics(node: ASTNode): ASTMetrics {
+  const metrics: ASTMetrics = {
+    maxDepth: 0,
+    maxComprehensionNesting: 0,
+    nodeCount: 0,
+    weightedCost: 0,
+    matchesCalls: [],
+  };
+  walkNode(node, 0, 0, metrics);
+  return metrics;
+}
+
+function walkNode(
+  node: ASTNode,
+  depth: number,
+  comprehensionNesting: number,
+  metrics: ASTMetrics,
+): void {
+  if (!node || typeof node !== "object" || !("op" in node)) return;
+
+  metrics.nodeCount++;
+  if (depth > metrics.maxDepth) metrics.maxDepth = depth;
+  if (comprehensionNesting > metrics.maxComprehensionNesting) {
+    metrics.maxComprehensionNesting = comprehensionNesting;
+  }
+
+  const { op, args } = node;
+
+  if (op === "value") {
+    metrics.weightedCost++;
+    return;
+  }
+
+  if (op === "id") {
+    metrics.weightedCost++;
+    return;
+  }
+
+  if (op === "." || op === ".?") {
+    metrics.weightedCost++;
+    const arr = args as [ASTNode, string];
+    walkNode(arr[0], depth + 1, comprehensionNesting, metrics);
+    return;
+  }
+
+  if (op === "[]" || op === "[?]") {
+    metrics.weightedCost++;
+    const arr = args as [ASTNode, ASTNode];
+    walkNode(arr[0], depth + 1, comprehensionNesting, metrics);
+    walkNode(arr[1], depth + 1, comprehensionNesting, metrics);
+    return;
+  }
+
+  if (op === "call") {
+    metrics.weightedCost++;
+    const arr = args as [string, ASTNode[]];
+    for (const arg of arr[1]) {
+      walkNode(arg, depth + 1, comprehensionNesting, metrics);
+    }
+    return;
+  }
+
+  if (op === "rcall") {
+    const arr = args as [string, ASTNode, ASTNode[]];
+    const methodName = arr[0];
+    const receiver = arr[1];
+    const callArgs = arr[2];
+
+    if (COMPREHENSION_MACROS.has(methodName)) {
+      const newNesting = comprehensionNesting + 1;
+      metrics.weightedCost += COMPREHENSION_COST_WEIGHT;
+      walkNode(receiver, depth + 1, newNesting, metrics);
+      for (const arg of callArgs) {
+        walkNode(arg, depth + 1, newNesting, metrics);
+      }
+      return;
+    }
+
+    if (methodName === "matches") {
+      metrics.weightedCost++;
+      const patternNode = callArgs[0];
+      if (
+        patternNode && patternNode.op === "value" &&
+        typeof patternNode.args === "string"
+      ) {
+        metrics.matchesCalls.push({
+          isLiteral: true,
+          pattern: patternNode.args,
+        });
+      } else {
+        metrics.matchesCalls.push({ isLiteral: false });
+      }
+      walkNode(receiver, depth + 1, comprehensionNesting, metrics);
+      for (const arg of callArgs) {
+        walkNode(arg, depth + 1, comprehensionNesting, metrics);
+      }
+      return;
+    }
+
+    metrics.weightedCost++;
+    walkNode(receiver, depth + 1, comprehensionNesting, metrics);
+    for (const arg of callArgs) {
+      walkNode(arg, depth + 1, comprehensionNesting, metrics);
+    }
+    return;
+  }
+
+  if (op === "?:") {
+    metrics.weightedCost++;
+    const arr = args as [ASTNode, ASTNode, ASTNode];
+    for (const child of arr) {
+      walkNode(child, depth + 1, comprehensionNesting, metrics);
+    }
+    return;
+  }
+
+  if (op === "!_" || op === "-_") {
+    metrics.weightedCost++;
+    walkNode(args as ASTNode, depth + 1, comprehensionNesting, metrics);
+    return;
+  }
+
+  if (op === "list") {
+    metrics.weightedCost++;
+    for (const elem of args as ASTNode[]) {
+      walkNode(elem, depth + 1, comprehensionNesting, metrics);
+    }
+    return;
+  }
+
+  if (op === "map") {
+    metrics.weightedCost++;
+    const entries = args as Array<[ASTNode, ASTNode]>;
+    for (const [key, value] of entries) {
+      walkNode(key, depth + 1, comprehensionNesting, metrics);
+      walkNode(value, depth + 1, comprehensionNesting, metrics);
+    }
+    return;
+  }
+
+  if (Array.isArray(args)) {
+    metrics.weightedCost++;
+    for (const child of args as unknown[]) {
+      if (child && typeof child === "object" && "op" in (child as ASTNode)) {
+        walkNode(child as ASTNode, depth + 1, comprehensionNesting, metrics);
+      }
+    }
+    return;
+  }
+
+  metrics.weightedCost++;
+}
+
+const CATASTROPHIC_BACKTRACKING_PATTERN =
+  /\([^)]*[+*][^)]*\)[+*?]|\(\?:[^)]*[+*][^)]*\)[+*?]/;
+
+function checkRegexComplexity(pattern: string): string | undefined {
+  if (CATASTROPHIC_BACKTRACKING_PATTERN.test(pattern)) {
+    return `matches() pattern "${pattern}" contains a potentially catastrophic backtracking construct`;
+  }
+  try {
+    new RegExp(pattern);
+  } catch {
+    return `matches() pattern "${pattern}" is not a valid regular expression`;
+  }
+  return undefined;
+}
+
+const WORKFLOW_RUN_FIELDS: Record<string, string> = {
+  workflowName: "string",
+  status: "string",
+  startedAt: "string",
+  completedAt: "string",
+  duration: "double",
+  instanceId: "string",
+  triggerSource: "string",
+  failedStep: "string",
+  failureReason: "string",
+  inputs: "map",
+  tags: "map",
+};
+
+function createWorkflowRunFilterEnvironment(): Environment {
+  const env = new Environment({ unlistedVariablesAreDyn: false });
+  registerArithmeticOverloads(env);
+
+  for (const [field, type] of Object.entries(WORKFLOW_RUN_FIELDS)) {
+    env.registerVariable(field, type);
+  }
+
+  return env;
+}
+
+export function validateWorkflowRunFilter(
+  filter: string,
+): WorkflowRunFilterValidationResult {
+  if (filter.length > MAX_FILTER_LENGTH) {
+    return {
+      valid: false,
+      error:
+        `Filter exceeds maximum length of ${MAX_FILTER_LENGTH} bytes (got ${filter.length})`,
+    };
+  }
+
+  const env = createWorkflowRunFilterEnvironment();
+
+  let parsed: { ast: ASTNode };
+  try {
+    parsed = env.parse(filter) as unknown as { ast: ASTNode };
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    return { valid: false, error: `CEL syntax error: ${message}` };
+  }
+
+  const checkResult = env.check(filter);
+  if (!checkResult.valid) {
+    const message = checkResult.error instanceof Error
+      ? checkResult.error.message
+      : String(checkResult.error);
+    return { valid: false, error: `CEL type error: ${message}` };
+  }
+
+  const metrics = collectASTMetrics(parsed.ast);
+
+  if (metrics.maxDepth > MAX_AST_DEPTH) {
+    return {
+      valid: false,
+      error:
+        `Filter exceeds maximum AST depth of ${MAX_AST_DEPTH} (got ${metrics.maxDepth})`,
+    };
+  }
+
+  if (metrics.maxComprehensionNesting > MAX_COMPREHENSION_NESTING) {
+    return {
+      valid: false,
+      error:
+        `Filter exceeds maximum comprehension nesting of ${MAX_COMPREHENSION_NESTING} (got ${metrics.maxComprehensionNesting})`,
+    };
+  }
+
+  if (metrics.weightedCost > MAX_FILTER_COST) {
+    return {
+      valid: false,
+      error:
+        `Filter exceeds maximum cost budget of ${MAX_FILTER_COST} (estimated ${metrics.weightedCost})`,
+    };
+  }
+
+  for (const matchesCall of metrics.matchesCalls) {
+    if (!matchesCall.isLiteral) {
+      return {
+        valid: false,
+        error:
+          "matches() pattern must be a string literal, not a dynamic expression",
+      };
+    }
+    const regexError = checkRegexComplexity(matchesCall.pattern!);
+    if (regexError) {
+      return { valid: false, error: regexError };
+    }
+  }
+
+  return { valid: true };
+}
+
+export interface WorkflowRunFilterContext {
+  workflowName: string;
+  status: string;
+  startedAt?: string;
+  completedAt?: string;
+  duration?: number;
+  inputs?: Record<string, unknown>;
+  tags?: Record<string, string>;
+  instanceId?: string;
+  triggerSource?: string;
+  failedStep?: string;
+  failureReason?: string;
+}
+
+export function evaluateWorkflowRunFilter(
+  filter: string,
+  run: WorkflowRunFilterContext,
+): boolean {
+  const env = createWorkflowRunFilterEnvironment();
+
+  const context: Record<string, unknown> = {
+    workflowName: run.workflowName,
+    status: run.status,
+    startedAt: run.startedAt ?? "",
+    completedAt: run.completedAt ?? "",
+    duration: run.duration ?? 0,
+    inputs: run.inputs ?? {},
+    tags: run.tags ?? {},
+    instanceId: run.instanceId ?? "",
+    triggerSource: run.triggerSource ?? "",
+    failedStep: run.failedStep ?? "",
+    failureReason: run.failureReason ?? "",
+  };
+
+  const result = env.evaluate(filter, context);
+  return result === true;
+}

--- a/src/infrastructure/cel/workflow_run_filter_test.ts
+++ b/src/infrastructure/cel/workflow_run_filter_test.ts
@@ -1,0 +1,224 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  evaluateWorkflowRunFilter,
+  MAX_FILTER_LENGTH,
+  validateWorkflowRunFilter,
+  type WorkflowRunFilterContext,
+} from "./workflow_run_filter.ts";
+
+const RUN: WorkflowRunFilterContext = {
+  workflowName: "verify-reviews",
+  status: "succeeded",
+  startedAt: "2026-08-26T10:00:00Z",
+  completedAt: "2026-08-26T10:05:00Z",
+  duration: 300000,
+  inputs: { commit: "b3ff3a8a", branch: "feature/foo" },
+  tags: { env: "ci", worktree: "1848" },
+  instanceId: "inst-123",
+  triggerSource: "cli",
+  failedStep: "",
+  failureReason: "",
+};
+
+// --- Validation: valid expressions ---
+
+Deno.test("validateWorkflowRunFilter: simple string equality", () => {
+  const result = validateWorkflowRunFilter('status == "succeeded"');
+  assertEquals(result, { valid: true });
+});
+
+Deno.test("validateWorkflowRunFilter: inputs map access", () => {
+  const result = validateWorkflowRunFilter(
+    'inputs.commit == "b3ff3a8a"',
+  );
+  assertEquals(result, { valid: true });
+});
+
+Deno.test("validateWorkflowRunFilter: tags map access", () => {
+  const result = validateWorkflowRunFilter('tags.env == "ci"');
+  assertEquals(result, { valid: true });
+});
+
+Deno.test("validateWorkflowRunFilter: duration numeric comparison", () => {
+  const result = validateWorkflowRunFilter("duration > 60000");
+  assertEquals(result, { valid: true });
+});
+
+Deno.test("validateWorkflowRunFilter: compound expression", () => {
+  const result = validateWorkflowRunFilter(
+    'status == "failed" && inputs.branch == "main"',
+  );
+  assertEquals(result, { valid: true });
+});
+
+Deno.test("validateWorkflowRunFilter: startedAt string comparison", () => {
+  const result = validateWorkflowRunFilter('startedAt > "2026-08-01"');
+  assertEquals(result, { valid: true });
+});
+
+Deno.test("validateWorkflowRunFilter: matches with literal pattern", () => {
+  const result = validateWorkflowRunFilter(
+    'workflowName.matches("verify-.*")',
+  );
+  assertEquals(result, { valid: true });
+});
+
+// --- Validation: invalid expressions ---
+
+Deno.test("validateWorkflowRunFilter: syntax error", () => {
+  const result = validateWorkflowRunFilter("status ==");
+  assertEquals(result.valid, false);
+  assertStringIncludes(result.error!, "CEL syntax error");
+});
+
+Deno.test("validateWorkflowRunFilter: unknown variable", () => {
+  const result = validateWorkflowRunFilter('nonexistent == "foo"');
+  assertEquals(result.valid, false);
+  assertStringIncludes(result.error!, "CEL type error");
+});
+
+Deno.test("validateWorkflowRunFilter: exceeds max length", () => {
+  const longFilter = "a".repeat(MAX_FILTER_LENGTH + 1);
+  const result = validateWorkflowRunFilter(longFilter);
+  assertEquals(result.valid, false);
+  assertStringIncludes(result.error!, "maximum length");
+});
+
+Deno.test("validateWorkflowRunFilter: matches with dynamic pattern rejected", () => {
+  const result = validateWorkflowRunFilter(
+    "workflowName.matches(status)",
+  );
+  assertEquals(result.valid, false);
+  assertStringIncludes(result.error!, "string literal");
+});
+
+Deno.test("validateWorkflowRunFilter: catastrophic backtracking pattern rejected", () => {
+  const result = validateWorkflowRunFilter(
+    'workflowName.matches("(a+)+")',
+  );
+  assertEquals(result.valid, false);
+  assertStringIncludes(result.error!, "catastrophic backtracking");
+});
+
+// --- Evaluation: matching ---
+
+Deno.test("evaluateWorkflowRunFilter: matches on status", () => {
+  assertEquals(
+    evaluateWorkflowRunFilter('status == "succeeded"', RUN),
+    true,
+  );
+});
+
+Deno.test("evaluateWorkflowRunFilter: matches on inputs.commit", () => {
+  assertEquals(
+    evaluateWorkflowRunFilter('inputs.commit == "b3ff3a8a"', RUN),
+    true,
+  );
+});
+
+Deno.test("evaluateWorkflowRunFilter: matches on tags.env", () => {
+  assertEquals(
+    evaluateWorkflowRunFilter('tags.env == "ci"', RUN),
+    true,
+  );
+});
+
+Deno.test("evaluateWorkflowRunFilter: matches on duration comparison", () => {
+  assertEquals(
+    evaluateWorkflowRunFilter("duration > 60000", RUN),
+    true,
+  );
+});
+
+Deno.test("evaluateWorkflowRunFilter: matches on compound expression", () => {
+  assertEquals(
+    evaluateWorkflowRunFilter(
+      'status == "succeeded" && inputs.branch == "feature/foo"',
+      RUN,
+    ),
+    true,
+  );
+});
+
+Deno.test("evaluateWorkflowRunFilter: matches on workflowName", () => {
+  assertEquals(
+    evaluateWorkflowRunFilter('workflowName == "verify-reviews"', RUN),
+    true,
+  );
+});
+
+Deno.test("evaluateWorkflowRunFilter: startedAt lexicographic comparison", () => {
+  assertEquals(
+    evaluateWorkflowRunFilter('startedAt > "2026-08-01"', RUN),
+    true,
+  );
+  assertEquals(
+    evaluateWorkflowRunFilter('startedAt > "2026-09-01"', RUN),
+    false,
+  );
+});
+
+// --- Evaluation: non-matching ---
+
+Deno.test("evaluateWorkflowRunFilter: does not match wrong status", () => {
+  assertEquals(
+    evaluateWorkflowRunFilter('status == "failed"', RUN),
+    false,
+  );
+});
+
+Deno.test("evaluateWorkflowRunFilter: does not match wrong input", () => {
+  assertEquals(
+    evaluateWorkflowRunFilter('inputs.commit == "deadbeef"', RUN),
+    false,
+  );
+});
+
+// --- Evaluation: missing optional fields ---
+
+Deno.test("evaluateWorkflowRunFilter: missing optional fields default to empty", () => {
+  const minimalRun: WorkflowRunFilterContext = {
+    workflowName: "deploy",
+    status: "running",
+  };
+  assertEquals(
+    evaluateWorkflowRunFilter('workflowName == "deploy"', minimalRun),
+    true,
+  );
+  assertEquals(
+    evaluateWorkflowRunFilter("duration == 0.0", minimalRun),
+    true,
+  );
+  assertEquals(
+    evaluateWorkflowRunFilter('startedAt == ""', minimalRun),
+    true,
+  );
+});
+
+// --- Evaluation: non-boolean result returns false ---
+
+Deno.test("evaluateWorkflowRunFilter: non-boolean result returns false", () => {
+  assertEquals(
+    evaluateWorkflowRunFilter("status", RUN),
+    false,
+  );
+});

--- a/src/infrastructure/cel/workflow_run_filter_test.ts
+++ b/src/infrastructure/cel/workflow_run_filter_test.ts
@@ -222,3 +222,15 @@ Deno.test("evaluateWorkflowRunFilter: non-boolean result returns false", () => {
     false,
   );
 });
+
+Deno.test("evaluateWorkflowRunFilter: missing input key returns false instead of throwing", () => {
+  const runWithoutCommit: WorkflowRunFilterContext = {
+    workflowName: "deploy",
+    status: "succeeded",
+    inputs: { branch: "main" },
+  };
+  assertEquals(
+    evaluateWorkflowRunFilter('inputs.commit == "abc123"', runWithoutCommit),
+    false,
+  );
+});

--- a/src/libswamp/workflows/history_search.ts
+++ b/src/libswamp/workflows/history_search.ts
@@ -20,9 +20,14 @@
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import type { WorkflowRunSearchItem } from "./run_search.ts";
+import { validationFailed } from "../errors.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 import { collectBounded, RUN_FANOUT_CONCURRENCY } from "./run_fanout.ts";
+import {
+  evaluateWorkflowRunFilter,
+  validateWorkflowRunFilter,
+} from "../../infrastructure/cel/workflow_run_filter.ts";
 /**
  * Re-export the shared item type for history search consumers.
  */
@@ -73,6 +78,7 @@ export interface WorkflowHistorySearchInput {
   query?: string;
   workflow?: string;
   inputs?: Record<string, string>;
+  filter?: string;
 }
 
 /**
@@ -153,6 +159,35 @@ export async function* workflowHistorySearch(
         const inputEntries = Object.entries(input.inputs);
         results = results.filter((r) =>
           inputEntries.every(([k, v]) => String(r.inputs?.[k]) === v)
+        );
+      }
+
+      if (input.filter) {
+        const validation = validateWorkflowRunFilter(input.filter);
+        if (!validation.valid) {
+          yield {
+            kind: "error",
+            error: validationFailed(
+              `Invalid --filter expression: ${validation.error}`,
+            ),
+          };
+          return;
+        }
+
+        results = results.filter((r) =>
+          evaluateWorkflowRunFilter(input.filter!, {
+            workflowName: r.workflowName,
+            status: r.status,
+            startedAt: r.startedAt,
+            completedAt: r.completedAt,
+            duration: r.duration,
+            inputs: r.inputs,
+            tags: r.tags,
+            instanceId: r.instanceId,
+            triggerSource: r.triggerSource,
+            failedStep: r.failedStep,
+            failureReason: r.failureReason,
+          })
         );
       }
 

--- a/src/libswamp/workflows/history_search_test.ts
+++ b/src/libswamp/workflows/history_search_test.ts
@@ -407,6 +407,49 @@ Deno.test("workflowHistorySearch: filter with compound expression", async () => 
   assertEquals(completed.data.results[0].runId, "run-a");
 });
 
+Deno.test("workflowHistorySearch: filter handles runs with missing input keys", async () => {
+  const deps: WorkflowHistorySearchDeps = {
+    findAllWorkflows: () =>
+      Promise.resolve([{ id: "wf-1", name: "verify" }]),
+    findAllRunsByWorkflowId: () =>
+      Promise.resolve([
+        {
+          id: "run-with-commit",
+          workflowId: "wf-1",
+          workflowName: "verify",
+          status: "succeeded",
+          startedAt: new Date(now - 1000),
+          completedAt: new Date(now),
+          tags: {},
+          inputs: { commit: "abc123", branch: "main" },
+        },
+        {
+          id: "run-without-commit",
+          workflowId: "wf-1",
+          workflowName: "verify",
+          status: "succeeded",
+          startedAt: new Date(now - 2000),
+          completedAt: new Date(now - 1000),
+          tags: {},
+          inputs: { branch: "feature/x" },
+        },
+      ]),
+  };
+
+  const events = await collect<WorkflowHistorySearchEvent>(
+    workflowHistorySearch(createLibSwampContext(), deps, {
+      filter: 'inputs.commit == "abc123"',
+    }),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowHistorySearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 1);
+  assertEquals(completed.data.results[0].runId, "run-with-commit");
+});
+
 Deno.test("workflowHistorySearch: invalid filter yields error event", async () => {
   const deps = makeDepsWithInputs();
   const events = await collect<WorkflowHistorySearchEvent>(

--- a/src/libswamp/workflows/history_search_test.ts
+++ b/src/libswamp/workflows/history_search_test.ts
@@ -409,8 +409,7 @@ Deno.test("workflowHistorySearch: filter with compound expression", async () => 
 
 Deno.test("workflowHistorySearch: filter handles runs with missing input keys", async () => {
   const deps: WorkflowHistorySearchDeps = {
-    findAllWorkflows: () =>
-      Promise.resolve([{ id: "wf-1", name: "verify" }]),
+    findAllWorkflows: () => Promise.resolve([{ id: "wf-1", name: "verify" }]),
     findAllRunsByWorkflowId: () =>
       Promise.resolve([
         {

--- a/src/libswamp/workflows/history_search_test.ts
+++ b/src/libswamp/workflows/history_search_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
@@ -291,4 +291,135 @@ Deno.test("workflowHistorySearch: returns empty results when no runs exist", asy
   >;
   assertEquals(completed.data.query, "foo");
   assertEquals(completed.data.results.length, 0);
+});
+
+// --- CEL filter tests ---
+
+function makeDepsWithInputs(): WorkflowHistorySearchDeps {
+  return {
+    findAllWorkflows: () =>
+      Promise.resolve([
+        { id: "wf-1", name: "verify-reviews" },
+      ]),
+    findAllRunsByWorkflowId: () =>
+      Promise.resolve([
+        {
+          id: "run-a",
+          workflowId: "wf-1",
+          workflowName: "verify-reviews",
+          status: "succeeded",
+          startedAt: new Date(now - 1000),
+          completedAt: new Date(now),
+          tags: { env: "ci" },
+          inputs: { commit: "abc123", branch: "main" },
+        },
+        {
+          id: "run-b",
+          workflowId: "wf-1",
+          workflowName: "verify-reviews",
+          status: "failed",
+          startedAt: new Date(now - 3000),
+          completedAt: new Date(now - 2000),
+          tags: { env: "ci" },
+          inputs: { commit: "def456", branch: "feature/foo" },
+        },
+      ]),
+  };
+}
+
+Deno.test("workflowHistorySearch: filter by inputs.commit", async () => {
+  const deps = makeDepsWithInputs();
+  const events = await collect<WorkflowHistorySearchEvent>(
+    workflowHistorySearch(createLibSwampContext(), deps, {
+      filter: 'inputs.commit == "abc123"',
+    }),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowHistorySearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 1);
+  assertEquals(completed.data.results[0].runId, "run-a");
+});
+
+Deno.test("workflowHistorySearch: filter by status", async () => {
+  const deps = makeDepsWithInputs();
+  const events = await collect<WorkflowHistorySearchEvent>(
+    workflowHistorySearch(createLibSwampContext(), deps, {
+      filter: 'status == "failed"',
+    }),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowHistorySearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 1);
+  assertEquals(completed.data.results[0].runId, "run-b");
+});
+
+Deno.test("workflowHistorySearch: filter combined with workflow name", async () => {
+  const deps = makeDepsWithInputs();
+  const events = await collect<WorkflowHistorySearchEvent>(
+    workflowHistorySearch(createLibSwampContext(), deps, {
+      workflow: "verify-reviews",
+      filter: 'inputs.branch == "main"',
+    }),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowHistorySearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 1);
+  assertEquals(completed.data.results[0].runId, "run-a");
+});
+
+Deno.test("workflowHistorySearch: filter with no matches returns empty", async () => {
+  const deps = makeDepsWithInputs();
+  const events = await collect<WorkflowHistorySearchEvent>(
+    workflowHistorySearch(createLibSwampContext(), deps, {
+      filter: 'inputs.commit == "nonexistent"',
+    }),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowHistorySearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 0);
+});
+
+Deno.test("workflowHistorySearch: filter with compound expression", async () => {
+  const deps = makeDepsWithInputs();
+  const events = await collect<WorkflowHistorySearchEvent>(
+    workflowHistorySearch(createLibSwampContext(), deps, {
+      filter: 'status == "succeeded" && tags.env == "ci"',
+    }),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowHistorySearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 1);
+  assertEquals(completed.data.results[0].runId, "run-a");
+});
+
+Deno.test("workflowHistorySearch: invalid filter yields error event", async () => {
+  const deps = makeDepsWithInputs();
+  const events = await collect<WorkflowHistorySearchEvent>(
+    workflowHistorySearch(createLibSwampContext(), deps, {
+      filter: "status ==",
+    }),
+  );
+
+  assertEquals(events.length, 2);
+  const errorEvent = events[1] as Extract<
+    WorkflowHistorySearchEvent,
+    { kind: "error" }
+  >;
+  assertEquals(errorEvent.kind, "error");
+  assertStringIncludes(errorEvent.error.message, "Invalid --filter expression");
 });

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -626,6 +626,7 @@ const WorkflowHistorySearchRequestSchema = z.object({
     query: z.string().optional(),
     workflow: z.string().optional(),
     inputs: z.record(z.string(), z.string()).optional(),
+    filter: z.string().max(1024).optional(),
   }).optional(),
 });
 

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -695,6 +695,7 @@ export async function handleWorkflowHistorySearch(
         query: payload?.query,
         workflow: payload?.workflow,
         inputs: payload?.inputs,
+        filter: payload?.filter,
       }),
       {
         resolving: () => {},

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -296,6 +296,7 @@ export interface WorkflowHistorySearchPayload {
   query?: string;
   workflow?: string;
   inputs?: Record<string, string>;
+  filter?: string;
 }
 
 export interface WorkflowRunSearchPayload {


### PR DESCRIPTION
## Summary

Add a `--filter` flag to `swamp workflow history search` that accepts a CEL expression evaluated against each workflow run's metadata. This enables precise querying of run history — e.g. finding the verification run for a specific commit SHA — without capturing run IDs at launch time.

- New CEL filter environment (`src/infrastructure/cel/workflow_run_filter.ts`) with AST complexity guards matching `grant_condition_environment.ts` (depth, cost, comprehension nesting, regex safety)
- Filter integrated into the `workflowHistorySearch` generator with validation-before-evaluation and try/catch for missing map keys
- `--filter` CLI option with examples, serve protocol/Zod schema updated, client package synced
- Skill docs updated with filter examples

### Examples

```bash
swamp workflow history search --filter 'inputs.commit == "b3ff3a8a"'
swamp workflow history search --filter 'status == "failed"'
swamp workflow history search verify-reviews --filter 'inputs.branch == "main"'
```

### Available filter fields

`workflowName`, `status`, `startedAt`, `completedAt`, `duration`, `inputs.*`, `tags.*`, `instanceId`, `triggerSource`, `failedStep`, `failureReason`

Closes swamp-club#1848

## Test Plan

- 24 unit tests for CEL filter environment (validation + evaluation, including missing keys, non-boolean results, complexity limits, catastrophic regex)
- 7 integration tests for history search generator with filter (matching, non-matching, compound, combined with --workflow, heterogeneous inputs, invalid expression error)
- End-to-end tested with compiled binary against a real swamp repo with workflow runs
- Verification passed: 16/17 steps (1 skipped by guard), all 3 agent reviews passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)