### PR TITLE
feat(ci): enforce attestation and review integrity as merge gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -895,8 +895,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # Informational only — not a merge gate. Validates that local verification
-    # ran on this commit and that config integrity checksums match.
+    # Mandatory merge gate. Validates that local verification ran on this commit
+    # and that config integrity checksums match.
     if: github.event.pull_request.draft == false
 
     steps:
@@ -930,7 +930,7 @@ jobs:
             --input branch=\$(git branch --show-current)
           \`\`\`
           EOF
-            exit 0
+            exit 1
           fi
 
           if ! jq . attestation.json > /dev/null 2>&1; then
@@ -1120,6 +1120,8 @@ jobs:
         claude-adversarial-review,
         claude-ux-review,
         claude-ci-security-review,
+        validate-attestation,
+        claude-review-integrity,
       ]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- Promote `validate-attestation` from informational to mandatory merge gate — `exit 0` → `exit 1` when no attestation found
- Add `validate-attestation` (mandatory) and `claude-review-integrity` (conditional on trust_root changes) to `auto-merge` needs list
- Update comment to reflect new blocking role

Closes swamp-club#1869

## Test plan

- [x] Local verification passed (build: 9/9, reviews: code-review pass, ci-security-review pass, adversarial/ux skipped by guard)
- [x] Attestation posted to swamp-club for commit `70b2de36`
- [ ] CI `validate-attestation` finds the posted attestation and passes
- [ ] CI `claude-review-integrity` skips (no trust_root changes) and auto-merge proceeds
- [ ] Auto-merge succeeds after all gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMw1EMaDZpu2hygNVo5RXn