### PR TITLE
feat(access): add `swamp access token reveal` command (swamp-club#1825)

### DIFF
--- a/src/cli/commands/access.ts
+++ b/src/cli/commands/access.ts
@@ -26,6 +26,7 @@ import { accessCheckCommand } from "./access_check.ts";
 import { accessReloadCommand } from "./access_reload.ts";
 import { accessTokenMintCommand } from "./access_token_mint.ts";
 import { accessTokenListCommand } from "./access_token_list.ts";
+import { accessTokenRevealCommand } from "./access_token_reveal.ts";
 import { accessTokenRevokeCommand } from "./access_token_revoke.ts";
 import { accessTokenRotateCommand } from "./access_token_rotate.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
@@ -37,6 +38,7 @@ export const accessTokenCommand = new Command()
   .action(groupCommandAction)
   .command("mint", accessTokenMintCommand)
   .command("list", accessTokenListCommand)
+  .command("reveal", accessTokenRevealCommand)
   .command("revoke", accessTokenRevokeCommand)
   .command("rotate", accessTokenRotateCommand);
 

--- a/src/cli/commands/access_token_reveal.ts
+++ b/src/cli/commands/access_token_reveal.ts
@@ -1,0 +1,126 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepoUnlocked } from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+import {
+  consumeStream,
+  createLibSwampContext,
+  createServerTokenRevealDeps,
+  serverTokenReveal,
+  type ServerTokenRevealData,
+  type ServerTokenRevealEvent,
+  withDefaults,
+} from "../../libswamp/mod.ts";
+import { renderServerTokenReveal } from "../../presentation/output/access_token_output.ts";
+import { initializeControlPlaneVaultForCli } from "../control_plane_vault.ts";
+import { VaultService } from "../../domain/vaults/vault_service.ts";
+import { promptConfirmation } from "../prompt_helpers.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const accessTokenRevealCommand = new Command()
+  .name("reveal")
+  .description(
+    "Show the full authentication credential for a server token",
+  )
+  .example(
+    "Reveal a token (interactive confirmation)",
+    "swamp access token reveal adam-token",
+  )
+  .example(
+    "Reveal a token (skip confirmation)",
+    "swamp access token reveal adam-token --yes",
+  )
+  .arguments("<name:string>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option(
+    "-y, --yes",
+    "Skip confirmation prompt",
+  )
+  .option(
+    "-f, --force",
+    "Skip confirmation prompt (alias for --yes)",
+  )
+  .action(async function (options: AnyOptions, name: string) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "access",
+      "token",
+      "reveal",
+    ]);
+
+    const { repoDir, repoContext, syncService } =
+      await requireInitializedRepoUnlocked({
+        repoDir: resolveRepoDir(options.repoDir),
+        outputMode: cliCtx.outputMode,
+      });
+
+    await initializeControlPlaneVaultForCli(repoDir, syncService);
+
+    const vaultService = await VaultService.fromRepository(repoDir);
+    const deps = createServerTokenRevealDeps(
+      repoContext.dataQueryService,
+      vaultService,
+    );
+
+    const skipConfirm = !!(options.yes || options.force);
+    if (cliCtx.outputMode === "log" && !skipConfirm) {
+      const confirmed = await promptConfirmation(
+        `This will reveal the secret for token '${name}'. Continue?`,
+      );
+      if (!confirmed) {
+        writeOutput("Reveal cancelled.");
+        return;
+      }
+    }
+
+    const libCtx = createLibSwampContext({ logger: cliCtx.logger });
+    let data: ServerTokenRevealData | undefined;
+    await consumeStream(
+      serverTokenReveal(libCtx, deps, name),
+      withDefaults<ServerTokenRevealEvent>({
+        completed: (event) => {
+          data = event.data;
+        },
+        error: (event) => {
+          throw new UserError(event.error.message);
+        },
+      }),
+    );
+    if (data === undefined) {
+      throw new UserError(
+        `Revealing token '${name}' ended without completing`,
+      );
+    }
+
+    renderServerTokenReveal(data, cliCtx.outputMode);
+
+    cliCtx.logger.debug("Server token reveal command completed");
+  });

