### PR TITLE
fix(auth): canonicalize server login URLs

### DIFF
--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -44,6 +44,7 @@ import { deserializeEvent } from "../serve/serializer.ts";
 import type { ServerCredentialRepository } from "../domain/auth/server_credential.ts";
 import { FileServerCredentialRepository } from "../infrastructure/persistence/server_credential_repository.ts";
 import { resolveExtraHeaders } from "../domain/auth/extra_headers.ts";
+import { normalizeServerUrl as normalizeCredentialServerUrl } from "../domain/auth/server_url.ts";
 
 /**
  * Resolves the server URL from the `--server` flag with env var fallbacks.
@@ -91,10 +92,7 @@ export interface ServerRunOptions {
  */
 function toHttpUrl(serverUrl: string): string {
   try {
-    const parsed = new URL(serverUrl);
-    if (parsed.protocol === "ws:") parsed.protocol = "http:";
-    else if (parsed.protocol === "wss:") parsed.protocol = "https:";
-    return parsed.href.replace(/\/+$/, "");
+    return normalizeCredentialServerUrl(serverUrl);
   } catch {
     return serverUrl;
   }
@@ -359,7 +357,7 @@ const HEALTH_PROBE_TIMEOUT_MS = 3_000;
 export async function probeServerHealth(wsUrl: string): Promise<boolean> {
   const httpUrl = toHttpUrl(wsUrl);
   try {
-    const healthUrl = new URL("/health", httpUrl);
+    const healthUrl = new URL(`${httpUrl}/health`);
     const fetchClient = getCaCertFetchClient();
     const fetchOpts: Record<string, unknown> = {
       signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
@@ -379,6 +377,7 @@ async function classifyConnectionError(
   wsUrl: string,
   originalMessage: string,
 ): Promise<string> {
+  const loginUrl = toHttpUrl(wsUrl);
   const statusMatch = originalMessage.match(/Invalid status code: (\d+)/);
   if (statusMatch) {
     const statusCode = parseInt(statusMatch[1], 10);
@@ -386,15 +385,23 @@ async function classifyConnectionError(
       return "Rate-limited by server — try again later";
     }
     if (statusCode === 401 || statusCode === 403) {
-      return `Authentication failed — run: swamp auth server-login --server ${wsUrl}`;
+      return `Authentication failed — run: swamp auth server-login --server ${
+        shellQuote(loginUrl)
+      }`;
     }
   }
   const tlsGuidance = diagnoseTlsMessage(originalMessage);
   if (tlsGuidance) return tlsGuidance;
   if (await probeServerHealth(wsUrl)) {
-    return `Authentication failed — run: swamp auth server-login --server ${wsUrl}`;
+    return `Authentication failed — run: swamp auth server-login --server ${
+      shellQuote(loginUrl)
+    }`;
   }
   return originalMessage;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
 const wsHttpClient = Deno.createHttpClient({});

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -494,6 +494,26 @@ Deno.test("resolveServerToken: converts ws URL to http for credential lookup", a
   assertEquals(result, "stored.ws-lookup");
 });
 
+Deno.test("resolveServerToken: canonicalizes path, query, and fragment", async () => {
+  const lookedUp: string[] = [];
+  const mockRepo: ServerCredentialRepository = {
+    get: (url: string): Promise<ServerCredential | null> => {
+      lookedUp.push(url);
+      return Promise.resolve(null);
+    },
+    save: () => Promise.resolve(),
+    remove: () => Promise.resolve(),
+    list: () => Promise.resolve([]),
+  };
+
+  await resolveServerToken(
+    "wss://SWAMP.example.com:443/base/path///?run=1#events",
+    undefined,
+    mockRepo,
+  );
+  assertEquals(lookedUp, ["https://swamp.example.com/base/path"]);
+});
+
 // ── extra headers tests ────────────────────────────────────────────────
 
 function headerCapturingServer(): {
@@ -665,7 +685,7 @@ Deno.test("resolveServerToken: returns undefined when no credential", async () =
  * credentials.
  */
 function authRejectingServer(
-  opts?: { healthBody?: unknown; healthStatus?: number },
+  opts?: { healthBody?: unknown; healthStatus?: number; basePath?: string },
 ): {
   url: string;
   shutdown: () => Promise<void>;
@@ -677,7 +697,10 @@ function authRejectingServer(
         return new Response("Unauthorized", { status: 401 });
       }
       const url = new URL(req.url);
-      if (url.pathname === "/health" || url.pathname === "/") {
+      if (
+        url.pathname === `${opts?.basePath ?? ""}/health` ||
+        url.pathname === "/"
+      ) {
         return Response.json(
           opts?.healthBody ?? { status: "ok" },
           { status: opts?.healthStatus ?? 200 },
@@ -687,7 +710,7 @@ function authRejectingServer(
     },
   );
   return {
-    url: `ws://127.0.0.1:${server.addr.port}`,
+    url: `ws://127.0.0.1:${server.addr.port}${opts?.basePath ?? ""}`,
     shutdown: () => server.shutdown(),
   };
 }
@@ -698,6 +721,20 @@ Deno.test({
   sanitizeResources: false,
   fn: async () => {
     const server = authRejectingServer();
+    try {
+      assertEquals(await probeServerHealth(server.url), true);
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name: "probeServerHealth: preserves a server base path",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = authRejectingServer({ basePath: "/base" });
     try {
       assertEquals(await probeServerHealth(server.url), true);
     } finally {
@@ -749,6 +786,8 @@ Deno.test({
       }, UserError);
       assertStringIncludes(error.message, "Authentication failed");
       assertStringIncludes(error.message, "swamp auth server-login");
+      assertStringIncludes(error.message, "--server 'http://127.0.0.1:");
+      assertEquals(error.message.includes("--server ws://"), false);
     } finally {
       await server.shutdown();
     }
@@ -773,6 +812,8 @@ Deno.test({
       );
       assertStringIncludes(error.message, "Authentication failed");
       assertStringIncludes(error.message, "swamp auth server-login");
+      assertStringIncludes(error.message, "--server 'http://127.0.0.1:");
+      assertEquals(error.message.includes("--server ws://"), false);
     } finally {
       await server.shutdown();
     }

--- a/src/domain/auth/server_url.ts
+++ b/src/domain/auth/server_url.ts
@@ -20,14 +20,16 @@
 /**
  * Normalize a server URL for use as a credential map key.
  *
- * Lowercases the hostname, strips trailing slashes from the path,
- * and removes default ports (80 for http, 443 for https).
+ * Converts WebSocket schemes to their HTTP equivalents, lowercases the
+ * hostname, strips trailing slashes from the path, and removes default ports.
  *
  * @throws {TypeError} if the input is not a valid URL
  */
 export function normalizeServerUrl(url: string): string {
   const parsed = new URL(url);
 
+  if (parsed.protocol === "ws:") parsed.protocol = "http:";
+  if (parsed.protocol === "wss:") parsed.protocol = "https:";
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new TypeError(
       `Unsupported protocol: ${parsed.protocol} (expected http: or https:)`,

--- a/src/domain/auth/server_url_property_test.ts
+++ b/src/domain/auth/server_url_property_test.ts
@@ -174,7 +174,7 @@ Deno.test("normalizeServerUrl: default ports are stripped, others are kept", () 
 Deno.test("normalizeServerUrl: rejects non-http(s) schemes", () => {
   fc.assert(
     fc.property(
-      fc.constantFrom("ftp", "file", "ws", "wss", "swamp"),
+      fc.constantFrom("ftp", "file", "swamp"),
       arbHost,
       (scheme, host) => {
         assertThrows(

--- a/src/domain/auth/server_url_test.ts
+++ b/src/domain/auth/server_url_test.ts
@@ -69,6 +69,13 @@ Deno.test("normalizeServerUrl: preserves non-root path", () => {
   );
 });
 
+Deno.test("normalizeServerUrl: removes query and fragment", () => {
+  assertEquals(
+    normalizeServerUrl("https://swamp.example.com/api/v1/?run=1#events"),
+    "https://swamp.example.com/api/v1",
+  );
+});
+
 Deno.test("normalizeServerUrl: handles IPv6 address", () => {
   assertEquals(
     normalizeServerUrl("https://[::1]:9090"),
@@ -97,6 +104,17 @@ Deno.test("normalizeServerUrl: throws on unsupported protocol", () => {
 Deno.test("normalizeServerUrl: http scheme preserved", () => {
   assertEquals(
     normalizeServerUrl("http://localhost:8080"),
+    "http://localhost:8080",
+  );
+});
+
+Deno.test("normalizeServerUrl: converts WebSocket schemes", () => {
+  assertEquals(
+    normalizeServerUrl("wss://swamp.example.com/base/"),
+    "https://swamp.example.com/base",
+  );
+  assertEquals(
+    normalizeServerUrl("ws://localhost:8080/"),
     "http://localhost:8080",
   );
 });

--- a/src/infrastructure/persistence/server_credential_repository_test.ts
+++ b/src/infrastructure/persistence/server_credential_repository_test.ts
@@ -352,3 +352,15 @@ Deno.test("FileServerCredentialRepository.get: SWAMP_SERVER_TOKEN normalizes env
   assertExists(loaded);
   assertEquals(loaded.token, "env_token_normalized");
 });
+
+Deno.test("FileServerCredentialRepository.get: accepts a WebSocket env URL", async () => {
+  const repo = new FileServerCredentialRepository({
+    getServerToken: () => "env_token_ws",
+    getServerUrl: () => "wss://swamp.example.com/base/",
+  });
+
+  const loaded = await repo.get("https://swamp.example.com/base");
+
+  assertExists(loaded);
+  assertEquals(loaded.token, "env_token_ws");
+});


### PR DESCRIPTION
## Summary
- show canonical HTTP(S) URLs in remote authentication guidance
- normalize WebSocket environment URLs for credential lookup
- preserve server base paths in health probes and shell-quote login commands

## Verification
- 77 focused tests passed
- deno task check
- deno lint and deno fmt --check passed

The documented local verification workflows were unavailable because the repository has no verify-build or verify-reviews definitions; GitHub CI remains the release gate.