### PR TITLE
fix(cli): replace hand-rolled list command clones with native Cliffy aliases (swamp-club#1759)

### DIFF
--- a/src/cli/commands/datastore.ts
+++ b/src/cli/commands/datastore.ts
@@ -32,25 +32,14 @@ import {
   datastoreNamespaceUnsetCommand,
 } from "./datastore_namespace.ts";
 import { datastoreNamespacesCommand } from "./datastore_namespaces.ts";
-import {
-  datastoreTypeSearchAction,
-  datastoreTypeSearchCommand,
-} from "./datastore_type_search.ts";
+import { datastoreTypeSearchCommand } from "./datastore_type_search.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
 
 export const datastoreTypeCommand = new Command()
   .name("type")
   .description("Inspect datastore types")
   .action(groupCommandAction)
-  .command("search", datastoreTypeSearchCommand)
-  .command(
-    "list",
-    new Command()
-      .description("Alias for datastore type search")
-      .hidden()
-      .arguments("[query:string]")
-      .action(datastoreTypeSearchAction),
-  );
+  .command("search", datastoreTypeSearchCommand);
 
 const datastoreCatalogCommand = new Command()
   .name("catalog")

--- a/src/cli/commands/datastore_type_search.ts
+++ b/src/cli/commands/datastore_type_search.ts
@@ -73,6 +73,7 @@ export async function datastoreTypeSearchAction(
 
 export const datastoreTypeSearchCommand = new Command()
   .name("search")
+  .alias("list")
   .description("Search for datastore types")
   .example("Browse datastore types", "swamp datastore type search")
   .example("Search by keyword", "swamp datastore type search s3")

--- a/src/cli/commands/hidden_aliases_test.ts
+++ b/src/cli/commands/hidden_aliases_test.ts
@@ -17,93 +17,127 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStrictEquals } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 
 // Initialize logging for tests
 await initializeLogging({});
 
-Deno.test("model list is registered as a hidden subcommand", async () => {
+Deno.test("model search has list as a native alias", async () => {
+  const { modelSearchCommand } = await import("./model_search.ts");
+  assertEquals(
+    modelSearchCommand.getAliases().includes("list"),
+    true,
+    "search command should have 'list' alias",
+  );
+});
+
+Deno.test("model list resolves to the search command", async () => {
   const { modelCommand } = await import("./model_create.ts");
-
-  // getCommand with second arg true includes hidden commands
+  const searchCmd = modelCommand.getCommand("search");
   const listCmd = modelCommand.getCommand("list", true);
-  assertEquals(
-    listCmd !== undefined,
-    true,
-    "list command should be registered",
-  );
+  assertStrictEquals(listCmd, searchCmd, "list should resolve to search");
+});
 
-  // Verify it's hidden: not in getCommands() (which excludes hidden)
-  const visibleCommands = modelCommand.getCommands();
-  const visibleList = visibleCommands.find((c) => c.getName() === "list");
+Deno.test("workflow search has list as a native alias", async () => {
+  const { workflowSearchCommand } = await import("./workflow_search.ts");
   assertEquals(
-    visibleList,
-    undefined,
-    "list should not appear in visible commands",
+    workflowSearchCommand.getAliases().includes("list"),
+    true,
+    "search command should have 'list' alias",
   );
 });
 
-Deno.test("workflow history list is registered as a hidden subcommand", async () => {
-  const { workflowHistoryCommand } = await import("./workflow_history.ts");
-
-  // getCommand with second arg true includes hidden commands
-  const listCmd = workflowHistoryCommand.getCommand("list", true);
-  assertEquals(
-    listCmd !== undefined,
-    true,
-    "list command should be registered",
+Deno.test("workflow run search has list as a native alias", async () => {
+  const { workflowRunSearchCommand } = await import(
+    "./workflow_run_search.ts"
   );
-
-  // Verify it's hidden: not in getCommands() (which excludes hidden)
-  const visibleCommands = workflowHistoryCommand.getCommands();
-  const visibleList = visibleCommands.find((c) => c.getName() === "list");
   assertEquals(
-    visibleList,
-    undefined,
-    "list should not appear in visible commands",
+    workflowRunSearchCommand.getAliases().includes("list"),
+    true,
+    "search command should have 'list' alias",
   );
 });
 
-Deno.test("vault list is registered as a hidden subcommand", async () => {
-  const { vaultCommand } = await import("./vault.ts");
-
-  // getCommand with second arg true includes hidden commands
-  const listCmd = vaultCommand.getCommand("list", true);
-  assertEquals(
-    listCmd !== undefined,
-    true,
-    "list command should be registered",
+Deno.test("workflow history search has list as a native alias", async () => {
+  const { workflowHistorySearchCommand } = await import(
+    "./workflow_history_search.ts"
   );
-
-  // Verify it's hidden: not in getCommands() (which excludes hidden)
-  const visibleCommands = vaultCommand.getCommands();
-  const visibleList = visibleCommands.find((c) => c.getName() === "list");
   assertEquals(
-    visibleList,
-    undefined,
-    "list should not appear in visible commands",
+    workflowHistorySearchCommand.getAliases().includes("list"),
+    true,
+    "search command should have 'list' alias",
   );
 });
 
-Deno.test("vault type list is registered as a hidden subcommand", async () => {
-  const { vaultTypeCommand } = await import("./vault.ts");
-
-  // getCommand with second arg true includes hidden commands
-  const listCmd = vaultTypeCommand.getCommand("list", true);
-  assertEquals(
-    listCmd !== undefined,
-    true,
-    "list command should be registered",
+Deno.test("model output search has list as a native alias", async () => {
+  const { modelOutputSearchCommand } = await import(
+    "./model_output_search.ts"
   );
-
-  // Verify it's hidden: not in getCommands() (which excludes hidden)
-  const visibleCommands = vaultTypeCommand.getCommands();
-  const visibleList = visibleCommands.find((c) => c.getName() === "list");
   assertEquals(
-    visibleList,
-    undefined,
-    "list should not appear in visible commands",
+    modelOutputSearchCommand.getAliases().includes("list"),
+    true,
+    "search command should have 'list' alias",
+  );
+});
+
+Deno.test("model type search has list as a native alias", async () => {
+  const { typeSearchCommand } = await import("./type_search.ts");
+  assertEquals(
+    typeSearchCommand.getAliases().includes("list"),
+    true,
+    "search command should have 'list' alias",
+  );
+});
+
+Deno.test("model method history search has list as a native alias", async () => {
+  const { modelMethodHistorySearchCommand } = await import(
+    "./model_method_history_search.ts"
+  );
+  assertEquals(
+    modelMethodHistorySearchCommand.getAliases().includes("list"),
+    true,
+    "search command should have 'list' alias",
+  );
+});
+
+Deno.test("vault search has list as a native alias", async () => {
+  const { vaultSearchCommand } = await import("./vault_search.ts");
+  assertEquals(
+    vaultSearchCommand.getAliases().includes("list"),
+    true,
+    "search command should have 'list' alias",
+  );
+});
+
+Deno.test("vault type search has list as a native alias", async () => {
+  const { vaultTypeSearchCommand } = await import("./vault_type_search.ts");
+  assertEquals(
+    vaultTypeSearchCommand.getAliases().includes("list"),
+    true,
+    "search command should have 'list' alias",
+  );
+});
+
+Deno.test("report type search has list as a native alias", async () => {
+  const { reportTypeSearchCommand } = await import(
+    "./report_type_search.ts"
+  );
+  assertEquals(
+    reportTypeSearchCommand.getAliases().includes("list"),
+    true,
+    "search command should have 'list' alias",
+  );
+});
+
+Deno.test("datastore type search has list as a native alias", async () => {
+  const { datastoreTypeSearchCommand } = await import(
+    "./datastore_type_search.ts"
+  );
+  assertEquals(
+    datastoreTypeSearchCommand.getAliases().includes("list"),
+    true,
+    "search command should have 'list' alias",
   );
 });
 

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -36,7 +36,7 @@ import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { parseKeyValueInputs } from "../input_parser.ts";
 import { modelValidateCommand } from "./model_validate.ts";
 import { modelMethodCommand } from "./model_method_run.ts";
-import { modelSearchAction, modelSearchCommand } from "./model_search.ts";
+import { modelSearchCommand } from "./model_search.ts";
 import { modelGetCommand } from "./model_get.ts";
 import { modelDeleteCommand } from "./model_delete.ts";
 import { modelEditCommand } from "./model_edit.ts";
@@ -146,17 +146,4 @@ export const modelCommand = new Command()
   .command("validate", modelValidateCommand)
   .command("method", modelMethodCommand)
   .command("output", modelOutputCommand)
-  .command("type", modelTypeCommand)
-  .command(
-    "list",
-    new Command()
-      .description("Alias for model search")
-      .hidden()
-      .arguments("[query:string]")
-      .option(
-        "--repo-dir <dir:string>",
-        "Repository directory (env: SWAMP_REPO_DIR)",
-      )
-      .option("--all", "Include internal model types")
-      .action(modelSearchAction),
-  );
+  .command("type", modelTypeCommand);

--- a/src/cli/commands/model_method_history.ts
+++ b/src/cli/commands/model_method_history.ts
@@ -23,10 +23,7 @@ import {
   modelMethodHistoryGetAction,
   modelMethodHistoryGetCommand,
 } from "./model_method_history_get.ts";
-import {
-  modelMethodHistorySearchAction,
-  modelMethodHistorySearchCommand,
-} from "./model_method_history_search.ts";
+import { modelMethodHistorySearchCommand } from "./model_method_history_search.ts";
 import { modelMethodHistoryLogsCommand } from "./model_method_history_logs.ts";
 
 export const modelMethodHistoryCommand = new Command()
@@ -45,16 +42,4 @@ export const modelMethodHistoryCommand = new Command()
   .action(modelMethodHistoryGetAction)
   .command("get", modelMethodHistoryGetCommand)
   .command("search", modelMethodHistorySearchCommand)
-  .command("logs", modelMethodHistoryLogsCommand)
-  .command(
-    "list",
-    new Command()
-      .description("Alias for model method history search")
-      .hidden()
-      .arguments("[query:string]")
-      .option(
-        "--repo-dir <dir:string>",
-        "Repository directory (env: SWAMP_REPO_DIR)",
-      )
-      .action(modelMethodHistorySearchAction),
-  );
+  .command("logs", modelMethodHistoryLogsCommand);

--- a/src/cli/commands/model_method_history_search.ts
+++ b/src/cli/commands/model_method_history_search.ts
@@ -133,6 +133,7 @@ export async function modelMethodHistorySearchAction(
 export const modelMethodHistorySearchCommand = withRemoteOptions(
   new Command()
     .name("search")
+    .alias("list")
     .description("Search model method run history")
     .example("Browse all history", "swamp model method history search")
     .example("Search by keyword", "swamp model method history search deploy")

--- a/src/cli/commands/model_output.ts
+++ b/src/cli/commands/model_output.ts
@@ -23,10 +23,7 @@ import {
   modelOutputGetAction,
   modelOutputGetCommand,
 } from "./model_output_get.ts";
-import {
-  modelOutputSearchAction,
-  modelOutputSearchCommand,
-} from "./model_output_search.ts";
+import { modelOutputSearchCommand } from "./model_output_search.ts";
 import { modelOutputLogsCommand } from "./model_output_logs.ts";
 import { modelOutputDataCommand } from "./model_output_data.ts";
 
@@ -44,16 +41,4 @@ export const modelOutputCommand = new Command()
   .command("get", modelOutputGetCommand)
   .command("search", modelOutputSearchCommand)
   .command("logs", modelOutputLogsCommand)
-  .command("data", modelOutputDataCommand)
-  .command(
-    "list",
-    new Command()
-      .description("Alias for model output search")
-      .hidden()
-      .arguments("[query:string]")
-      .option(
-        "--repo-dir <dir:string>",
-        "Repository directory (env: SWAMP_REPO_DIR)",
-      )
-      .action(modelOutputSearchAction),
-  );
+  .command("data", modelOutputDataCommand);

--- a/src/cli/commands/model_output_search.ts
+++ b/src/cli/commands/model_output_search.ts
@@ -167,6 +167,7 @@ export async function modelOutputSearchAction(
 export const modelOutputSearchCommand = withRemoteOptions(
   new Command()
     .name("search")
+    .alias("list")
     .description("Search for model outputs")
     .example("Browse all outputs", "swamp model output search")
     .example("Search by keyword", "swamp model output search deploy")

--- a/src/cli/commands/model_search.ts
+++ b/src/cli/commands/model_search.ts
@@ -141,6 +141,7 @@ export async function modelSearchAction(
 export const modelSearchCommand = withRemoteOptions(
   new Command()
     .name("search")
+    .alias("list")
     .description("Search for model definitions")
     .example("Browse all models", "swamp model search")
     .example("Search by keyword", "swamp model search aws")

--- a/src/cli/commands/model_type.ts
+++ b/src/cli/commands/model_type.ts
@@ -20,7 +20,7 @@
 import { Command } from "@cliffy/command";
 import { groupCommandAction } from "../group_action.ts";
 import { typeDescribeCommand } from "./type_describe.ts";
-import { typeSearchAction, typeSearchCommand } from "./type_search.ts";
+import { typeSearchCommand } from "./type_search.ts";
 
 /**
  * Parent command for model type operations.
@@ -30,16 +30,4 @@ export const modelTypeCommand = new Command()
   .description("Inspect model types")
   .action(groupCommandAction)
   .command("describe", typeDescribeCommand)
-  .command("search", typeSearchCommand)
-  .command(
-    "list",
-    new Command()
-      .description("Alias for type search")
-      .hidden()
-      .arguments("[query:string]")
-      .option(
-        "--repo-dir <dir:string>",
-        "Repository directory (env: SWAMP_REPO_DIR; not required for type search)",
-      )
-      .action(typeSearchAction),
-  );
+  .command("search", typeSearchCommand);

--- a/src/cli/commands/report.ts
+++ b/src/cli/commands/report.ts
@@ -26,6 +26,7 @@ import {
   reportTypeSearchAction,
   reportTypeSearchCommand,
 } from "./report_type_search.ts";
+import { withRemoteOptions } from "../remote_run.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
 
 export const reportTypeCommand = new Command()
@@ -45,8 +46,9 @@ export const reportCommand = new Command()
   .command("describe", reportDescribeCommand)
   .command(
     "list",
-    new Command()
-      .description("List registered report definitions")
-      .arguments("[query:string]")
-      .action(reportTypeSearchAction),
+    withRemoteOptions(
+      new Command()
+        .description("List registered report definitions")
+        .arguments("[query:string]"),
+    ).action(reportTypeSearchAction),
   );

--- a/src/cli/commands/report.ts
+++ b/src/cli/commands/report.ts
@@ -32,15 +32,7 @@ export const reportTypeCommand = new Command()
   .name("type")
   .description("Inspect report types")
   .action(groupCommandAction)
-  .command("search", reportTypeSearchCommand)
-  .command(
-    "list",
-    new Command()
-      .description("Alias for report type search")
-      .hidden()
-      .arguments("[query:string]")
-      .action(reportTypeSearchAction),
-  );
+  .command("search", reportTypeSearchCommand);
 
 export const reportCommand = new Command()
   .name("report")

--- a/src/cli/commands/report_type_search.ts
+++ b/src/cli/commands/report_type_search.ts
@@ -108,6 +108,7 @@ export async function reportTypeSearchAction(
 export const reportTypeSearchCommand = withRemoteOptions(
   new Command()
     .name("search")
+    .alias("list")
     .description("Search for report types")
     .example("Browse report types", "swamp report type search")
     .example("Search by keyword", "swamp report type search cost")

--- a/src/cli/commands/type_search.ts
+++ b/src/cli/commands/type_search.ts
@@ -146,6 +146,7 @@ export async function typeSearchAction(
 export const typeSearchCommand = withRemoteOptions(
   new Command()
     .name("search")
+    .alias("list")
     .description("Search for model types")
     .example("Browse all types", "swamp type search")
     .example("Search by keyword", "swamp type search aws")

--- a/src/cli/commands/vault.ts
+++ b/src/cli/commands/vault.ts
@@ -19,12 +19,9 @@
 
 import { Command } from "@cliffy/command";
 import { groupCommandAction } from "../group_action.ts";
-import {
-  vaultTypeSearchAction,
-  vaultTypeSearchCommand,
-} from "./vault_type_search.ts";
+import { vaultTypeSearchCommand } from "./vault_type_search.ts";
 import { vaultCreateCommand } from "./vault_create.ts";
-import { vaultSearchAction, vaultSearchCommand } from "./vault_search.ts";
+import { vaultSearchCommand } from "./vault_search.ts";
 import { vaultGetCommand } from "./vault_get.ts";
 import { vaultDescribeCommand } from "./vault_describe.ts";
 import { vaultEditCommand } from "./vault_edit.ts";
@@ -45,15 +42,7 @@ export const vaultTypeCommand = new Command()
   .name("type")
   .description("Inspect vault types")
   .action(groupCommandAction)
-  .command("search", vaultTypeSearchCommand)
-  .command(
-    "list",
-    new Command()
-      .description("Alias for vault type search")
-      .hidden()
-      .arguments("[query:string]")
-      .action(vaultTypeSearchAction),
-  );
+  .command("search", vaultTypeSearchCommand);
 
 /**
  * Parent command for vault operations.
@@ -76,16 +65,4 @@ export const vaultCommand = new Command()
   .command("migrate", vaultMigrateCommand)
   .command("read-secret", vaultReadSecretCommand)
   .command("list-keys", vaultListKeysCommand)
-  .command("audit-trail", vaultAuditTrailCommand)
-  .command(
-    "list",
-    new Command()
-      .description("Alias for vault search")
-      .hidden()
-      .arguments("[query:string]")
-      .option(
-        "--repo-dir <dir:string>",
-        "Repository directory (env: SWAMP_REPO_DIR)",
-      )
-      .action(vaultSearchAction),
-  );
+  .command("audit-trail", vaultAuditTrailCommand);

--- a/src/cli/commands/vault_search.ts
+++ b/src/cli/commands/vault_search.ts
@@ -155,6 +155,7 @@ export async function vaultSearchAction(
 export const vaultSearchCommand = withRemoteOptions(
   new Command()
     .name("search")
+    .alias("list")
     .description("Search for vaults in the repository")
     .example("Browse all vaults", "swamp vault search")
     .example("Search by keyword", "swamp vault search aws")

--- a/src/cli/commands/vault_type_search.ts
+++ b/src/cli/commands/vault_type_search.ts
@@ -104,6 +104,7 @@ export async function vaultTypeSearchAction(
 export const vaultTypeSearchCommand = withRemoteOptions(
   new Command()
     .name("search")
+    .alias("list")
     .description("Search for vault types")
     .example("Browse vault types", "swamp vault type-search")
     .example("Search by keyword", "swamp vault type-search aws")

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -26,10 +26,7 @@ import { workflowEvaluateCommand } from "./workflow_evaluate.ts";
 import { workflowGetCommand } from "./workflow_get.ts";
 import { workflowHistoryCommand } from "./workflow_history.ts";
 import { workflowValidateCommand } from "./workflow_validate.ts";
-import {
-  workflowSearchAction,
-  workflowSearchCommand,
-} from "./workflow_search.ts";
+import { workflowSearchCommand } from "./workflow_search.ts";
 import { workflowRunCommand } from "./workflow_run.ts";
 import { workflowSchemaCommand } from "./workflow_schema.ts";
 import { workflowApproveCommand } from "./workflow_approve.ts";
@@ -60,16 +57,4 @@ export const workflowCommand = new Command()
   .command("resume", workflowResumeCommand)
   .command("approvals", workflowApprovalsCommand)
   .command("schema", workflowSchemaCommand)
-  .command("trigger", workflowTriggerCommand)
-  .command(
-    "list",
-    new Command()
-      .description("Alias for workflow search")
-      .hidden()
-      .arguments("[query:string]")
-      .option(
-        "--repo-dir <dir:string>",
-        "Repository directory (env: SWAMP_REPO_DIR)",
-      )
-      .action(workflowSearchAction),
-  );
+  .command("trigger", workflowTriggerCommand);

--- a/src/cli/commands/workflow_history.ts
+++ b/src/cli/commands/workflow_history.ts
@@ -23,10 +23,7 @@ import {
   workflowHistoryGetAction,
   workflowHistoryGetCommand,
 } from "./workflow_history_get.ts";
-import {
-  workflowHistorySearchAction,
-  workflowHistorySearchCommand,
-} from "./workflow_history_search.ts";
+import { workflowHistorySearchCommand } from "./workflow_history_search.ts";
 import { workflowHistoryLogsCommand } from "./workflow_history_logs.ts";
 
 export const workflowHistoryCommand = new Command()
@@ -46,16 +43,4 @@ export const workflowHistoryCommand = new Command()
   .action(workflowHistoryGetAction)
   .command("get", workflowHistoryGetCommand)
   .command("search", workflowHistorySearchCommand)
-  .command("logs", workflowHistoryLogsCommand)
-  .command(
-    "list",
-    new Command()
-      .description("Alias for workflow history search")
-      .hidden()
-      .arguments("[query:string]")
-      .option(
-        "--repo-dir <dir:string>",
-        "Repository directory (env: SWAMP_REPO_DIR)",
-      )
-      .action(workflowHistorySearchAction),
-  );
+  .command("logs", workflowHistoryLogsCommand);

--- a/src/cli/commands/workflow_history_search.ts
+++ b/src/cli/commands/workflow_history_search.ts
@@ -262,6 +262,7 @@ export async function workflowHistorySearchAction(
 export const workflowHistorySearchCommand = withRemoteOptions(
   new Command()
     .name("search")
+    .alias("list")
     .description("Search workflow run history")
     .example("Browse run history", "swamp workflow history search")
     .example("Search runs", "swamp workflow history search deploy")

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -69,10 +69,7 @@ import { modelRegistry } from "../../domain/models/model.ts";
 import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
 import { reportRegistry } from "../../domain/reports/report_registry.ts";
 import { parseTags } from "../../libswamp/mod.ts";
-import {
-  workflowRunSearchAction,
-  workflowRunSearchCommand,
-} from "./workflow_run_search.ts";
+import { workflowRunSearchCommand } from "./workflow_run_search.ts";
 import {
   consumeStream,
   createLibSwampContext,
@@ -574,19 +571,7 @@ export const workflowRunCommand = new Command()
       exitSuppress.dispose();
     }
   })
-  .command("search", workflowRunSearchCommand)
-  .command(
-    "list",
-    new Command()
-      .description("Alias for workflow run search")
-      .hidden()
-      .arguments("[query:string]")
-      .option(
-        "--repo-dir <dir:string>",
-        "Repository directory (env: SWAMP_REPO_DIR)",
-      )
-      .action(workflowRunSearchAction),
-  );
+  .command("search", workflowRunSearchCommand);
 
 /**
  * The --server branch: dispatch the run through a `swamp serve` server and

--- a/src/cli/commands/workflow_run_search.ts
+++ b/src/cli/commands/workflow_run_search.ts
@@ -250,6 +250,7 @@ export async function workflowRunSearchAction(
 export const workflowRunSearchCommand = withRemoteOptions(
   new Command()
     .name("search")
+    .alias("list")
     .description("Search workflow run history")
     .example("Browse all runs", "swamp workflow run search")
     .example("Search runs", "swamp workflow run search deploy")

--- a/src/cli/commands/workflow_search.ts
+++ b/src/cli/commands/workflow_search.ts
@@ -148,6 +148,7 @@ export async function workflowSearchAction(
 export const workflowSearchCommand = withRemoteOptions(
   new Command()
     .name("search")
+    .alias("list")
     .description("Search for workflows")
     .example("Browse all workflows", "swamp workflow search")
     .example("Search by keyword", "swamp workflow search deploy")


### PR DESCRIPTION
## Summary

- Replace all 11 hand-rolled `list` Command clones with `.alias("list")` on their corresponding `search` commands — option drift is now unrepresentable by construction
- Add `withRemoteOptions` to the `report list` cross-hierarchy shortcut, which was also missing `--server`/`--token`
- Update `hidden_aliases_test.ts` with 12 alias tests covering all 11 search commands

Closes swamp-club/lab#1759

## Test plan

- [x] All 17 tests in `hidden_aliases_test.ts` pass (12 alias + 5 existing)
- [x] `deno check` passes on all 22 modified files
- [x] `deno lint` and `deno fmt` clean
- [x] Full test suite passes
- [x] Compilation succeeds with binary smoke test
- [x] Code review: VERDICT pass
- [x] Adversarial review: VERDICT pass
- [x] UX review: VERDICT pass

Co-authored-by: Magistr <umag@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)