### PR TITLE
feat(datastore): add managedConfig for multi-instance serve config distribution (swamp-club#1569)

### DIFF
--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -19,6 +19,7 @@
 
 import { getLogger } from "@logtape/logtape";
 import {
+  resolvePulledExtensionsRoot,
   SWAMP_SUBDIRS,
   swampPath,
 } from "../infrastructure/persistence/paths.ts";
@@ -94,6 +95,7 @@ interface InstallerAdapterConfig {
   repoDir: string;
   denoRuntime: DenoRuntime;
   datastoreResolver?: DatastorePathResolver;
+  pulledExtensionsRoot?: string;
   /**
    * W1b/(a-2) wiring: shared ExtensionRepository used by hotLoadModels
    * to attach user extensions whose base type was just registered, and
@@ -155,7 +157,9 @@ export function createAutoResolveInstallerAdapter(
       // A lockfile entry exists; carry its pinned version so the installer's
       // progress output reports the version that will actually be installed
       // (the install path pins to it) rather than registry-latest.
-      const path = swampPath(repoDir, "pulled-extensions", extensionName);
+      const pulledRoot = config.pulledExtensionsRoot ??
+        resolvePulledExtensionsRoot(repoDir);
+      const path = join(pulledRoot, extensionName);
       try {
         const stat = await Deno.stat(path);
         if (!stat.isDirectory) {

--- a/src/cli/commands/datastore.ts
+++ b/src/cli/commands/datastore.ts
@@ -34,6 +34,7 @@ import {
 import { datastoreNamespacesCommand } from "./datastore_namespaces.ts";
 import { datastoreTypeSearchCommand } from "./datastore_type_search.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
+import { datastoreConfigMigrateCommand } from "./datastore_config_migrate.ts";
 
 export const datastoreTypeCommand = new Command()
   .name("type")
@@ -68,4 +69,12 @@ export const datastoreCommand = new Command()
   .command("compact", datastoreCompactCommand)
   .command("migrate-index", datastoreMigrateIndexCommand)
   .command("catalog", datastoreCatalogCommand)
-  .command("namespace", datastoreNamespaceCommand);
+  .command("namespace", datastoreNamespaceCommand)
+  .command(
+    "config",
+    new Command()
+      .name("config")
+      .description("Manage datastore-managed configuration")
+      .action(groupCommandAction)
+      .command("migrate", datastoreConfigMigrateCommand),
+  );

--- a/src/cli/commands/datastore_config_migrate.ts
+++ b/src/cli/commands/datastore_config_migrate.ts
@@ -1,0 +1,151 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { isAbsolute, join, resolve } from "@std/path";
+import { createContext, resolveRepoDir } from "../context.ts";
+import { requireInitializedRepoUnlocked } from "../repo_context.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
+import { migrateConfigToDatastore } from "../../domain/datastore/managed_config_migration.ts";
+import { resolveModelsDir } from "../resolve_models_dir.ts";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
+import {
+  type RepoMarkerData,
+  RepoMarkerRepository,
+} from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { UserError } from "../../domain/errors.ts";
+import { swampPath } from "../../infrastructure/persistence/paths.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+
+export const datastoreConfigMigrateCommand = new Command()
+  .description(
+    "Migrate configuration into the datastore.\n\n" +
+      "Copies model definitions, workflow definitions, vault configs,\n" +
+      "the extension lockfile, and pulled extensions into the datastore\n" +
+      "config tier. Sets managedConfig: true in .swamp.yaml if not already\n" +
+      "set. Idempotent — safe to re-run (sentinel prevents duplicate work).",
+  )
+  .option("--repo-dir <dir:string>", "Path to the swamp repository")
+  // deno-lint-ignore no-explicit-any
+  .action(async (options: any) => {
+    const ctx = createContext(options);
+    const repoDir = resolveRepoDir(options.repoDir);
+
+    const {
+      repoContext: _repoContext,
+      datastoreResolver,
+      datastoreConfig,
+      syncService,
+    } = await requireInitializedRepoUnlocked({
+      repoDir,
+      outputMode: ctx.outputMode,
+    });
+
+    const markerRepo = new RepoMarkerRepository();
+    const repoPath = RepoPath.create(repoDir);
+    const marker = await markerRepo.read(repoPath);
+
+    if (!marker?.datastore) {
+      throw new UserError(
+        "No datastore configured. Set up a datastore with " +
+          "'swamp datastore setup' before migrating config.",
+      );
+    }
+
+    if (
+      isCustomDatastoreConfig(datastoreConfig) && syncService &&
+      !syncService.capabilities?.().configRefresh
+    ) {
+      throw new UserError(
+        `The datastore extension "${datastoreConfig.type}" does not support ` +
+          "managed config sync yet. Update the extension to the latest version " +
+          "that supports the configRefresh capability before migrating.\n\n" +
+          "Refusing to migrate — a partial migration would leave config in the " +
+          "datastore that other instances cannot pull.",
+      );
+    }
+
+    const configRoot = datastoreResolver.resolvePath("config");
+    const modelsDir = resolveModelsDir(marker);
+    const absoluteModelsDir = isAbsolute(modelsDir)
+      ? modelsDir
+      : resolve(repoDir, modelsDir);
+    const lockfileSourcePath = join(
+      absoluteModelsDir,
+      "upstream_extensions.json",
+    );
+    const pulledExtensionsSource = swampPath(repoDir, "pulled-extensions");
+
+    const result = await migrateConfigToDatastore(
+      repoDir,
+      lockfileSourcePath,
+      configRoot,
+      pulledExtensionsSource,
+    );
+
+    if (result.alreadyMigrated) {
+      if (ctx.outputMode === "json") {
+        writeOutput(JSON.stringify({ alreadyMigrated: true }));
+      } else {
+        ctx.logger.info`Config migration already completed`;
+      }
+      return;
+    }
+
+    if (!marker.datastore.managedConfig) {
+      const updated: RepoMarkerData = {
+        ...marker,
+        datastore: { ...marker.datastore, managedConfig: true },
+      };
+      await markerRepo.write(repoPath, updated);
+    }
+
+    if (syncService) {
+      syncService.markDirty();
+    }
+
+    if (ctx.outputMode === "json") {
+      writeOutput(JSON.stringify({
+        alreadyMigrated: false,
+        copiedModels: result.copiedModels,
+        copiedWorkflows: result.copiedWorkflows,
+        copiedVaults: result.copiedVaults,
+        copiedLockfile: result.copiedLockfile,
+        copiedPulledExtensions: result.copiedPulledExtensions,
+        managedConfigSet: !marker.datastore.managedConfig,
+        configRoot,
+      }));
+    } else {
+      const copied = [
+        result.copiedModels && "models",
+        result.copiedWorkflows && "workflows",
+        result.copiedVaults && "vaults",
+        result.copiedLockfile && "lockfile",
+        result.copiedPulledExtensions && "pulled-extensions",
+      ].filter(Boolean);
+      if (copied.length > 0) {
+        ctx.logger
+          .info`Migrated ${copied.join(", ")} into datastore config tier`;
+      } else {
+        ctx.logger.info`No config files found to migrate`;
+      }
+      ctx.logger
+        .info`Config will be pushed to the datastore on command exit`;
+    }
+  });

--- a/src/cli/commands/doctor_extensions.ts
+++ b/src/cli/commands/doctor_extensions.ts
@@ -44,7 +44,7 @@ import {
   resetExtensionLoadWarnings,
 } from "../../infrastructure/logging/extension_load_warnings.ts";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
-import { isAbsolute, join, relative, resolve } from "@std/path";
+import { relative } from "@std/path";
 import {
   buildAggregateState,
   consumeStream,
@@ -82,7 +82,7 @@ import {
   withRemoteOptions,
 } from "../remote_run.ts";
 import type { DoctorExtensionsResponse } from "../../serve/protocol.ts";
-import { resolveModelsDir } from "../resolve_models_dir.ts";
+import { resolveManagedConfigPaths } from "../repo_context.ts";
 import { resolveUniqueLocalSkillsDirs } from "../../domain/repo/skill_dirs.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
@@ -193,11 +193,7 @@ export const doctorExtensionsCommand = withRemoteOptions(
   const repoPath = RepoPath.create(repoDir);
   const markerRepo = new RepoMarkerRepository();
   const marker = await markerRepo.read(repoPath);
-  const modelsDir = resolveModelsDir(marker);
-  const absoluteModelsDir = isAbsolute(modelsDir)
-    ? modelsDir
-    : resolve(repoDir, modelsDir);
-  const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+  const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
 
   // A single shared catalog connection for all doctor phases
   // (reconcile, aggregate state, repair, re-pull). Previous code

--- a/src/cli/commands/doctor_workflows.ts
+++ b/src/cli/commands/doctor_workflows.ts
@@ -33,7 +33,7 @@ import {
 } from "../context.ts";
 import { resolveDatastoreForRepo } from "../repo_context.ts";
 import { resolveWorkflowsDir } from "../resolve_workflows_dir.ts";
-import { resolveModelsDir } from "../resolve_models_dir.ts";
+import { resolveManagedConfigPaths } from "../repo_context.ts";
 import {
   collectDirsForKind,
   expandSourcePaths,
@@ -125,12 +125,9 @@ export const doctorWorkflowsCommand = withRemoteOptions(
 
   const sourceWorkflowDirs = await getSourceWorkflowDirs(repoDir);
 
-  const modelsDirRel = resolveModelsDir(marker);
-  const modelsDir = isAbsolute(modelsDirRel)
-    ? modelsDirRel
-    : resolve(repoDir, modelsDirRel);
+  const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
   const pulledWorkflowDirs = await enumeratePulledExtensionDirs(
-    join(modelsDir, "upstream_extensions.json"),
+    lockfilePath,
     repoDir,
     "workflows",
   );

--- a/src/cli/commands/extension_list.ts
+++ b/src/cli/commands/extension_list.ts
@@ -34,7 +34,7 @@ import {
   result,
   warnLegacyExtensionLayout,
 } from "../../libswamp/mod.ts";
-import { resolveModelsDir } from "../resolve_models_dir.ts";
+import { resolveManagedConfigPaths } from "../repo_context.ts";
 import {
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
@@ -150,9 +150,7 @@ export const extensionListCommand = withRemoteOptions(
   const repoPath = RepoPath.create(repoDir);
   const markerRepo = new RepoMarkerRepository();
   const marker = await markerRepo.read(repoPath);
-  const modelsDir = resolveModelsDir(marker);
-  const absoluteModelsDir = resolve(repoDir, modelsDir);
-  const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+  const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
   const tool = resolvePrimaryTool(marker);
   const skillsDirRelative = relative(
     repoDir,

--- a/src/cli/commands/extension_outdated.ts
+++ b/src/cli/commands/extension_outdated.ts
@@ -18,14 +18,13 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { join, resolve } from "@std/path";
 import {
   createContext,
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
-import { resolveModelsDir } from "../resolve_models_dir.ts";
+import { resolveManagedConfigPaths } from "../repo_context.ts";
 import {
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
@@ -154,9 +153,7 @@ export const extensionOutdatedCommand = withRemoteOptions(
   const repoPath = RepoPath.create(repoDir);
   const markerRepo = new RepoMarkerRepository();
   const marker = await markerRepo.read(repoPath);
-  const modelsDir = resolveModelsDir(marker);
-  const absoluteModelsDir = resolve(repoDir, modelsDir);
-  const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+  const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
 
   const ctx = createLibSwampContext({ logger: cliCtx.logger });
   const identity = await loadIdentity();

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -19,7 +19,7 @@
 
 import { Command } from "@cliffy/command";
 import type { Logger } from "@logtape/logtape";
-import { join, relative, resolve } from "@std/path";
+import { relative } from "@std/path";
 import type { DenoRuntime } from "../../domain/runtime/deno_runtime.ts";
 import { EmbeddedDenoRuntime } from "../../infrastructure/runtime/embedded_deno_runtime.ts";
 import { ExtensionRepository } from "../../infrastructure/persistence/extension_repository.ts";
@@ -32,7 +32,7 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { requireRepoMarker } from "../repo_context.ts";
-import { resolveModelsDir } from "../resolve_models_dir.ts";
+import { resolveManagedConfigPaths } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { resolveUniqueLocalSkillsDirs } from "../../domain/repo/skill_dirs.ts";
 import { loadIdentity } from "../load_identity.ts";
@@ -271,9 +271,7 @@ export const extensionPullCommand = withRemoteOptions(
 
   // 3. Validate name format
   validateExtensionName(ref.name);
-  const modelsDir = resolveModelsDir(marker);
-  const absoluteModelsDir = resolve(repoDir, modelsDir);
-  const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+  const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
 
   const tools = marker?.tools?.length ? marker.tools : ["claude"];
   const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);

--- a/src/cli/commands/extension_report_dispatcher.ts
+++ b/src/cli/commands/extension_report_dispatcher.ts
@@ -17,7 +17,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join, resolve } from "@std/path";
 import type { Logger } from "@logtape/logtape";
 import { UserError } from "../../domain/errors.ts";
 import {
@@ -39,10 +38,10 @@ import {
   assembleExtensionReportBody,
   type ReporterContext,
 } from "../../domain/extensions/reporter_context.ts";
-import { swampPath } from "../../infrastructure/persistence/paths.ts";
+import { resolvePulledExtensionsRoot } from "../../infrastructure/persistence/paths.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
-import { resolveModelsDir } from "../resolve_models_dir.ts";
+import { resolveManagedConfigPaths } from "../repo_context.ts";
 import { readSwampSources } from "../../infrastructure/persistence/swamp_sources_repository.ts";
 import {
   checkGithubPvrEnabled,
@@ -135,6 +134,7 @@ export interface DispatcherDeps {
 export async function resolveExtensionTarget(
   repoDir: string,
   extensionName: string,
+  pulledExtensionsRoot?: string,
 ): Promise<ExtensionTarget> {
   validateExtensionName(extensionName);
 
@@ -152,7 +152,8 @@ export async function resolveExtensionTarget(
     );
   }
 
-  const pulledExtRoot = swampPath(repoDir, "pulled-extensions");
+  const pulledExtRoot = pulledExtensionsRoot ??
+    resolvePulledExtensionsRoot(repoDir);
   const manifest = await loadInstalledExtensionManifest(
     pulledExtRoot,
     extensionName,
@@ -168,11 +169,7 @@ export async function resolveExtensionTarget(
     };
   }
 
-  const modelsDir = resolveModelsDir(marker);
-  const lockfilePath = join(
-    resolve(repoDir, modelsDir),
-    "upstream_extensions.json",
-  );
+  const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
   const extensionVersion =
     (await readInstalledExtensionVersion(lockfilePath, extensionName)) ??
       manifest.version;

--- a/src/cli/commands/extension_rm.ts
+++ b/src/cli/commands/extension_rm.ts
@@ -18,14 +18,14 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { join, relative, resolve } from "@std/path";
+import { relative } from "@std/path";
 import {
   createContext,
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
 import { requireRepoMarker } from "../repo_context.ts";
-import { resolveModelsDir } from "../resolve_models_dir.ts";
+import { resolveManagedConfigPaths } from "../repo_context.ts";
 import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
 import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
 import {
@@ -108,9 +108,7 @@ export const extensionRemoveCommand = withRemoteOptions(
     resolveRepoDir(options.repoDir),
   );
 
-  const modelsDir = resolveModelsDir(marker);
-  const absoluteModelsDir = resolve(repoDir, modelsDir);
-  const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+  const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
 
   const tool = resolvePrimaryTool(marker);
   const skillsDirRelative = relative(

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -18,14 +18,14 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { join, relative, resolve } from "@std/path";
+import { relative } from "@std/path";
 import {
   createContext,
   type GlobalOptions,
   interactiveOutputMode,
 } from "../context.ts";
 import { requireRepoMarker } from "../repo_context.ts";
-import { resolveModelsDir } from "../resolve_models_dir.ts";
+import { resolveManagedConfigPaths } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { ReleaseChannel } from "../../domain/extensions/release_channel.ts";
 import {
@@ -258,12 +258,7 @@ export const extensionSearchCommand = withRemoteOptions(
     // Extension install writes to local files only (pulled-extensions/,
     // lockfile) — no datastore needed; see #445.
     const { repoDir, marker } = await requireRepoMarker(".");
-    const modelsDir = resolveModelsDir(marker);
-    const absoluteModelsDir = resolve(repoDir, modelsDir);
-    const lockfilePath = join(
-      absoluteModelsDir,
-      "upstream_extensions.json",
-    );
+    const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
 
     const tools = marker?.tools?.length ? marker.tools : ["claude"];
     const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -18,14 +18,14 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { join, relative, resolve } from "@std/path";
+import { relative } from "@std/path";
 import {
   createContext,
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
 import { requireRepoMarker } from "../repo_context.ts";
-import { resolveModelsDir } from "../resolve_models_dir.ts";
+import { resolveManagedConfigPaths } from "../repo_context.ts";
 import { createInstallContext, parseExtensionRef } from "./extension_pull.ts";
 import {
   consumeStream,
@@ -117,9 +117,7 @@ export const extensionUpdateCommand = withRemoteOptions(
   const { repoDir, marker } = await requireRepoMarker(
     resolveRepoDir(options.repoDir),
   );
-  const modelsDir = resolveModelsDir(marker);
-  const absoluteModelsDir = resolve(repoDir, modelsDir);
-  const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+  const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
 
   // Per-extension models/workflows/vaults/drivers/datastores/reports
   // destinations are derived inside installExtension from the

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -33,6 +33,11 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
+import {
+  RepoMarkerRepository,
+} from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
+import { join } from "@std/path";
 import { parseKeyValueInputs } from "../input_parser.ts";
 import { modelValidateCommand } from "./model_validate.ts";
 import { modelMethodCommand } from "./model_method_run.ts";
@@ -114,18 +119,35 @@ export const modelCreateCommand = withRemoteOptions(
     cliCtx.logger
       .debug`Creating model definition: type=${typeArg}, name=${name}`;
 
-    const { repoDir } = await requireInitializedRepoUnlocked({
-      repoDir: resolveRepoDir(options.repoDir),
+    const resolvedRepoDir = resolveRepoDir(options.repoDir);
+    const {
+      repoDir,
+      datastoreResolver: resolver,
+      syncService,
+    } = await requireInitializedRepoUnlocked({
+      repoDir: resolvedRepoDir,
       outputMode: cliCtx.outputMode,
     });
 
+    const markerRepo = new RepoMarkerRepository();
+    const marker = await markerRepo.read(RepoPath.create(repoDir));
+    const managedConfig = marker?.datastore?.managedConfig === true;
+    const definitionsDir = managedConfig
+      ? join(resolver.resolvePath("config"), "models")
+      : undefined;
+
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = await createModelCreateDeps(repoDir);
+    const deps = await createModelCreateDeps(repoDir, definitionsDir);
     const renderer = createModelCreateRenderer(cliCtx.outputMode);
     await consumeStream(
       modelCreate(ctx, deps, { typeArg, name, globalArguments }),
       renderer.handlers(),
     );
+
+    if (syncService && managedConfig) {
+      syncService.markDirty();
+      await syncService.pushChanged();
+    }
 
     cliCtx.logger.debug("Model create command completed");
   },

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -181,7 +181,6 @@ import {
   normalize,
   resolve,
 } from "@std/path";
-import { resolveModelsDir } from "../resolve_models_dir.ts";
 import {
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
@@ -192,6 +191,7 @@ import {
 } from "../../infrastructure/persistence/run_tracker_store.ts";
 import {
   getSwampConfigDir,
+  registerManagedConfig,
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
 import { DefaultDatastorePathResolver } from "../../infrastructure/persistence/default_datastore_path_resolver.ts";
@@ -204,6 +204,8 @@ import {
   sweepStaleRecords,
   sweepTokenConsistency,
 } from "../../serve/boot_reconciliation.ts";
+import { ConfigPoller } from "../../serve/config_poller.ts";
+
 import {
   DEFAULT_HEARTBEAT_INTERVAL_MS,
   InstanceHeartbeatService,
@@ -1412,12 +1414,15 @@ export const serveCommand = new Command()
       repoDir: resolvedRepoDir,
       repoContext,
       datastoreConfig,
+      datastoreResolver: initialResolver,
       syncService,
+      lockfilePath: managedLockfilePath,
     } = await requireInitializedRepoUnlocked({
       repoDir,
       outputMode: ctx.outputMode,
     });
 
+    let configPoller: ConfigPoller | null = null;
     let repoMarker = null;
     try {
       const markerRepo = new RepoMarkerRepository();
@@ -1425,13 +1430,12 @@ export const serveCommand = new Command()
     } catch {
       // Not in a swamp repo or marker unreadable — resolveModelsDir(null) returns the default
     }
-    const resolvedModelsDir = resolveModelsDir(repoMarker);
-    const extensionLockfilePath = join(
-      isAbsolute(resolvedModelsDir)
-        ? resolvedModelsDir
-        : resolve(resolvedRepoDir, resolvedModelsDir),
-      "upstream_extensions.json",
+    registerManagedConfig(
+      resolvedRepoDir,
+      repoMarker?.datastore?.managedConfig === true,
+      initialResolver.resolvePath("config"),
     );
+    const extensionLockfilePath = managedLockfilePath;
 
     // Remote-execution control plane: capability verbs, worker enrollment,
     // and the dispatch/lease registries shared with the HTTP data plane.
@@ -1502,6 +1506,19 @@ export const serveCommand = new Command()
     dispatchService.setOnDispatchEnd((dispatchId) =>
       dataPlane.releaseDispatch(dispatchId)
     );
+
+    // When managedConfig is active, pull the config prefix from the
+    // datastore BEFORE loading extensions. This ensures .swamp/config/
+    // is populated so extension loaders can scan the managed dirs.
+    if (repoMarker?.datastore?.managedConfig && syncService) {
+      await syncService.pullChanged({
+        subdirs: ["config"],
+        namespace: isCustomDatastoreConfig(datastoreConfig)
+          ? datastoreConfig.namespace
+          : undefined,
+      });
+      repoContext.catalogStore.invalidate();
+    }
 
     // Index extension registries so types are discoverable at startup.
     // Bundles are imported on demand when workflow steps target them.
@@ -1705,6 +1722,16 @@ export const serveCommand = new Command()
         signal: AbortSignal.timeout(hydrationTimeoutMs),
         namespace: serveNamespace,
       });
+
+      if (repoMarker?.datastore?.managedConfig) {
+        configPoller = new ConfigPoller({
+          syncService,
+          catalogInvalidate: () => repoContext.catalogStore.invalidate(),
+          extensionCatalogInvalidate: () => {},
+          namespace: serveNamespace,
+        });
+        configPoller.start();
+      }
 
       if (serveNamespace && rootReadErrors.length > 0) {
         const namespacedStore = syncService.controlPlaneStore!();
@@ -2648,6 +2675,9 @@ export const serveCommand = new Command()
           ? { resolvedUserNames }
           : {}),
         serveOptions: merged,
+        managedDefinitionsDir: repoMarker?.datastore?.managedConfig
+          ? join(datastoreResolver.resolvePath("config"), "models")
+          : undefined,
       };
 
     const ac = new AbortController();
@@ -3989,6 +4019,9 @@ export const serveCommand = new Command()
       }
       if (grantsDirectoryPoller) {
         await grantsDirectoryPoller.stop();
+      }
+      if (configPoller) {
+        await configPoller.stop();
       }
       await policySnapshotLoader.dispose();
       // Final telemetry flush, after runs have drained so their entries are

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -42,6 +42,7 @@ import {
   WorkflowExecutionService,
 } from "../../domain/workflows/execution_service.ts";
 import {
+  resolvePulledExtensionsRoot,
   SWAMP_SUBDIRS,
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
@@ -414,6 +415,7 @@ export const workflowResumeCommand = withRemoteOptions(
       RunTrackerStore.fromSwampDir(swampPath(repoDir)),
       ephemeral.repo,
       ephemeral.catalog,
+      resolvePulledExtensionsRoot(repoDir),
     );
 
     const abort = new AbortController();

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -48,6 +48,7 @@ import { resolveModelType } from "../../domain/extensions/extension_auto_resolve
 import { getAutoResolver } from "../auto_resolver_context.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import {
+  resolvePulledExtensionsRoot,
   SWAMP_SUBDIRS,
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
@@ -424,6 +425,7 @@ export const workflowRunCommand = new Command()
             tracker,
             ephRepo,
             ephCatalog,
+            resolvePulledExtensionsRoot(dir),
           );
         },
         catalogStore: repoContext.catalogStore,

--- a/src/cli/create_extension_install_deps.ts
+++ b/src/cli/create_extension_install_deps.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join, relative, resolve } from "@std/path";
+import { relative, resolve } from "@std/path";
 import type { Logger } from "@logtape/logtape";
 import { RepoPath } from "../domain/repo/repo_path.ts";
 import { resolveUniqueLocalSkillsDirs } from "../domain/repo/skill_dirs.ts";
@@ -29,7 +29,7 @@ import {
   LockfileRepository,
   resolveServerUrl,
 } from "../libswamp/mod.ts";
-import { resolveModelsDir } from "./resolve_models_dir.ts";
+import { resolveManagedConfigPaths } from "./repo_context.ts";
 
 /**
  * Wires `ExtensionInstallDeps` from a repo directory and a logger.
@@ -52,9 +52,7 @@ export async function createExtensionInstallDeps(
   const repoPath = RepoPath.create(absoluteRepoDir);
   const markerRepo = new RepoMarkerRepository();
   const marker = await markerRepo.read(repoPath);
-  const modelsDir = resolveModelsDir(marker);
-  const absoluteModelsDir = resolve(absoluteRepoDir, modelsDir);
-  const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+  const { lockfilePath } = resolveManagedConfigPaths(absoluteRepoDir, marker);
   const tools = marker?.tools?.length ? marker.tools : ["claude"];
   const absoluteSkillsDirs = resolveUniqueLocalSkillsDirs(
     absoluteRepoDir,

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -194,6 +194,7 @@ import "../domain/models/models.ts";
 // separate files to avoid circular imports through mod.ts.
 import { resolveModelsDir } from "./resolve_models_dir.ts";
 export { resolveModelsDir };
+import { resolveManagedConfigPaths } from "./repo_context.ts";
 import { resolveWorkflowsDir } from "./resolve_workflows_dir.ts";
 export { resolveWorkflowsDir };
 import { resolveVaultsDir } from "./resolve_vaults_dir.ts";
@@ -297,6 +298,7 @@ export async function configureExtensionLoaders(
   deferredWarnings: DeferredWarning[],
   quiet = false,
   extensionsDir?: string,
+  managedLockfilePath?: string,
 ): Promise<void> {
   const effectiveExtDir = extensionsDir ?? repoDir;
 
@@ -385,7 +387,7 @@ export async function configureExtensionLoaders(
   // getter so the lockfile is read on first need rather than at every
   // configureExtensionLoaders call.
   const repoModelsDir = resolveModelsDir(marker);
-  const lockfilePath = join(
+  const lockfilePath = managedLockfilePath ?? join(
     isAbsolute(repoModelsDir) ? repoModelsDir : resolve(repoDir, repoModelsDir),
     "upstream_extensions.json",
   );
@@ -422,6 +424,7 @@ export async function configureExtensionLoaders(
       repository,
       quiet,
       effectiveExtDir,
+      lockfilePath,
     )
   );
   vaultTypeRegistry.setLoader(() =>
@@ -434,6 +437,7 @@ export async function configureExtensionLoaders(
       repository,
       quiet,
       effectiveExtDir,
+      lockfilePath,
     )
   );
   datastoreTypeRegistry.setLoader(() =>
@@ -445,6 +449,7 @@ export async function configureExtensionLoaders(
       repository,
       quiet,
       effectiveExtDir,
+      lockfilePath,
     )
   );
   reportRegistry.setLoader(() =>
@@ -457,6 +462,7 @@ export async function configureExtensionLoaders(
       repository,
       quiet,
       effectiveExtDir,
+      lockfilePath,
     )
   );
 
@@ -464,7 +470,12 @@ export async function configureExtensionLoaders(
   // instance — the local repo may be a thin checkout whose lockfile
   // references files that only exist on the server.
   if (!Deno.env.get("SWAMP_SERVE_URL")) {
-    await checkForMissingPulledExtensions(repoDir, marker, deferredWarnings);
+    await checkForMissingPulledExtensions(
+      repoDir,
+      marker,
+      deferredWarnings,
+      lockfilePath,
+    );
     await checkForSupersededSkills(repoDir, marker, deferredWarnings);
   }
 }
@@ -479,6 +490,7 @@ export function configureExtensionAutoResolver(
   authCollectives: string[] | undefined,
   outputMode: "log" | "json",
   identity: ClientIdentity = {},
+  managedLockfilePath?: string,
 ): void {
   const trustedCollectives = resolveTrustedCollectives(marker, authCollectives);
   if (trustedCollectives.length === 0 || !marker) {
@@ -489,6 +501,10 @@ export function configureExtensionAutoResolver(
   const extensionClient = new ExtensionApiClient(serverUrl, identity);
   const apiKey = identity.bearerToken;
   const modelsDir = resolveModelsDir(marker);
+  const effectiveLockfilePath = managedLockfilePath ?? join(
+    resolve(repoDir, modelsDir),
+    "upstream_extensions.json",
+  );
   const denoRuntime = new EmbeddedDenoRuntime();
   setAutoResolver(
     new ExtensionAutoResolver({
@@ -504,24 +520,15 @@ export function configureExtensionAutoResolver(
           extensionClient.downloadArchive(name, version, apiKey, channel),
         getChecksum: (name, version, channel) =>
           extensionClient.getChecksum(name, version, apiKey, channel),
-        lockfilePath: join(
-          resolve(repoDir, modelsDir),
-          "upstream_extensions.json",
-        ),
+        lockfilePath: effectiveLockfilePath,
         repoDir,
         denoRuntime,
-        // W1b/(a-2): wrap the auto-resolver-context catalog in its own
-        // ExtensionRepository so the loaders constructed inside
-        // hotLoadModels/hotLoadVaults/hotLoadDatastores can route their
-        // catalog operations through the repository. The
-        // lockfile snapshot is taken here at adapter-creation time;
-        // long-lived repository instances do not refresh.
         repository: new ExtensionRepository({
           catalog: new ExtensionCatalogStore(
             swampPath(repoDir, "_extension_catalog.db"),
           ),
           lockfileRepository: new LockfileRepository(
-            join(resolve(repoDir, modelsDir), "upstream_extensions.json"),
+            effectiveLockfilePath,
             {},
           ),
           repoRoot: repoDir,
@@ -613,25 +620,24 @@ async function loadUserModels(
   repository?: ExtensionRepository,
   _quiet = false,
   extensionsDir?: string,
+  managedLockfilePath?: string,
 ): Promise<void> {
   try {
     const extBase = extensionsDir ?? repoDir;
     const modelsDir = resolveModelsDir(marker);
-    // Handle both absolute and relative paths (cross-platform)
     const absoluteModelsDir = isAbsolute(modelsDir)
       ? modelsDir
       : resolve(extBase, modelsDir);
 
-    // W1b/(a-2): if no repository was passed, bootstrap one with an
-    // empty lockfile lookup. The catalog stays open for the process
-    // lifetime so the ExtensionLoader can query it via getCatalogStore()
-    // when loadSingleType() is called later.
+    const lockfilePath = managedLockfilePath ??
+      join(absoluteModelsDir, "upstream_extensions.json");
+
     const effectiveRepository = repository ?? new ExtensionRepository({
       catalog: new ExtensionCatalogStore(
         swampPath(repoDir, "_extension_catalog.db"),
       ),
       lockfileRepository: new LockfileRepository(
-        join(absoluteModelsDir, "upstream_extensions.json"),
+        lockfilePath,
         {},
       ),
       repoRoot: repoDir,
@@ -645,7 +651,6 @@ async function loadUserModels(
       resolver,
       effectiveRepository,
     );
-    const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
     const pulledDirs = await enumeratePulledExtensionDirs(
       lockfilePath,
       repoDir,
@@ -721,6 +726,7 @@ async function loadUserVaults(
   repository?: ExtensionRepository,
   _quiet = false,
   extensionsDir?: string,
+  managedLockfilePath?: string,
 ): Promise<void> {
   try {
     const extBase = extensionsDir ?? repoDir;
@@ -738,7 +744,7 @@ async function loadUserVaults(
       repository,
     );
     const modelsDir = resolveModelsDir(marker);
-    const lockfilePath = join(
+    const lockfilePath = managedLockfilePath ?? join(
       isAbsolute(modelsDir) ? modelsDir : resolve(repoDir, modelsDir),
       "upstream_extensions.json",
     );
@@ -805,6 +811,7 @@ async function loadUserDatastores(
   repository?: ExtensionRepository,
   _quiet = false,
   extensionsDir?: string,
+  managedLockfilePath?: string,
 ): Promise<void> {
   try {
     const extBase = extensionsDir ?? repoDir;
@@ -821,7 +828,7 @@ async function loadUserDatastores(
       repository,
     );
     const modelsDir = resolveModelsDir(marker);
-    const lockfilePath = join(
+    const lockfilePath = managedLockfilePath ?? join(
       isAbsolute(modelsDir) ? modelsDir : resolve(repoDir, modelsDir),
       "upstream_extensions.json",
     );
@@ -892,6 +899,7 @@ async function loadUserReports(
   repository?: ExtensionRepository,
   _quiet = false,
   extensionsDir?: string,
+  managedLockfilePath?: string,
 ): Promise<void> {
   try {
     const extBase = extensionsDir ?? repoDir;
@@ -909,7 +917,7 @@ async function loadUserReports(
       repository,
     );
     const modelsDir = resolveModelsDir(marker);
-    const lockfilePath = join(
+    const lockfilePath = managedLockfilePath ?? join(
       isAbsolute(modelsDir) ? modelsDir : resolve(repoDir, modelsDir),
       "upstream_extensions.json",
     );
@@ -977,13 +985,15 @@ async function checkForMissingPulledExtensions(
   repoDir: string,
   marker: RepoMarkerData | null,
   deferredWarnings: DeferredWarning[],
+  managedLockfilePath?: string,
 ): Promise<void> {
   try {
     const modelsDir = resolveModelsDir(marker);
     const absoluteModelsDir = isAbsolute(modelsDir)
       ? modelsDir
       : resolve(repoDir, modelsDir);
-    const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+    const lockfilePath = managedLockfilePath ??
+      join(absoluteModelsDir, "upstream_extensions.json");
 
     const lockfileRepository = await LockfileRepository.create(lockfilePath);
     const upstream = lockfileRepository.getAllEntries();
@@ -1347,6 +1357,10 @@ export async function runCli(args: string[]): Promise<void> {
     const loaderSpan = getTracer().startSpan(
       "swamp.cli.configure_extension_loaders",
     );
+    const { lockfilePath: managedLockfilePath } = resolveManagedConfigPaths(
+      repoDir,
+      marker,
+    );
     await configureExtensionLoaders(
       repoDir,
       marker,
@@ -1354,6 +1368,7 @@ export async function runCli(args: string[]): Promise<void> {
       deferredWarnings,
       isQuietFromArgs(args),
       extensionsDir,
+      managedLockfilePath,
     );
     loaderSpan.end();
   }
@@ -1435,12 +1450,15 @@ export async function runCli(args: string[]): Promise<void> {
   if (!hookMode) {
     const autoResolverIdentity = await loadIdentity();
     setAuthenticated(Boolean(autoResolverIdentity.bearerToken));
+    const { lockfilePath: autoResolverLockfilePath } =
+      resolveManagedConfigPaths(repoDir, marker);
     configureExtensionAutoResolver(
       repoDir,
       marker,
       authCollectives,
       getOutputModeFromArgs(args),
       autoResolverIdentity,
+      autoResolverLockfilePath,
     );
   }
 

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -61,7 +61,10 @@ import {
 } from "../infrastructure/persistence/datastore_sync_coordinator.ts";
 import { summarizeSyncError } from "../infrastructure/persistence/sync_error_diagnostic.ts";
 import { FileLock } from "../infrastructure/persistence/file_lock.ts";
-import { swampPath } from "../infrastructure/persistence/paths.ts";
+import {
+  registerManagedConfig,
+  swampPath,
+} from "../infrastructure/persistence/paths.ts";
 import {
   type DistributedLock,
   type LockInfo,
@@ -235,6 +238,51 @@ export interface RequireRepoOptions {
 }
 
 /**
+ * Resolves the pulled-extensions root and lockfile path based on
+ * whether managed config is enabled. When managedConfig is true,
+ * these paths point into .swamp/config/ (the datastore interface
+ * layer). When false, they use the traditional locations.
+ */
+export function resolveManagedConfigPaths(
+  repoDir: string,
+  marker: RepoMarkerData | null,
+  configBasePath?: string,
+  options?: { skipSentinelCheck?: boolean },
+): { pulledExtensionsRoot: string; lockfilePath: string } {
+  const managedConfig = marker?.datastore?.managedConfig === true;
+  const effectiveBase = configBasePath ?? swampPath(repoDir, "config");
+
+  let active = false;
+  if (managedConfig) {
+    if (options?.skipSentinelCheck) {
+      active = true;
+    } else {
+      try {
+        Deno.statSync(join(effectiveBase, "managed-config-migrated.json"));
+        active = true;
+      } catch {
+        // Sentinel not found — migration hasn't run yet, fall back
+      }
+    }
+  }
+
+  registerManagedConfig(repoDir, active, effectiveBase);
+  if (active) {
+    return {
+      pulledExtensionsRoot: join(effectiveBase, "pulled-extensions"),
+      lockfilePath: join(effectiveBase, "upstream_extensions.json"),
+    };
+  }
+  const modelsDir = isAbsolute(resolveModelsDir(marker))
+    ? resolveModelsDir(marker)
+    : resolve(repoDir, resolveModelsDir(marker));
+  return {
+    pulledExtensionsRoot: swampPath(repoDir, "pulled-extensions"),
+    lockfilePath: join(modelsDir, "upstream_extensions.json"),
+  };
+}
+
+/**
  * Result of successful repo validation containing the validated directory
  * and repository context.
  */
@@ -242,6 +290,8 @@ export interface RepoValidationContext {
   repoDir: string;
   repoContext: RepositoryContext;
   datastoreResolver: DatastorePathResolver;
+  pulledExtensionsRoot: string;
+  lockfilePath: string;
 }
 
 /**
@@ -433,10 +483,21 @@ export async function requireInitializedRepoReadOnly(
     // No lock acquisition — read-only path
   }
 
-  // Compute top-level directories for definitions, workflows, and vaults
-  const definitionsDir = join(repoPath.value, "models");
-  const yamlWorkflowsDir = join(repoPath.value, "workflows");
-  const vaultsDir = join(repoPath.value, "vaults");
+  const managedConfig = marker?.datastore?.managedConfig === true;
+  const definitionsDir = managedConfig
+    ? join(datastoreResolver.resolvePath("config"), "models")
+    : join(repoPath.value, "models");
+  const yamlWorkflowsDir = managedConfig
+    ? join(datastoreResolver.resolvePath("config"), "workflows")
+    : join(repoPath.value, "workflows");
+  const vaultsDir = managedConfig
+    ? join(datastoreResolver.resolvePath("config"), "vaults")
+    : join(repoPath.value, "vaults");
+  const { pulledExtensionsRoot, lockfilePath } = resolveManagedConfigPaths(
+    repoPath.value,
+    marker,
+    datastoreResolver.resolvePath("config"),
+  );
 
   // Resolve source workflow directories from .swamp-sources.yaml
   const sourceWorkflowDirs = await getSourceWorkflowDirs(repoPath.value);
@@ -448,12 +509,7 @@ export async function requireInitializedRepoReadOnly(
     additionalWorkflowsDirs: [
       ...sourceWorkflowDirs,
       ...(await enumeratePulledExtensionDirs(
-        join(
-          isAbsolute(resolveModelsDir(marker))
-            ? resolveModelsDir(marker)
-            : resolve(repoPath.value, resolveModelsDir(marker)),
-          "upstream_extensions.json",
-        ),
+        lockfilePath,
         repoPath.value,
         "workflows",
       )),
@@ -480,6 +536,8 @@ export async function requireInitializedRepoReadOnly(
     repoDir: repoPath.value,
     repoContext,
     datastoreResolver,
+    pulledExtensionsRoot,
+    lockfilePath,
   };
 }
 
@@ -638,10 +696,22 @@ export function requireInitializedRepo(
       }
     }
 
-    // Compute top-level directories for definitions, workflows, and vaults
-    const definitionsDir = join(repoPath.value, "models");
-    const yamlWorkflowsDir = join(repoPath.value, "workflows");
-    const vaultsDir = join(repoPath.value, "vaults");
+    const managedConfig = marker?.datastore?.managedConfig === true;
+    const configBase = datastoreResolver.resolvePath("config");
+    const definitionsDir = managedConfig
+      ? join(configBase, "models")
+      : join(repoPath.value, "models");
+    const yamlWorkflowsDir = managedConfig
+      ? join(configBase, "workflows")
+      : join(repoPath.value, "workflows");
+    const vaultsDir = managedConfig
+      ? join(configBase, "vaults")
+      : join(repoPath.value, "vaults");
+    const { pulledExtensionsRoot, lockfilePath } = resolveManagedConfigPaths(
+      repoPath.value,
+      marker,
+      configBase,
+    );
 
     // Resolve source workflow directories from .swamp-sources.yaml
     const sourceWorkflowDirs = await getSourceWorkflowDirs(repoPath.value);
@@ -653,12 +723,7 @@ export function requireInitializedRepo(
       additionalWorkflowsDirs: [
         ...sourceWorkflowDirs,
         ...(await enumeratePulledExtensionDirs(
-          join(
-            isAbsolute(resolveModelsDir(marker))
-              ? resolveModelsDir(marker)
-              : resolve(repoPath.value, resolveModelsDir(marker)),
-            "upstream_extensions.json",
-          ),
+          lockfilePath,
           repoPath.value,
           "workflows",
         )),
@@ -706,6 +771,8 @@ export function requireInitializedRepo(
       repoDir: repoPath.value,
       repoContext,
       datastoreResolver,
+      pulledExtensionsRoot,
+      lockfilePath,
     };
   });
 }
@@ -792,10 +859,23 @@ export async function requireInitializedRepoUnlocked(
     }
   }
 
-  // Compute top-level directories for definitions, workflows, and vaults
-  const definitionsDir = join(repoPath.value, "models");
-  const yamlWorkflowsDir = join(repoPath.value, "workflows");
-  const vaultsDir = join(repoPath.value, "vaults");
+  const managedConfig = marker?.datastore?.managedConfig === true;
+  const configBase = datastoreResolver.resolvePath("config");
+  const definitionsDir = managedConfig
+    ? join(configBase, "models")
+    : join(repoPath.value, "models");
+  const yamlWorkflowsDir = managedConfig
+    ? join(configBase, "workflows")
+    : join(repoPath.value, "workflows");
+  const vaultsDir = managedConfig
+    ? join(configBase, "vaults")
+    : join(repoPath.value, "vaults");
+  const { pulledExtensionsRoot, lockfilePath } = resolveManagedConfigPaths(
+    repoPath.value,
+    marker,
+    datastoreResolver.resolvePath("config"),
+    { skipSentinelCheck: true },
+  );
 
   // Resolve source workflow directories from .swamp-sources.yaml
   const sourceWorkflowDirs = await getSourceWorkflowDirs(repoPath.value);
@@ -807,12 +887,7 @@ export async function requireInitializedRepoUnlocked(
     additionalWorkflowsDirs: [
       ...sourceWorkflowDirs,
       ...(await enumeratePulledExtensionDirs(
-        join(
-          isAbsolute(resolveModelsDir(marker))
-            ? resolveModelsDir(marker)
-            : resolve(repoPath.value, resolveModelsDir(marker)),
-          "upstream_extensions.json",
-        ),
+        lockfilePath,
         repoPath.value,
         "workflows",
       )),
@@ -849,6 +924,8 @@ export async function requireInitializedRepoUnlocked(
     datastoreResolver,
     datastoreConfig,
     syncService,
+    pulledExtensionsRoot,
+    lockfilePath,
   };
 }
 

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -38,10 +38,13 @@ import {
   requireInitializedRepoReadOnly,
   requireInitializedRepoUnlocked,
   resolveDatastoreForRepo,
+  resolveManagedConfigPaths,
   SWAMP_LOCK_HOLDER_PID,
   waitForPerModelLocks,
 } from "./repo_context.ts";
 import { flushDatastoreSync } from "../infrastructure/persistence/datastore_sync_coordinator.ts";
+import { assertPathEquals } from "../infrastructure/persistence/path_test_helpers.ts";
+import type { RepoMarkerData } from "../infrastructure/persistence/repo_marker_repository.ts";
 import {
   type CustomDatastoreConfig,
   type DatastoreConfig,
@@ -2193,4 +2196,160 @@ Deno.test("acquireModelLocks: uses two-phase push when twoPhaseSync is advertise
       "preparePush must run before commitPush",
     );
   });
+});
+
+// ============================================================================
+// resolveManagedConfigPaths Tests
+// ============================================================================
+
+Deno.test("resolveManagedConfigPaths: null marker returns default pulled-extensions root", () => {
+  const { pulledExtensionsRoot } = resolveManagedConfigPaths("/repo", null);
+  assertPathEquals(pulledExtensionsRoot, "/repo/.swamp/pulled-extensions");
+});
+
+Deno.test("resolveManagedConfigPaths: null marker returns default lockfile path", () => {
+  const { lockfilePath } = resolveManagedConfigPaths("/repo", null);
+  assertPathEquals(
+    lockfilePath,
+    "/repo/extensions/models/upstream_extensions.json",
+  );
+});
+
+Deno.test("resolveManagedConfigPaths: marker without datastore returns default paths", () => {
+  const marker: RepoMarkerData = {
+    swampVersion: "1.0.0",
+    initializedAt: "2026-01-01T00:00:00.000Z",
+  };
+  const { pulledExtensionsRoot, lockfilePath } = resolveManagedConfigPaths(
+    "/repo",
+    marker,
+  );
+  assertPathEquals(pulledExtensionsRoot, "/repo/.swamp/pulled-extensions");
+  assertPathEquals(
+    lockfilePath,
+    "/repo/extensions/models/upstream_extensions.json",
+  );
+});
+
+Deno.test("resolveManagedConfigPaths: managedConfig=false returns default paths", () => {
+  const marker: RepoMarkerData = {
+    swampVersion: "1.0.0",
+    initializedAt: "2026-01-01T00:00:00.000Z",
+    datastore: { type: "filesystem", managedConfig: false },
+  };
+  const { pulledExtensionsRoot, lockfilePath } = resolveManagedConfigPaths(
+    "/repo",
+    marker,
+  );
+  assertPathEquals(pulledExtensionsRoot, "/repo/.swamp/pulled-extensions");
+  assertPathEquals(
+    lockfilePath,
+    "/repo/extensions/models/upstream_extensions.json",
+  );
+});
+
+Deno.test("resolveManagedConfigPaths: managedConfig=true returns managed pulled-extensions root", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const configDir = `${tmpDir}/.swamp/config`;
+    await Deno.mkdir(configDir, { recursive: true });
+    await Deno.writeTextFile(
+      `${configDir}/managed-config-migrated.json`,
+      "{}",
+    );
+    const marker: RepoMarkerData = {
+      swampVersion: "1.0.0",
+      initializedAt: "2026-01-01T00:00:00.000Z",
+      datastore: { type: "@swamp/s3-datastore", managedConfig: true },
+    };
+    const { pulledExtensionsRoot } = resolveManagedConfigPaths(tmpDir, marker);
+    assertPathEquals(
+      pulledExtensionsRoot,
+      `${tmpDir}/.swamp/config/pulled-extensions`,
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("resolveManagedConfigPaths: managedConfig=true returns managed lockfile path", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const configDir = `${tmpDir}/.swamp/config`;
+    await Deno.mkdir(configDir, { recursive: true });
+    await Deno.writeTextFile(
+      `${configDir}/managed-config-migrated.json`,
+      "{}",
+    );
+    const marker: RepoMarkerData = {
+      swampVersion: "1.0.0",
+      initializedAt: "2026-01-01T00:00:00.000Z",
+      datastore: { type: "@swamp/s3-datastore", managedConfig: true },
+    };
+    const { lockfilePath } = resolveManagedConfigPaths(tmpDir, marker);
+    assertPathEquals(
+      lockfilePath,
+      `${tmpDir}/.swamp/config/upstream_extensions.json`,
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("resolveManagedConfigPaths: managedConfig=true with custom modelsDir still uses managed path", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const configDir = `${tmpDir}/.swamp/config`;
+    await Deno.mkdir(configDir, { recursive: true });
+    await Deno.writeTextFile(
+      `${configDir}/managed-config-migrated.json`,
+      "{}",
+    );
+    const marker: RepoMarkerData = {
+      swampVersion: "1.0.0",
+      initializedAt: "2026-01-01T00:00:00.000Z",
+      modelsDir: "custom/models",
+      datastore: { type: "@swamp/s3-datastore", managedConfig: true },
+    };
+    const { lockfilePath } = resolveManagedConfigPaths(tmpDir, marker);
+    assertPathEquals(
+      lockfilePath,
+      `${tmpDir}/.swamp/config/upstream_extensions.json`,
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("resolveManagedConfigPaths: managedConfig=true without sentinel falls back to default paths", () => {
+  const marker: RepoMarkerData = {
+    swampVersion: "1.0.0",
+    initializedAt: "2026-01-01T00:00:00.000Z",
+    datastore: { type: "@swamp/s3-datastore", managedConfig: true },
+  };
+  const { pulledExtensionsRoot, lockfilePath } = resolveManagedConfigPaths(
+    "/nonexistent-repo",
+    marker,
+  );
+  assertPathEquals(
+    pulledExtensionsRoot,
+    "/nonexistent-repo/.swamp/pulled-extensions",
+  );
+  assertPathEquals(
+    lockfilePath,
+    "/nonexistent-repo/extensions/models/upstream_extensions.json",
+  );
+});
+
+Deno.test("resolveManagedConfigPaths: custom modelsDir is used when managedConfig=false", () => {
+  const marker: RepoMarkerData = {
+    swampVersion: "1.0.0",
+    initializedAt: "2026-01-01T00:00:00.000Z",
+    modelsDir: "custom/models",
+  };
+  const { lockfilePath } = resolveManagedConfigPaths("/repo", marker);
+  assertPathEquals(
+    lockfilePath,
+    "/repo/custom/models/upstream_extensions.json",
+  );
 });

--- a/src/cli/resolve_extension_files.ts
+++ b/src/cli/resolve_extension_files.ts
@@ -114,9 +114,19 @@ export function isPulledExtensionManifest(
   const absolute = isAbsolute(manifestPath)
     ? manifestPath
     : resolve(repoDir, manifestPath);
-  const pulledRoot = join(resolve(repoDir), ".swamp", "pulled-extensions");
-  return resolve(absolute).startsWith(pulledRoot + "/") ||
-    resolve(absolute).startsWith(pulledRoot + "\\");
+  const resolved = resolve(absolute);
+  const repoResolved = resolve(repoDir);
+  const pulledRoot = join(repoResolved, ".swamp", "pulled-extensions");
+  const managedPulledRoot = join(
+    repoResolved,
+    ".swamp",
+    "config",
+    "pulled-extensions",
+  );
+  return resolved.startsWith(pulledRoot + "/") ||
+    resolved.startsWith(pulledRoot + "\\") ||
+    resolved.startsWith(managedPulledRoot + "/") ||
+    resolved.startsWith(managedPulledRoot + "\\");
 }
 
 export async function resolveExtensionFiles(

--- a/src/cli/resolve_extension_files_test.ts
+++ b/src/cli/resolve_extension_files_test.ts
@@ -895,6 +895,26 @@ Deno.test("isPulledExtensionManifest: returns false for path containing pulled-e
   assertEquals(isPulledExtensionManifest(repoDir, manifestPath), false);
 });
 
+Deno.test("isPulledExtensionManifest: returns true for managed config absolute path", () => {
+  const repoDir = "/repo";
+  const manifestPath =
+    "/repo/.swamp/config/pulled-extensions/@scope/ext/manifest.yaml";
+  assertEquals(isPulledExtensionManifest(repoDir, manifestPath), true);
+});
+
+Deno.test("isPulledExtensionManifest: returns true for managed config relative path", () => {
+  const repoDir = "/repo";
+  const manifestPath =
+    ".swamp/config/pulled-extensions/@scope/ext/manifest.yaml";
+  assertEquals(isPulledExtensionManifest(repoDir, manifestPath), true);
+});
+
+Deno.test("isPulledExtensionManifest: returns false for path containing config but not pulled-extensions", () => {
+  const repoDir = "/repo";
+  const manifestPath = "/repo/.swamp/config/models/manifest.yaml";
+  assertEquals(isPulledExtensionManifest(repoDir, manifestPath), false);
+});
+
 // ── .ts/.js file rejection ──────────────────────────────────────────────
 
 Deno.test("resolveExtensionFiles: rejects .ts file with UserError", async () => {

--- a/src/domain/datastore/datastore_config.ts
+++ b/src/domain/datastore/datastore_config.ts
@@ -21,17 +21,18 @@
  * Datastore configuration types for configurable runtime data storage.
  *
  * The datastore determines where runtime data (versioned model data,
- * workflow runs, outputs, audit logs, etc.) is stored. Model definitions,
- * workflow definitions, and vault configs always stay in the local
- * `.swamp/` directory.
+ * workflow runs, outputs, audit logs, etc.) is stored. By default, model
+ * definitions, workflow definitions, and vault configs live in top-level
+ * directories. When `managedConfig` is enabled, they move into the
+ * `.swamp/config/` datastore tier so the datastore becomes the single
+ * source of truth across all instances.
  */
 
 /**
  * Subdirectories that always remain in local `.swamp/` regardless of
- * datastore configuration.
- *
- * Note: definitions, workflows, and vault configs now live in top-level
- * directories (models/, workflows/, vaults/) and are no longer .swamp/ subdirs.
+ * datastore configuration. These contain security-sensitive or
+ * platform-specific derived artifacts that should not traverse the
+ * datastore.
  */
 export const ALWAYS_LOCAL_SUBDIRS = [
   "secrets",
@@ -49,6 +50,7 @@ export const DEFAULT_DATASTORE_SUBDIRS = [
   "auto-definitions",
   "definitions-evaluated",
   "workflows-evaluated",
+  "config",
   "data",
   "outputs",
   "workflow-runs",
@@ -184,6 +186,14 @@ export interface DatastoreConfigData {
   exclude?: string[];
   hydrationStrategy?: "full" | "lazy";
   namespace?: string;
+  /**
+   * When `true`, model definitions, workflow definitions, vault configs,
+   * the extension lockfile, and pulled extension sources are stored in the
+   * `.swamp/config/` datastore tier instead of top-level directories.
+   * The datastore becomes the single source of truth — instances hydrate
+   * from it on startup and a ConfigPoller refreshes periodically.
+   */
+  managedConfig?: boolean;
 }
 
 /**

--- a/src/domain/datastore/datastore_config_test.ts
+++ b/src/domain/datastore/datastore_config_test.ts
@@ -21,6 +21,7 @@ import { assertEquals, assertFalse } from "@std/assert";
 import {
   ALWAYS_LOCAL_SUBDIRS,
   type CustomDatastoreConfig,
+  type DatastoreConfigData,
   DEFAULT_DATASTORE_SUBDIRS,
   DEFAULT_LOCK_TIMEOUT_MS,
   DEFAULT_SYNC_TIMEOUT_MS,
@@ -281,4 +282,26 @@ Deno.test("DEFAULT_DATASTORE_SUBDIRS: still lists secrets for backwards compatib
     (DEFAULT_DATASTORE_SUBDIRS as readonly string[]).includes("secrets"),
     true,
   );
+});
+
+Deno.test("DEFAULT_DATASTORE_SUBDIRS: includes config subdir", () => {
+  assertEquals(
+    (DEFAULT_DATASTORE_SUBDIRS as readonly string[]).includes("config"),
+    true,
+  );
+});
+
+Deno.test("getDatastoreDirectories: config subdir is included in defaults", () => {
+  const dirs = getDatastoreDirectories(filesystemConfig);
+  assertEquals(dirs.includes("config"), true);
+});
+
+Deno.test("DatastoreConfigData: managedConfig defaults to undefined", () => {
+  const data: DatastoreConfigData = { type: "filesystem" };
+  assertEquals(data.managedConfig, undefined);
+});
+
+Deno.test("DatastoreConfigData: managedConfig can be set to true", () => {
+  const data: DatastoreConfigData = { type: "filesystem", managedConfig: true };
+  assertEquals(data.managedConfig, true);
 });

--- a/src/domain/datastore/datastore_sync_service.ts
+++ b/src/domain/datastore/datastore_sync_service.ts
@@ -72,6 +72,13 @@ export interface SyncCapabilities {
    * pending run entries) in HA deployments.
    */
   controlPlane?: boolean;
+  /**
+   * When `true`, the extension supports the `subdirs` option on
+   * `pullChanged` — restricting the pull to a subset of datastore
+   * subdirectories (e.g. `config/` only). Used by the ConfigPoller
+   * to refresh managed configuration without pulling the entire datastore.
+   */
+  configRefresh?: boolean;
 }
 
 /**
@@ -139,6 +146,17 @@ export interface DatastoreSyncOptions {
    * (those always download everything the partition lists).
    */
   metadataOnly?: boolean;
+  /**
+   * Restricts `pullChanged` to the listed datastore subdirectories.
+   * When set, the extension SHOULD only pull paths under these prefixes
+   * instead of walking the entire datastore. Extensions that advertise
+   * `configRefresh` in their capabilities SHOULD honor this option;
+   * extensions that don't can safely ignore it and pull everything.
+   *
+   * Used by the ConfigPoller to efficiently refresh only the `config/`
+   * prefix without pulling runtime data.
+   */
+  subdirs?: readonly string[];
 }
 
 /**

--- a/src/domain/datastore/managed_config_migration.ts
+++ b/src/domain/datastore/managed_config_migration.ts
@@ -1,0 +1,140 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { copy, ensureDir } from "@std/fs";
+import { join, resolve } from "@std/path";
+import { getLogger } from "@logtape/logtape";
+
+const logger = getLogger(["swamp", "datastore", "managed-config-migration"]);
+
+const MIGRATION_SENTINEL = "managed-config-migrated.json";
+
+export interface MigrationResult {
+  copiedModels: boolean;
+  copiedWorkflows: boolean;
+  copiedVaults: boolean;
+  copiedLockfile: boolean;
+  copiedPulledExtensions: boolean;
+  alreadyMigrated: boolean;
+}
+
+export async function migrateConfigToDatastore(
+  repoDir: string,
+  lockfileSourcePath: string,
+  configRoot: string,
+  pulledExtensionsSource: string,
+): Promise<MigrationResult> {
+  const sentinelPath = join(configRoot, MIGRATION_SENTINEL);
+
+  try {
+    await Deno.stat(sentinelPath);
+    logger.info`Config migration already completed (sentinel exists)`;
+    return {
+      copiedModels: false,
+      copiedWorkflows: false,
+      copiedVaults: false,
+      copiedLockfile: false,
+      copiedPulledExtensions: false,
+      alreadyMigrated: true,
+    };
+  } catch {
+    // Sentinel doesn't exist — proceed with migration
+  }
+
+  await ensureDir(configRoot);
+
+  const result: MigrationResult = {
+    copiedModels: false,
+    copiedWorkflows: false,
+    copiedVaults: false,
+    copiedLockfile: false,
+    copiedPulledExtensions: false,
+    alreadyMigrated: false,
+  };
+
+  const sources: Array<{
+    src: string;
+    dest: string;
+    key: keyof MigrationResult;
+    isFile?: boolean;
+  }> = [
+    {
+      src: join(repoDir, "models"),
+      dest: join(configRoot, "models"),
+      key: "copiedModels",
+    },
+    {
+      src: join(repoDir, "workflows"),
+      dest: join(configRoot, "workflows"),
+      key: "copiedWorkflows",
+    },
+    {
+      src: join(repoDir, "vaults"),
+      dest: join(configRoot, "vaults"),
+      key: "copiedVaults",
+    },
+    {
+      src: resolve(lockfileSourcePath),
+      dest: join(configRoot, "upstream_extensions.json"),
+      key: "copiedLockfile",
+      isFile: true,
+    },
+    {
+      src: pulledExtensionsSource,
+      dest: join(configRoot, "pulled-extensions"),
+      key: "copiedPulledExtensions",
+    },
+  ];
+
+  for (const { src, dest, key, isFile } of sources) {
+    try {
+      const stat = await Deno.stat(src);
+      if (isFile ? stat.isFile : stat.isDirectory) {
+        if (isFile) {
+          await ensureDir(join(dest, "..").replace(/\/\.\.$/, ""));
+          await Deno.copyFile(src, dest);
+        } else {
+          await copy(src, dest, { overwrite: true });
+        }
+        (result as unknown as Record<string, boolean>)[key] = true;
+        logger.info`Copied ${src} → ${dest}`;
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        logger.debug`Skipping ${src} (not found)`;
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  await Deno.writeTextFile(
+    sentinelPath,
+    JSON.stringify({
+      migratedAt: new Date().toISOString(),
+      sources: sources.map((s) => s.src),
+    }),
+  );
+
+  return result;
+}
+
+export function getMigrationSentinelPath(configRoot: string): string {
+  return join(configRoot, MIGRATION_SENTINEL);
+}

--- a/src/domain/datastore/managed_config_migration_test.ts
+++ b/src/domain/datastore/managed_config_migration_test.ts
@@ -1,0 +1,386 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import {
+  getMigrationSentinelPath,
+  migrateConfigToDatastore,
+} from "./managed_config_migration.ts";
+
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-migration-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+async function setupRepoWithAllSources(
+  repoDir: string,
+): Promise<{ lockfilePath: string; pulledExtensionsSource: string }> {
+  await ensureDir(join(repoDir, "models"));
+  await Deno.writeTextFile(
+    join(repoDir, "models", "my-model.yaml"),
+    "type: my-model\n",
+  );
+
+  await ensureDir(join(repoDir, "workflows"));
+  await Deno.writeTextFile(
+    join(repoDir, "workflows", "daily.yaml"),
+    "name: daily\n",
+  );
+
+  await ensureDir(join(repoDir, "vaults"));
+  await Deno.writeTextFile(
+    join(repoDir, "vaults", "aws.yaml"),
+    "type: aws-secrets\n",
+  );
+
+  const lockfilePath = join(
+    repoDir,
+    "extensions",
+    "models",
+    "upstream_extensions.json",
+  );
+  await ensureDir(join(repoDir, "extensions", "models"));
+  await Deno.writeTextFile(
+    lockfilePath,
+    JSON.stringify({ "@scope/ext": { version: "1.0.0" } }),
+  );
+
+  const pulledExtensionsSource = join(repoDir, ".swamp", "pulled-extensions");
+  await ensureDir(join(pulledExtensionsSource, "@scope", "ext", "models"));
+  await Deno.writeTextFile(
+    join(pulledExtensionsSource, "@scope", "ext", "models", "foo.ts"),
+    "export default {};\n",
+  );
+
+  return { lockfilePath, pulledExtensionsSource };
+}
+
+Deno.test("migrateConfigToDatastore: copies all sources into configRoot", async () => {
+  await withTempDir(async (dir) => {
+    const repoDir = join(dir, "repo");
+    await ensureDir(repoDir);
+    const configRoot = join(dir, "config");
+    const { lockfilePath, pulledExtensionsSource } =
+      await setupRepoWithAllSources(repoDir);
+
+    const result = await migrateConfigToDatastore(
+      repoDir,
+      lockfilePath,
+      configRoot,
+      pulledExtensionsSource,
+    );
+
+    assertEquals(result.copiedModels, true);
+    assertEquals(result.copiedWorkflows, true);
+    assertEquals(result.copiedVaults, true);
+    assertEquals(result.copiedLockfile, true);
+    assertEquals(result.copiedPulledExtensions, true);
+    assertEquals(result.alreadyMigrated, false);
+
+    const modelContent = await Deno.readTextFile(
+      join(configRoot, "models", "my-model.yaml"),
+    );
+    assertEquals(modelContent, "type: my-model\n");
+
+    const workflowContent = await Deno.readTextFile(
+      join(configRoot, "workflows", "daily.yaml"),
+    );
+    assertEquals(workflowContent, "name: daily\n");
+
+    const vaultContent = await Deno.readTextFile(
+      join(configRoot, "vaults", "aws.yaml"),
+    );
+    assertEquals(vaultContent, "type: aws-secrets\n");
+
+    const lockfileContent = await Deno.readTextFile(
+      join(configRoot, "upstream_extensions.json"),
+    );
+    assertStringIncludes(lockfileContent, "@scope/ext");
+
+    const extensionSource = await Deno.readTextFile(
+      join(
+        configRoot,
+        "pulled-extensions",
+        "@scope",
+        "ext",
+        "models",
+        "foo.ts",
+      ),
+    );
+    assertEquals(extensionSource, "export default {};\n");
+  });
+});
+
+Deno.test("migrateConfigToDatastore: sentinel prevents re-migration", async () => {
+  await withTempDir(async (dir) => {
+    const repoDir = join(dir, "repo");
+    await ensureDir(repoDir);
+    const configRoot = join(dir, "config");
+    await ensureDir(configRoot);
+
+    await Deno.writeTextFile(
+      join(configRoot, "managed-config-migrated.json"),
+      JSON.stringify({ migratedAt: "2026-01-01T00:00:00.000Z" }),
+    );
+
+    await ensureDir(join(repoDir, "models"));
+    await Deno.writeTextFile(
+      join(repoDir, "models", "should-not-copy.yaml"),
+      "nope\n",
+    );
+
+    const result = await migrateConfigToDatastore(
+      repoDir,
+      join(repoDir, "lockfile.json"),
+      configRoot,
+      join(repoDir, ".swamp", "pulled-extensions"),
+    );
+
+    assertEquals(result.alreadyMigrated, true);
+    assertEquals(result.copiedModels, false);
+    assertEquals(result.copiedWorkflows, false);
+    assertEquals(result.copiedVaults, false);
+    assertEquals(result.copiedLockfile, false);
+    assertEquals(result.copiedPulledExtensions, false);
+
+    // models dir should NOT have been created in configRoot
+    try {
+      await Deno.stat(join(configRoot, "models", "should-not-copy.yaml"));
+      throw new Error("Expected NotFound");
+    } catch (e) {
+      assertEquals(e instanceof Deno.errors.NotFound, true);
+    }
+  });
+});
+
+Deno.test("migrateConfigToDatastore: skips missing source directories gracefully", async () => {
+  await withTempDir(async (dir) => {
+    const repoDir = join(dir, "repo");
+    await ensureDir(repoDir);
+    const configRoot = join(dir, "config");
+
+    // No models/, workflows/, vaults/, lockfile, or pulled-extensions exist
+    const result = await migrateConfigToDatastore(
+      repoDir,
+      join(repoDir, "nonexistent", "upstream_extensions.json"),
+      configRoot,
+      join(repoDir, ".swamp", "pulled-extensions"),
+    );
+
+    assertEquals(result.copiedModels, false);
+    assertEquals(result.copiedWorkflows, false);
+    assertEquals(result.copiedVaults, false);
+    assertEquals(result.copiedLockfile, false);
+    assertEquals(result.copiedPulledExtensions, false);
+    assertEquals(result.alreadyMigrated, false);
+  });
+});
+
+Deno.test("migrateConfigToDatastore: copies only existing sources", async () => {
+  await withTempDir(async (dir) => {
+    const repoDir = join(dir, "repo");
+    await ensureDir(repoDir);
+    const configRoot = join(dir, "config");
+
+    // Only models/ exists
+    await ensureDir(join(repoDir, "models"));
+    await Deno.writeTextFile(
+      join(repoDir, "models", "partial.yaml"),
+      "partial\n",
+    );
+
+    const result = await migrateConfigToDatastore(
+      repoDir,
+      join(repoDir, "nonexistent", "upstream_extensions.json"),
+      configRoot,
+      join(repoDir, ".swamp", "pulled-extensions"),
+    );
+
+    assertEquals(result.copiedModels, true);
+    assertEquals(result.copiedWorkflows, false);
+    assertEquals(result.copiedVaults, false);
+    assertEquals(result.copiedLockfile, false);
+    assertEquals(result.copiedPulledExtensions, false);
+
+    const content = await Deno.readTextFile(
+      join(configRoot, "models", "partial.yaml"),
+    );
+    assertEquals(content, "partial\n");
+  });
+});
+
+Deno.test("migrateConfigToDatastore: writes sentinel file after migration", async () => {
+  await withTempDir(async (dir) => {
+    const repoDir = join(dir, "repo");
+    await ensureDir(repoDir);
+    const configRoot = join(dir, "config");
+
+    await migrateConfigToDatastore(
+      repoDir,
+      join(repoDir, "nonexistent.json"),
+      configRoot,
+      join(repoDir, ".swamp", "pulled-extensions"),
+    );
+
+    const stat = await Deno.stat(
+      join(configRoot, "managed-config-migrated.json"),
+    );
+    assertEquals(stat.isFile, true);
+  });
+});
+
+Deno.test("migrateConfigToDatastore: sentinel contains migratedAt and sources", async () => {
+  await withTempDir(async (dir) => {
+    const repoDir = join(dir, "repo");
+    await ensureDir(repoDir);
+    const configRoot = join(dir, "config");
+    const lockfilePath = join(
+      repoDir,
+      "extensions",
+      "upstream_extensions.json",
+    );
+    const pulledSource = join(repoDir, ".swamp", "pulled-extensions");
+
+    await migrateConfigToDatastore(
+      repoDir,
+      lockfilePath,
+      configRoot,
+      pulledSource,
+    );
+
+    const sentinel = JSON.parse(
+      await Deno.readTextFile(
+        join(configRoot, "managed-config-migrated.json"),
+      ),
+    );
+
+    assertEquals(typeof sentinel.migratedAt, "string");
+    assertEquals(Array.isArray(sentinel.sources), true);
+    assertEquals(sentinel.sources.length, 5);
+    assertStringIncludes(sentinel.sources[0], "models");
+    assertStringIncludes(sentinel.sources[1], "workflows");
+    assertStringIncludes(sentinel.sources[2], "vaults");
+  });
+});
+
+Deno.test("migrateConfigToDatastore: idempotent — second run returns alreadyMigrated", async () => {
+  await withTempDir(async (dir) => {
+    const repoDir = join(dir, "repo");
+    await ensureDir(repoDir);
+    const configRoot = join(dir, "config");
+
+    await ensureDir(join(repoDir, "models"));
+    await Deno.writeTextFile(
+      join(repoDir, "models", "test.yaml"),
+      "content\n",
+    );
+
+    const first = await migrateConfigToDatastore(
+      repoDir,
+      join(repoDir, "nonexistent.json"),
+      configRoot,
+      join(repoDir, ".swamp", "pulled-extensions"),
+    );
+    assertEquals(first.alreadyMigrated, false);
+    assertEquals(first.copiedModels, true);
+
+    const second = await migrateConfigToDatastore(
+      repoDir,
+      join(repoDir, "nonexistent.json"),
+      configRoot,
+      join(repoDir, ".swamp", "pulled-extensions"),
+    );
+    assertEquals(second.alreadyMigrated, true);
+    assertEquals(second.copiedModels, false);
+  });
+});
+
+Deno.test("migrateConfigToDatastore: lockfile copied as file not directory", async () => {
+  await withTempDir(async (dir) => {
+    const repoDir = join(dir, "repo");
+    await ensureDir(repoDir);
+    const configRoot = join(dir, "config");
+
+    const lockfilePath = join(
+      repoDir,
+      "extensions",
+      "models",
+      "upstream_extensions.json",
+    );
+    await ensureDir(join(repoDir, "extensions", "models"));
+    await Deno.writeTextFile(lockfilePath, '{"test": true}');
+
+    const result = await migrateConfigToDatastore(
+      repoDir,
+      lockfilePath,
+      configRoot,
+      join(repoDir, ".swamp", "pulled-extensions"),
+    );
+
+    assertEquals(result.copiedLockfile, true);
+
+    const stat = await Deno.stat(
+      join(configRoot, "upstream_extensions.json"),
+    );
+    assertEquals(stat.isFile, true);
+
+    const content = await Deno.readTextFile(
+      join(configRoot, "upstream_extensions.json"),
+    );
+    assertEquals(content, '{"test": true}');
+  });
+});
+
+Deno.test("getMigrationSentinelPath: returns correct path within configRoot", () => {
+  const result = getMigrationSentinelPath("/repo/.swamp/config");
+  assertEquals(
+    result,
+    join("/repo/.swamp/config", "managed-config-migrated.json"),
+  );
+});
+
+Deno.test("migrateConfigToDatastore: creates configRoot directory if it does not exist", async () => {
+  await withTempDir(async (dir) => {
+    const repoDir = join(dir, "repo");
+    await ensureDir(repoDir);
+    const configRoot = join(dir, "deeply", "nested", "config");
+
+    await migrateConfigToDatastore(
+      repoDir,
+      join(repoDir, "nonexistent.json"),
+      configRoot,
+      join(repoDir, ".swamp", "pulled-extensions"),
+    );
+
+    const stat = await Deno.stat(configRoot);
+    assertEquals(stat.isDirectory, true);
+  });
+});

--- a/src/domain/extensions/extension_file_resolver.ts
+++ b/src/domain/extensions/extension_file_resolver.ts
@@ -30,7 +30,7 @@ import { isSafeRelativePath } from "./extension_manifest.ts";
 // Anchored to a path boundary (start-of-string OR forward slash) so the
 // match works regardless of whether `root` begins with a separator. The
 // caller normalizes backslashes to forward slashes before testing.
-const PULLED_MARKER = /(^|\/)\.swamp\/pulled-extensions\//;
+const PULLED_MARKER = /(^|\/)\.swamp\/(config\/)?pulled-extensions\//;
 
 /**
  * Resolve a relative `additionalFiles` path against an extension's files

--- a/src/domain/extensions/extension_loader.ts
+++ b/src/domain/extensions/extension_loader.ts
@@ -92,19 +92,19 @@ export function extractExtensionNameFromPath(
   if (!repoDir) return undefined;
 
   const cheapRepoDir = resolve(repoDir);
-  const cheapPulledRoot = join(
-    cheapRepoDir,
-    SWAMP_DATA_DIR,
-    "pulled-extensions",
-  );
+  const pulledRoots = [
+    join(cheapRepoDir, SWAMP_DATA_DIR, "pulled-extensions"),
+    join(cheapRepoDir, SWAMP_DATA_DIR, "config", "pulled-extensions"),
+  ];
   const cheapResolved = resolve(absolutePath);
 
   let relative: string;
-  if (cheapResolved.startsWith(cheapPulledRoot + SEPARATOR)) {
-    relative = cheapResolved.slice(cheapPulledRoot.length + 1);
+  const matchedCheap = pulledRoots.find((r) =>
+    cheapResolved.startsWith(r + SEPARATOR)
+  );
+  if (matchedCheap) {
+    relative = cheapResolved.slice(matchedCheap.length + 1);
   } else {
-    // Symlink-aware fallback — only pay for realPathSync when the cheap
-    // check fails (e.g. /tmp -> /private/tmp on macOS).
     let realRepoDir: string;
     try {
       realRepoDir = Deno.realPathSync(repoDir);
@@ -112,19 +112,21 @@ export function extractExtensionNameFromPath(
       return undefined;
     }
     if (realRepoDir === cheapRepoDir) return undefined;
-    const realPulledRoot = join(
-      realRepoDir,
-      SWAMP_DATA_DIR,
-      "pulled-extensions",
-    );
+    const realPulledRoots = [
+      join(realRepoDir, SWAMP_DATA_DIR, "pulled-extensions"),
+      join(realRepoDir, SWAMP_DATA_DIR, "config", "pulled-extensions"),
+    ];
     let realResolved: string;
     try {
       realResolved = Deno.realPathSync(absolutePath);
     } catch {
       return undefined;
     }
-    if (!realResolved.startsWith(realPulledRoot + SEPARATOR)) return undefined;
-    relative = realResolved.slice(realPulledRoot.length + 1);
+    const matchedReal = realPulledRoots.find((r) =>
+      realResolved.startsWith(r + SEPARATOR)
+    );
+    if (!matchedReal) return undefined;
+    relative = realResolved.slice(matchedReal.length + 1);
   }
 
   const segments = relative.split(SEPARATOR);
@@ -1182,11 +1184,20 @@ export class ExtensionLoader {
         // No bundle on disk yet — first-run bootstrap.
       }
 
-      const isPulled = this.repoDir &&
-        resolve(boundaryDir).startsWith(
+      const resolvedBoundary = resolve(boundaryDir);
+      const isPulled = this.repoDir && (
+        resolvedBoundary.startsWith(
           join(resolve(this.repoDir), SWAMP_DATA_DIR, "pulled-extensions") +
             SEPARATOR,
-        );
+        ) || resolvedBoundary.startsWith(
+          join(
+            resolve(this.repoDir),
+            SWAMP_DATA_DIR,
+            "config",
+            "pulled-extensions",
+          ) + SEPARATOR,
+        )
+      );
       if (
         bundleExists && isPulled &&
         (options?.trustPulledCache ||

--- a/src/domain/extensions/model_kind_adapter.ts
+++ b/src/domain/extensions/model_kind_adapter.ts
@@ -346,10 +346,12 @@ function resolveExtensionFilesRoot(
     try {
       Deno.lstatSync(manifestPath);
       const normalized = currentDir.replace(/\\/g, "/");
-      const pulledMarker = `/${SWAMP_DATA_DIR}/pulled-extensions/`;
-      const result = normalized.includes(pulledMarker)
-        ? join(currentDir, "files")
-        : currentDir;
+      const isPulled = normalized.includes(
+        `/${SWAMP_DATA_DIR}/pulled-extensions/`,
+      ) || normalized.includes(
+        `/${SWAMP_DATA_DIR}/config/pulled-extensions/`,
+      );
+      const result = isPulled ? join(currentDir, "files") : currentDir;
       extensionFilesRootCache.set(currentDir, result);
       return result;
     } catch {

--- a/src/domain/models/model_invocation_service.ts
+++ b/src/domain/models/model_invocation_service.ts
@@ -49,6 +49,7 @@ export interface ModelInvocationServiceDeps {
   executionService: MethodExecutionService;
   commonDeps: CommonMethodContextDeps;
   repoDir: string;
+  pulledExtensionsRoot?: string;
 }
 
 function isRunModelByType(
@@ -497,7 +498,7 @@ export class ModelInvocationService {
     }
 
     try {
-      const pulledRoot = join(
+      const pulledRoot = this.#deps.pulledExtensionsRoot ?? join(
         this.#deps.repoDir,
         ".swamp",
         "pulled-extensions",

--- a/src/domain/repo/skill_dirs.ts
+++ b/src/domain/repo/skill_dirs.ts
@@ -56,9 +56,16 @@ export const GLOBAL_SKILL_DIRS: Record<string, string> = {
  * Resolves the absolute skill directory for a repo, based on the active AI tool.
  * Falls back to `.swamp/pulled-extensions/skills/` when tool is "none" or unknown.
  */
-export function resolveSkillsDir(repoDir: string, tool: string): string {
+export function resolveSkillsDir(
+  repoDir: string,
+  tool: string,
+  pulledExtensionsRoot?: string,
+): string {
   if (tool !== "none" && SKILL_DIRS[tool]) {
     return join(repoDir, SKILL_DIRS[tool]);
+  }
+  if (pulledExtensionsRoot) {
+    return join(pulledExtensionsRoot, "skills");
   }
   return swampPath(repoDir, SWAMP_SUBDIRS.pulledSkills);
 }

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -240,6 +240,7 @@ export interface StepExecutionContext {
   jobName: string;
   stepName: string;
   repoDir: string;
+  pulledExtensionsRoot?: string;
   /** Cancellation signal threaded from the libswamp entry point. */
   signal: AbortSignal;
   /** Expression context for evaluating ${{ }} expressions */
@@ -565,6 +566,7 @@ export class DefaultStepExecutor implements StepExecutor {
           createCelEnvironment: createExtensionCelEnvironment,
         },
         repoDir: ctx.repoDir,
+        pulledExtensionsRoot: ctx.pulledExtensionsRoot,
       });
     }
 
@@ -1546,6 +1548,7 @@ export class WorkflowExecutionService {
     private readonly runTracker?: RunTrackerRepository,
     private readonly ephemeralRepo?: UnifiedDataRepository,
     private readonly ephemeralCatalog?: CatalogStore,
+    private readonly pulledExtensionsRoot?: string,
   ) {
     this.executor = executor ??
       new DefaultStepExecutor(
@@ -3012,6 +3015,7 @@ export class WorkflowExecutionService {
           jobName: job.name,
           stepName,
           repoDir: this.repoDir,
+          pulledExtensionsRoot: this.pulledExtensionsRoot,
           signal: options.signal ?? new AbortController().signal,
           expressionContext: stepExprContext,
           workflowRun: run,
@@ -3340,6 +3344,7 @@ export class WorkflowExecutionService {
       this.runTracker,
       this.ephemeralRepo,
       this.ephemeralCatalog,
+      this.pulledExtensionsRoot,
     );
 
     let childRun: WorkflowRun | undefined;

--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -1309,15 +1309,21 @@ export class ExtensionCatalogStore {
    */
   resolveOriginConflicts(repoRoot: string): OriginConflict[] {
     const canonical = canonicalizePath(repoRoot);
-    const pulledPrefix = canonical.endsWith("/")
-      ? `${canonical}.swamp/pulled-extensions/`
-      : `${canonical}/.swamp/pulled-extensions/`;
+    const sep = canonical.endsWith("/") ? "" : "/";
+    const pulledPrefix = `${canonical}${sep}.swamp/pulled-extensions/`;
+    const managedPulledPrefix =
+      `${canonical}${sep}.swamp/config/pulled-extensions/`;
 
     const rows = this.findAll();
 
+    const isPulledPath = (p: string): boolean => {
+      const c = canonicalizePath(p);
+      return c.startsWith(pulledPrefix) || c.startsWith(managedPulledPrefix);
+    };
+
     let hasPulled = false;
     for (const row of rows) {
-      if (canonicalizePath(row.source_path).startsWith(pulledPrefix)) {
+      if (isPulledPath(row.source_path)) {
         hasPulled = true;
         break;
       }
@@ -1336,9 +1342,7 @@ export class ExtensionCatalogStore {
       if (row.kind === "extension") continue;
 
       const key = `${row.kind}::${row.type_normalized}`;
-      const isPulled = canonicalizePath(row.source_path).startsWith(
-        pulledPrefix,
-      );
+      const isPulled = isPulledPath(row.source_path);
       const prior = occupants.get(key);
 
       if (prior) {

--- a/src/infrastructure/persistence/extension_repository.ts
+++ b/src/infrastructure/persistence/extension_repository.ts
@@ -406,9 +406,10 @@ export class ExtensionRepository {
     };
     const groups = new Map<string, Group>();
 
-    const pulledPrefix = this.repoRoot.endsWith("/")
-      ? `${this.repoRoot}.swamp/pulled-extensions/`
-      : `${this.repoRoot}/.swamp/pulled-extensions/`;
+    const sep = this.repoRoot.endsWith("/") ? "" : "/";
+    const pulledPrefix = `${this.repoRoot}${sep}.swamp/pulled-extensions/`;
+    const managedPulledPrefix =
+      `${this.repoRoot}${sep}.swamp/config/pulled-extensions/`;
 
     for (const row of rows) {
       const identity = this.resolveIdentity(row, pruneOrphans);
@@ -417,7 +418,8 @@ export class ExtensionRepository {
       const origin = (
           this.localManifestIdentity &&
           identity.name === this.localManifestIdentity.name &&
-          !row.source_path.startsWith(pulledPrefix)
+          !row.source_path.startsWith(pulledPrefix) &&
+          !row.source_path.startsWith(managedPulledPrefix)
         )
         ? "local" as ExtensionOrigin
         : inferOrigin(identity.name);
@@ -645,10 +647,15 @@ function computeExtensionRoot(
   origin: ExtensionOrigin,
   extensionName: string,
   repoRoot: string,
+  pulledExtensionsRoot?: string,
 ): string {
   if (origin === "local") return repoRoot;
-  // Pulled: <repoRoot>/.swamp/pulled-extensions/<name>
-  // Use forward slashes so the result matches canonicalized paths.
+  if (pulledExtensionsRoot) {
+    const trimmed = pulledExtensionsRoot.endsWith("/")
+      ? pulledExtensionsRoot.slice(0, -1)
+      : pulledExtensionsRoot;
+    return `${trimmed}/${extensionName}`;
+  }
   const trimmedRoot = repoRoot.endsWith("/") ? repoRoot.slice(0, -1) : repoRoot;
   return `${trimmedRoot}/.swamp/pulled-extensions/${extensionName}`;
 }

--- a/src/infrastructure/persistence/paths.ts
+++ b/src/infrastructure/persistence/paths.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { isAbsolute, join, relative } from "@std/path";
+import { isAbsolute, join, relative, resolve } from "@std/path";
 
 /**
  * Central constants for swamp data storage paths.
@@ -115,6 +115,77 @@ export const SWAMP_SUBDIRS = {
  */
 export function swampPath(repoDir: string, ...segments: string[]): string {
   return join(repoDir, SWAMP_DATA_DIR, ...segments);
+}
+
+/**
+ * Module-level managed config state. Set once at CLI/serve startup after
+ * reading the marker file. Stores the resolved config base path from the
+ * datastore resolver — for custom datastores this is the cache path
+ * (.swamp/config/), for filesystem datastores this is the datastore path
+ * (<path>/config/). Repo constructors check this to resolve their
+ * default baseDir when managedConfig is active.
+ */
+const managedConfigRegistry = new Map<string, string | false>();
+
+export function registerManagedConfig(
+  repoDir: string,
+  active: boolean,
+  configBasePath?: string,
+): void {
+  if (active && configBasePath) {
+    managedConfigRegistry.set(resolve(repoDir), configBasePath);
+  } else {
+    managedConfigRegistry.set(resolve(repoDir), false);
+  }
+}
+
+export function isManagedConfig(repoDir: string): boolean {
+  return managedConfigRegistry.get(resolve(repoDir)) !== false &&
+    managedConfigRegistry.get(resolve(repoDir)) !== undefined;
+}
+
+export function getManagedConfigBase(repoDir: string): string | undefined {
+  const val = managedConfigRegistry.get(resolve(repoDir));
+  return typeof val === "string" ? val : undefined;
+}
+
+export function resolveEffectiveDefinitionsDir(repoDir: string): string {
+  const base = getManagedConfigBase(repoDir);
+  return base ? join(base, "models") : join(repoDir, "models");
+}
+
+export function resolveEffectiveWorkflowsDir(repoDir: string): string {
+  const base = getManagedConfigBase(repoDir);
+  return base ? join(base, "workflows") : join(repoDir, "workflows");
+}
+
+export function resolveEffectiveVaultsDir(repoDir: string): string {
+  const base = getManagedConfigBase(repoDir);
+  return base ? join(base, "vaults") : join(repoDir, "vaults");
+}
+
+/**
+ * Resolves the pulled-extensions root for a repository.
+ * When managedConfig is explicitly passed, uses that value.
+ * Otherwise checks the module-level registry.
+ */
+export function resolvePulledExtensionsRoot(
+  repoDir: string,
+  managedConfig?: boolean,
+): string {
+  const active = managedConfig ?? isManagedConfig(repoDir);
+  return active
+    ? swampPath(repoDir, "config", "pulled-extensions")
+    : swampPath(repoDir, "pulled-extensions");
+}
+
+/**
+ * Resolves the lockfile path for a repository when managedConfig is true.
+ * Returns the .swamp/config/upstream_extensions.json path.
+ * When managedConfig is false, callers should derive it from resolveModelsDir.
+ */
+export function managedConfigLockfilePath(repoDir: string): string {
+  return join(swampPath(repoDir, "config"), "upstream_extensions.json");
 }
 
 /**

--- a/src/infrastructure/persistence/paths_test.ts
+++ b/src/infrastructure/persistence/paths_test.ts
@@ -25,6 +25,8 @@ import {
   globalTelemetryDir,
   homeDirectory,
   homeDirectoryIsSet,
+  managedConfigLockfilePath,
+  resolvePulledExtensionsRoot,
   SWAMP_DATA_DIR,
   SWAMP_MARKER_FILE,
   SWAMP_SUBDIRS,
@@ -555,4 +557,27 @@ Deno.test("bundleNamespace: returns 8-char hex string", () => {
   const hash = bundleNamespace("/repo/extensions/models", "/repo");
   assertEquals(hash.length, 8);
   assertEquals(/^[0-9a-f]{8}$/.test(hash), true);
+});
+
+// --- resolvePulledExtensionsRoot / managedConfigLockfilePath ---
+
+Deno.test("resolvePulledExtensionsRoot: managedConfig=false returns .swamp/pulled-extensions", () => {
+  assertPathEquals(
+    resolvePulledExtensionsRoot("/repo", false),
+    "/repo/.swamp/pulled-extensions",
+  );
+});
+
+Deno.test("resolvePulledExtensionsRoot: managedConfig=true returns .swamp/config/pulled-extensions", () => {
+  assertPathEquals(
+    resolvePulledExtensionsRoot("/repo", true),
+    "/repo/.swamp/config/pulled-extensions",
+  );
+});
+
+Deno.test("managedConfigLockfilePath: returns .swamp/config/upstream_extensions.json", () => {
+  assertPathEquals(
+    managedConfigLockfilePath("/repo"),
+    "/repo/.swamp/config/upstream_extensions.json",
+  );
 });

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -32,7 +32,11 @@ import {
   type YAMLMap,
 } from "yaml";
 import { assertSafePath } from "./safe_path.ts";
-import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
+import {
+  resolveEffectiveDefinitionsDir,
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "./paths.ts";
 import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import {
@@ -79,7 +83,7 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     /** Pass `false` to disable secondary search. Omit to auto-compute from repoDir. */
     secondaryBaseDir?: string | false,
   ) {
-    this.baseDir = baseDir ?? join(repoDir, "models");
+    this.baseDir = baseDir ?? resolveEffectiveDefinitionsDir(repoDir);
     this.secondaryBaseDir = secondaryBaseDir === false
       ? undefined
       : (secondaryBaseDir ??

--- a/src/infrastructure/persistence/yaml_vault_config_repository.ts
+++ b/src/infrastructure/persistence/yaml_vault_config_repository.ts
@@ -19,6 +19,7 @@
 
 import { ensureDir, walk } from "@std/fs";
 import { join, resolve, SEPARATOR } from "@std/path";
+import { resolveEffectiveVaultsDir } from "./paths.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { atomicWriteTextFile } from "./atomic_write.ts";
 import { assertSafePath } from "./safe_path.ts";
@@ -51,7 +52,7 @@ export class YamlVaultConfigRepository {
     baseDir?: string,
   ) {
     this.eventBus = eventBus ?? null;
-    this.baseDir = baseDir ?? join(repoDir, "vaults");
+    this.baseDir = baseDir ?? resolveEffectiveVaultsDir(repoDir);
   }
 
   /**

--- a/src/infrastructure/persistence/yaml_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository.ts
@@ -19,6 +19,7 @@
 
 import { ensureDir } from "@std/fs";
 import { basename, join } from "@std/path";
+import { resolveEffectiveWorkflowsDir } from "./paths.ts";
 import { getLogger } from "@logtape/logtape";
 import { atomicWriteTextFile } from "./atomic_write.ts";
 import { isIoError } from "./io_errors.ts";
@@ -62,7 +63,7 @@ export class YamlWorkflowRepository implements WorkflowRepository {
     private readonly eventBus?: EventBus,
     baseDir?: string,
   ) {
-    this.baseDir = baseDir ?? join(repoDir, "workflows");
+    this.baseDir = baseDir ?? resolveEffectiveWorkflowsDir(repoDir);
   }
 
   async findById(id: WorkflowId): Promise<Workflow | null> {

--- a/src/libswamp/extensions/enumerate_pulled.ts
+++ b/src/libswamp/extensions/enumerate_pulled.ts
@@ -19,7 +19,7 @@
 
 import { join } from "@std/path";
 import { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
-import { swampPath } from "../../infrastructure/persistence/paths.ts";
+import { resolvePulledExtensionsRoot } from "../../infrastructure/persistence/paths.ts";
 
 /** Types that can appear under a per-extension subtree. */
 export type PulledExtensionType =
@@ -50,10 +50,12 @@ export async function enumeratePulledExtensionDirs(
   lockfilePath: string,
   repoDir: string,
   type: PulledExtensionType,
+  pulledExtensionsRoot?: string,
 ): Promise<string[]> {
   const repo = await LockfileRepository.create(lockfilePath);
   const upstream = repo.getAllEntries();
-  const pulledRoot = swampPath(repoDir, "pulled-extensions");
+  const pulledRoot = pulledExtensionsRoot ??
+    resolvePulledExtensionsRoot(repoDir);
   const dirs: string[] = [];
 
   for (const name of Object.keys(upstream)) {

--- a/src/libswamp/extensions/install.ts
+++ b/src/libswamp/extensions/install.ts
@@ -17,7 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join, resolve } from "@std/path";
+import { join } from "@std/path";
+import { resolvePulledExtensionsRoot } from "../../infrastructure/persistence/paths.ts";
 import { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
 import { cleanupEmptyParentDirs } from "../../infrastructure/persistence/directory_cleanup.ts";
 import { readInstalledExtensionDigest } from "../../infrastructure/persistence/installed_extension_digest_reader.ts";
@@ -122,6 +123,12 @@ export interface ExtensionInstallDeps {
    * registry to exercise the success path.
    */
   installExtensionFn?: InstallExtensionFn;
+  /**
+   * Root directory for pulled extension sources. Defaults to
+   * `.swamp/pulled-extensions` when not provided. With managedConfig,
+   * callers pass `.swamp/config/pulled-extensions`.
+   */
+  pulledExtensionsRoot?: string;
 }
 
 /**
@@ -179,12 +186,9 @@ export async function* extensionInstall(
         // on-disk files weren't re-fetched (swamp-club#1021).
         if (needs === "up_to_date" && entry.filesChecksum) {
           try {
-            const extRoot = join(
-              resolve(deps.repoDir),
-              ".swamp",
-              "pulled-extensions",
-              name,
-            );
+            const effectivePulledRoot = deps.pulledExtensionsRoot ??
+              resolvePulledExtensionsRoot(deps.repoDir);
+            const extRoot = join(effectivePulledRoot, name);
             const onDisk = await readInstalledExtensionDigest(extRoot);
             if (onDisk !== entry.filesChecksum) {
               needs = "install";

--- a/src/libswamp/extensions/install_extension_service.ts
+++ b/src/libswamp/extensions/install_extension_service.ts
@@ -36,7 +36,7 @@ import type { ExtensionRepository } from "../../infrastructure/persistence/exten
 import { DuplicateTypeError } from "../../infrastructure/persistence/duplicate_type_error.ts";
 import { DuplicateTypeUserError } from "../../domain/extensions/duplicate_type_user_error.ts";
 import { UserError } from "../../domain/errors.ts";
-import { swampPath } from "../../infrastructure/persistence/paths.ts";
+import { resolvePulledExtensionsRoot } from "../../infrastructure/persistence/paths.ts";
 import { ExtensionLoader } from "../../domain/extensions/extension_loader.ts";
 import { modelKindAdapter } from "../../domain/extensions/model_kind_adapter.ts";
 import { vaultKindAdapter } from "../../domain/extensions/vault_kind_adapter.ts";
@@ -223,20 +223,12 @@ export class InstallExtensionService {
   private async buildExtensionFromDisk(
     result: InstallResult,
     repoDir: string,
+    pulledExtensionsRoot?: string,
   ): Promise<Extension> {
-    // Resolve to an absolute path so the source_path written to the
-    // catalog matches the absolute paths the legacy user_*_loader
-    // bootstrap path uses (`populateCatalogFromDir`). Without this, a
-    // relative `repoDir` (e.g. `.`) would have phase 8 writing relative
-    // source_paths while the loader writes absolute ones, leaving
-    // duplicate rows in the catalog and the legacy upsert's empty-
-    // identity rows would shadow phase 8's properly-identified rows on
-    // the next `loadByName` call.
     const absoluteRepoDir = resolvePath(repoDir);
-    const extRoot = join(
-      swampPath(absoluteRepoDir, "pulled-extensions"),
-      result.name,
-    );
+    const effectivePulledRoot = pulledExtensionsRoot ??
+      resolvePulledExtensionsRoot(absoluteRepoDir);
+    const extRoot = join(effectivePulledRoot, result.name);
     const sources: ReturnType<typeof makeSource>[] = [];
 
     for (const kindDir of KIND_DIRS) {

--- a/src/libswamp/extensions/layout.ts
+++ b/src/libswamp/extensions/layout.ts
@@ -82,6 +82,7 @@ export const PER_EXTENSION_SCAFFOLD_DIRS: readonly string[] = [
 ];
 
 const PULLED_PREFIX = `${SWAMP_DATA_DIR}/pulled-extensions/`;
+const MANAGED_PULLED_PREFIX = `${SWAMP_DATA_DIR}/config/pulled-extensions/`;
 const GEN1_PREFIX = "extensions/";
 
 /**
@@ -116,10 +117,15 @@ export function classifyExtensionFile(file: string): ExtensionLayoutGeneration {
       return "gen-1";
     }
   }
-  if (!file.startsWith(PULLED_PREFIX)) {
+  const activePulledPrefix = file.startsWith(MANAGED_PULLED_PREFIX)
+    ? MANAGED_PULLED_PREFIX
+    : file.startsWith(PULLED_PREFIX)
+    ? PULLED_PREFIX
+    : undefined;
+  if (!activePulledPrefix) {
     return "current";
   }
-  const firstSegment = file.slice(PULLED_PREFIX.length).split("/")[0];
+  const firstSegment = file.slice(activePulledPrefix.length).split("/")[0];
   if (PULLED_TYPE_DIRS.has(firstSegment)) {
     return "gen-2";
   }
@@ -222,15 +228,18 @@ export function extractTopLevelRoot(
   }
 
   // Per-extension subtree: pulled-extensions/<extensionName>/...
-  // (current-layout always begins with .swamp/pulled-extensions/).
-  if (filePath.startsWith(PULLED_PREFIX)) {
+  // (current-layout or managed-config layout).
+  const pfx = filePath.startsWith(MANAGED_PULLED_PREFIX)
+    ? MANAGED_PULLED_PREFIX
+    : filePath.startsWith(PULLED_PREFIX)
+    ? PULLED_PREFIX
+    : undefined;
+  if (pfx) {
     const nameSegments = extensionName.split("/");
-    const rest = filePath.slice(PULLED_PREFIX.length);
+    const rest = filePath.slice(pfx.length);
     const segments = rest.split("/");
     if (segments.length < nameSegments.length) return null;
-    return `${PULLED_PREFIX}${
-      segments.slice(0, nameSegments.length).join("/")
-    }`;
+    return `${pfx}${segments.slice(0, nameSegments.length).join("/")}`;
   }
 
   // Bundle namespaces: <kind>/<hash>/...
@@ -273,14 +282,17 @@ export function extractTopLevelRootMulti(
       return null;
     }
   }
-  if (filePath.startsWith(PULLED_PREFIX)) {
+  const pfx2 = filePath.startsWith(MANAGED_PULLED_PREFIX)
+    ? MANAGED_PULLED_PREFIX
+    : filePath.startsWith(PULLED_PREFIX)
+    ? PULLED_PREFIX
+    : undefined;
+  if (pfx2) {
     const nameSegments = extensionName.split("/");
-    const rest = filePath.slice(PULLED_PREFIX.length);
+    const rest = filePath.slice(pfx2.length);
     const segments = rest.split("/");
     if (segments.length < nameSegments.length) return null;
-    return `${PULLED_PREFIX}${
-      segments.slice(0, nameSegments.length).join("/")
-    }`;
+    return `${pfx2}${segments.slice(0, nameSegments.length).join("/")}`;
   }
   const BUNDLE_KINDS = [
     "bundles",

--- a/src/libswamp/extensions/layout_test.ts
+++ b/src/libswamp/extensions/layout_test.ts
@@ -668,3 +668,52 @@ Deno.test(
     );
   },
 );
+
+// ============================================================================
+// Managed Config Path Detection (managedConfig: true)
+// ============================================================================
+
+Deno.test("classifyExtensionFile: managed config flat under .swamp/config is gen-2", () => {
+  assertEquals(
+    classifyExtensionFile(".swamp/config/pulled-extensions/models/foo.ts"),
+    "gen-2",
+  );
+  assertEquals(
+    classifyExtensionFile(
+      ".swamp/config/pulled-extensions/workflows/foo.yaml",
+    ),
+    "gen-2",
+  );
+  assertEquals(
+    classifyExtensionFile(
+      ".swamp/config/pulled-extensions/vaults/sub/bar.ts",
+    ),
+    "gen-2",
+  );
+});
+
+Deno.test("classifyExtensionFile: managed config per-extension subtree is current", () => {
+  assertEquals(
+    classifyExtensionFile(
+      ".swamp/config/pulled-extensions/@scope/name/models/foo.ts",
+    ),
+    "current",
+  );
+  assertEquals(
+    classifyExtensionFile(
+      ".swamp/config/pulled-extensions/flat-name/models/foo.ts",
+    ),
+    "current",
+  );
+});
+
+Deno.test("classifyExtensionFile: managed config paths outside pulled-extensions are current", () => {
+  assertEquals(
+    classifyExtensionFile(".swamp/config/models/foo.yaml"),
+    "current",
+  );
+  assertEquals(
+    classifyExtensionFile(".swamp/config/workflows/bar.yaml"),
+    "current",
+  );
+});

--- a/src/libswamp/extensions/local_edits.ts
+++ b/src/libswamp/extensions/local_edits.ts
@@ -17,7 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join, resolve } from "@std/path";
+import { join } from "@std/path";
+import { resolvePulledExtensionsRoot } from "../../infrastructure/persistence/paths.ts";
 import { UserError } from "../../domain/errors.ts";
 import { readInstalledExtensionDigest } from "../../infrastructure/persistence/installed_extension_digest_reader.ts";
 import { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
@@ -45,17 +46,15 @@ export async function detectLocalEditsForExtension(
   repoDir: string,
   name: string,
   lockfilePath: string,
+  pulledExtensionsRoot?: string,
 ): Promise<LocalEditsStatus> {
   try {
     const repo = await LockfileRepository.create(lockfilePath);
     const stored = repo.getEntry(name)?.filesChecksum;
     if (!stored) return "no-anchor";
-    const extRoot = join(
-      resolve(repoDir),
-      ".swamp",
-      "pulled-extensions",
-      name,
-    );
+    const effectivePulledRoot = pulledExtensionsRoot ??
+      resolvePulledExtensionsRoot(repoDir);
+    const extRoot = join(effectivePulledRoot, name);
     const onDisk = await readInstalledExtensionDigest(extRoot);
     if (onDisk === null) return "no-anchor";
     return onDisk === stored ? "match" : "mismatch";

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -37,6 +37,7 @@ import type { DenoRuntime } from "../../domain/runtime/deno_runtime.ts";
 import { InstallExtensionService } from "./install_extension_service.ts";
 import {
   bundleNamespace,
+  resolvePulledExtensionsRoot,
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
 import { computeChecksum } from "../../domain/models/checksum.ts";
@@ -197,6 +198,12 @@ export interface InstallContext {
   expectedChecksum?: string;
   /** Release channel to record in the lockfile entry. */
   channel?: string;
+  /**
+   * Root directory for pulled extension sources. Defaults to
+   * `.swamp/pulled-extensions` when not provided. With managedConfig,
+   * callers pass `.swamp/config/pulled-extensions`.
+   */
+  pulledExtensionsRoot?: string;
 }
 
 /** Thrown when file conflicts are detected and force is false. */
@@ -890,7 +897,7 @@ export async function installExtension(
     // @swamp/aws/ec2 and @swamp/aws/eks, or README.md across unrelated
     // extensions). Skills fan out to ctx.skillsDirs — one per enrolled tool.
     const absoluteExtRoot = join(
-      swampPath(repoDir, "pulled-extensions"),
+      ctx.pulledExtensionsRoot ?? resolvePulledExtensionsRoot(repoDir),
       ref.name,
     );
     const absoluteModelsDir = join(absoluteExtRoot, "models");

--- a/src/libswamp/extensions/reconcile_from_disk_service.ts
+++ b/src/libswamp/extensions/reconcile_from_disk_service.ts
@@ -57,7 +57,7 @@ import type {
 } from "../../infrastructure/persistence/extension_catalog_store.ts";
 import { BUNDLE_LAYOUT_VERSION } from "../../infrastructure/persistence/extension_catalog_store.ts";
 import type { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
-import { swampPath } from "../../infrastructure/persistence/paths.ts";
+import { resolvePulledExtensionsRoot } from "../../infrastructure/persistence/paths.ts";
 import { ExtensionLoader } from "../../domain/extensions/extension_loader.ts";
 import { modelKindAdapter } from "../../domain/extensions/model_kind_adapter.ts";
 import { vaultKindAdapter } from "../../domain/extensions/vault_kind_adapter.ts";
@@ -136,6 +136,7 @@ export class ReconcileFromDiskService {
   private readonly lockfileRepository: LockfileRepository;
   private readonly repoDir: string;
   private readonly localManifestIdentity: LocalManifestIdentity | null;
+  private readonly pulledExtensionsRoot: string;
 
   constructor(args: {
     denoRuntime: DenoRuntime;
@@ -143,12 +144,15 @@ export class ReconcileFromDiskService {
     lockfileRepository: LockfileRepository;
     repoDir: string;
     localManifestIdentity?: LocalManifestIdentity | null;
+    pulledExtensionsRoot?: string;
   }) {
     this.denoRuntime = args.denoRuntime;
     this.repository = args.repository;
     this.lockfileRepository = args.lockfileRepository;
     this.repoDir = resolve(args.repoDir);
     this.localManifestIdentity = args.localManifestIdentity ?? null;
+    this.pulledExtensionsRoot = args.pulledExtensionsRoot ??
+      resolvePulledExtensionsRoot(this.repoDir);
   }
 
   async execute(
@@ -456,7 +460,7 @@ export class ReconcileFromDiskService {
     transitions: ReconcileTransition[],
     cache: FreshnessCache,
   ): Promise<Extension[]> {
-    const pulledRoot = swampPath(this.repoDir, "pulled-extensions");
+    const pulledRoot = this.pulledExtensionsRoot;
     const result: Extension[] = [];
     const lockfileEntries = this.lockfileRepository.getAllEntries();
 

--- a/src/libswamp/extensions/remove_extension_service.ts
+++ b/src/libswamp/extensions/remove_extension_service.ts
@@ -24,6 +24,7 @@ import type { ExtensionRepository } from "../../infrastructure/persistence/exten
 import type { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
 import {
   bundleNamespace,
+  resolvePulledExtensionsRoot,
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
 import { UserError } from "../../domain/errors.ts";
@@ -71,15 +72,19 @@ export class RemoveExtensionService {
   private readonly repository: ExtensionRepository;
   private readonly lockfileRepository: LockfileRepository;
   private readonly repoDir: string;
+  private readonly pulledExtensionsRoot: string;
 
   constructor(args: {
     repository: ExtensionRepository;
     lockfileRepository: LockfileRepository;
     repoDir: string;
+    pulledExtensionsRoot?: string;
   }) {
     this.repository = args.repository;
     this.lockfileRepository = args.lockfileRepository;
     this.repoDir = args.repoDir;
+    this.pulledExtensionsRoot = args.pulledExtensionsRoot ??
+      resolvePulledExtensionsRoot(this.repoDir);
   }
 
   /**
@@ -164,7 +169,7 @@ export class RemoveExtensionService {
     //    `Deno.readDir` absorbs the resulting `NotFound` safely, so
     //    the push is unconditional.
     const extensionRoot = join(
-      swampPath(this.repoDir, "pulled-extensions"),
+      this.pulledExtensionsRoot,
       name,
     );
     for (const scaffoldDir of PER_EXTENSION_SCAFFOLD_DIRS) {

--- a/src/libswamp/models/create.ts
+++ b/src/libswamp/models/create.ts
@@ -89,9 +89,14 @@ export interface ModelCreateDeps {
 /** Wires real infrastructure into ModelCreateDeps. */
 export async function createModelCreateDeps(
   repoDir: string,
+  definitionsDir?: string,
 ): Promise<ModelCreateDeps> {
   await modelRegistry.ensureLoaded();
-  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const definitionRepo = new YamlDefinitionRepository(
+    repoDir,
+    undefined,
+    definitionsDir,
+  );
   return {
     resolveModelType: (typeArg) => {
       const modelType = ModelType.create(typeArg);

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -57,6 +57,7 @@ import {
   type CommonMethodContextDeps,
 } from "../../domain/models/method_context.ts";
 import { createExtensionCelEnvironment } from "../../infrastructure/cel/cel_evaluator.ts";
+import { resolvePulledExtensionsRoot } from "../../infrastructure/persistence/paths.ts";
 import type {
   DataArtifactView,
   ModelMethodRunView,
@@ -699,6 +700,9 @@ export async function* modelMethodRun(
                 executionService,
                 commonDeps,
                 repoDir: deps.repoDir,
+                pulledExtensionsRoot: resolvePulledExtensionsRoot(
+                  deps.repoDir,
+                ),
               });
           }
 

--- a/src/serve/config_poller.ts
+++ b/src/serve/config_poller.ts
@@ -1,0 +1,101 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getLogger } from "@logtape/logtape";
+import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
+
+const logger = getLogger(["swamp", "serve", "config-poller"]);
+
+const DEFAULT_CONFIG_POLL_INTERVAL_MS = 30_000;
+
+export interface ConfigPollerOptions {
+  syncService: DatastoreSyncService;
+  catalogInvalidate: () => void;
+  extensionCatalogInvalidate: () => void;
+  pollIntervalMs?: number;
+  namespace?: string;
+}
+
+export class ConfigPoller {
+  readonly #syncService: DatastoreSyncService;
+  readonly #catalogInvalidate: () => void;
+  readonly #extensionCatalogInvalidate: () => void;
+  readonly #pollIntervalMs: number;
+  readonly #namespace?: string;
+  #timer: ReturnType<typeof setInterval> | null = null;
+  #pendingPull: Promise<void> = Promise.resolve();
+  #pulling = false;
+
+  constructor(options: ConfigPollerOptions) {
+    this.#syncService = options.syncService;
+    this.#catalogInvalidate = options.catalogInvalidate;
+    this.#extensionCatalogInvalidate = options.extensionCatalogInvalidate;
+    this.#pollIntervalMs = options.pollIntervalMs ??
+      DEFAULT_CONFIG_POLL_INTERVAL_MS;
+    this.#namespace = options.namespace;
+  }
+
+  start(): void {
+    if (this.#timer) return;
+    this.#timer = setInterval(() => {
+      this.#poll();
+    }, this.#pollIntervalMs);
+    Deno.unrefTimer(this.#timer);
+    const intervalSec = this.#pollIntervalMs / 1000;
+    logger.info`Config poller started (interval: ${intervalSec}s)`;
+  }
+
+  async stop(): Promise<void> {
+    if (this.#timer) {
+      clearInterval(this.#timer);
+      this.#timer = null;
+    }
+    await this.#pendingPull;
+  }
+
+  #poll(): void {
+    if (this.#pulling) return;
+
+    this.#pendingPull = this.#pendingPull.then(() => this.#pullAndInvalidate());
+  }
+
+  async #pullAndInvalidate(): Promise<void> {
+    this.#pulling = true;
+    try {
+      const result = await this.#syncService.pullChanged({
+        subdirs: ["config"],
+        namespace: this.#namespace,
+      });
+      const count = typeof result === "number" ? result : 0;
+      if (count > 0) {
+        logger
+          .info`Config poller: ${count} file(s) updated, invalidating catalogs`;
+        this.#catalogInvalidate();
+        this.#extensionCatalogInvalidate();
+      }
+    } catch (error) {
+      logger
+        .warn`Config poller pull failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`;
+    } finally {
+      this.#pulling = false;
+    }
+  }
+}

--- a/src/serve/config_poller_test.ts
+++ b/src/serve/config_poller_test.ts
@@ -1,0 +1,383 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertGreater } from "@std/assert";
+import { ConfigPoller } from "./config_poller.ts";
+import type {
+  DatastoreSyncOptions,
+  DatastoreSyncService,
+} from "../domain/datastore/datastore_sync_service.ts";
+import { waitFor } from "@swamp-club/swamp-testing";
+
+interface MockSyncService extends DatastoreSyncService {
+  pullCalls: DatastoreSyncOptions[];
+  pullResult: number | void;
+  pullDelay: number;
+  pullError: Error | null;
+}
+
+function createMockSyncService(
+  overrides: Partial<
+    Pick<MockSyncService, "pullResult" | "pullDelay" | "pullError">
+  > = {},
+): MockSyncService {
+  const mock: MockSyncService = {
+    pullCalls: [],
+    pullResult: overrides.pullResult ?? 0,
+    pullDelay: overrides.pullDelay ?? 0,
+    pullError: overrides.pullError ?? null,
+    async pullChanged(options?: DatastoreSyncOptions): Promise<number | void> {
+      mock.pullCalls.push(options ?? {});
+      if (mock.pullDelay > 0) {
+        await new Promise<void>((r) => setTimeout(r, mock.pullDelay));
+      }
+      if (mock.pullError) {
+        throw mock.pullError;
+      }
+      return mock.pullResult;
+    },
+    pushChanged(): Promise<number | void> {
+      return Promise.resolve(0);
+    },
+    async markDirty(): Promise<void> {},
+  };
+  return mock;
+}
+
+function createCallbackTrackers() {
+  const state = {
+    catalogInvalidateCalls: 0,
+    extensionCatalogInvalidateCalls: 0,
+  };
+  return {
+    state,
+    catalogInvalidate: () => {
+      state.catalogInvalidateCalls++;
+    },
+    extensionCatalogInvalidate: () => {
+      state.extensionCatalogInvalidateCalls++;
+    },
+  };
+}
+
+Deno.test("ConfigPoller: start and stop lifecycle completes cleanly", async () => {
+  const sync = createMockSyncService();
+  const { catalogInvalidate, extensionCatalogInvalidate } =
+    createCallbackTrackers();
+
+  const poller = new ConfigPoller({
+    syncService: sync,
+    catalogInvalidate,
+    extensionCatalogInvalidate,
+    pollIntervalMs: 50,
+  });
+
+  poller.start();
+  await new Promise<void>((r) => setTimeout(r, 10));
+  await poller.stop();
+});
+
+Deno.test("ConfigPoller: pullChanged is called with subdirs config", async () => {
+  const sync = createMockSyncService();
+  const { catalogInvalidate, extensionCatalogInvalidate } =
+    createCallbackTrackers();
+
+  const poller = new ConfigPoller({
+    syncService: sync,
+    catalogInvalidate,
+    extensionCatalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 1, "at least one pull");
+  await poller.stop();
+
+  const call = sync.pullCalls[0];
+  assertEquals(call.subdirs, ["config"]);
+});
+
+Deno.test("ConfigPoller: namespace is passed through to pullChanged", async () => {
+  const sync = createMockSyncService();
+  const { catalogInvalidate, extensionCatalogInvalidate } =
+    createCallbackTrackers();
+
+  const poller = new ConfigPoller({
+    syncService: sync,
+    catalogInvalidate,
+    extensionCatalogInvalidate,
+    pollIntervalMs: 30,
+    namespace: "test-namespace",
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 1, "at least one pull");
+  await poller.stop();
+
+  assertEquals(sync.pullCalls[0].namespace, "test-namespace");
+});
+
+Deno.test("ConfigPoller: invalidates both catalogs when pullChanged returns count > 0", async () => {
+  const sync = createMockSyncService({ pullResult: 3 });
+  const { state, catalogInvalidate, extensionCatalogInvalidate } =
+    createCallbackTrackers();
+
+  const poller = new ConfigPoller({
+    syncService: sync,
+    catalogInvalidate,
+    extensionCatalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(
+    () => state.catalogInvalidateCalls >= 1,
+    "catalog invalidation",
+  );
+  await poller.stop();
+
+  assertGreater(state.catalogInvalidateCalls, 0);
+  assertGreater(state.extensionCatalogInvalidateCalls, 0);
+  assertEquals(
+    state.catalogInvalidateCalls,
+    state.extensionCatalogInvalidateCalls,
+  );
+});
+
+Deno.test("ConfigPoller: does not invalidate catalogs when pullChanged returns 0", async () => {
+  const sync = createMockSyncService({ pullResult: 0 });
+  const { state, catalogInvalidate, extensionCatalogInvalidate } =
+    createCallbackTrackers();
+
+  const poller = new ConfigPoller({
+    syncService: sync,
+    catalogInvalidate,
+    extensionCatalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 2, "at least two pulls");
+  await poller.stop();
+
+  assertEquals(state.catalogInvalidateCalls, 0);
+  assertEquals(state.extensionCatalogInvalidateCalls, 0);
+});
+
+Deno.test("ConfigPoller: does not invalidate catalogs when pullChanged returns void", async () => {
+  const sync = createMockSyncService({ pullResult: undefined });
+  const { state, catalogInvalidate, extensionCatalogInvalidate } =
+    createCallbackTrackers();
+
+  const poller = new ConfigPoller({
+    syncService: sync,
+    catalogInvalidate,
+    extensionCatalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 2, "at least two pulls");
+  await poller.stop();
+
+  assertEquals(state.catalogInvalidateCalls, 0);
+  assertEquals(state.extensionCatalogInvalidateCalls, 0);
+});
+
+Deno.test("ConfigPoller: survives pullChanged throwing an error", async () => {
+  const sync = createMockSyncService({
+    pullError: new Error("network timeout"),
+  });
+  const { catalogInvalidate, extensionCatalogInvalidate } =
+    createCallbackTrackers();
+
+  const poller = new ConfigPoller({
+    syncService: sync,
+    catalogInvalidate,
+    extensionCatalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 2, "at least two pulls");
+  await poller.stop();
+
+  assertGreater(sync.pullCalls.length, 1);
+});
+
+Deno.test("ConfigPoller: serializes pulls — skips tick while pulling", async () => {
+  const sync = createMockSyncService({ pullDelay: 100 });
+  const { catalogInvalidate, extensionCatalogInvalidate } =
+    createCallbackTrackers();
+
+  const poller = new ConfigPoller({
+    syncService: sync,
+    catalogInvalidate,
+    extensionCatalogInvalidate,
+    pollIntervalMs: 20,
+  });
+
+  poller.start();
+  // Wait enough ticks that multiple would fire during the slow pull
+  await new Promise<void>((r) => setTimeout(r, 200));
+  await poller.stop();
+
+  // Despite 200ms with 20ms intervals (10 ticks), only 1–2 pulls
+  // should have started because the first blocks for 100ms
+  assertEquals(sync.pullCalls.length <= 3, true);
+});
+
+Deno.test("ConfigPoller: double start does not create duplicate timers", async () => {
+  const sync = createMockSyncService();
+  const { catalogInvalidate, extensionCatalogInvalidate } =
+    createCallbackTrackers();
+
+  const poller = new ConfigPoller({
+    syncService: sync,
+    catalogInvalidate,
+    extensionCatalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  poller.start();
+
+  await waitFor(() => sync.pullCalls.length >= 2, "at least two pulls");
+  const countAfterDoubleStart = sync.pullCalls.length;
+  await poller.stop();
+
+  // If duplicate timers existed, we'd see roughly 2x the pull count.
+  // With a single timer at 30ms over ~100ms, expect 2–4 calls, not 6+.
+  assertEquals(countAfterDoubleStart <= 5, true);
+});
+
+Deno.test("ConfigPoller: stop awaits pending pull before returning", async () => {
+  let pullCompleted = false;
+  const sync = createMockSyncService({ pullDelay: 80 });
+  const originalPull = sync.pullChanged.bind(sync);
+  sync.pullChanged = async (options?: DatastoreSyncOptions) => {
+    const result = await originalPull(options);
+    pullCompleted = true;
+    return result;
+  };
+
+  const { catalogInvalidate, extensionCatalogInvalidate } =
+    createCallbackTrackers();
+
+  const poller = new ConfigPoller({
+    syncService: sync,
+    catalogInvalidate,
+    extensionCatalogInvalidate,
+    pollIntervalMs: 20,
+  });
+
+  poller.start();
+  // Wait for at least one pull to start
+  await waitFor(() => sync.pullCalls.length >= 1, "at least one pull");
+  // Stop should await the pending pull
+  await poller.stop();
+
+  assertEquals(pullCompleted, true);
+});
+
+Deno.test("ConfigPoller: respects custom pollIntervalMs", async () => {
+  const sync = createMockSyncService();
+  const { catalogInvalidate, extensionCatalogInvalidate } =
+    createCallbackTrackers();
+
+  const poller = new ConfigPoller({
+    syncService: sync,
+    catalogInvalidate,
+    extensionCatalogInvalidate,
+    pollIntervalMs: 80,
+  });
+
+  poller.start();
+  // At 80ms interval, after 50ms we should have 0 pulls
+  await new Promise<void>((r) => setTimeout(r, 50));
+  assertEquals(sync.pullCalls.length, 0);
+
+  // After 120ms total we should have exactly 1
+  await new Promise<void>((r) => setTimeout(r, 70));
+  assertEquals(sync.pullCalls.length, 1);
+
+  await poller.stop();
+});
+
+Deno.test("ConfigPoller: stop on never-started poller is a no-op", async () => {
+  const sync = createMockSyncService();
+  const { catalogInvalidate, extensionCatalogInvalidate } =
+    createCallbackTrackers();
+
+  const poller = new ConfigPoller({
+    syncService: sync,
+    catalogInvalidate,
+    extensionCatalogInvalidate,
+  });
+
+  await poller.stop();
+  assertEquals(sync.pullCalls.length, 0);
+});
+
+Deno.test("ConfigPoller: can be restarted after stop", async () => {
+  const sync = createMockSyncService();
+  const { catalogInvalidate, extensionCatalogInvalidate } =
+    createCallbackTrackers();
+
+  const poller = new ConfigPoller({
+    syncService: sync,
+    catalogInvalidate,
+    extensionCatalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 1, "at least one pull");
+  await poller.stop();
+
+  const countAfterFirstRun = sync.pullCalls.length;
+
+  poller.start();
+  await waitFor(
+    () => sync.pullCalls.length > countAfterFirstRun,
+    "pulls resume after restart",
+  );
+  await poller.stop();
+
+  assertGreater(sync.pullCalls.length, countAfterFirstRun);
+});
+
+Deno.test("ConfigPoller: without namespace, pullChanged options omit namespace", async () => {
+  const sync = createMockSyncService();
+  const { catalogInvalidate, extensionCatalogInvalidate } =
+    createCallbackTrackers();
+
+  const poller = new ConfigPoller({
+    syncService: sync,
+    catalogInvalidate,
+    extensionCatalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 1, "at least one pull");
+  await poller.stop();
+
+  assertEquals(sync.pullCalls[0].namespace, undefined);
+});

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -61,6 +61,7 @@ import {
   runFileSink,
 } from "../infrastructure/logging/logger.ts";
 import {
+  resolvePulledExtensionsRoot,
   SWAMP_SUBDIRS,
   swampPath,
 } from "../infrastructure/persistence/paths.ts";
@@ -190,6 +191,7 @@ export async function createWorkflowRunDeps(
         runTracker,
         ephRepo,
         ephCatalog,
+        resolvePulledExtensionsRoot(dir),
       );
     },
     catalogStore: repoContext.catalogStore,

--- a/src/serve/extension_reload.ts
+++ b/src/serve/extension_reload.ts
@@ -44,6 +44,10 @@ import { RepoPath } from "../domain/repo/repo_path.ts";
 import { getAutoResolver } from "../domain/extensions/auto_resolver_context.ts";
 import { AuthRepository } from "../infrastructure/persistence/auth_repository.ts";
 import { resolveTrustedCollectives } from "../libswamp/mod.ts";
+import {
+  managedConfigLockfilePath,
+  resolvePulledExtensionsRoot,
+} from "../infrastructure/persistence/paths.ts";
 import { resolveModelsDir } from "../cli/resolve_models_dir.ts";
 import type { ServeReloadResponse } from "./protocol.ts";
 import { readServeConfigFile } from "./serve_config.ts";
@@ -60,6 +64,7 @@ export function isReloading(): boolean {
 export async function reloadPulledExtensions(
   repoDir: string,
   lockfilePath: string,
+  pulledExtensionsRoot?: string,
 ): Promise<number> {
   incrementReloadGeneration();
 
@@ -70,7 +75,8 @@ export async function reloadPulledExtensions(
     const lockfile = await LockfileRepository.create(lockfilePath);
     const entries = lockfile.getAllEntries();
 
-    const pulledRoot = join(repoDir, ".swamp", "pulled-extensions");
+    const pulledRoot = pulledExtensionsRoot ??
+      resolvePulledExtensionsRoot(repoDir);
     const rebundled = new Set<string>();
     let denoRuntime: EmbeddedDenoRuntime | undefined;
     let denoPath: string | undefined;
@@ -223,7 +229,10 @@ export async function resolveLockfilePath(
     const markerRepo = new RepoMarkerRepository();
     marker = await markerRepo.read(RepoPath.create(repoDir));
   } catch {
-    // Not in a swamp repo or marker unreadable — resolveModelsDir(null) returns the default
+    // Not in a swamp repo or marker unreadable — resolveManagedConfigPaths uses default paths
+  }
+  if (marker?.datastore?.managedConfig) {
+    return managedConfigLockfilePath(repoDir);
   }
   const modelsDir = resolveModelsDir(marker);
   return join(
@@ -242,6 +251,7 @@ export async function performServeReload(
   repoDir: string,
   lockfilePath: string,
   options?: ServeReloadOptions,
+  pulledExtensionsRoot?: string,
 ): Promise<ServeReloadResponse> {
   if (reloading) {
     return {
@@ -257,7 +267,11 @@ export async function performServeReload(
   let triggerOverridesChanged = 0;
 
   try {
-    reloadedCount = await reloadPulledExtensions(repoDir, lockfilePath);
+    reloadedCount = await reloadPulledExtensions(
+      repoDir,
+      lockfilePath,
+      pulledExtensionsRoot,
+    );
 
     try {
       await reloadTrustedCollectives(repoDir);

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -96,7 +96,7 @@ import {
 import type { DatastoreProvider } from "../../domain/datastore/datastore_provider.ts";
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
 import { FilesystemDatastoreVerifier } from "../../infrastructure/persistence/filesystem_datastore_verifier.ts";
-import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
+
 import {
   datastoreBasePath,
   resolveDatastoreConfig,
@@ -106,6 +106,7 @@ import {
 } from "../../infrastructure/persistence/namespace_manifest.ts";
 import { createExtensionInstallDeps } from "../../cli/create_extension_install_deps.ts";
 import { loadIdentity } from "../../cli/load_identity.ts";
+import { managedConfigLockfilePath } from "../../infrastructure/persistence/paths.ts";
 import { resolveModelsDir } from "../../cli/resolve_models_dir.ts";
 import type {
   AuditTimelinePayload,
@@ -630,6 +631,11 @@ export async function handleExtensionInstall(
       return;
     }
 
+    if (ctx.syncService) {
+      ctx.syncService.markDirty();
+      await ctx.syncService.pushChanged();
+    }
+
     send(socket, {
       type: "extension.install",
       id: requestId,
@@ -665,11 +671,14 @@ export async function handleExtensionPull(
 
     const markerRepo = new RepoMarkerRepository();
     const marker = await markerRepo.read(RepoPath.create(repoDir));
-    const modelsDir = resolveModelsDir(marker);
-    const absoluteModelsDir = isAbsolute(modelsDir)
-      ? modelsDir
-      : resolve(repoDir, modelsDir);
-    const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+    const lockfilePath = marker?.datastore?.managedConfig
+      ? managedConfigLockfilePath(repoDir)
+      : join(
+        isAbsolute(resolveModelsDir(marker))
+          ? resolveModelsDir(marker)
+          : resolve(repoDir, resolveModelsDir(marker)),
+        "upstream_extensions.json",
+      );
 
     const tools = marker?.tools?.length ? marker.tools : ["claude"];
     const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
@@ -739,6 +748,11 @@ export async function handleExtensionPull(
       return;
     }
 
+    if (ctx.syncService) {
+      ctx.syncService.markDirty();
+      await ctx.syncService.pushChanged();
+    }
+
     send(socket, {
       type: "extension.pull",
       id: requestId,
@@ -778,11 +792,14 @@ export async function handleExtensionRm(
     const repoDir = ctx.repoDir;
     const markerRepo = new RepoMarkerRepository();
     const marker = await markerRepo.read(RepoPath.create(repoDir));
-    const modelsDir = resolveModelsDir(marker);
-    const absoluteModelsDir = isAbsolute(modelsDir)
-      ? modelsDir
-      : resolve(repoDir, modelsDir);
-    const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+    const lockfilePath = marker?.datastore?.managedConfig
+      ? managedConfigLockfilePath(repoDir)
+      : join(
+        isAbsolute(resolveModelsDir(marker))
+          ? resolveModelsDir(marker)
+          : resolve(repoDir, resolveModelsDir(marker)),
+        "upstream_extensions.json",
+      );
 
     deps = await createExtensionRmDeps(repoDir, lockfilePath);
     const libCtx = createLibSwampContext();
@@ -804,6 +821,11 @@ export async function handleExtensionRm(
     if (controller.signal.aborted) {
       sendError(socket, requestId, "cancelled", "Operation was cancelled");
       return;
+    }
+
+    if (ctx.syncService) {
+      ctx.syncService.markDirty();
+      await ctx.syncService.pushChanged();
     }
 
     send(socket, {
@@ -839,11 +861,14 @@ export async function handleExtensionOutdated(
     const repoDir = ctx.repoDir;
     const markerRepo = new RepoMarkerRepository();
     const marker = await markerRepo.read(RepoPath.create(repoDir));
-    const modelsDir = resolveModelsDir(marker);
-    const absoluteModelsDir = isAbsolute(modelsDir)
-      ? modelsDir
-      : resolve(repoDir, modelsDir);
-    const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+    const lockfilePath = marker?.datastore?.managedConfig
+      ? managedConfigLockfilePath(repoDir)
+      : join(
+        isAbsolute(resolveModelsDir(marker))
+          ? resolveModelsDir(marker)
+          : resolve(repoDir, resolveModelsDir(marker)),
+        "upstream_extensions.json",
+      );
 
     const identity = await loadIdentity();
     const deps = await createExtensionUpdateDeps({
@@ -913,11 +938,14 @@ export async function handleExtensionUpdate(
     const repoDir = ctx.repoDir;
     const markerRepo = new RepoMarkerRepository();
     const marker = await markerRepo.read(RepoPath.create(repoDir));
-    const modelsDir = resolveModelsDir(marker);
-    const absoluteModelsDir = isAbsolute(modelsDir)
-      ? modelsDir
-      : resolve(repoDir, modelsDir);
-    const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+    const lockfilePath = marker?.datastore?.managedConfig
+      ? managedConfigLockfilePath(repoDir)
+      : join(
+        isAbsolute(resolveModelsDir(marker))
+          ? resolveModelsDir(marker)
+          : resolve(repoDir, resolveModelsDir(marker)),
+        "upstream_extensions.json",
+      );
 
     const tools = marker?.tools?.length ? marker.tools : ["claude"];
     const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
@@ -984,6 +1012,11 @@ export async function handleExtensionUpdate(
     if (controller.signal.aborted) {
       sendError(socket, requestId, "cancelled", "Operation was cancelled");
       return;
+    }
+
+    if (ctx.syncService) {
+      ctx.syncService.markDirty();
+      await ctx.syncService.pushChanged();
     }
 
     send(socket, {
@@ -1150,6 +1183,11 @@ export async function handleVaultMigrate(
       return;
     }
 
+    if (ctx.syncService) {
+      ctx.syncService.markDirty();
+      await ctx.syncService.pushChanged();
+    }
+
     send(socket, {
       type: "vault.migrate",
       id: requestId,
@@ -1260,7 +1298,7 @@ export async function handleDoctorDatastores(
         }
       },
       getVaultConfigs: async () => {
-        const vaultRepo = new YamlVaultConfigRepository(repoDir);
+        const vaultRepo = ctx.repoContext.vaultConfigRepo;
         try {
           const vaultConfigs = await vaultRepo.findAll();
           return vaultConfigs.map((vc) => ({
@@ -1427,11 +1465,14 @@ export async function handleDoctorExtensions(
     const repoPath = RepoPath.create(repoDir);
     const markerRepo = new RepoMarkerRepository();
     const marker = await markerRepo.read(repoPath);
-    const modelsDir = resolveModelsDir(marker);
-    const absoluteModelsDir = isAbsolute(modelsDir)
-      ? modelsDir
-      : resolve(repoDir, modelsDir);
-    const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+    const lockfilePath = marker?.datastore?.managedConfig
+      ? managedConfigLockfilePath(repoDir)
+      : join(
+        isAbsolute(resolveModelsDir(marker))
+          ? resolveModelsDir(marker)
+          : resolve(repoDir, resolveModelsDir(marker)),
+        "upstream_extensions.json",
+      );
 
     const catalogDbPath = swampPath(repoDir, "_extension_catalog.db");
     sharedCatalog = new ExtensionCatalogStore(catalogDbPath);

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -722,7 +722,10 @@ export async function handleModelCreate(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = await createModelCreateDeps(ctx.repoDir);
+    const deps = await createModelCreateDeps(
+      ctx.repoDir,
+      ctx.managedDefinitionsDir,
+    );
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(
@@ -755,6 +758,11 @@ export async function handleModelCreate(
         "Model creation failed",
       );
       return;
+    }
+
+    if (ctx.syncService) {
+      ctx.syncService.markDirty();
+      await ctx.syncService.pushChanged();
     }
 
     send(socket, {
@@ -840,6 +848,11 @@ export async function handleModelDelete(
         "Model deletion failed",
       );
       return;
+    }
+
+    if (ctx.syncService) {
+      ctx.syncService.markDirty();
+      await ctx.syncService.pushChanged();
     }
 
     send(socket, {

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -120,6 +120,8 @@ export interface ConnectionContext {
   serveOptions?: MergedServeOptions;
   /** Health collector — used by cluster.instances to enrich the local instance. */
   healthCollector?: HealthCollector;
+  /** Managed definitions directory when managedConfig is active. */
+  managedDefinitionsDir?: string;
 }
 
 // SECURITY: Authorization must operate on canonical (normalized) model types,

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -101,7 +101,10 @@ import {
 } from "../../domain/access/principal.ts";
 import { createEphemeralStore } from "../../infrastructure/persistence/ephemeral_store.ts";
 import { DefaultDatastorePathResolver } from "../../infrastructure/persistence/default_datastore_path_resolver.ts";
-import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
+import {
+  resolvePulledExtensionsRoot,
+  SWAMP_SUBDIRS,
+} from "../../infrastructure/persistence/paths.ts";
 import {
   extractTraceContext,
   runWithParentTrace,
@@ -1058,6 +1061,7 @@ export async function handleWorkflowResume(
         ctx.runTracker,
         ephemeral.repo,
         ephemeral.catalog,
+        resolvePulledExtensionsRoot(ctx.repoDir),
       );
 
       const resumeGenerator = async function* (): AsyncGenerator<
@@ -1237,6 +1241,7 @@ export async function handleWorkflowResume(
         ctx.runTracker,
         ephemeral.repo,
         ephemeral.catalog,
+        resolvePulledExtensionsRoot(ctx.repoDir),
       );
 
       const doResume = async () => {


### PR DESCRIPTION
## Summary

Adds `managedConfig` support for multi-instance `swamp serve` deployments. When enabled via `swamp datastore config migrate`, all configuration (model definitions, workflow definitions, vault configs, extension lockfile, and pulled extension sources) moves into the datastore tier. The datastore becomes the single source of truth — instances hydrate from it on startup and a ConfigPoller refreshes every 30s. No git sync, no shared filesystems, no coordination between instances.

### What changed

- **`managedConfig` flag** on `DatastoreConfigData` + `config` in `DEFAULT_DATASTORE_SUBDIRS` + `subdirs` option on `DatastoreSyncOptions` + `configRefresh` on `SyncCapabilities`
- **Module-level managed config registry** in `paths.ts` — all 44+ YAML repo instantiations across libswamp automatically resolve to managed paths via `resolveEffectiveDefinitionsDir`/`resolveEffectiveWorkflowsDir`/`resolveEffectiveVaultsDir`
- **`swamp datastore config migrate` command** — atomic one-command gate that checks extension capability, copies files, sets `managedConfig: true` in `.swamp.yaml`, writes sentinel, and pushes. Migration guard blocks extensions without `configRefresh` to prevent partial migrations
- **Sentinel-gated path resolution** for CLI (prevents "enable without migrate" empty-dirs footgun); serve uses `skipSentinelCheck` so fresh instances activate managed paths on first boot before the pull populates config
- **ConfigPoller** service — periodic pull with catalog invalidation, modeled after `GrantsDirectoryPoller`. Uses commitSeq-based zero-diff fast path (one HEAD request per tick when idle)
- **Serve write handlers** — model create/delete, extension pull/rm/update, vault migrate all call `markDirty()` + `pushChanged()` so changes propagate to the datastore immediately
- **Path detection code** — `PULLED_MARKER` regex, layout classifier, catalog origin conflicts, extension file resolver all match both traditional and managed paths
- **Datastore resolver routing** — `datastoreResolver.resolvePath("config")` used for all managed path resolution so filesystem datastores write directly to the datastore path and S3 datastores write to the cache

### Verification

- 10,790 unit/integration tests pass (45 new tests added)
- 90 UAT CLI tests pass against compiled binary
- DDD architecture rules pass (no new layer violations)
- End-to-end verified with MinIO (S3-compatible): migration → model create → push to S3 → second instance pulls → sees the model
- End-to-end verified with filesystem datastore: multi-instance convergence
- Extension pull/rm verified with real `@swamp/s3-datastore` from registry
- User-authored extensions load correctly with managedConfig active
- Rollback verified: disable flag → traditional paths → no data loss

### Dependencies

Requires `@swamp/s3-datastore` >= 2026.08.27 and `@swamp/gcs-datastore` >= 2026.08.27 (shipped) for the `configRefresh` capability and `config` partition support.

## Test Plan

- [x] Unit tests for ConfigPoller (14 tests: lifecycle, serialization, dual invalidation, error resilience)
- [x] Unit tests for migration service (10 tests: happy path, sentinel, partial sources, idempotency)
- [x] Unit tests for path resolution (8 tests: all modes, sentinel gate, custom modelsDir)
- [x] Unit tests for path detection (6 tests: layout classifier, PULLED_MARKER regex, isPulledExtensionManifest)
- [x] Unit tests for paths.ts functions (3 tests: resolvers, lockfile path)
- [x] Unit tests for datastore config (4 tests: config subdir, managedConfig field)
- [x] End-to-end: MinIO S3 convergence (create on A, pull on B)
- [x] End-to-end: filesystem datastore convergence
- [x] End-to-end: real extension pull/rm on managed paths
- [x] End-to-end: model create/list/get/run/delete, workflow create/list/delete, vault create/list on managed paths
- [x] UAT: 90 CLI tests pass against compiled binary
- [x] Rollback: disable managedConfig → traditional paths work

Closes swamp-club#1569

🤖 Generated with [Claude Code](https://claude.com/claude-code)