### PR TITLE
fix(resolver): preserve explicit file extensions in local import resolver (swamp-club#1829)

### DIFF
--- a/src/domain/models/local_import_resolver.ts
+++ b/src/domain/models/local_import_resolver.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { dirname, normalize, resolve } from "@std/path";
+import { dirname, extname, normalize, resolve } from "@std/path";
 
 /** Result of resolving local imports from entry points. */
 export interface ImportResolverResult {
@@ -93,8 +93,7 @@ export async function resolveLocalImports(
 function resolveImportPath(fromFile: string, importPath: string): string {
   const dir = dirname(fromFile);
   let resolved = resolve(dir, importPath);
-  // Add .ts extension if missing
-  if (!resolved.endsWith(".ts") && !resolved.endsWith(".js")) {
+  if (!extname(resolved)) {
     resolved = resolved + ".ts";
   }
   return normalize(resolved);

--- a/src/domain/models/local_import_resolver_test.ts
+++ b/src/domain/models/local_import_resolver_test.ts
@@ -1,0 +1,111 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { resolveLocalImports } from "./local_import_resolver.ts";
+
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+Deno.test("resolveLocalImports: appends .ts to extensionless imports", async () => {
+  await withTempDir(async (dir) => {
+    const entry = join(dir, "entry.ts");
+    const utils = join(dir, "utils.ts");
+    await Deno.writeTextFile(entry, `import { foo } from "./utils";`);
+    await Deno.writeTextFile(utils, "export const foo = 1;");
+
+    const result = await resolveLocalImports([entry], dir);
+    assertEquals(result.resolvedFiles.includes(utils), true);
+  });
+});
+
+Deno.test("resolveLocalImports: preserves explicit .ts extension", async () => {
+  await withTempDir(async (dir) => {
+    const entry = join(dir, "entry.ts");
+    const helper = join(dir, "helper.ts");
+    await Deno.writeTextFile(entry, `import { bar } from "./helper.ts";`);
+    await Deno.writeTextFile(helper, "export const bar = 2;");
+
+    const result = await resolveLocalImports([entry], dir);
+    assertEquals(result.resolvedFiles.includes(helper), true);
+  });
+});
+
+Deno.test("resolveLocalImports: preserves explicit .js extension", async () => {
+  await withTempDir(async (dir) => {
+    const entry = join(dir, "entry.ts");
+    const lib = join(dir, "lib.js");
+    await Deno.writeTextFile(entry, `import { baz } from "./lib.js";`);
+    await Deno.writeTextFile(lib, "export const baz = 3;");
+
+    const result = await resolveLocalImports([entry], dir);
+    assertEquals(result.resolvedFiles.includes(lib), true);
+  });
+});
+
+Deno.test("resolveLocalImports: preserves explicit .json extension", async () => {
+  await withTempDir(async (dir) => {
+    const entry = join(dir, "entry.ts");
+    const pkg = join(dir, "package-lock.json");
+    await Deno.writeTextFile(
+      entry,
+      `import lock from "./package-lock.json" with { type: "json" };`,
+    );
+    await Deno.writeTextFile(pkg, "{}");
+
+    const result = await resolveLocalImports([entry], dir);
+    assertEquals(result.resolvedFiles.includes(pkg), true);
+  });
+});
+
+Deno.test("resolveLocalImports: preserves explicit .wasm extension", async () => {
+  await withTempDir(async (dir) => {
+    const entry = join(dir, "entry.ts");
+    const wasm = join(dir, "compute.wasm");
+    await Deno.writeTextFile(entry, `import mod from "./compute.wasm";`);
+    await Deno.writeTextFile(wasm, "");
+
+    const result = await resolveLocalImports([entry], dir);
+    assertEquals(result.resolvedFiles.includes(wasm), true);
+  });
+});
+
+Deno.test("resolveLocalImports: does not resolve json import as .json.ts", async () => {
+  await withTempDir(async (dir) => {
+    const entry = join(dir, "entry.ts");
+    const jsonTs = join(dir, "data.json.ts");
+    await Deno.writeTextFile(
+      entry,
+      `import data from "./data.json" with { type: "json" };`,
+    );
+    await Deno.writeTextFile(jsonTs, "export default {};");
+
+    const result = await resolveLocalImports([entry], dir);
+    assertEquals(result.resolvedFiles.includes(jsonTs), false);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix `resolveImportPath` in `src/domain/models/local_import_resolver.ts` to preserve explicit file extensions (like `.json`, `.wasm`) instead of blindly appending `.ts`. Uses `extname()` from `@std/path` to check whether the resolved path already has any extension.
- Add unit tests covering extensionless imports, explicit `.ts`/`.js`/`.json`/`.wasm` extensions, and a negative case verifying `.json` imports don't resolve to `.json.ts`.

Closes swamp-club#1829

## Test Plan

- [x] 6 new unit tests in `local_import_resolver_test.ts` all pass
- [x] 24 existing `bundle_freshness_test.ts` tests pass (no regressions)
- [x] Full test suite passes (verification workflow)
- [x] Code review: VERDICT pass
- [x] Adversarial review: VERDICT pass
- [x] Bug reproduced before fix, confirmed resolved after

Co-authored-by: mgreten <mgreten@users.noreply.github.com>