### PR TITLE
fix(remote): add step-level `writes` declaration to prevent re-dispatch of externally-mutating steps (swamp-club#1784)

### DIFF
--- a/.claude/skills/swamp/references/workflow/reference.md
+++ b/.claude/skills/swamp/references/workflow/reference.md
@@ -574,6 +574,33 @@ jobs:
   since there are no remote steps to co-locate)
 - Requires `swamp serve` (same as all placement features)
 
+## Write-Bearing Declaration
+
+Add `writes: true` at the **step**, **job**, or **workflow** level to declare
+that the step performs external mutations (API calls, `kubectl apply`, SSH
+commands) that the orchestrator cannot observe through data-plane writes. When
+declared, a worker disconnect fails the run immediately instead of
+re-dispatching the step — preventing double-execution of non-idempotent side
+effects.
+
+```yaml
+steps:
+  - name: deploy
+    writes: true
+    target: deploy-worker
+    task:
+      model: k8s-deployer
+      method: apply
+```
+
+Inheritance is child-wins: step overrides job, job overrides workflow.
+Validation warns when `writes: true` is set without any remote placement (a
+no-op since local steps are never re-dispatched).
+
+Without the declaration, write-bearing status is inferred at runtime from
+data-plane writes (`writeResource` / `createFileWriter`). Steps that only
+perform orchestrator-visible writes do not need `writes: true`.
+
 ## Concurrency Limits
 
 Add `concurrency: N` at the workflow, job, or step level to cap parallel

--- a/.claude/skills/swamp/references/workflow/references/remote-execution.md
+++ b/.claude/skills/swamp/references/workflow/references/remote-execution.md
@@ -138,6 +138,11 @@ authentication yet — same trust model as `swamp serve` itself.
   orchestrator — workers hold no credentials or repository. Writes are durable
   at the orchestrator immediately; a step that wrote and then lost its worker
   fails the run (no-write steps re-dispatch automatically).
+- Steps that mutate external systems (API calls, `kubectl apply`, SSH) without
+  calling `writeResource` should declare `writes: true` to prevent re-dispatch
+  on worker disconnect. Without the declaration, the orchestrator classifies the
+  step as no-write (based on runtime data-plane inference) and re-dispatches it,
+  potentially double-executing non-idempotent side effects.
 - The orchestrator ships its environment variables with each dispatch
   (process-identity vars like HOME/PATH excluded), so ambient credentials work
   remotely as they do locally.

--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -989,6 +989,28 @@ re-dispatch never race into double execution:
   as a local mid-method crash leaves partial data today. swamp does not
   auto-retry crashed methods locally either, so this is not a regression.
 
+### Write-bearing classification
+
+Write-bearing status is determined by **two complementary mechanisms**:
+
+- **Runtime inference (default):** The `DispatchService` tracks whether a
+  dispatch performed any durable data-plane write via `recordFirstWrite`. This
+  is automatic and requires no workflow author action — any `writeResource` or
+  `createFileWriter` call through the orchestrator marks the dispatch as
+  write-bearing.
+
+- **Declared at the step level (`writes: true`):** A step, job, or workflow may
+  declare `writes: true` in the workflow YAML. When set, the dispatch is
+  pre-marked as write-bearing **before the method body runs** — a worker
+  disconnect fails the run immediately instead of re-dispatching, even if no
+  data-plane write has occurred. This is necessary for steps that mutate
+  external systems (API calls, `kubectl apply`, SSH commands) without calling
+  `writeResource`, because the orchestrator cannot observe those side effects.
+  Inheritance is child-wins: step overrides job, job overrides workflow.
+
+A step with both `writes: true` and runtime data-plane writes is handled
+correctly — `recordFirstWrite` is a no-op when the dispatch is already marked.
+
 Transparent re-dispatch (or mid-step resume) of a write-bearing step is a later
 feature that must first solve write idempotency. It is not promised in v1.
 