--- a/src/libswamp/access/token_create.ts
+++ b/src/libswamp/access/token_create.ts
@@ -22,8 +22,8 @@
  *
  * Runs the `mint` method on the built-in `swamp/server-token` model via
  * direct type execution — auto-creating the model instance named after the
- * token — then reads the plaintext back from the vault so the CLI can show
- * it exactly once.
+ * token. The plaintext is stored in the vault; use `swamp access token
+ * reveal` to retrieve it.
  */
 
 import type { LibSwampContext } from "../context.ts";

--- a/src/libswamp/access/token_reveal.ts
+++ b/src/libswamp/access/token_reveal.ts
@@ -1,0 +1,172 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Reveal the plaintext secret for a server token so the operator can
+ * form the `<name>.<secret>` credential string for authentication.
+ */
+
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import type { DataRecord } from "../../domain/data/data_record.ts";
+import type { DataQueryService } from "../../domain/data/data_query_service.ts";
+import type { VaultService } from "../../domain/vaults/vault_service.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+import {
+  SERVER_TOKEN_MODEL_TYPE,
+  ServerTokenSchema,
+} from "../../domain/models/access/server_token_model.ts";
+
+const TOKEN_DATA_NAME = "token-main";
+
+function escapeCelString(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+export interface ServerTokenRevealData {
+  name: string;
+  token: string;
+  expired: boolean;
+  vaultRef: { vaultName: string; secretKey: string };
+}
+
+export type ServerTokenRevealEvent =
+  | { kind: "resolving"; name: string }
+  | { kind: "completed"; data: ServerTokenRevealData }
+  | { kind: "error"; error: SwampError };
+
+export interface ServerTokenRevealDeps {
+  query: (predicate: string) => Promise<DataRecord[]>;
+  readSecret: (vaultName: string, secretKey: string) => Promise<string>;
+}
+
+export function createServerTokenRevealDeps(
+  dataQueryService: DataQueryService,
+  vaultService: VaultService,
+): ServerTokenRevealDeps {
+  return {
+    query: async (predicate) => {
+      const results = await dataQueryService.query(predicate, {
+        loadAttributes: true,
+      });
+      return results as DataRecord[];
+    },
+    readSecret: (vaultName, secretKey) =>
+      vaultService.get(vaultName, secretKey, "access:server-token-reveal"),
+  };
+}
+
+export async function* serverTokenReveal(
+  _ctx: LibSwampContext,
+  deps: ServerTokenRevealDeps,
+  name: string,
+): AsyncGenerator<ServerTokenRevealEvent> {
+  yield* withGeneratorSpan(
+    "swamp.access.token.reveal",
+    { "token.name": name },
+    (async function* () {
+      yield { kind: "resolving" as const, name };
+
+      let records: DataRecord[];
+      try {
+        records = await deps.query(
+          `modelType == "${SERVER_TOKEN_MODEL_TYPE.normalized}" && ` +
+            `name == "${TOKEN_DATA_NAME}" && ` +
+            `modelName == "${escapeCelString(name)}"`,
+        );
+      } catch (error) {
+        yield {
+          kind: "error" as const,
+          error: {
+            code: "token_query_failed",
+            message: error instanceof Error ? error.message : String(error),
+          },
+        };
+        return;
+      }
+
+      if (records.length === 0) {
+        yield {
+          kind: "error" as const,
+          error: {
+            code: "token_not_found",
+            message: `Server token '${name}' not found`,
+          },
+        };
+        return;
+      }
+
+      const parsed = ServerTokenSchema.safeParse(records[0].attributes);
+      if (!parsed.success) {
+        yield {
+          kind: "error" as const,
+          error: {
+            code: "token_record_invalid",
+            message:
+              `Token record for '${name}' has invalid schema: ${parsed.error.message}`,
+          },
+        };
+        return;
+      }
+
+      const token = parsed.data;
+      if (token.state === "revoked") {
+        yield {
+          kind: "error" as const,
+          error: {
+            code: "token_revoked",
+            message: `Server token '${name}' has been revoked`,
+          },
+        };
+        return;
+      }
+
+      const expired = token.state === "expired" ||
+        Date.parse(token.expiresAt) <= Date.now();
+      const { vaultName, secretKey } = token;
+
+      let plaintext: string;
+      try {
+        plaintext = await deps.readSecret(vaultName, secretKey);
+      } catch (error) {
+        yield {
+          kind: "error" as const,
+          error: {
+            code: "vault_read_failed",
+            message:
+              `Failed to read secret for token '${name}' from vault '${vaultName}': ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+          },
+        };
+        return;
+      }
+
+      yield {
+        kind: "completed" as const,
+        data: {
+          name,
+          token: `${name}.${plaintext}`,
+          expired,
+          vaultRef: { vaultName, secretKey },
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/access/token_reveal_test.ts
+++ b/src/libswamp/access/token_reveal_test.ts
@@ -1,0 +1,147 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  serverTokenReveal,
+  type ServerTokenRevealDeps,
+  type ServerTokenRevealEvent,
+} from "./token_reveal.ts";
+import type { DataRecord } from "../../domain/data/data_record.ts";
+
+function tokenRecord(
+  name: string,
+  overrides?: Partial<Record<string, unknown>>,
+): DataRecord {
+  return {
+    id: `data-${name}`,
+    name: "token-main",
+    modelId: name,
+    modelName: name,
+    modelType: "swamp/server-token",
+    attributes: {
+      name,
+      state: "active",
+      principalId: "user:adam",
+      principalEmail: "adam@example.com",
+      createdAt: "2026-06-18T00:00:00.000Z",
+      expiresAt: "2026-12-18T00:00:00.000Z",
+      vaultName: "_token-secrets",
+      secretKey: `server-token-${name}`,
+      ...overrides,
+    },
+  } as unknown as DataRecord;
+}
+
+function makeDeps(
+  overrides?: Partial<ServerTokenRevealDeps>,
+): ServerTokenRevealDeps {
+  return {
+    query: () => Promise.resolve([tokenRecord("test-token")]),
+    readSecret: () => Promise.resolve("abc123secret"),
+    ...overrides,
+  };
+}
+
+Deno.test("serverTokenReveal: reveals the full token credential", async () => {
+  const events = await collect<ServerTokenRevealEvent>(
+    serverTokenReveal(createLibSwampContext(), makeDeps(), "test-token"),
+  );
+
+  assertEquals(events[0], { kind: "resolving", name: "test-token" });
+  const completed = events[1] as Extract<
+    ServerTokenRevealEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data, {
+    name: "test-token",
+    token: "test-token.abc123secret",
+    expired: false,
+    vaultRef: {
+      vaultName: "_token-secrets",
+      secretKey: "server-token-test-token",
+    },
+  });
+});
+
+Deno.test("serverTokenReveal: errors when token does not exist", async () => {
+  const deps = makeDeps({ query: () => Promise.resolve([]) });
+  const events = await collect<ServerTokenRevealEvent>(
+    serverTokenReveal(createLibSwampContext(), deps, "missing"),
+  );
+  const error = events[1] as Extract<
+    ServerTokenRevealEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertEquals(error.error.code, "token_not_found");
+  assertStringIncludes(error.error.message, "'missing'");
+});
+
+Deno.test("serverTokenReveal: errors when token is revoked", async () => {
+  const deps = makeDeps({
+    query: () =>
+      Promise.resolve([tokenRecord("revoked-token", { state: "revoked" })]),
+  });
+  const events = await collect<ServerTokenRevealEvent>(
+    serverTokenReveal(createLibSwampContext(), deps, "revoked-token"),
+  );
+  const error = events[1] as Extract<
+    ServerTokenRevealEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertEquals(error.error.code, "token_revoked");
+  assertStringIncludes(error.error.message, "'revoked-token'");
+});
+
+Deno.test("serverTokenReveal: errors when vault read fails", async () => {
+  const deps = makeDeps({
+    readSecret: () => Promise.reject(new Error("vault provider unavailable")),
+  });
+  const events = await collect<ServerTokenRevealEvent>(
+    serverTokenReveal(createLibSwampContext(), deps, "test-token"),
+  );
+  const error = events[1] as Extract<
+    ServerTokenRevealEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertEquals(error.error.code, "vault_read_failed");
+  assertStringIncludes(error.error.message, "vault provider unavailable");
+});
+
+Deno.test("serverTokenReveal: errors when query fails", async () => {
+  const deps = makeDeps({
+    query: () => Promise.reject(new Error("datastore unreachable")),
+  });
+  const events = await collect<ServerTokenRevealEvent>(
+    serverTokenReveal(createLibSwampContext(), deps, "test-token"),
+  );
+  const error = events[1] as Extract<
+    ServerTokenRevealEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertEquals(error.error.code, "token_query_failed");
+  assertStringIncludes(error.error.message, "datastore unreachable");
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -466,6 +466,13 @@ export {
   type ServerTokenRevokeInput,
 } from "./access/token_revoke.ts";
 export {
+  createServerTokenRevealDeps,
+  serverTokenReveal,
+  type ServerTokenRevealData,
+  type ServerTokenRevealDeps,
+  type ServerTokenRevealEvent,
+} from "./access/token_reveal.ts";
+export {
   createServerTokenRotateDeps,
   serverTokenRotate,
   type ServerTokenRotateData,

--- a/src/presentation/output/access_token_output.ts
+++ b/src/presentation/output/access_token_output.ts
@@ -23,11 +23,12 @@
  * terminal-output design system.
  */
 
-import { bold, cyan, dim, green, red } from "@std/fmt/colors";
+import { bold, cyan, dim, green, red, yellow } from "@std/fmt/colors";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import type {
   ServerTokenCreateData,
   ServerTokenListData,
+  ServerTokenRevealData,
   ServerTokenRevokeData,
   ServerTokenRotateData,
 } from "../../libswamp/mod.ts";
@@ -90,12 +91,7 @@ export function renderServerTokenCreate(
     }`,
     "",
     `Retrieve the token with: ${
-      bold(
-        `swamp vault read-secret ${data.vaultRef.vaultName} ${data.vaultRef.secretKey} --yes`,
-      )
-    }`,
-    `The client token is ${bold("<name>.<secret>")} — prepend the token name: ${
-      bold(`${data.name}.<secret>`)
+      bold(`swamp access token reveal ${data.name} --yes`)
     }`,
   ];
   writeOutput(lines.join("\n"));
@@ -171,13 +167,34 @@ export function renderServerTokenRotate(
     }`,
     "",
     `Retrieve the new token with: ${
-      bold(
-        `swamp vault read-secret ${data.vaultRef.vaultName} ${data.vaultRef.secretKey} --yes`,
-      )
-    }`,
-    `The client token is ${bold("<name>.<secret>")} — prepend the token name: ${
-      bold(`${data.name}.<secret>`)
+      bold(`swamp access token reveal ${data.name} --yes`)
     }`,
   ];
   writeOutput(lines.join("\n"));
+}
+
+export function renderServerTokenReveal(
+  data: ServerTokenRevealData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    // Secret goes directly to stdout — never through the logger.
+    console.log(
+      JSON.stringify(
+        { name: data.name, token: data.token, expired: data.expired },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  writeOutput(`${bold(cyan("Token:"))} ${bold(data.name)}`);
+  if (data.expired) {
+    writeOutput(yellow("Warning: this token has expired."));
+  }
+  // Secret goes directly to stdout — never through the logger.
+  console.log(`\n  ${bold(data.token)}\n`);
+  writeOutput(
+    yellow("Store this token securely — do not share it in logs or messages."),
+  );
 }

--- a/src/presentation/output/access_token_output_test.ts
+++ b/src/presentation/output/access_token_output_test.ts
@@ -17,14 +17,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertStringIncludes } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { stripAnsiCode } from "@std/fmt/colors";
 import type {
   ServerTokenCreateData,
+  ServerTokenRevealData,
   ServerTokenRotateData,
 } from "../../libswamp/mod.ts";
 import {
   renderServerTokenCreate,
+  renderServerTokenReveal,
   renderServerTokenRotate,
 } from "./access_token_output.ts";
 
@@ -54,28 +56,47 @@ const rotateData: ServerTokenRotateData = {
   vaultRef: { vaultName: "serve-local", secretKey: "server-token-swamp-ui" },
 };
 
-Deno.test("renderServerTokenCreate: hint uses vault read-secret, not vault get", () => {
+const revealData: ServerTokenRevealData = {
+  name: "swamp-ui",
+  token: "swamp-ui.abc123secret",
+  expired: false,
+  vaultRef: { vaultName: "serve-local", secretKey: "server-token-swamp-ui" },
+};
+
+Deno.test("renderServerTokenCreate: hint uses access token reveal", () => {
   const output = captureLogs(() => renderServerTokenCreate(createData, "log"));
-  assertStringIncludes(
-    output,
-    "swamp vault read-secret serve-local server-token-swamp-ui --yes",
-  );
+  assertStringIncludes(output, "swamp access token reveal swamp-ui --yes");
 });
 
-Deno.test("renderServerTokenCreate: includes wire-format guidance", () => {
-  const output = captureLogs(() => renderServerTokenCreate(createData, "log"));
-  assertStringIncludes(output, "swamp-ui.<secret>");
-});
-
-Deno.test("renderServerTokenRotate: hint uses vault read-secret, not vault get", () => {
+Deno.test("renderServerTokenRotate: hint uses access token reveal", () => {
   const output = captureLogs(() => renderServerTokenRotate(rotateData, "log"));
-  assertStringIncludes(
-    output,
-    "swamp vault read-secret serve-local server-token-swamp-ui --yes",
-  );
+  assertStringIncludes(output, "swamp access token reveal swamp-ui --yes");
 });
 
-Deno.test("renderServerTokenRotate: includes wire-format guidance", () => {
-  const output = captureLogs(() => renderServerTokenRotate(rotateData, "log"));
-  assertStringIncludes(output, "swamp-ui.<secret>");
+Deno.test("renderServerTokenReveal: log mode shows token credential", () => {
+  const output = captureLogs(() => renderServerTokenReveal(revealData, "log"));
+  assertStringIncludes(output, "swamp-ui.abc123secret");
+  assertStringIncludes(output, "Store this token securely");
+});
+
+Deno.test("renderServerTokenReveal: json mode outputs name and token", () => {
+  const output = captureLogs(() => renderServerTokenReveal(revealData, "json"));
+  const parsed = JSON.parse(output);
+  assertEquals(parsed.name, "swamp-ui");
+  assertEquals(parsed.token, "swamp-ui.abc123secret");
+});
+
+Deno.test("renderServerTokenReveal: json mode excludes vault ref", () => {
+  const output = captureLogs(() => renderServerTokenReveal(revealData, "json"));
+  const parsed = JSON.parse(output);
+  assertEquals(parsed.vaultRef, undefined);
+});
+
+Deno.test("renderServerTokenReveal: log mode shows expiry warning when expired", () => {
+  const expiredData: ServerTokenRevealData = {
+    ...revealData,
+    expired: true,
+  };
+  const output = captureLogs(() => renderServerTokenReveal(expiredData, "log"));
+  assertStringIncludes(output, "this token has expired");
 });


### PR DESCRIPTION
## Summary

- Adds `swamp access token reveal <name>` command that reads the token secret from the control-plane vault and displays the full `<name>.<secret>` credential string
- Updates `mint` and `rotate` output hints to point to the new command instead of the non-functional `vault read-secret _token-secrets` path
- Fixes stale doc comment in `token_create.ts` that claimed plaintext was read back from the vault
- Secret is written directly to stdout via `console.log`, never through LogTape, preventing accidental leakage to log sinks

### Security hardening from review feedback
- CEL predicate injection prevented via `escapeCelString()` on user-supplied token name
- Expired tokens are revealed with a yellow warning so operators know the credential is no longer valid
- Revoked tokens are rejected entirely
- JSON output excludes `vaultRef` to avoid leaking internal vault details
- Interactive confirmation prompt before revealing (skippable with `-y`/`--yes`/`-f`/`--force`)

Fixes swamp-club#1825

## Test plan

- [x] 5 unit tests for `serverTokenReveal` (happy path, not found, revoked, vault read failure, query failure)
- [x] 6 unit tests for presentation output (create/rotate hint text, reveal log/json modes, vault ref exclusion, expiry warning)
- [x] 7 existing `token_create` tests still pass
- [x] Manual verification: compiled binary, minted token, revealed it, tested JSON mode, error cases (not found, revoked)
- [x] Build verification: 9/9 passed (lint, fmt, type-check, tests, deps audit, compile, smoke)
- [x] Code review: VERDICT pass
- [x] UX review: VERDICT pass
- [x] Adversarial review: VERDICT pass (content confirmed clean; harness parsing issue on verdict marker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: webframp <webframp@users.noreply.github.com>