### PR TITLE
fix(access): sort explain() results deny-first to match decide() semantics (swamp-club#1858)

### DIFF
--- a/src/domain/access/grant_based_access_decision_service.ts
+++ b/src/domain/access/grant_based_access_decision_service.ts
@@ -202,7 +202,8 @@ export class GrantBasedAccessDecisionService implements AccessDecisionService {
     const principalContext = buildPrincipalContext(principal, localGroups);
 
     let conditionsEvaluated = 0;
-    const decisions: AccessDecision[] = [];
+    const denyDecisions: AccessDecision[] = [];
+    const allowDecisions: AccessDecision[] = [];
     for (const grant of candidates) {
       if (!grantMatchesResource(grant, resource)) continue;
       if (!grantMatchesAction(grant, action)) continue;
@@ -215,10 +216,14 @@ export class GrantBasedAccessDecisionService implements AccessDecisionService {
         }
       }
       if (evaluateGrant(grant, snapshot, resource, principalContext)) {
-        decisions.push(toDecision(grant));
+        if (grant.effect === "deny") {
+          denyDecisions.push(toDecision(grant));
+        } else {
+          allowDecisions.push(toDecision(grant));
+        }
       }
     }
 
-    return decisions;
+    return [...denyDecisions, ...allowDecisions];
   }
 }

--- a/src/domain/access/grant_based_access_decision_service_test.ts
+++ b/src/domain/access/grant_based_access_decision_service_test.ts
@@ -293,6 +293,79 @@ Deno.test("explain: returns all matching grants without short-circuit", () => {
   const effects = result.map((d) => d.effect);
   assertEquals(effects.includes("deny"), true);
   assertEquals(effects.filter((e) => e === "allow").length, 2);
+  assertEquals(result[0].effect, "deny");
+});
+
+Deno.test("explain: sorts deny grants before allow grants regardless of input order", () => {
+  const allow = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["run"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const deny = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "deny",
+    actions: ["run"],
+    resource: { kind: "workflow", pattern: "@acme/deploy" },
+  });
+  const snapshot = new PolicySnapshot([allow, deny], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.explain(
+    makePrincipal("adam"),
+    "run",
+    makeResource(),
+  );
+  assertEquals(result.length, 2);
+  assertEquals(result[0].effect, "deny");
+  assertEquals(result[0].grantId, deny.id);
+  assertEquals(result[1].effect, "allow");
+  assertEquals(result[1].grantId, allow.id);
+});
+
+Deno.test("explain: preserves relative order within deny and allow buckets", () => {
+  const deny1 = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "deny",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "@acme/deploy" },
+  });
+  const allow1 = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const deny2 = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "deny",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "@acme/*" },
+  });
+  const allow2 = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "@acme/*" },
+  });
+  const snapshot = new PolicySnapshot(
+    [deny1, allow1, deny2, allow2],
+    [],
+    celEvaluator,
+  );
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.explain(
+    makePrincipal("adam"),
+    "read",
+    makeResource(),
+  );
+  assertEquals(result.length, 4);
+  assertEquals(result[0].grantId, deny1.id);
+  assertEquals(result[1].grantId, deny2.id);
+  assertEquals(result[2].grantId, allow1.id);
+  assertEquals(result[3].grantId, allow2.id);
 });
 
 Deno.test("explain: returns empty when no grants match", () => {

--- a/src/presentation/renderers/access_can_i_test.ts
+++ b/src/presentation/renderers/access_can_i_test.ts
@@ -204,3 +204,31 @@ Deno.test("accessCanIRenderer json: enumeration outputs principal and decisions"
   assertEquals(parsed.decisions.length, 2);
   assertEquals(parsed.effect, undefined);
 });
+
+// ── Deny-first verdict ─────────────────────────────────────────────────
+
+Deno.test("accessCanIRenderer log: specific check shows DENY when deny decision comes first", () => {
+  const output = captureRender("log", {
+    principal: "user:adam",
+    decisions: [
+      makeDecision({ effect: "deny", via: "user:adam" }),
+      makeDecision({ effect: "allow" }),
+    ],
+    query: { action: "run", resource: "workflow:@acme/deploy" },
+  });
+  assertStringIncludes(output[0], "DENY");
+});
+
+Deno.test("accessCanIRenderer json: specific check verdict is deny when deny decision comes first", () => {
+  const output = captureRender("json", {
+    principal: "user:adam",
+    decisions: [
+      makeDecision({ effect: "deny", via: "user:adam" }),
+      makeDecision({ effect: "allow" }),
+    ],
+    query: { action: "run", resource: "workflow:@acme/deploy" },
+  });
+  const parsed = JSON.parse(output.join(""));
+  assertEquals(parsed.effect, "deny");
+  assertEquals(parsed.decisions.length, 2);
+});

--- a/src/presentation/renderers/access_check_test.ts
+++ b/src/presentation/renderers/access_check_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertStringIncludes } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
   type AccessCheckResult,
   createAccessCheckRenderer,
