### PR TITLE
fix(test): use platform-aware paths in resolveManagedConfigPaths tests (swamp-club#1868)

### DIFF
--- a/.claude/skills/issue-lifecycle/references/verification.md
+++ b/.claude/skills/issue-lifecycle/references/verification.md
@@ -71,9 +71,13 @@ swamp data get <model-name> <data-name>
 succeeded.** A partial pass is NOT a pass. If any step failed, go to "Any step
 failed" below.
 
-1. Construct the combined attestation JSON including the `configIntegrity`
-   checksums (see `agent-constraints/verification-conventions.md` for the full
-   schema).
+1. **Build a fresh attestation from the actual run data.** Query
+   `workflow history get <run-id> --json` for both workflows, extract real step
+   durations and statuses, and recompute `configIntegrity` checksums from the
+   files at the verified commit (`sha256sum`). **NEVER reuse or edit a previous
+   attestation** — swapping the commit SHA or run IDs in an old attestation is a
+   trust chain violation. See `agent-constraints/verification-conventions.md`
+   for the full schema.
 
 2. Call `verification_passed` with the attestation data:
 

--- a/agent-constraints/verification-conventions.md
+++ b/agent-constraints/verification-conventions.md
@@ -171,7 +171,17 @@ To construct this checklist:
    — the attestation must carry actual measured durations from the workflow
    run.
 
-4. Construct the combined attestation JSON:
+4. **NEVER reuse or edit a previous attestation.** Every attestation must be
+   built from scratch using the actual data from the workflow runs for the
+   current commit. Editing an old attestation to swap the commit SHA, run IDs,
+   or any other field is a trust chain violation — the attestation would claim
+   durations, timestamps, and config hashes from a different run against a
+   different commit. Always query `workflow history get <run-id> --json` for
+   each workflow, extract the real step durations and statuses, recompute
+   config integrity hashes from the files at the verified commit
+   (`sha256sum`), and construct a fresh JSON object.
+
+5. Construct the combined attestation JSON:
 
    ```json
    {
@@ -257,7 +267,7 @@ To construct this checklist:
    sha256sum CLAUDE.md verification/review-prompts/*.md verification/workflow-verify-*.yaml
    ```
 
-5. Present the checklist AND the workflow run file paths to the user so they
+6. Present the checklist AND the workflow run file paths to the user so they
    can inspect the full details:
 
    ```
@@ -265,7 +275,7 @@ To construct this checklist:
    Review run: .swamp/workflow-runs/<id>/workflow-run-<review-run-id>.yaml
    ```
 
-6. Determine the overall result. **Only call `verification_passed` when
+7. Determine the overall result. **Only call `verification_passed` when
    `gate.allPassed` is true — every non-skipped step must have succeeded.**
    If any step failed, call `verification_failed` instead. Do not treat a
    partial pass as success.
@@ -273,12 +283,12 @@ To construct this checklist:
    - **All pass** → present checklist to user, wait for confirmation
    - **Any fail** → call `verification_failed`, fix the issues, re-verify
 
-7. **Wait for the user to confirm they are ready to open the PR.** Present
+8. **Wait for the user to confirm they are ready to open the PR.** Present
    the full verification checklist and stop. Do NOT post the attestation or
    open a PR until the user explicitly says to proceed. The user's
    confirmation is the trigger for the attestation push.
 
-8. **After the user confirms, post the attestation to swamp-club** using the
+9. **After the user confirms, post the attestation to swamp-club** using the
    issue-lifecycle model's `post_attestation` method. This is a **hard
    requirement** — the PR MUST NOT open until the attestation has been
    successfully posted.
@@ -375,7 +385,7 @@ each run.
 
 Do NOT open a PR until the user has seen a fully green checklist,
 confirmed they want to proceed, and the attestation has been posted to
-swamp-club (step 8). The user's confirmation triggers the attestation
+swamp-club (step 9). The user's confirmation triggers the attestation
 push — do not post it automatically.
 
 ## Review Prompts

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -24,7 +24,7 @@ import {
   assertStringIncludes,
 } from "@std/assert";
 import { ensureDir } from "@std/fs";
-import { join } from "@std/path";
+import { join, resolve } from "@std/path";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 import {
   acquireModelLocks,
@@ -2203,48 +2203,61 @@ Deno.test("acquireModelLocks: uses two-phase push when twoPhaseSync is advertise
 // ============================================================================
 
 Deno.test("resolveManagedConfigPaths: null marker returns default pulled-extensions root", () => {
-  const { pulledExtensionsRoot } = resolveManagedConfigPaths("/repo", null);
-  assertPathEquals(pulledExtensionsRoot, "/repo/.swamp/pulled-extensions");
+  const repo = resolve("/repo");
+  const { pulledExtensionsRoot } = resolveManagedConfigPaths(repo, null);
+  assertPathEquals(
+    pulledExtensionsRoot,
+    join(repo, ".swamp", "pulled-extensions"),
+  );
 });
 
 Deno.test("resolveManagedConfigPaths: null marker returns default lockfile path", () => {
-  const { lockfilePath } = resolveManagedConfigPaths("/repo", null);
+  const repo = resolve("/repo");
+  const { lockfilePath } = resolveManagedConfigPaths(repo, null);
   assertPathEquals(
     lockfilePath,
-    "/repo/extensions/models/upstream_extensions.json",
+    join(repo, "extensions", "models", "upstream_extensions.json"),
   );
 });
 
 Deno.test("resolveManagedConfigPaths: marker without datastore returns default paths", () => {
+  const repo = resolve("/repo");
   const marker: RepoMarkerData = {
     swampVersion: "1.0.0",
     initializedAt: "2026-01-01T00:00:00.000Z",
   };
   const { pulledExtensionsRoot, lockfilePath } = resolveManagedConfigPaths(
-    "/repo",
+    repo,
     marker,
   );
-  assertPathEquals(pulledExtensionsRoot, "/repo/.swamp/pulled-extensions");
+  assertPathEquals(
+    pulledExtensionsRoot,
+    join(repo, ".swamp", "pulled-extensions"),
+  );
   assertPathEquals(
     lockfilePath,
-    "/repo/extensions/models/upstream_extensions.json",
+    join(repo, "extensions", "models", "upstream_extensions.json"),
   );
 });
 
 Deno.test("resolveManagedConfigPaths: managedConfig=false returns default paths", () => {
+  const repo = resolve("/repo");
   const marker: RepoMarkerData = {
     swampVersion: "1.0.0",
     initializedAt: "2026-01-01T00:00:00.000Z",
     datastore: { type: "filesystem", managedConfig: false },
   };
   const { pulledExtensionsRoot, lockfilePath } = resolveManagedConfigPaths(
-    "/repo",
+    repo,
     marker,
   );
-  assertPathEquals(pulledExtensionsRoot, "/repo/.swamp/pulled-extensions");
+  assertPathEquals(
+    pulledExtensionsRoot,
+    join(repo, ".swamp", "pulled-extensions"),
+  );
   assertPathEquals(
     lockfilePath,
-    "/repo/extensions/models/upstream_extensions.json",
+    join(repo, "extensions", "models", "upstream_extensions.json"),
   );
 });
 
@@ -2322,34 +2335,36 @@ Deno.test("resolveManagedConfigPaths: managedConfig=true with custom modelsDir s
 });
 
 Deno.test("resolveManagedConfigPaths: managedConfig=true without sentinel falls back to default paths", () => {
+  const repo = resolve("/nonexistent-repo");
   const marker: RepoMarkerData = {
     swampVersion: "1.0.0",
     initializedAt: "2026-01-01T00:00:00.000Z",
     datastore: { type: "@swamp/s3-datastore", managedConfig: true },
   };
   const { pulledExtensionsRoot, lockfilePath } = resolveManagedConfigPaths(
-    "/nonexistent-repo",
+    repo,
     marker,
   );
   assertPathEquals(
     pulledExtensionsRoot,
-    "/nonexistent-repo/.swamp/pulled-extensions",
+    join(repo, ".swamp", "pulled-extensions"),
   );
   assertPathEquals(
     lockfilePath,
-    "/nonexistent-repo/extensions/models/upstream_extensions.json",
+    join(repo, "extensions", "models", "upstream_extensions.json"),
   );
 });
 
 Deno.test("resolveManagedConfigPaths: custom modelsDir is used when managedConfig=false", () => {
+  const repo = resolve("/repo");
   const marker: RepoMarkerData = {
     swampVersion: "1.0.0",
     initializedAt: "2026-01-01T00:00:00.000Z",
     modelsDir: "custom/models",
   };
-  const { lockfilePath } = resolveManagedConfigPaths("/repo", marker);
+  const { lockfilePath } = resolveManagedConfigPaths(repo, marker);
   assertPathEquals(
     lockfilePath,
-    "/repo/custom/models/upstream_extensions.json",
+    join(repo, "custom", "models", "upstream_extensions.json"),
   );
 });


### PR DESCRIPTION
## Summary

- Fix 5 Windows CI test failures in `resolveManagedConfigPaths` tests introduced by the managedConfig PR (#2288)
- Replace hardcoded Unix path literals (`"/repo"`, `"/nonexistent-repo"`) with `resolve()`/`join()`-constructed paths so the drive letter prefix is included on Windows
- Also fix 1 additional test with the same pattern that hadn't failed yet

## Test Plan

- All 10804 tests pass locally (`deno run test`)
- All `resolveManagedConfigPaths` tests pass (`deno run test src/cli/repo_context_test.ts` — 60 passed)
- Verification workflow passed: 8/8 steps green, 3 skipped (guard)
- Windows CI should now pass — the fix uses the same `resolve()`+`join()` pattern as the passing `Deno.makeTempDir()`-based tests

Closes swamp-club#1868