--- a/src/domain/models/method_context.ts
+++ b/src/domain/models/method_context.ts
@@ -80,6 +80,7 @@ export interface MethodInvocationContext {
   reportNames?: MethodContext["reportNames"];
   reportLabels?: MethodContext["reportLabels"];
   placement?: MethodContext["placement"];
+  declaredWrites?: MethodContext["declaredWrites"];
   vaultSecrets?: MethodContext["vaultSecrets"];
   unresolvedMethodArgs?: MethodContext["unresolvedMethodArgs"];
   /**
@@ -137,6 +138,7 @@ export function buildMethodContext(
     reportNames: invocation.reportNames,
     reportLabels: invocation.reportLabels,
     placement: invocation.placement,
+    declaredWrites: invocation.declaredWrites,
     vaultSecrets: invocation.vaultSecrets,
     unresolvedMethodArgs: invocation.unresolvedMethodArgs,
     extensionFile: (relPath: string) => resolveExtensionFile(root, relPath),

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -416,6 +416,7 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
         signal: context.signal,
         dataRepo: context.dataRepository,
         secretValues: secretValues.length > 0 ? secretValues : undefined,
+        declaredWrites: context.declaredWrites,
         onEvent: context.onEvent
           ? (event: RpcStreamEvent) => {
             if (event.kind === "method_event" && "event" in event) {

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -296,6 +296,13 @@ export interface MethodContext {
   };
 
   /**
+   * When true, the step has declared that it performs external writes
+   * (API calls, kubectl, SSH) that are not tracked by the data-plane
+   * write path. Forces fail-instead-of-redispatch on worker disconnect.
+   */
+  declaredWrites?: boolean;
+
+  /**
    * Optional callback for emitting domain events during method execution.
    * Used for process output streaming, vault storage, schema warnings, etc.
    * Output lines are emitted as `{ type: "output", line, stream }` events.

--- a/src/domain/remote/remote_dispatch.ts
+++ b/src/domain/remote/remote_dispatch.ts
@@ -77,6 +77,12 @@ export interface RemoteStepRequest {
    * Requires `placement.target` to be set.
    */
   skipScheduler?: boolean;
+  /**
+   * When true, the dispatch is pre-marked as write-bearing before the
+   * method body runs. A worker disconnect fails the run immediately
+   * instead of re-dispatching — even if no data-plane write has occurred.
+   */
+  declaredWrites?: boolean;
 }
 
 export interface RemoteStepResult {

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -308,6 +308,11 @@ export interface StepExecutionContext {
    * to the same remote worker. Computed from workflow/job affinity settings.
    */
   affinityKey?: string;
+  /**
+   * Effective `writes` declaration, merged workflow → job → step (child wins).
+   * When true, forces fail-instead-of-redispatch on worker disconnect.
+   */
+  declaredWrites?: boolean;
 }
 
 /**
@@ -1157,6 +1162,7 @@ export class DefaultStepExecutor implements StepExecutor {
           ),
           vaultSecrets: secretBag,
           placement: resolvedPlacement,
+          declaredWrites: ctx.declaredWrites,
           skipCheckNames: ctx.skipCheckNames,
           skipCheckLabels: ctx.skipCheckLabels,
           skipAllChecks: ctx.skipAllChecks,
@@ -3044,6 +3050,7 @@ export class WorkflowExecutionService {
             : job.affinity
             ? `${run.id}:${job.name}`
             : undefined,
+          declaredWrites: step.writes ?? job.writes ?? workflow.writes,
         };
         return this.executor.execute(step, ctx);
       });

--- a/src/domain/workflows/job.ts
+++ b/src/domain/workflows/job.ts
@@ -70,6 +70,7 @@ const JobObjectSchema = z.object({
   weight: z.number().default(0),
   concurrency: z.number().int().nonnegative().optional(),
   affinity: z.boolean().optional(),
+  writes: z.boolean().optional(),
   ...PlacementFieldsSchema.shape,
 });
 
@@ -115,6 +116,7 @@ export interface CreateJobProps {
   weight?: number;
   concurrency?: number;
   affinity?: boolean;
+  writes?: boolean;
   target?: string;
   labels?: Record<string, string>;
   platform?: string;
@@ -140,6 +142,7 @@ export class Job {
     readonly weight: number,
     readonly concurrency: number | undefined,
     readonly affinity: boolean | undefined,
+    readonly writes: boolean | undefined,
     readonly target: string | undefined,
     readonly labels: Record<string, string> | undefined,
     readonly platform: string | undefined,
@@ -165,6 +168,7 @@ export class Job {
       weight: props.weight ?? 0,
       concurrency: props.concurrency,
       affinity: props.affinity,
+      writes: props.writes,
       target: props.target,
       labels: props.labels,
       platform: props.platform,
@@ -193,6 +197,7 @@ export class Job {
       validated.weight,
       validated.concurrency,
       validated.affinity,
+      validated.writes,
       validated.target,
       validated.labels,
       validated.platform,
@@ -252,6 +257,7 @@ export class Job {
       weight: this.weight,
       concurrency: this.concurrency,
       affinity: this.affinity,
+      writes: this.writes,
       target: this.target,
       labels: this.labels,
       platform: this.platform,

--- a/src/domain/workflows/job_test.ts
+++ b/src/domain/workflows/job_test.ts
@@ -410,3 +410,25 @@ Deno.test("JobSchema throws clear error for string dependsOn entries", () => {
     "dependsOn entries must be objects, not strings",
   );
 });
+
+Deno.test("Job: writes field roundtrips through toData", () => {
+  const step = Step.create({
+    name: "deploy",
+    task: StepTask.model("test-model", "run"),
+  });
+  const job = Job.create({ name: "main", steps: [step], writes: true });
+  assertEquals(job.writes, true);
+  const data = job.toData();
+  assertEquals(data.writes, true);
+  const restored = Job.fromData(data);
+  assertEquals(restored.writes, true);
+});
+
+Deno.test("Job: writes field is undefined when absent", () => {
+  const step = Step.create({
+    name: "deploy",
+    task: StepTask.model("test-model", "run"),
+  });
+  const job = Job.create({ name: "main", steps: [step] });
+  assertEquals(job.writes, undefined);
+});

--- a/src/domain/workflows/step.ts
+++ b/src/domain/workflows/step.ts
@@ -94,6 +94,7 @@ const StepObjectSchema = z.object({
   allowFailure: z.boolean().default(false),
   ...PlacementFieldsSchema.shape,
   guard: z.string().optional(),
+  writes: z.boolean().optional(),
 });
 
 /**
@@ -155,6 +156,7 @@ export interface CreateStepProps {
   platform?: string;
   queueTimeout?: number;
   guard?: string;
+  writes?: boolean;
 }
 
 /**
@@ -184,6 +186,7 @@ export class Step {
     readonly platform: string | undefined,
     readonly queueTimeout: number | undefined,
     readonly guard: string | undefined,
+    readonly writes: boolean | undefined,
   ) {}
 
   /**
@@ -208,6 +211,7 @@ export class Step {
       platform: props.platform,
       queueTimeout: props.queueTimeout,
       guard: props.guard,
+      writes: props.writes,
     });
 
     return Step.fromData(data);
@@ -254,6 +258,7 @@ export class Step {
       validated.platform,
       validated.queueTimeout,
       validated.guard,
+      validated.writes,
     );
   }
 
@@ -317,6 +322,7 @@ export class Step {
       platform: this.platform,
       queueTimeout: this.queueTimeout,
       guard: this.guard,
+      writes: this.writes,
     };
   }
 

--- a/src/domain/workflows/step_test.ts
+++ b/src/domain/workflows/step_test.ts
@@ -530,3 +530,27 @@ Deno.test("Step.create: guard field is passed through", () => {
   const step = Step.create({ name: "guarded", task, guard });
   assertEquals(step.guard, guard);
 });
+
+Deno.test("Step: writes field is undefined when absent", () => {
+  const task = StepTask.model("my-model", "run");
+  const step = Step.create({ name: "no-writes", task });
+  assertEquals(step.writes, undefined);
+});
+
+Deno.test("Step: writes field roundtrips through toData", () => {
+  const task = StepTask.model("my-model", "run");
+  const step = Step.create({ name: "has-writes", task, writes: true });
+  assertEquals(step.writes, true);
+  const data = step.toData();
+  assertEquals(data.writes, true);
+  const restored = Step.fromData(data);
+  assertEquals(restored.writes, true);
+});
+
+Deno.test("StepSchema: accepts writes field", () => {
+  const task = StepTask.model("deploy-model", "apply");
+  const step = Step.create({ name: "deploy", task, writes: true });
+  assertEquals(step.writes, true);
+  const step2 = Step.create({ name: "deploy-no-writes", task });
+  assertEquals(step2.writes, undefined);
+});

--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -286,8 +286,8 @@ export class DefaultWorkflowValidationService
     const results: WorkflowValidationResult[] = [];
 
     const effectiveWrites = (
-      step: import("./step.ts").Step,
-      job: import("./job.ts").Job,
+      step: (typeof workflow.jobs)[number]["steps"][number],
+      job: (typeof workflow.jobs)[number],
     ): boolean | undefined => step.writes ?? job.writes ?? workflow.writes;
 
     for (const job of workflow.jobs) {

--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -184,6 +184,9 @@ export class DefaultWorkflowValidationService
     // 13. Guard expression type matches input type
     results.push(...this.validateGuardExpressionTypes(workflow));
 
+    // 14. writes without placement is a no-op
+    results.push(...this.validateWritesPlacement(workflow));
+
     return results;
   }
 
@@ -270,6 +273,48 @@ export class DefaultWorkflowValidationService
                 `affinity only applies to remote-execution steps with placement requirements`,
             ),
           );
+        }
+      }
+    }
+
+    return results;
+  }
+
+  private validateWritesPlacement(
+    workflow: Workflow,
+  ): WorkflowValidationResult[] {
+    const results: WorkflowValidationResult[] = [];
+
+    const effectiveWrites = (
+      step: import("./step.ts").Step,
+      job: import("./job.ts").Job,
+    ): boolean | undefined => step.writes ?? job.writes ?? workflow.writes;
+
+    for (const job of workflow.jobs) {
+      for (const step of job.steps) {
+        if (effectiveWrites(step, job)) {
+          const wfFields = mergePlacementFields(
+            workflow.placementFields,
+            job.placementFields,
+          );
+          const effective = mergePlacementFields(
+            wfFields,
+            step.placementFields,
+          );
+          if (resolvePlacement(effective) === undefined) {
+            const source = step.writes !== undefined
+              ? `step '${step.name}'`
+              : job.writes !== undefined
+              ? `job '${job.name}'`
+              : "workflow";
+            results.push(
+              WorkflowValidationResult.warning(
+                `writes without placement on ${source}`,
+                `Step '${step.name}' in job '${job.name}' has effective 'writes: true' (from ${source}) ` +
+                  `but no remote placement — writes only affects failure semantics for remote-execution steps`,
+              ),
+            );
+          }
         }
       }
     }

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -2373,3 +2373,128 @@ Deno.test("validate: fails when guard references boolean input via bracket notat
   assertEquals(guardResult?.error?.includes("boolean"), true);
   assertEquals(guardResult?.error?.includes('inputs["dry-run"]'), true);
 });
+
+Deno.test("validate: warns when step writes is set without placement", async () => {
+  const workflow = Workflow.create({
+    name: "writes-no-placement",
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "deploy",
+            task: StepTask.model("test-model", "run"),
+            writes: true,
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const warning = results.find((r) =>
+    r.name.includes("writes without placement")
+  );
+  assertEquals(warning?.passed, true);
+  assertEquals(warning?.warning, true);
+});
+
+Deno.test("validate: no warning when step writes is set with placement", async () => {
+  const workflow = Workflow.create({
+    name: "writes-with-placement",
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "deploy",
+            task: StepTask.model("test-model", "run"),
+            writes: true,
+            target: "deploy-worker",
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const warning = results.find((r) =>
+    r.name.includes("writes without placement")
+  );
+  assertEquals(warning, undefined);
+});
+
+Deno.test("validate: warns when job writes is inherited without placement", async () => {
+  const workflow = Workflow.create({
+    name: "job-writes-no-placement",
+    jobs: [
+      Job.create({
+        name: "main",
+        writes: true,
+        steps: [
+          Step.create({
+            name: "deploy",
+            task: StepTask.model("test-model", "run"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const warning = results.find((r) =>
+    r.name.includes("writes without placement")
+  );
+  assertEquals(warning?.passed, true);
+  assertEquals(warning?.warning, true);
+});
+
+Deno.test("validate: warns when workflow writes is inherited without placement", async () => {
+  const workflow = Workflow.create({
+    name: "wf-writes-no-placement",
+    writes: true,
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "deploy",
+            task: StepTask.model("test-model", "run"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const warning = results.find((r) =>
+    r.name.includes("writes without placement")
+  );
+  assertEquals(warning?.passed, true);
+  assertEquals(warning?.warning, true);
+});
+
+Deno.test("validate: step writes false overrides job writes true — no warning", async () => {
+  const workflow = Workflow.create({
+    name: "writes-child-wins",
+    jobs: [
+      Job.create({
+        name: "main",
+        writes: true,
+        steps: [
+          Step.create({
+            name: "read-only",
+            task: StepTask.model("test-model", "run"),
+            writes: false,
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const warning = results.find((r) =>
+    r.name.includes("writes without placement")
+  );
+  assertEquals(warning, undefined);
+});

--- a/src/domain/workflows/workflow.ts
+++ b/src/domain/workflows/workflow.ts
@@ -106,6 +106,7 @@ const WorkflowObjectSchema = z.object({
   concurrency: z.number().int().nonnegative().optional(),
   reports: ReportSelectionSchema,
   affinity: z.boolean().optional(),
+  writes: z.boolean().optional(),
   ...PlacementFieldsSchema.shape,
 });
 
@@ -149,6 +150,7 @@ export interface CreateWorkflowProps {
   concurrency?: number;
   reports?: ReportSelection;
   affinity?: boolean;
+  writes?: boolean;
   target?: string;
   labels?: Record<string, string>;
   platform?: string;
@@ -180,6 +182,7 @@ export class Workflow {
     readonly concurrency: number | undefined,
     readonly reports: ReportSelection | undefined,
     readonly affinity: boolean | undefined,
+    readonly writes: boolean | undefined,
     readonly target: string | undefined,
     readonly labels: Record<string, string> | undefined,
     readonly platform: string | undefined,
@@ -208,6 +211,7 @@ export class Workflow {
       concurrency: props.concurrency,
       reports: props.reports,
       affinity: props.affinity,
+      writes: props.writes,
       target: props.target,
       labels: props.labels,
       platform: props.platform,
@@ -239,6 +243,7 @@ export class Workflow {
       data.concurrency,
       data.reports,
       data.affinity,
+      data.writes,
       data.target,
       data.labels,
       data.platform,
@@ -265,6 +270,7 @@ export class Workflow {
       validated.concurrency,
       validated.reports,
       validated.affinity,
+      validated.writes,
       validated.target,
       validated.labels,
       validated.platform,
@@ -366,6 +372,7 @@ export class Workflow {
       concurrency: this.concurrency,
       reports: this.reports,
       affinity: this.affinity,
+      writes: this.writes,
       target: this.target,
       labels: this.labels,
       platform: this.platform,

--- a/src/domain/workflows/workflow_test.ts
+++ b/src/domain/workflows/workflow_test.ts
@@ -1094,3 +1094,24 @@ Deno.test("Workflow.fromData handles missing tags (backward compat)", () => {
   );
   assertEquals(workflow.tags, {});
 });
+
+Deno.test("Workflow: writes field roundtrips through toData", () => {
+  const workflow = Workflow.create({
+    name: "wf-writes",
+    writes: true,
+    jobs: [createTestJob("main")],
+  });
+  assertEquals(workflow.writes, true);
+  const data = workflow.toData();
+  assertEquals(data.writes, true);
+  const restored = Workflow.fromData(data);
+  assertEquals(restored.writes, true);
+});
+
+Deno.test("Workflow: writes field is undefined when absent", () => {
+  const workflow = Workflow.create({
+    name: "wf-no-writes",
+    jobs: [createTestJob("main")],
+  });
+  assertEquals(workflow.writes, undefined);
+});

--- a/src/serve/dispatch_service.ts
+++ b/src/serve/dispatch_service.ts
@@ -473,6 +473,11 @@ export class DispatchService {
       stepName: request.stepName,
     });
 
+    if (request.declaredWrites) {
+      this.#writesByDispatch.add(dispatchId);
+      await this.#leaseTransition("mark_writes", { leaseId });
+    }
+
     this.#options.dispatches.register({
       workerName,
       dispatchId,

--- a/src/serve/dispatch_service_test.ts
+++ b/src/serve/dispatch_service_test.ts
@@ -411,6 +411,65 @@ Deno.test("DispatchService: recordFirstWrite marks the lease exactly once", asyn
   );
 });
 
+Deno.test("DispatchService: declaredWrites pre-marks dispatch as write-bearing", async () => {
+  const h = createHarness({
+    workers: [snapshot({ name: "w1" }), snapshot({ name: "w2" })],
+  });
+  let attempts = 0;
+  h.setBehavior((name) => {
+    attempts++;
+    if (attempts === 1) {
+      h.pool.delete(name);
+      h.service.notifyGraceExpired(snapshot({ name }));
+      return Promise.reject(new ChannelClosedError("control socket closed"));
+    }
+    return Promise.resolve({
+      status: "success",
+      outputs: [],
+      logs: [],
+      durationMs: 1,
+    });
+  });
+
+  await assertRejects(
+    () => h.service.executeRemote(stepRequest({ declaredWrites: true })),
+    Error,
+    "write-then-drop",
+  );
+  assertEquals(
+    h.transitions.map((t) => t.methodName),
+    ["acquire", "mark_writes", "fail"],
+  );
+  assertEquals(attempts, 1);
+});
+
+Deno.test("DispatchService: declaredWrites false behaves like no declaration", async () => {
+  const h = createHarness({
+    workers: [snapshot({ name: "w1" }), snapshot({ name: "w2" })],
+  });
+  let attempts = 0;
+  h.setBehavior((name) => {
+    attempts++;
+    if (attempts === 1) {
+      h.pool.delete(name);
+      h.service.notifyGraceExpired(snapshot({ name }));
+      return Promise.reject(new ChannelClosedError("control socket closed"));
+    }
+    return Promise.resolve({
+      status: "success",
+      outputs: [],
+      logs: [],
+      durationMs: 1,
+    });
+  });
+
+  const result = await h.service.executeRemote(
+    stepRequest({ declaredWrites: false }),
+  );
+  assertEquals(result.durationMs, 1);
+  assertEquals(attempts, 2);
+});
+
 Deno.test("DispatchService: abort during queue wait rejects", async () => {
   const h = createHarness({
     workers: [


### PR DESCRIPTION
## Summary

- Add `writes: true` boolean field at step/job/workflow level that declares a step performs external mutations (API calls, kubectl, SSH) not tracked by data-plane writes
- When declared, the dispatch service pre-marks the dispatch as write-bearing before the method body runs — a worker disconnect fails the run instead of re-dispatching
- Inheritance is child-wins: step > job > workflow
- Validation warns when `writes: true` is set without remote placement (a no-op locally)
- Filed #2290 for the incorrect `failure-semantics.md` manual page on swamp-club.com

## Test plan

- [x] Step schema accepts `writes` field and roundtrips through toData/fromData
- [x] Job and Workflow `writes` roundtrip tests
- [x] Dispatch service test: `declaredWrites: true` → pre-marks write-bearing → fails on disconnect (not re-dispatched)
- [x] Dispatch service test: `declaredWrites: false` → behaves like no declaration (re-dispatched)
- [x] Validation service tests: warns for writes without placement at step/job/workflow level
- [x] Validation service test: `step.writes: false` overrides `job.writes: true` (child-wins) — no warning
- [x] All 230 existing + new tests pass
- [x] Build verification: 9/9 passed (lint, fmt, type-check, tests, deps-audit, compile, binary-check)

Closes swamp-club#1784

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Randy Bias <randybias@gmail.com>