### PR TITLE
docs(skills): document --filter fields in workflow skill

### DIFF
--- a/.claude/skills/swamp/references/workflow/guide.md
+++ b/.claude/skills/swamp/references/workflow/guide.md
@@ -56,6 +56,10 @@ skill.
 | Query wf data      | `swamp data query 'tags.workflow == "<name>"'`                           |
 | Get workflow data  | `swamp data get --workflow <name> <data_name> --json`                    |
 
+`--filter` accepts a CEL expression over run metadata (`status`, `inputs.*`,
+`tags.*`, `duration`, `startedAt`, `workflowName`, etc.). See
+[reference.md](reference.md) for the full field list.
+
 ## Repository Structure
 
 Workflow files are stored directly in the `workflows/` directory:

--- a/.claude/skills/swamp/references/workflow/reference.md
+++ b/.claude/skills/swamp/references/workflow/reference.md
@@ -315,7 +315,35 @@ swamp workflow history search "deploy" --json
 swamp workflow history search --filter 'inputs.commit == "b3ff3a8a"' --json
 swamp workflow history search --filter 'status == "failed"' --json
 swamp workflow history search verify-reviews --filter 'inputs.branch == "main"' --json
+
+# Combine --filter with --workflow and --input
+swamp workflow history search --workflow verify-build --filter 'duration > 60000' --json
 ```
+
+### Filter Fields
+
+The `--filter` flag accepts a
+[CEL expression](https://github.com/google/cel-spec) evaluated against each
+run's metadata. Available fields:
+
+| Field           | Type              | Description                         |
+| --------------- | ----------------- | ----------------------------------- |
+| `workflowName`  | string            | Workflow name                       |
+| `status`        | string            | `succeeded`, `failed`, `running`, … |
+| `startedAt`     | string (ISO 8601) | Run start time                      |
+| `completedAt`   | string (ISO 8601) | Run completion time                 |
+| `duration`      | double (ms)       | Elapsed time in milliseconds        |
+| `inputs`        | map               | Workflow input values               |
+| `tags`          | map               | Run tags                            |
+| `instanceId`    | string            | Instance identifier                 |
+| `triggerSource` | string            | What triggered the run              |
+| `failedStep`    | string            | Name of the failed step (if any)    |
+| `failureReason` | string            | Failure message (if any)            |
+
+Timestamps are ISO 8601 strings — lexicographic comparison works (e.g.
+`startedAt > "2026-08-01"`). Duration is milliseconds as a double. Missing map
+keys (e.g. `inputs.commit` on a run without a `commit` input) return false
+rather than erroring.
 
 **Output shape:**
 


### PR DESCRIPTION
## Summary

Enhance the workflow skill reference and guide to fully document the `--filter` flag added in #2269:

- **reference.md**: Add a filter fields table listing all 11 CEL variables with types and descriptions. Add notes on timestamp comparison semantics, duration units (milliseconds), and missing-key behavior (returns false, doesn't crash).
- **guide.md**: Add a brief summary of available fields below the quick-reference table with a link to the full reference.

## Test Plan

- Skill docs only — no code changes
- `deno fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)