### PR TITLE
fix(verification): write diff to temp file instead of inlining in prompt

### DIFF
--- a/verification/workflow-verify-reviews.yaml
+++ b/verification/workflow-verify-reviews.yaml
@@ -92,15 +92,16 @@ jobs:
             run: |
               set -o pipefail
               MERGE_BASE=$(git merge-base main HEAD)
+              DIFF_FILE=$(mktemp)
               PROMPT_FILE=$(mktemp)
               RESULT_FILE=$(mktemp)
+              git diff "$MERGE_BASE" > "$DIFF_FILE"
               cat verification/review-prompts/code-review.md > "$PROMPT_FILE"
-              printf '\n\nOutput your review. Start with a single line: VERDICT: pass or VERDICT: fail\nThen provide your full review.\n\nDIFF:\n' >> "$PROMPT_FILE"
-              git diff "$MERGE_BASE" >> "$PROMPT_FILE"
+              printf '\n\nThe diff to review is at: %s\nRead that file to see the changes.\n\nOutput your review. Start with a single line: VERDICT: pass or VERDICT: fail\nThen provide your full review.\n' "$DIFF_FILE" >> "$PROMPT_FILE"
               claude -p - \
                 --model claude-opus-4-6 \
                 --allowedTools "Read,Glob,Grep" < "$PROMPT_FILE" | tee "$RESULT_FILE"
-              rm -f "$PROMPT_FILE"
+              rm -f "$PROMPT_FILE" "$DIFF_FILE"
               VERDICT=$(head -5 "$RESULT_FILE" | grep -o 'VERDICT: [a-z]*' | head -1 | cut -d' ' -f2)
               rm -f "$RESULT_FILE"
               if [ "$VERDICT" != "pass" ]; then
@@ -120,15 +121,16 @@ jobs:
             run: |
               set -o pipefail
               MERGE_BASE=$(git merge-base main HEAD)
+              DIFF_FILE=$(mktemp)
               PROMPT_FILE=$(mktemp)
               RESULT_FILE=$(mktemp)
+              git diff "$MERGE_BASE" > "$DIFF_FILE"
               cat verification/review-prompts/adversarial-review.md > "$PROMPT_FILE"
-              printf '\n\nOutput your review. Start with a single line: VERDICT: pass or VERDICT: fail\nThen provide your full review.\n\nDIFF:\n' >> "$PROMPT_FILE"
-              git diff "$MERGE_BASE" >> "$PROMPT_FILE"
+              printf '\n\nThe diff to review is at: %s\nRead that file to see the changes.\n\nOutput your review. Start with a single line: VERDICT: pass or VERDICT: fail\nThen provide your full review.\n' "$DIFF_FILE" >> "$PROMPT_FILE"
               claude -p - \
                 --model claude-opus-4-6 \
                 --allowedTools "Read,Glob,Grep" < "$PROMPT_FILE" | tee "$RESULT_FILE"
-              rm -f "$PROMPT_FILE"
+              rm -f "$PROMPT_FILE" "$DIFF_FILE"
               VERDICT=$(head -5 "$RESULT_FILE" | grep -o 'VERDICT: [a-z]*' | head -1 | cut -d' ' -f2)
               rm -f "$RESULT_FILE"
               if [ "$VERDICT" != "pass" ]; then
@@ -148,15 +150,16 @@ jobs:
             run: |
               set -o pipefail
               MERGE_BASE=$(git merge-base main HEAD)
+              DIFF_FILE=$(mktemp)
               PROMPT_FILE=$(mktemp)
               RESULT_FILE=$(mktemp)
+              git diff "$MERGE_BASE" > "$DIFF_FILE"
               cat verification/review-prompts/ux-review.md > "$PROMPT_FILE"
-              printf '\n\nOutput your review. Start with a single line: VERDICT: pass or VERDICT: fail\nThen provide your full review.\n\nDIFF:\n' >> "$PROMPT_FILE"
-              git diff "$MERGE_BASE" >> "$PROMPT_FILE"
+              printf '\n\nThe diff to review is at: %s\nRead that file to see the changes.\n\nOutput your review. Start with a single line: VERDICT: pass or VERDICT: fail\nThen provide your full review.\n' "$DIFF_FILE" >> "$PROMPT_FILE"
               claude -p - \
                 --model claude-sonnet-4-6 \
                 --allowedTools "Read,Glob,Grep" < "$PROMPT_FILE" | tee "$RESULT_FILE"
-              rm -f "$PROMPT_FILE"
+              rm -f "$PROMPT_FILE" "$DIFF_FILE"
               VERDICT=$(head -5 "$RESULT_FILE" | grep -o 'VERDICT: [a-z]*' | head -1 | cut -d' ' -f2)
               rm -f "$RESULT_FILE"
               if [ "$VERDICT" != "pass" ]; then
@@ -176,15 +179,16 @@ jobs:
             run: |
               set -o pipefail
               MERGE_BASE=$(git merge-base main HEAD)
+              DIFF_FILE=$(mktemp)
               PROMPT_FILE=$(mktemp)
               RESULT_FILE=$(mktemp)
+              git diff "$MERGE_BASE" > "$DIFF_FILE"
               cat verification/review-prompts/ci-security-review.md > "$PROMPT_FILE"
-              printf '\n\nOutput your review. Start with a single line: VERDICT: pass or VERDICT: fail\nThen provide your full review.\n\nDIFF:\n' >> "$PROMPT_FILE"
-              git diff "$MERGE_BASE" >> "$PROMPT_FILE"
+              printf '\n\nThe diff to review is at: %s\nRead that file to see the changes.\n\nOutput your review. Start with a single line: VERDICT: pass or VERDICT: fail\nThen provide your full review.\n' "$DIFF_FILE" >> "$PROMPT_FILE"
               claude -p - \
                 --model claude-opus-4-6 \
                 --allowedTools "Read,Glob,Grep" < "$PROMPT_FILE" | tee "$RESULT_FILE"
-              rm -f "$PROMPT_FILE"
+              rm -f "$PROMPT_FILE" "$DIFF_FILE"
               VERDICT=$(head -5 "$RESULT_FILE" | grep -o 'VERDICT: [a-z]*' | head -1 | cut -d' ' -f2)
               rm -f "$RESULT_FILE"
               if [ "$VERDICT" != "pass" ]; then


### PR DESCRIPTION
## Summary

The review steps in `verify-reviews` were appending the full `git diff` to the prompt file and piping everything via stdin to `claude -p`. Large diffs (22+ files, many deletions) caused intermittent failures where the review harness couldn't start — reporting `verdict: missing` in a few seconds before any review ran.

Fix: write the diff to a separate temp file, and tell Claude where to find it. The prompt says "The diff to review is at: /tmp/xxx — Read that file to see the changes." Claude uses its `Read` tool to load the diff, which handles any size since it's a tool call, not prompt content.

All four review steps (code, adversarial, ux, ci-security) updated with the same pattern.

## Test plan

- [x] Tested `claude -p` reads a temp file when given the path — returns file contents correctly
- [x] Tested with a real 5KB diff — Claude reads, reviews, and produces `VERDICT: pass` in the expected format
- [x] YAML validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEUofYG1ehMUVSfmEsjmMt