### PR TITLE
fix(datastore): address managedConfig review feedback — split-brain gate, one-shot registry, push consistency (swamp-club#1569)

### DIFF
--- a/src/cli/commands/datastore_config_migrate.ts
+++ b/src/cli/commands/datastore_config_migrate.ts
@@ -108,16 +108,32 @@ export const datastoreConfigMigrateCommand = new Command()
       return;
     }
 
-    if (!marker.datastore.managedConfig) {
+    const managedConfigSet = !marker.datastore.managedConfig;
+    if (managedConfigSet) {
       const updated: RepoMarkerData = {
         ...marker,
         datastore: { ...marker.datastore, managedConfig: true },
       };
       await markerRepo.write(repoPath, updated);
+      if (ctx.outputMode !== "json") {
+        ctx.logger.info`Set managedConfig: true in .swamp.yaml`;
+      }
     }
 
-    if (syncService) {
-      syncService.markDirty();
+    const copied = [
+      result.copiedModels && "models",
+      result.copiedWorkflows && "workflows",
+      result.copiedVaults && "vaults",
+      result.copiedLockfile && "lockfile",
+      result.copiedPulledExtensions && "pulled-extensions",
+    ].filter(Boolean);
+
+    if (syncService && (copied.length > 0 || managedConfigSet)) {
+      await syncService.markDirty();
+      await syncService.pushChanged();
+      if (ctx.outputMode !== "json") {
+        ctx.logger.info`Pushed config to datastore`;
+      }
     }
 
     if (ctx.outputMode === "json") {
@@ -128,24 +144,13 @@ export const datastoreConfigMigrateCommand = new Command()
         copiedVaults: result.copiedVaults,
         copiedLockfile: result.copiedLockfile,
         copiedPulledExtensions: result.copiedPulledExtensions,
-        managedConfigSet: !marker.datastore.managedConfig,
+        managedConfigSet,
         configRoot,
       }));
-    } else {
-      const copied = [
-        result.copiedModels && "models",
-        result.copiedWorkflows && "workflows",
-        result.copiedVaults && "vaults",
-        result.copiedLockfile && "lockfile",
-        result.copiedPulledExtensions && "pulled-extensions",
-      ].filter(Boolean);
-      if (copied.length > 0) {
-        ctx.logger
-          .info`Migrated ${copied.join(", ")} into datastore config tier`;
-      } else {
-        ctx.logger.info`No config files found to migrate`;
-      }
+    } else if (copied.length > 0) {
       ctx.logger
-        .info`Config will be pushed to the datastore on command exit`;
+        .info`Migrated ${copied.join(", ")} into datastore config tier`;
+    } else {
+      ctx.logger.info`No config files found to migrate`;
     }
   });

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -145,7 +145,7 @@ export const modelCreateCommand = withRemoteOptions(
     );
 
     if (syncService && managedConfig) {
-      syncService.markDirty();
+      await syncService.markDirty();
       await syncService.pushChanged();
     }
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1727,6 +1727,9 @@ export const serveCommand = new Command()
         configPoller = new ConfigPoller({
           syncService,
           catalogInvalidate: () => repoContext.catalogStore.invalidate(),
+          // No-op: extension type registries (model/vault/datastore/report)
+          // require a full ensureLoaded() reload, not just catalog invalidation.
+          // Deferred to a future extension hot-reload feature.
           extensionCatalogInvalidate: () => {},
           namespace: serveNamespace,
         });

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -248,7 +248,7 @@ export function resolveManagedConfigPaths(
   marker: RepoMarkerData | null,
   configBasePath?: string,
   options?: { skipSentinelCheck?: boolean },
-): { pulledExtensionsRoot: string; lockfilePath: string } {
+): { pulledExtensionsRoot: string; lockfilePath: string; active: boolean } {
   const managedConfig = marker?.datastore?.managedConfig === true;
   const effectiveBase = configBasePath ?? swampPath(repoDir, "config");
 
@@ -271,14 +271,17 @@ export function resolveManagedConfigPaths(
     return {
       pulledExtensionsRoot: join(effectiveBase, "pulled-extensions"),
       lockfilePath: join(effectiveBase, "upstream_extensions.json"),
+      active,
     };
   }
-  const modelsDir = isAbsolute(resolveModelsDir(marker))
-    ? resolveModelsDir(marker)
-    : resolve(repoDir, resolveModelsDir(marker));
+  const rawModelsDir = resolveModelsDir(marker);
+  const modelsDir = isAbsolute(rawModelsDir)
+    ? rawModelsDir
+    : resolve(repoDir, rawModelsDir);
   return {
     pulledExtensionsRoot: swampPath(repoDir, "pulled-extensions"),
     lockfilePath: join(modelsDir, "upstream_extensions.json"),
+    active,
   };
 }
 
