### PR TITLE
fix(workflows): match forEach expansions by template provenance in --from reset (swamp-club#1781)

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -3778,7 +3778,7 @@ function resolveEffectiveConcurrency(
  * to reset for a --from resume. The result includes the fromStep itself and
  * all its transitive downstream dependents across all jobs.
  */
-function computeStepsToReset(
+export function computeStepsToReset(
   workflow: Workflow,
   run: WorkflowRun,
   fromStep: string,
@@ -3875,10 +3875,16 @@ function computeStepsToReset(
       const name = stepRun.stepName;
       if (templateNamesToReset.has(name)) {
         stepsToReset.add(name);
+      } else if (
+        stepRun.forEachTemplate &&
+        templateNamesToReset.has(stepRun.forEachTemplate)
+      ) {
+        stepsToReset.add(name);
       } else if (!allTemplateNames.has(name)) {
-        // Only prefix-match against steps that are NOT themselves template
-        // names. This prevents a forEach template "read" from matching a
-        // non-forEach step "read-plate".
+        // Backward-compat fallback for runs persisted before forEachTemplate
+        // was recorded: prefix-match against forEach templates. Only applies
+        // to steps that are NOT themselves template names (prevents a forEach
+        // template "read" from matching a non-forEach step "read-plate").
         for (const tmpl of templateNamesToReset) {
           if (
             forEachTemplates.has(tmpl) &&
@@ -3890,6 +3896,13 @@ function computeStepsToReset(
         }
       }
     }
+  }
+
+  if (stepsToReset.size === 0) {
+    throw new UserError(
+      `--from "${fromStep}" matched zero persisted steps in the run. ` +
+        `The step may not have been reached during execution.`,
+    );
   }
 
   return stepsToReset;

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -23,9 +23,11 @@ import {
   assertNotEquals,
   assertRejects,
   assertStringIncludes,
+  assertThrows,
 } from "@std/assert";
 import { join } from "@std/path";
 import {
+  computeStepsToReset,
   DefaultStepExecutor,
   type StepExecutionContext,
   type StepExecutor,
@@ -50,7 +52,7 @@ import type {
   WorkflowRepository,
   WorkflowRunRepository,
 } from "./repositories.ts";
-import type { WorkflowRun } from "./workflow_run.ts";
+import { WorkflowRun } from "./workflow_run.ts";
 import type { ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-base";
 import type { ExportResult } from "@opentelemetry/core";
 
@@ -5190,4 +5192,125 @@ Deno.test("step output stored on WorkflowRun has stripped content and attributes
     assertEquals(step1Handles[0].name, "default");
     assertEquals(step1Handles[0].attributes, null);
   });
+});
+
+// ---------------------------------------------------------------------------
+// computeStepsToReset
+// ---------------------------------------------------------------------------
+
+function makeWorkflowWithForEach(
+  templateName: string,
+  opts?: { extraSteps?: Step[] },
+): Workflow {
+  const forEachStep = Step.create({
+    name: templateName,
+    task: StepTask.model("m", "run"),
+    forEach: { item: "env", in: '${{ ["dev", "qa"] }}' },
+  });
+  return Workflow.create({
+    name: "test-wf",
+    jobs: [
+      Job.create({
+        name: "deploy",
+        steps: [
+          ...(opts?.extraSteps ?? []),
+          forEachStep,
+        ],
+      }),
+    ],
+  });
+}
+
+function makeRunWithExpandedSteps(
+  workflow: Workflow,
+  expandedSteps: { name: string; forEachTemplate?: string }[],
+): WorkflowRun {
+  const wfId = workflow.id;
+  return WorkflowRun.fromData({
+    id: crypto.randomUUID(),
+    workflowId: wfId,
+    workflowName: workflow.name,
+    status: "failed",
+    jobs: [{
+      jobName: "deploy",
+      status: "failed",
+      steps: expandedSteps.map((s) => ({
+        stepName: s.name,
+        status: s.name.endsWith("-qa") ? "failed" : "succeeded",
+        forEachTemplate: s.forEachTemplate,
+      })),
+    }],
+  });
+}
+
+Deno.test("computeStepsToReset: matches expression-containing template via forEachTemplate", () => {
+  const tmpl = "deploy-${{ self.env }}";
+  const workflow = makeWorkflowWithForEach(tmpl);
+  const run = makeRunWithExpandedSteps(workflow, [
+    { name: "deploy-dev", forEachTemplate: tmpl },
+    { name: "deploy-qa", forEachTemplate: tmpl },
+  ]);
+
+  const result = computeStepsToReset(workflow, run, tmpl);
+  assertEquals(result, new Set(["deploy-dev", "deploy-qa"]));
+});
+
+Deno.test("computeStepsToReset: matches plain template via prefix (non-regression)", () => {
+  const tmpl = "deploy";
+  const workflow = makeWorkflowWithForEach(tmpl);
+  const run = makeRunWithExpandedSteps(workflow, [
+    { name: "deploy-dev", forEachTemplate: tmpl },
+    { name: "deploy-qa", forEachTemplate: tmpl },
+  ]);
+
+  const result = computeStepsToReset(workflow, run, tmpl);
+  assertEquals(result, new Set(["deploy-dev", "deploy-qa"]));
+});
+
+Deno.test("computeStepsToReset: falls back to prefix when forEachTemplate absent (backward compat)", () => {
+  const tmpl = "deploy";
+  const workflow = makeWorkflowWithForEach(tmpl);
+  const run = makeRunWithExpandedSteps(workflow, [
+    { name: "deploy-dev" },
+    { name: "deploy-qa" },
+  ]);
+
+  const result = computeStepsToReset(workflow, run, tmpl);
+  assertEquals(result, new Set(["deploy-dev", "deploy-qa"]));
+});
+
+Deno.test("computeStepsToReset: throws when --from resolves to zero steps", () => {
+  const tmpl = "deploy-${{ self.env }}";
+  const workflow = makeWorkflowWithForEach(tmpl);
+  // Simulate a run where the forEach step was never reached
+  const run = WorkflowRun.fromData({
+    id: crypto.randomUUID(),
+    workflowId: workflow.id,
+    workflowName: workflow.name,
+    status: "failed",
+    jobs: [{
+      jobName: "deploy",
+      status: "failed",
+      steps: [],
+    }],
+  });
+
+  assertThrows(
+    () => computeStepsToReset(workflow, run, tmpl),
+    Error,
+    "matched zero persisted steps",
+  );
+});
+
+Deno.test("computeStepsToReset: throws for unknown step name", () => {
+  const workflow = makeWorkflowWithForEach("deploy");
+  const run = makeRunWithExpandedSteps(workflow, [
+    { name: "deploy-dev", forEachTemplate: "deploy" },
+  ]);
+
+  assertThrows(
+    () => computeStepsToReset(workflow, run, "nonexistent"),
+    Error,
+    'Step "nonexistent" not found',
+  );
 });

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -72,6 +72,7 @@ export const StepRunSchema = z.object({
   approvalDecision: ApprovalDecisionSchema.optional(),
   approvalPrompt: z.string().optional(),
   assertResult: AssertResultSchema.optional(),
+  forEachTemplate: z.string().optional(),
 });
 
 /**
@@ -169,12 +170,16 @@ export class StepRun {
     private _approvalDecision: ApprovalDecisionData | undefined = undefined,
     private _approvalPrompt: string | undefined = undefined,
     private _assertResult: AssertResultData | undefined = undefined,
+    private _forEachTemplate: string | undefined = undefined,
   ) {}
 
   /**
    * Creates a pending step run.
    */
-  static pending(stepName: string): StepRun {
+  static pending(
+    stepName: string,
+    forEachTemplate?: string,
+  ): StepRun {
     return new StepRun(
       stepName,
       "pending",
@@ -184,6 +189,10 @@ export class StepRun {
       undefined,
       [],
       false,
+      undefined,
+      undefined,
+      undefined,
+      forEachTemplate,
     );
   }
 
@@ -204,6 +213,7 @@ export class StepRun {
       validated.approvalDecision,
       validated.approvalPrompt,
       validated.assertResult,
+      validated.forEachTemplate,
     );
   }
 
@@ -251,6 +261,10 @@ export class StepRun {
 
   get assertResult(): AssertResultData | undefined {
     return this._assertResult;
+  }
+
+  get forEachTemplate(): string | undefined {
+    return this._forEachTemplate;
   }
 
   /**
@@ -363,6 +377,9 @@ export class StepRun {
     }
     if (this._assertResult) {
       data.assertResult = { ...this._assertResult };
+    }
+    if (this._forEachTemplate) {
+      data.forEachTemplate = this._forEachTemplate;
     }
     return data;
   }
@@ -500,7 +517,7 @@ export class JobRun implements TriggerEvaluationContext {
     const insertions: StepRun[] = [];
     for (const name of expandedNames) {
       if (!existing.has(name)) {
-        insertions.push(StepRun.pending(name));
+        insertions.push(StepRun.pending(name, templateName));
       }
     }
     this._steps.splice(templateIndex, 1, ...insertions);


### PR DESCRIPTION
## Summary

- `workflow resume --from` was a silent no-op when the forEach step template name contained `${{ }}` expressions (e.g. `deploy-${{ self.env }}`). `computeStepsToReset()` used `name.startsWith(tmpl + "-")` which failed because the unexpanded template prefix never matched expanded step names like `deploy-dev`.
- Added a persisted `forEachTemplate` field to `StepRun` so each expanded step records which template produced it. `computeStepsToReset()` now matches by `forEachTemplate` first, falls back to prefix matching for backward compatibility, and throws a `UserError` when `--from` resolves to zero steps.
- Added 5 unit tests for `computeStepsToReset()` covering expression templates, plain templates, backward compat, and error cases.

## Test plan

- [x] New unit tests pass: expression-containing template match, plain template match (non-regression), backward compat fallback, zero-match error, unknown step error
- [x] Bug reproduced in scratch repo: `--from 'deploy-${{ self.env }}'` was silent no-op
- [x] Fix verified in scratch repo: `--from 'deploy-${{ self.env }}'` correctly resets and re-runs expanded steps
- [x] `forEachTemplate` field persisted in run YAML for new runs
- [x] Full verification passed: lint, fmt, type-check, tests, deps audit, compile, code review

Closes swamp-club#1781

🤖 Generated with [Claude Code](https://claude.com/claude-code)