### PR TITLE
fix(serve): honour SWAMP_SERVER_URL as routing fallback for --server (swamp-club#1830)

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -190,10 +190,11 @@ The CLI consumes this protocol via `--server <url>` on each command:
 repo-less, streaming the run's events through the same renderers as a local
 run (the wire codec is lossless for run events; `deserializeEvent` in
 `src/serve/serializer.ts` is the anti-corruption seam). The `--server` flag
-on all remote commands falls back to the `SWAMP_SERVE_URL` env var when not
-provided, so `export SWAMP_SERVE_URL=wss://demo.swamp-club.ai` avoids
-repeating the URL on every invocation. The explicit flag takes precedence when
-both are set.
+on all remote commands falls back to the `SWAMP_SERVE_URL` env var (or
+`SWAMP_SERVER_URL` as a secondary fallback) when not provided, so
+`export SWAMP_SERVE_URL=wss://demo.swamp-club.ai` avoids repeating the URL
+on every invocation. Precedence: `--server` flag > `SWAMP_SERVE_URL` >
+`SWAMP_SERVER_URL`.
 
 When `--auth-mode token` is active, the server validates the token presented at
 WebSocket upgrade time via the `swamp/server-token` model's `redeem` method

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -150,7 +150,7 @@ steps:
 failed. No resume needed.
 
 `swamp workflow approvals` lists all suspended runs awaiting approval. Supports
-`--server` / `SWAMP_SERVE_URL` via the `workflow.approvals` wire-protocol
+`--server` / `SWAMP_SERVE_URL` / `SWAMP_SERVER_URL` via the `workflow.approvals` wire-protocol
 endpoint (read-only, `read` authorization verb).
 
 **Programmatic gate control:** Gates can also be approved or rejected from within

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -46,13 +46,14 @@ import { FileServerCredentialRepository } from "../infrastructure/persistence/se
 import { resolveExtraHeaders } from "../domain/auth/extra_headers.ts";
 
 /**
- * Resolves the server URL from the `--server` flag with `SWAMP_SERVE_URL`
- * env var as fallback. Flag takes precedence when both are provided.
+ * Resolves the server URL from the `--server` flag with env var fallbacks.
+ * Precedence: flag > SWAMP_SERVE_URL > SWAMP_SERVER_URL.
  */
 export function resolveServeUrl(
   flagValue: string | undefined,
 ): string | undefined {
-  return flagValue ?? Deno.env.get("SWAMP_SERVE_URL");
+  return flagValue ?? Deno.env.get("SWAMP_SERVE_URL") ??
+    Deno.env.get("SWAMP_SERVER_URL");
 }
 
 /** How long to keep draining after sending `cancel` before giving up. */
@@ -335,7 +336,7 @@ export function withRemoteOptions<T extends AnyCommand>(command: T): T {
   return command
     .option(
       "--server <url:string>",
-      "Run through a 'swamp serve' server (ws:// or http://) instead of locally; no local repo required (env: SWAMP_SERVE_URL). For proxy/tunnel pass-through headers see SWAMP_SERVE_EXTRA_HEADERS.",
+      "Run through a 'swamp serve' server (ws:// or http://) instead of locally; no local repo required (env: SWAMP_SERVE_URL or SWAMP_SERVER_URL). For proxy/tunnel pass-through headers see SWAMP_SERVE_EXTRA_HEADERS.",
     )
     .option(
       "--token <token:string>",

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -103,13 +103,46 @@ Deno.test("resolveServeUrl: falls back to SWAMP_SERVE_URL env var", () => {
   }
 });
 
-Deno.test("resolveServeUrl: returns undefined when neither flag nor env var set", () => {
-  const prev = Deno.env.get("SWAMP_SERVE_URL");
+Deno.test("resolveServeUrl: falls back to SWAMP_SERVER_URL when SWAMP_SERVE_URL is not set", () => {
+  const prevServe = Deno.env.get("SWAMP_SERVE_URL");
+  const prevServer = Deno.env.get("SWAMP_SERVER_URL");
   try {
     Deno.env.delete("SWAMP_SERVE_URL");
+    Deno.env.set("SWAMP_SERVER_URL", "wss://server-env.example.com");
+    assertEquals(resolveServeUrl(undefined), "wss://server-env.example.com");
+  } finally {
+    if (prevServe !== undefined) Deno.env.set("SWAMP_SERVE_URL", prevServe);
+    else Deno.env.delete("SWAMP_SERVE_URL");
+    if (prevServer !== undefined) Deno.env.set("SWAMP_SERVER_URL", prevServer);
+    else Deno.env.delete("SWAMP_SERVER_URL");
+  }
+});
+
+Deno.test("resolveServeUrl: SWAMP_SERVE_URL takes precedence over SWAMP_SERVER_URL", () => {
+  const prevServe = Deno.env.get("SWAMP_SERVE_URL");
+  const prevServer = Deno.env.get("SWAMP_SERVER_URL");
+  try {
+    Deno.env.set("SWAMP_SERVE_URL", "wss://serve.example.com");
+    Deno.env.set("SWAMP_SERVER_URL", "wss://server.example.com");
+    assertEquals(resolveServeUrl(undefined), "wss://serve.example.com");
+  } finally {
+    if (prevServe !== undefined) Deno.env.set("SWAMP_SERVE_URL", prevServe);
+    else Deno.env.delete("SWAMP_SERVE_URL");
+    if (prevServer !== undefined) Deno.env.set("SWAMP_SERVER_URL", prevServer);
+    else Deno.env.delete("SWAMP_SERVER_URL");
+  }
+});
+
+Deno.test("resolveServeUrl: returns undefined when no flag or env var set", () => {
+  const prevServe = Deno.env.get("SWAMP_SERVE_URL");
+  const prevServer = Deno.env.get("SWAMP_SERVER_URL");
+  try {
+    Deno.env.delete("SWAMP_SERVE_URL");
+    Deno.env.delete("SWAMP_SERVER_URL");
     assertEquals(resolveServeUrl(undefined), undefined);
   } finally {
-    if (prev !== undefined) Deno.env.set("SWAMP_SERVE_URL", prev);
+    if (prevServe !== undefined) Deno.env.set("SWAMP_SERVE_URL", prevServe);
+    if (prevServer !== undefined) Deno.env.set("SWAMP_SERVER_URL", prevServer);
   }
 });
 


### PR DESCRIPTION
## Summary

- `resolveServeUrl()` now checks `SWAMP_SERVER_URL` after `SWAMP_SERVE_URL`, so users who set the credential-scoping env var also get routing. Precedence: `--server` flag > `SWAMP_SERVE_URL` > `SWAMP_SERVER_URL`.
- Updated `--server` help text to mention both env vars.
- Added tests for the new fallback and precedence behaviour.
- Updated `design/remote-execution.md` and `design/workflow.md` to document both env vars.

Fixes swamp-club#1830

## Test plan

- [x] `resolveServeUrl` returns `SWAMP_SERVER_URL` when `SWAMP_SERVE_URL` is not set
- [x] `SWAMP_SERVE_URL` takes precedence over `SWAMP_SERVER_URL` when both are set
- [x] `--server` flag takes precedence over both env vars
- [x] Returns `undefined` when neither flag nor env var is set
- [x] All 44 tests in `remote_run_test.ts` pass
- [x] Full build verification (lint, fmt, type-check, tests, compile) passed
- [x] Code review passed (VERDICT: pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Keith Hudgins <khudgins@users.noreply.github.com>