@@ -483,21 +486,25 @@ export async function requireInitializedRepoReadOnly(
     // No lock acquisition — read-only path
   }
 
-  const managedConfig = marker?.datastore?.managedConfig === true;
-  const definitionsDir = managedConfig
-    ? join(datastoreResolver.resolvePath("config"), "models")
-    : join(repoPath.value, "models");
-  const yamlWorkflowsDir = managedConfig
-    ? join(datastoreResolver.resolvePath("config"), "workflows")
-    : join(repoPath.value, "workflows");
-  const vaultsDir = managedConfig
-    ? join(datastoreResolver.resolvePath("config"), "vaults")
-    : join(repoPath.value, "vaults");
-  const { pulledExtensionsRoot, lockfilePath } = resolveManagedConfigPaths(
+  const configBase = datastoreResolver.resolvePath("config");
+  const {
+    pulledExtensionsRoot,
+    lockfilePath,
+    active: managedActive,
+  } = resolveManagedConfigPaths(
     repoPath.value,
     marker,
-    datastoreResolver.resolvePath("config"),
+    configBase,
   );
+  const definitionsDir = managedActive
+    ? join(configBase, "models")
+    : join(repoPath.value, "models");
+  const yamlWorkflowsDir = managedActive
+    ? join(configBase, "workflows")
+    : join(repoPath.value, "workflows");
+  const vaultsDir = managedActive
+    ? join(configBase, "vaults")
+    : join(repoPath.value, "vaults");
 
   // Resolve source workflow directories from .swamp-sources.yaml
   const sourceWorkflowDirs = await getSourceWorkflowDirs(repoPath.value);
@@ -696,22 +703,25 @@ export function requireInitializedRepo(
       }
     }
 
-    const managedConfig = marker?.datastore?.managedConfig === true;
     const configBase = datastoreResolver.resolvePath("config");
-    const definitionsDir = managedConfig
-      ? join(configBase, "models")
-      : join(repoPath.value, "models");
-    const yamlWorkflowsDir = managedConfig
-      ? join(configBase, "workflows")
-      : join(repoPath.value, "workflows");
-    const vaultsDir = managedConfig
-      ? join(configBase, "vaults")
-      : join(repoPath.value, "vaults");
-    const { pulledExtensionsRoot, lockfilePath } = resolveManagedConfigPaths(
+    const {
+      pulledExtensionsRoot,
+      lockfilePath,
+      active: managedActive,
+    } = resolveManagedConfigPaths(
       repoPath.value,
       marker,
       configBase,
     );
+    const definitionsDir = managedActive
+      ? join(configBase, "models")
+      : join(repoPath.value, "models");
+    const yamlWorkflowsDir = managedActive
+      ? join(configBase, "workflows")
+      : join(repoPath.value, "workflows");
+    const vaultsDir = managedActive
+      ? join(configBase, "vaults")
+      : join(repoPath.value, "vaults");
 
     // Resolve source workflow directories from .swamp-sources.yaml
     const sourceWorkflowDirs = await getSourceWorkflowDirs(repoPath.value);
@@ -859,23 +869,26 @@ export async function requireInitializedRepoUnlocked(
     }
   }
 
-  const managedConfig = marker?.datastore?.managedConfig === true;
   const configBase = datastoreResolver.resolvePath("config");
