### PR TITLE
fix(extensions): reject nested typed-key entries under paths.base=manifest (swamp-club#1855)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -293,7 +293,10 @@ containing `..` or starting with `/`.
   (`modelsDir`, `vaultsDir`, etc.). `"manifest"` resolves every typed entry plus
   `additionalFiles` relative to the manifest's own directory — pick this for
   per-extension-subdir layouts where manifest, source, README, and LICENSE all
-  sit alongside each other. See "Path resolution" below.
+  sit alongside each other. Under `"manifest"`, entries must not repeat the
+  typed directory prefix — e.g. `models: ["project.ts"]`, not
+  `models: ["models/project.ts"]` — because the archive already places each
+  entry under its typed directory. See "Path resolution" below.
 - `models`: Array of relative paths to TypeScript model files (e.g.,
   `["aws/ec2/instance.ts"]`). Resolved via `paths.base`.
 - `workflows`: Array of relative paths to YAML workflow files. Resolved via

--- a/src/cli/resolve_extension_files.ts
+++ b/src/cli/resolve_extension_files.ts
@@ -208,6 +208,39 @@ export async function resolveExtensionFiles(
     ? manifestDir
     : resolve(extensionsDir, resolveReportsDir(marker));
 
+  // 2b. When paths.base=manifest, reject entries that start with their own
+  // archive directory prefix — the archive places each typed-key file under
+  // its directory name, so `models: [models/foo.ts]` would land at
+  // `extension/models/models/foo.ts` instead of `extension/models/foo.ts`.
+  if (useManifestBase) {
+    const typedFieldPrefixes: Array<{ field: string; prefix: string }> = [
+      { field: "models", prefix: "models/" },
+      { field: "vaults", prefix: "vaults/" },
+      { field: "drivers", prefix: "drivers/" },
+      { field: "datastores", prefix: "datastores/" },
+      { field: "reports", prefix: "reports/" },
+      { field: "include", prefix: "models/" },
+    ];
+    for (const { field, prefix } of typedFieldPrefixes) {
+      const entries = manifest[field as keyof typeof manifest];
+      if (!Array.isArray(entries)) continue;
+      for (const entry of entries) {
+        if (typeof entry !== "string") continue;
+        const normalized = entry.replace(/^\.\//, "");
+        if (normalized.startsWith(prefix)) {
+          throw new UserError(
+            `Manifest field '${field}' entry '${entry}' starts with '${prefix}', ` +
+              `which would double the archive path to ${prefix}${normalized}. ` +
+              `With paths.base: manifest, use the bare filename (e.g. '${
+                normalized.slice(prefix.length)
+              }') ` +
+              `and place the file next to the manifest, or remove paths.base to resolve from the repository's typed directory.`,
+          );
+        }
+      }
+    }
+  }
+
   // 3. Collect model files from manifest
   const modelEntryPoints: string[] = [];
   for (const modelRef of manifest.models) {

--- a/src/cli/resolve_extension_files_test.ts
+++ b/src/cli/resolve_extension_files_test.ts
@@ -1257,3 +1257,173 @@ Deno.test("resolveExtensionFiles paths.base=manifest prefers manifest-relative f
     assertEquals(result.workflowFiles[0].sourcePath, manifestRelativePath);
   });
 });
+
+Deno.test("resolveExtensionFiles paths.base=manifest rejects models entry starting with models/", async () => {
+  await withTempRepo(async (dir) => {
+    const subdir = join(dir, "extensions", "models", "myext");
+    await Deno.mkdir(join(subdir, "models"), { recursive: true });
+    await Deno.writeTextFile(
+      join(subdir, "models", "project.ts"),
+      'export const name = "project";',
+    );
+    const manifestPath = join(subdir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/nested-model",
+        version: "2026.08.27.1",
+        paths: { base: "manifest" },
+        models: ["models/project.ts"],
+      }),
+    );
+
+    await assertRejects(
+      () =>
+        resolveExtensionFiles({
+          repoDir: dir,
+          manifestPath,
+          repoContext: stubRepoContext,
+          logger,
+        }),
+      UserError,
+      "starts with 'models/'",
+    );
+  });
+});
+
+Deno.test("resolveExtensionFiles paths.base=manifest rejects vaults entry starting with vaults/", async () => {
+  await withTempRepo(async (dir) => {
+    const subdir = join(dir, "extensions", "vaults", "myvault");
+    await Deno.mkdir(join(subdir, "vaults"), { recursive: true });
+    await Deno.writeTextFile(
+      join(subdir, "vaults", "secret.ts"),
+      'export const name = "secret";',
+    );
+    const manifestPath = join(subdir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/nested-vault",
+        version: "2026.08.27.1",
+        paths: { base: "manifest" },
+        vaults: ["vaults/secret.ts"],
+      }),
+    );
+
+    await assertRejects(
+      () =>
+        resolveExtensionFiles({
+          repoDir: dir,
+          manifestPath,
+          repoContext: stubRepoContext,
+          logger,
+        }),
+      UserError,
+      "starts with 'vaults/'",
+    );
+  });
+});
+
+Deno.test("resolveExtensionFiles paths.base=manifest rejects include entry starting with models/", async () => {
+  await withTempRepo(async (dir) => {
+    const subdir = join(dir, "extensions", "models", "myext");
+    await Deno.mkdir(join(subdir, "models"), { recursive: true });
+    await Deno.writeTextFile(
+      join(subdir, "models", "helper.sh"),
+      "#!/bin/sh\necho hello",
+    );
+    await Deno.writeTextFile(
+      join(subdir, "entry.ts"),
+      'export const name = "entry";',
+    );
+    const manifestPath = join(subdir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/nested-include",
+        version: "2026.08.27.1",
+        paths: { base: "manifest" },
+        models: ["entry.ts"],
+        include: ["models/helper.sh"],
+      }),
+    );
+
+    await assertRejects(
+      () =>
+        resolveExtensionFiles({
+          repoDir: dir,
+          manifestPath,
+          repoContext: stubRepoContext,
+          logger,
+        }),
+      UserError,
+      "starts with 'models/'",
+    );
+  });
+});
+
+Deno.test("resolveExtensionFiles paths.base=manifest allows unrelated subdirectory in models entry", async () => {
+  await withTempRepo(async (dir) => {
+    const subdir = join(dir, "extensions", "models", "myext");
+    await Deno.mkdir(join(subdir, "aws"), { recursive: true });
+    await Deno.writeTextFile(
+      join(subdir, "aws", "ec2.ts"),
+      'export const name = "ec2";',
+    );
+    const manifestPath = join(subdir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/aws-subdir",
+        version: "2026.08.27.1",
+        paths: { base: "manifest" },
+        models: ["aws/ec2.ts"],
+      }),
+    );
+
+    const result = await resolveExtensionFiles({
+      repoDir: dir,
+      manifestPath,
+      repoContext: stubRepoContext,
+      logger,
+    });
+
+    assertEquals(result.modelEntryPoints, [join(subdir, "aws", "ec2.ts")]);
+  });
+});
+
+Deno.test("resolveExtensionFiles paths.base=typedDir allows models/ prefix in entry", async () => {
+  await withTempRepo(async (dir) => {
+    const modelsDir = join(dir, "extensions", "models");
+    await Deno.mkdir(join(modelsDir, "models"), { recursive: true });
+    await Deno.writeTextFile(
+      join(modelsDir, "models", "project.ts"),
+      'export const name = "project";',
+    );
+    const manifestPath = join(dir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/typeddir-nested",
+        version: "2026.08.27.1",
+        models: ["models/project.ts"],
+      }),
+    );
+
+    const result = await resolveExtensionFiles({
+      repoDir: dir,
+      manifestPath,
+      repoContext: stubRepoContext,
+      logger,
+    });
+
+    assertEquals(result.modelEntryPoints, [
+      join(modelsDir, "models", "project.ts"),
+    ]);
+  });
+});