@@ -95,4 +95,58 @@ Deno.test("accessCheckRenderer json: implicit deny when no grants", () => {
   }
   const parsed = JSON.parse(output.join(""));
   assertStringIncludes(parsed.effect, "deny");
+});
+
+Deno.test("accessCheckRenderer log: shows DENY when deny grant precedes allow", () => {
+  const renderer = createAccessCheckRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.render(makeResult({
+      decisions: [
+        {
+          effect: "deny",
+          grantId: "deny-uuid-1234-5678-abcd-ef0123456789",
+          subject: { kind: "user", name: "adam" },
+        },
+        {
+          effect: "allow",
+          grantId: "allow-uuid-1234-5678-abcd-ef012345678",
+          subject: { kind: "user", name: "adam" },
+        },
+      ],
+    }));
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[0], "DENY");
+});
+
+Deno.test("accessCheckRenderer json: verdict is deny when deny grant comes first", () => {
+  const renderer = createAccessCheckRenderer("json");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.render(makeResult({
+      decisions: [
+        {
+          effect: "deny",
+          grantId: "deny-uuid-1234-5678-abcd-ef0123456789",
+          subject: { kind: "user", name: "adam" },
+        },
+        {
+          effect: "allow",
+          grantId: "allow-uuid-1234-5678-abcd-ef012345678",
+          subject: { kind: "user", name: "adam" },
+        },
+      ],
+    }));
+  } finally {
+    console.log = origLog;
+  }
+  const parsed = JSON.parse(output.join(""));
+  assertEquals(parsed.effect, "deny");
+  assertEquals(parsed.matchingGrants.length, 2);
 });


### PR DESCRIPTION
## Summary

Closes swamp-club#1858.

`explain()` in `GrantBasedAccessDecisionService` returned matching grants in
snapshot candidate order, without deny-first sorting. Since all renderers and
CLI exit codes derive the verdict from `decisions[0].effect`, this caused
`swamp access check` and `can-i` to report ALLOW where enforcement (`decide()`)
would DENY.

- Sort `explain()` results deny-first using the same deny/allow bucketing
  pattern as `decide()`, preserving relative order within each bucket
- Add unit tests verifying deny-first ordering and bucket stability
- Add renderer tests for both `access_check` and `access_can_i` verifying
  correct verdict when deny and allow grants coexist

The fix propagates to all three callers: `access_check.ts` (CLI local path),
`access_handlers.ts:handleAccessCheck` (server), and
`access_handlers.ts:handleAccessCanI` (server query mode).

## Test Plan

- [x] `explain()` unit tests: deny-first ordering regardless of input order
- [x] `explain()` unit tests: relative order preserved within deny and allow buckets
- [x] `access_check` renderer tests: log and JSON mode show DENY when deny grant precedes allow
- [x] `access_can_i` renderer tests: log and JSON mode show DENY when deny decision comes first
- [x] All 22 existing decision service tests pass
- [x] All 20 renderer tests pass
- [x] Full verification workflow: lint, fmt, type-check, tests (10705 passed), compile, 4 agent reviews (all VERDICT: pass)