-  const definitionsDir = managedConfig
-    ? join(configBase, "models")
-    : join(repoPath.value, "models");
-  const yamlWorkflowsDir = managedConfig
-    ? join(configBase, "workflows")
-    : join(repoPath.value, "workflows");
-  const vaultsDir = managedConfig
-    ? join(configBase, "vaults")
-    : join(repoPath.value, "vaults");
-  const { pulledExtensionsRoot, lockfilePath } = resolveManagedConfigPaths(
+  const {
+    pulledExtensionsRoot,
+    lockfilePath,
+    active: managedActive,
+  } = resolveManagedConfigPaths(
     repoPath.value,
     marker,
-    datastoreResolver.resolvePath("config"),
+    configBase,
     { skipSentinelCheck: true },
   );
+  const definitionsDir = managedActive
+    ? join(configBase, "models")
+    : join(repoPath.value, "models");
+  const yamlWorkflowsDir = managedActive
+    ? join(configBase, "workflows")
+    : join(repoPath.value, "workflows");
+  const vaultsDir = managedActive
+    ? join(configBase, "vaults")
+    : join(repoPath.value, "vaults");
 
   // Resolve source workflow directories from .swamp-sources.yaml
   const sourceWorkflowDirs = await getSourceWorkflowDirs(repoPath.value);

--- a/src/domain/datastore/managed_config_migration.ts
+++ b/src/domain/datastore/managed_config_migration.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { copy, ensureDir } from "@std/fs";
-import { join, resolve } from "@std/path";
+import { dirname, join, resolve } from "@std/path";
 import { getLogger } from "@logtape/logtape";
 
 const logger = getLogger(["swamp", "datastore", "managed-config-migration"]);
@@ -107,7 +107,7 @@ export async function migrateConfigToDatastore(
       const stat = await Deno.stat(src);
       if (isFile ? stat.isFile : stat.isDirectory) {
         if (isFile) {
-          await ensureDir(join(dest, "..").replace(/\/\.\.$/, ""));
+          await ensureDir(dirname(dest));
           await Deno.copyFile(src, dest);
         } else {
           await copy(src, dest, { overwrite: true });

--- a/src/infrastructure/persistence/paths.ts
+++ b/src/infrastructure/persistence/paths.ts
@@ -132,10 +132,13 @@ export function registerManagedConfig(
   active: boolean,
   configBasePath?: string,
 ): void {
+  const key = resolve(repoDir);
+  const existing = managedConfigRegistry.get(key);
+  if (typeof existing === "string") return;
   if (active && configBasePath) {
-    managedConfigRegistry.set(resolve(repoDir), configBasePath);
-  } else {
-    managedConfigRegistry.set(resolve(repoDir), false);
+    managedConfigRegistry.set(key, configBasePath);
+  } else if (existing === undefined) {
+    managedConfigRegistry.set(key, false);
   }
 }
 

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -632,7 +632,7 @@ export async function handleExtensionInstall(
     }
 
     if (ctx.syncService) {
-      ctx.syncService.markDirty();
+      await ctx.syncService.markDirty();
       await ctx.syncService.pushChanged();
     }
 
@@ -749,7 +749,7 @@ export async function handleExtensionPull(
     }
 
     if (ctx.syncService) {
-      ctx.syncService.markDirty();
+      await ctx.syncService.markDirty();
       await ctx.syncService.pushChanged();
     }
 
@@ -824,7 +824,7 @@ export async function handleExtensionRm(
     }
 
     if (ctx.syncService) {
-      ctx.syncService.markDirty();
+      await ctx.syncService.markDirty();
       await ctx.syncService.pushChanged();
     }
 
@@ -1015,7 +1015,7 @@ export async function handleExtensionUpdate(
     }
 
     if (ctx.syncService) {
-      ctx.syncService.markDirty();
+      await ctx.syncService.markDirty();
       await ctx.syncService.pushChanged();
     }
 
@@ -1184,7 +1184,7 @@ export async function handleVaultMigrate(
     }
 
     if (ctx.syncService) {
-      ctx.syncService.markDirty();
+      await ctx.syncService.markDirty();
       await ctx.syncService.pushChanged();
     }
 

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -761,7 +761,7 @@ export async function handleModelCreate(
     }
 
     if (ctx.syncService) {
-      ctx.syncService.markDirty();
+      await ctx.syncService.markDirty();
       await ctx.syncService.pushChanged();
     }
 
@@ -851,7 +851,7 @@ export async function handleModelDelete(
     }
 
     if (ctx.syncService) {
-      ctx.syncService.markDirty();
+      await ctx.syncService.markDirty();
       await ctx.syncService.pushChanged();
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #2288 addressing review feedback. Fixes the split-brain path resolution and all review items.

- **Split-brain fix**: `definitionsDir`/`yamlWorkflowsDir`/`vaultsDir` now derive from `resolveManagedConfigPaths`' sentinel-gated `active` result, not the raw `managedConfig` flag. Prevents the "enable without migrate" footgun for all config paths, not just lockfile/pulled-extensions.
- **One-shot registry**: `registerManagedConfig` never downgrades `true→false` — protects against transient sentinel stat failures flipping the global registry.
- **Push consistency**: Migration command now calls `markDirty()` + `pushChanged()` synchronously instead of relying on implicit exit flush. Push notice suppressed when nothing was copied.
- **Log mode parity**: Reports `.swamp.yaml` change in log mode.
- **`dirname`**: Replaces dead `join(dest, "..").replace(...)` regex.
- **Cache `resolveModelsDir`**: Fallback path caches the result instead of calling 3x.
- **Document no-op**: `extensionCatalogInvalidate` comment explains why it's deferred.
- **Await `markDirty`**: All 8 call sites now await the promise.

## Test Plan

- [x] 10,790 unit/integration tests pass
- [x] `deno lint` clean
- [x] `deno fmt --check` clean
- [x] Split-brain scenario: `managedConfig: true` without sentinel → all paths fall back to traditional (verified by existing test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)