--- a/src/libswamp/extensions/push_pull_roundtrip_test.ts
+++ b/src/libswamp/extensions/push_pull_roundtrip_test.ts
@@ -571,3 +571,94 @@ Deno.test(
     }
   },
 );
+
+Deno.test(
+  "round-trip: paths.base=manifest nested model entry doubles archive path (issue 1855)",
+  async () => {
+    const { collectEntrypoints, findManifestRoot } = await import(
+      "../../domain/extensions/extension_rubric_scorer.ts"
+    );
+    const src = await Deno.makeTempDir({ prefix: "rt-1855-src-" });
+    const dst = await Deno.makeTempDir({ prefix: "rt-1855-dst-" });
+    try {
+      // Layout matching the reporter's scenario: manifest beside a
+      // models/ subdirectory, with paths.base=manifest.
+      const extDir = join(src, "extensions", "myext");
+      await Deno.mkdir(join(extDir, "models"), { recursive: true });
+      await Deno.writeTextFile(
+        join(extDir, "models", "project.ts"),
+        'export const model = { type: "@t/nested", version: "1.0.0" };',
+      );
+      await Deno.writeTextFile(join(extDir, "README.md"), "# README");
+
+      const manifest = makeManifest({
+        paths: { base: "manifest" },
+        models: ["models/project.ts"],
+        additionalFiles: ["README.md"],
+      });
+
+      // modelsDir = manifestDir (paths.base=manifest), so the archive
+      // will place the file at models/models/project.ts (doubled).
+      const input: ExtensionPushPrepareInput = {
+        manifest,
+        repoDir: src,
+        modelsDir: extDir,
+        allModelFiles: [join(extDir, "models", "project.ts")],
+        modelEntryPoints: [join(extDir, "models", "project.ts")],
+        vaultsDir: extDir,
+        allVaultFiles: [],
+        vaultEntryPoints: [],
+        driversDir: extDir,
+        allDriverFiles: [],
+        driverEntryPoints: [],
+        datastoresDir: extDir,
+        allDatastoreFiles: [],
+        datastoreEntryPoints: [],
+        reportsDir: extDir,
+        allReportFiles: [],
+        reportEntryPoints: [],
+        workflowFiles: [],
+        skillDirs: [],
+        allSkillFiles: [],
+        includeFilePaths: [],
+        additionalFilePaths: [join(extDir, "README.md")],
+        binaryFilePaths: [],
+        dryRun: true,
+      };
+
+      const ctx = createLibSwampContext();
+      const prepared = await extensionPushPrepare(
+        ctx,
+        makePrepareDeps(),
+        input,
+      );
+
+      await untarArchiveTo(prepared.archiveBytes, dst);
+      const extRoot = await findManifestRoot(dst);
+
+      // The archive places the model at the doubled path.
+      await Deno.stat(join(extRoot, "models", "models", "project.ts"));
+
+      // The scorer looks for it at the un-doubled path, which does NOT exist.
+      const entrypoints = collectEntrypoints(extRoot, extRoot, manifest);
+      assertEquals(entrypoints, [
+        join(extRoot, "models", "project.ts"),
+      ]);
+
+      // The entrypoint the scorer expects does not exist in the archive —
+      // this is the mismatch that causes empty contentTypes/contentMetadata.
+      // CLI-layer validation in resolveExtensionFiles now rejects this
+      // manifest shape before it reaches extensionPushPrepare.
+      let found = true;
+      try {
+        await Deno.stat(entrypoints[0]);
+      } catch {
+        found = false;
+      }
+      assertEquals(found, false);
+    } finally {
+      await Deno.remove(src, { recursive: true }).catch(() => {});
+      await Deno.remove(dst, { recursive: true }).catch(() => {});
+    }
+  },
+);


### PR DESCRIPTION
## Summary

- When `paths.base: manifest` is used with a model entry like `models/project.ts`, the archive doubles the path to `extension/models/models/project.ts` while the scorer and registry expect `extension/models/project.ts`, causing empty `contentTypes` and `contentMetadata` on published extensions
- Adds validation in `resolveExtensionFiles()` that rejects typed-key entries starting with their own archive directory prefix when `paths.base` is `manifest`, with a clear error message explaining the fix
- Covers all typed fields (models, vaults, drivers, datastores, reports) plus the cross-field case (`include` archives under `models/`)

Closes swamp-club#1855

## Test plan

- [x] Unit tests for rejection of models/, vaults/, and models/ (include cross-field) prefixes
- [x] Unit test confirming unrelated subdirectory prefixes (e.g. `aws/ec2.ts`) still work
- [x] Unit test confirming `paths.base: typedDir` allows `models/` prefix (no validation needed)
- [x] Roundtrip integration test documenting the archive-level doubling mismatch
- [x] All existing `paths.base=manifest` tests continue to pass
- [x] Full verification: lint, fmt, type-check, tests, compile, code review, adversarial review, UX review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Sai Nimmagadda <funsaized@users.noreply.github.com>