### PR TITLE
fix(verification): use origin/main as diff base to prevent stale diffs in worktrees (swamp-club#1872)

### DIFF
--- a/.claude/skills/issue-lifecycle/references/code-conformance-review.md
+++ b/.claude/skills/issue-lifecycle/references/code-conformance-review.md
@@ -23,8 +23,9 @@ reference it.
 Diff the branch against main to see all changes:
 
 ```
-git diff main...HEAD --stat
-git diff main...HEAD
+git fetch origin main
+git diff origin/main...HEAD --stat
+git diff origin/main...HEAD
 ```
 
 For each plan step, read the files listed in the step and verify the described

--- a/agent-constraints/verification-conventions.md
+++ b/agent-constraints/verification-conventions.md
@@ -45,9 +45,9 @@ The workflow:
    worktree
 4. Each review uses the factory pattern — one `reviewer` model, called once per
    review type with different prompt files and models
-5. Review diffs use `git merge-base main HEAD` so only the branch's own changes
-   are reviewed — not the inverse of what landed on main since the branch
-   diverged
+5. Review diffs use `git merge-base origin/main HEAD` so only the branch's own
+   changes are reviewed — the setup step fetches `origin main` first to ensure
+   the diff base is current regardless of local branch state
 6. Cleans up the worktree regardless of pass/fail
 
 ### Guards

--- a/verification/workflow-verify-reviews.yaml
+++ b/verification/workflow-verify-reviews.yaml
@@ -38,6 +38,7 @@ jobs:
           inputs:
             run: |
               set -e
+              git fetch origin main
               CHECKOUT_DIR="/tmp/swamp-verify-reviews-${{ run.id }}"
               rm -rf "$CHECKOUT_DIR"
               git worktree prune
@@ -58,7 +59,7 @@ jobs:
           modelName: repo
           methodName: diff
           inputs:
-            base: "main"
+            base: "origin/main"
 
       - name: changed-files
         dependsOn:
@@ -71,7 +72,7 @@ jobs:
           modelName: repo
           methodName: diff
           inputs:
-            base: "main"
+            base: "origin/main"
             nameOnly: true
 
   # ── Agent Reviews ────────────────────────────────────────────
@@ -91,7 +92,7 @@ jobs:
           inputs:
             run: |
               set -o pipefail
-              MERGE_BASE=$(git merge-base main HEAD)
+              MERGE_BASE=$(git merge-base origin/main HEAD)
               DIFF_FILE=$(mktemp)
               PROMPT_FILE=$(mktemp)
               RESULT_FILE=$(mktemp)
@@ -120,7 +121,7 @@ jobs:
           inputs:
             run: |
               set -o pipefail
-              MERGE_BASE=$(git merge-base main HEAD)
+              MERGE_BASE=$(git merge-base origin/main HEAD)
               DIFF_FILE=$(mktemp)
               PROMPT_FILE=$(mktemp)
               RESULT_FILE=$(mktemp)
@@ -149,7 +150,7 @@ jobs:
           inputs:
             run: |
               set -o pipefail
-              MERGE_BASE=$(git merge-base main HEAD)
+              MERGE_BASE=$(git merge-base origin/main HEAD)
               DIFF_FILE=$(mktemp)
               PROMPT_FILE=$(mktemp)
               RESULT_FILE=$(mktemp)
@@ -178,7 +179,7 @@ jobs:
           inputs:
             run: |
               set -o pipefail
-              MERGE_BASE=$(git merge-base main HEAD)
+              MERGE_BASE=$(git merge-base origin/main HEAD)
               DIFF_FILE=$(mktemp)
               PROMPT_FILE=$(mktemp)
               RESULT_FILE=$(mktemp)


### PR DESCRIPTION
## Summary

The verify-reviews workflow computed diffs against the local `main` branch, which can be behind `origin/main` in worktrees. This caused reviewers to see phantom changes from upstream commits not part of the branch, producing false-positive findings that blocked verification twice during #1869.

- Add `git fetch origin main` to the setup step so `origin/main` is guaranteed fresh
- Change all `git merge-base main HEAD` invocations (4 review steps) to `git merge-base origin/main HEAD`
- Change `@swamp/git` diff inputs from `base: "main"` to `base: "origin/main"` (2 detect-changes steps)
- Update verification-conventions.md and code-conformance-review.md to match

## Test Plan

- Verification workflow ran successfully against this commit (build: 9/9 passed, reviews: code-review VERDICT: pass, 3 reviews correctly guard-skipped)
- Attestation posted to swamp-club