### PR TITLE
fix(workflows): detect guard type mismatch in workflow validate (swamp-club#1837)

### DIFF
--- a/src/domain/expressions/expression_parser.ts
+++ b/src/domain/expressions/expression_parser.ts
@@ -320,17 +320,21 @@ export function extractInputReferencesFromCel(
   return inputNames;
 }
 
-/**
- * Scans a data structure for `${{ ... }}` expressions and returns the unique
- * set of `inputs.*` field names referenced. Handles both CEL syntaxes:
- * - Dot notation: `inputs.fieldName`
- * - Bracket notation: `inputs["field-name"]` (for hyphenated names)
- *
- * Excludes cross-model references like `model.foo.input.bar`.
- *
- * @param data - The data structure to scan (object, array, or primitive)
- * @returns Set of unique input field names referenced
- */
+export function extractWholeFieldInputRef(value: string): string | null {
+  const singleMatch = value.match(SINGLE_EXPRESSION_PATTERN);
+  if (!singleMatch) return null;
+
+  const cel = singleMatch[1].replace(/^\$\{\{\s*/, "").replace(/\s*\}\}$/, "");
+
+  const dotMatch = cel.match(/^inputs\.([a-zA-Z_][a-zA-Z0-9_]*)$/);
+  if (dotMatch) return dotMatch[1];
+
+  const bracketMatch = cel.match(/^inputs\["([^"]+)"\]$/);
+  if (bracketMatch) return bracketMatch[1];
+
+  return null;
+}
+
 export function extractInputReferences(data: unknown): Set<string> {
   const expressions = extractExpressions(data);
   const inputNames = new Set<string>();

--- a/src/domain/expressions/expression_parser_test.ts
+++ b/src/domain/expressions/expression_parser_test.ts
@@ -24,6 +24,7 @@ import {
   extractExpressions,
   extractInputReferences,
   extractInputReferencesFromCel,
+  extractWholeFieldInputRef,
   isAssertMessagePath,
   isTaskGlobalArgsPath,
   isTaskInputsPath,
@@ -545,4 +546,60 @@ Deno.test("extractCelExpression: extracts expression spanning newlines", () => {
     ),
     'webhook.route == "/hooks/github"\n? webhook.headers["x"]',
   );
+});
+
+Deno.test("extractWholeFieldInputRef: returns input name for dot notation", () => {
+  assertEquals(extractWholeFieldInputRef("${{ inputs.dryRun }}"), "dryRun");
+});
+
+Deno.test("extractWholeFieldInputRef: returns input name for bracket notation", () => {
+  assertEquals(
+    extractWholeFieldInputRef('${{ inputs["dry-run"] }}'),
+    "dry-run",
+  );
+});
+
+Deno.test("extractWholeFieldInputRef: returns null for non-input expression", () => {
+  assertEquals(extractWholeFieldInputRef("${{ data.latest() }}"), null);
+  assertEquals(extractWholeFieldInputRef("${{ model.foo.input.x }}"), null);
+  assertEquals(extractWholeFieldInputRef("${{ self.name }}"), null);
+});
+
+Deno.test("extractWholeFieldInputRef: returns null for multi-expression string", () => {
+  assertEquals(
+    extractWholeFieldInputRef("${{ inputs.a }} and ${{ inputs.b }}"),
+    null,
+  );
+});
+
+Deno.test("extractWholeFieldInputRef: returns null for expression with operators", () => {
+  assertEquals(
+    extractWholeFieldInputRef("${{ inputs.a || inputs.b }}"),
+    null,
+  );
+  assertEquals(
+    extractWholeFieldInputRef("${{ inputs.a == true }}"),
+    null,
+  );
+});
+
+Deno.test("extractWholeFieldInputRef: returns null for embedded expression", () => {
+  assertEquals(
+    extractWholeFieldInputRef("prefix-${{ inputs.name }}-suffix"),
+    null,
+  );
+});
+
+Deno.test("extractWholeFieldInputRef: returns null for non-expression string", () => {
+  assertEquals(extractWholeFieldInputRef("plain string"), null);
+  assertEquals(extractWholeFieldInputRef(""), null);
+});
+
+Deno.test("extractWholeFieldInputRef: handles trailing whitespace", () => {
+  assertEquals(extractWholeFieldInputRef("${{ inputs.foo }}  "), "foo");
+});
+
+Deno.test("extractWholeFieldInputRef: handles inner whitespace variations", () => {
+  assertEquals(extractWholeFieldInputRef("${{inputs.foo}}"), "foo");
+  assertEquals(extractWholeFieldInputRef("${{  inputs.foo  }}"), "foo");
 });

--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -28,7 +28,10 @@ import {
   type GraphNode,
   TopologicalSortService,
 } from "./topological_sort_service.ts";
-import { extractInputReferences } from "../expressions/expression_parser.ts";
+import {
+  extractInputReferences,
+  extractWholeFieldInputRef,
+} from "../expressions/expression_parser.ts";
 
 /**
  * Value object representing the result of a single validation.
@@ -177,6 +180,9 @@ export class DefaultWorkflowValidationService
 
     // 12. affinity without placement is a no-op
     results.push(...this.validateAffinityPlacement(workflow));
+
+    // 13. Guard expression type matches input type
+    results.push(...this.validateGuardExpressionTypes(workflow));
 
     return results;
   }
@@ -745,6 +751,44 @@ export class DefaultWorkflowValidationService
           );
         } else {
           results.push(WorkflowValidationResult.pass(checkName));
+        }
+      }
+    }
+
+    return results;
+  }
+
+  private validateGuardExpressionTypes(
+    workflow: Workflow,
+  ): WorkflowValidationResult[] {
+    const results: WorkflowValidationResult[] = [];
+    const inputProperties = workflow.inputs?.properties;
+
+    for (const job of workflow.jobs) {
+      for (const step of job.steps) {
+        if (!step.guard) continue;
+
+        const inputName = extractWholeFieldInputRef(step.guard);
+        if (!inputName) continue;
+
+        if (!inputProperties) continue;
+        const inputDef = inputProperties[inputName];
+        if (!inputDef?.type) continue;
+
+        if (inputDef.type !== "string") {
+          const inputRef = /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(inputName)
+            ? `inputs.${inputName}`
+            : `inputs["${inputName}"]`;
+          results.push(
+            WorkflowValidationResult.fail(
+              `Guard type in job '${job.name}' step '${step.name}'`,
+              `guard received a ${inputDef.type} via \${{ ${inputRef} }}; ` +
+                `the guard field requires a string (CEL expression). ` +
+                `Whole-field \${{ }} substitutions preserve the input's native type, ` +
+                `so a ${inputDef.type} would replace the string at runtime. ` +
+                `Use a CEL expression that evaluates the condition instead`,
+            ),
+          );
         }
       }
     }

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -2141,3 +2141,235 @@ Deno.test("validate: warns when job affinity is set without placement", async ()
   assertEquals(warning?.passed, true);
   assertEquals(warning?.warning, true);
 });
+
+// --- Guard expression type validation tests ---
+
+Deno.test("validate: fails when guard references boolean input", async () => {
+  const workflow = Workflow.create({
+    name: "guard-bool",
+    inputs: {
+      type: "object",
+      properties: {
+        dryRun: { type: "boolean" },
+      },
+    },
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "deploy",
+            task: StepTask.model("test-model", "run"),
+            guard: "${{ inputs.dryRun }}",
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const guardResult = results.find((r) => r.name.includes("Guard type"));
+  assertEquals(guardResult?.passed, false);
+  assertEquals(guardResult?.error?.includes("boolean"), true);
+});
+
+Deno.test("validate: fails when guard references number input", async () => {
+  const workflow = Workflow.create({
+    name: "guard-number",
+    inputs: {
+      type: "object",
+      properties: {
+        count: { type: "number" },
+      },
+    },
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "deploy",
+            task: StepTask.model("test-model", "run"),
+            guard: "${{ inputs.count }}",
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const guardResult = results.find((r) => r.name.includes("Guard type"));
+  assertEquals(guardResult?.passed, false);
+  assertEquals(guardResult?.error?.includes("number"), true);
+});
+
+Deno.test("validate: fails when guard references array input", async () => {
+  const workflow = Workflow.create({
+    name: "guard-array",
+    inputs: {
+      type: "object",
+      properties: {
+        items: { type: "array" },
+      },
+    },
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "deploy",
+            task: StepTask.model("test-model", "run"),
+            guard: "${{ inputs.items }}",
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const guardResult = results.find((r) => r.name.includes("Guard type"));
+  assertEquals(guardResult?.passed, false);
+  assertEquals(guardResult?.error?.includes("array"), true);
+});
+
+Deno.test("validate: passes when guard references string input", async () => {
+  const workflow = Workflow.create({
+    name: "guard-string",
+    inputs: {
+      type: "object",
+      properties: {
+        condition: { type: "string" },
+      },
+    },
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "deploy",
+            task: StepTask.model("test-model", "run"),
+            guard: "${{ inputs.condition }}",
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const guardResult = results.find((r) => r.name.includes("Guard type"));
+  assertEquals(guardResult, undefined);
+});
+
+Deno.test("validate: passes when guard references untyped input", async () => {
+  const workflow = Workflow.create({
+    name: "guard-untyped",
+    inputs: {
+      type: "object",
+      properties: {
+        flag: { description: "no type declared" },
+      },
+    },
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "deploy",
+            task: StepTask.model("test-model", "run"),
+            guard: "${{ inputs.flag }}",
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const guardResult = results.find((r) => r.name.includes("Guard type"));
+  assertEquals(guardResult, undefined);
+});
+
+Deno.test("validate: passes when guard uses embedded expression", async () => {
+  const workflow = Workflow.create({
+    name: "guard-embedded",
+    inputs: {
+      type: "object",
+      properties: {
+        dryRun: { type: "boolean" },
+      },
+    },
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "deploy",
+            task: StepTask.model("test-model", "run"),
+            guard: "prefix-${{ inputs.dryRun }}-suffix",
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const guardResult = results.find((r) => r.name.includes("Guard type"));
+  assertEquals(guardResult, undefined);
+});
+
+Deno.test("validate: passes when guard uses non-input expression", async () => {
+  const workflow = Workflow.create({
+    name: "guard-data",
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "deploy",
+            task: StepTask.model("test-model", "run"),
+            guard: '${{ data.latest("m", "r").attributes.done }}',
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const guardResult = results.find((r) => r.name.includes("Guard type"));
+  assertEquals(guardResult, undefined);
+});
+
+Deno.test("validate: passes when step has no guard", async () => {
+  const workflow = createSimpleWorkflow();
+  const results = await service.validate(workflow);
+  const guardResult = results.find((r) => r.name.includes("Guard type"));
+  assertEquals(guardResult, undefined);
+});
+
+Deno.test("validate: fails when guard references boolean input via bracket notation", async () => {
+  const workflow = Workflow.create({
+    name: "guard-bracket",
+    inputs: {
+      type: "object",
+      properties: {
+        "dry-run": { type: "boolean" },
+      },
+    },
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "deploy",
+            task: StepTask.model("test-model", "run"),
+            guard: '${{ inputs["dry-run"] }}',
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const guardResult = results.find((r) => r.name.includes("Guard type"));
+  assertEquals(guardResult?.passed, false);
+  assertEquals(guardResult?.error?.includes("boolean"), true);
+  assertEquals(guardResult?.error?.includes('inputs["dry-run"]'), true);
+});


### PR DESCRIPTION
## Summary

- `workflow validate` now detects when a `guard` field holds a whole-field `${{ inputs.X }}` expression referencing a non-string input (boolean, number, array, object), and reports an actionable error instead of silently passing
- Previously, validate passed cleanly but the workflow failed at runtime because `replaceExpressions()` preserves the native type for single-expression substitutions — a boolean input produced `guard: true`, failing the `z.string()` schema validation
- For hyphenated input names accessed via bracket notation, the error message preserves bracket syntax to avoid showing a broken CEL expression

Closes swamp-club#1837

## Test plan

- [x] Unit tests for `extractWholeFieldInputRef` helper (9 tests: dot notation, bracket notation, multi-expression, operators, embedded, non-input, non-expression, whitespace)
- [x] Unit tests for `validateGuardExpressionTypes` check (9 tests: boolean/number/array fail, string/untyped/embedded/non-input/no-guard pass, bracket notation fail with correct error message)
- [x] Reproduced bug in scratch repo: `swamp workflow validate` now correctly fails with guard type mismatch error
- [x] Verification: lint, fmt, type-check, tests (10716 passed), compile, and 4 agent reviews (code, adversarial, UX, CI security) — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)