### PR TITLE
feat(ci): move Windows to post-merge compatibility check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,16 +58,9 @@ jobs:
 
   test:
     name: Lint, Test, and Format Check
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      # Surface failures on every platform rather than aborting the whole
-      # matrix on the first failure — Linux signal stays clean if Windows
-      # flakes, and vice versa.
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout code
@@ -100,19 +93,9 @@ jobs:
         run: deno task compile
 
       - name: Smoke test compiled binary
-        # Compiling proves the binary builds; running --version and --help
-        # proves it actually boots, registers the command tree, and exits
-        # cleanly. Catches runtime regressions (e.g. a top-level import
-        # that throws on load) that the compile step alone doesn't.
-        shell: bash
         run: |
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            binary="./swamp.exe"
-          else
-            binary="./swamp"
-          fi
-          "$binary" --version
-          "$binary" --help > /dev/null
+          ./swamp --version
+          ./swamp --help > /dev/null
 
   deps-audit:
     name: Dependency Audit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,12 +76,6 @@ jobs:
             --target aarch64-apple-darwin \
             --output dist/swamp-darwin-aarch64
 
-          # Windows x86_64
-          deno run -A scripts/compile.ts \
-            --version "$VERSION" \
-            --target x86_64-pc-windows-msvc \
-            --output dist/swamp-windows-x86_64.exe
-
       - name: Create checksums
         working-directory: dist
         run: |
@@ -159,7 +153,6 @@ jobs:
             dist/swamp-linux-aarch64
             dist/swamp-darwin-x86_64
             dist/swamp-darwin-aarch64
-            dist/swamp-windows-x86_64.exe
             dist/checksums.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows-compat.yml
+++ b/.github/workflows/windows-compat.yml
@@ -1,0 +1,53 @@
+name: Windows Compatibility
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'integration/**'
+      - 'deno.json'
+      - 'deno.lock'
+
+jobs:
+  windows-test:
+    name: Windows Lint, Test, and Compile
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.8.x
+
+      - name: Run deno lint
+        run: deno lint
+
+      - name: Run deno fmt --check
+        run: deno fmt --check
+
+      - name: Run deno check
+        run: deno task check
+
+      - name: Run deno test
+        run: deno task test
+
+      - name: Build dashboard
+        working-directory: packages/dashboard
+        run: |
+          npm ci
+          npm run build
+
+      - name: Compile binary
+        run: deno task compile
+
+      - name: Smoke test compiled binary
+        shell: bash
+        run: |
+          ./swamp.exe --version
+          ./swamp.exe --help > /dev/null


### PR DESCRIPTION
## Summary

- Remove `windows-latest` from CI test matrix — PRs run on Ubuntu only
- Remove Windows cross-compile from release workflow — no `.exe` in release assets
- Add `windows-compat.yml`: post-merge workflow that runs lint, fmt, check, test, compile, and smoke test on `windows-latest` when code changes land on main

## Context

Windows is not fully supported yet. Running it in the PR matrix doubles CI time for every PR without adding value to the verification loop (which runs on the developer's macOS/Linux machine). Moving it to post-merge treats it as a compatibility check — if it breaks, we fix-forward, same as acceptance test failures.

When Windows support is ready to be a first-class gate, the workflow moves back to pre-merge.

## Test plan

- [x] YAML validates for all three workflow files
- [x] actionlint passes
- [x] CI test job no longer references matrix or Windows
- [x] Release workflow no longer compiles or uploads Windows binary
- [x] Windows compat workflow triggers on push to main with code path changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEUofYG1ehMUVSfmEsjmMt