### PR TITLE
fix(serve): populate workflow and data authorization fields for CEL conditions

### DIFF
--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -33,6 +33,7 @@ import { PolicySnapshot } from "../domain/access/policy_snapshot.ts";
 import type { PolicySnapshotLoader } from "../domain/access/policy_snapshot_loader.ts";
 import type { Grant } from "../domain/models/access/grant_model.ts";
 import { GrantBasedAccessDecisionService } from "../domain/access/grant_based_access_decision_service.ts";
+import { waitFor } from "@swamp-club/swamp-testing";
 
 await initializeLogging({});
 
@@ -683,8 +684,7 @@ Deno.test("authorizeOrReject: unauthorized workflow.run returns error frame", as
     testPrincipal,
   );
 
-  await new Promise((r) => setTimeout(r, 0));
-  assertEquals(mock.sent.length, 1);
+  await waitFor(() => mock.sent.length >= 1, "unauthorized error frame sent");
   const msg = parseSent(mock);
   assertEquals(msg.type, "error");
   assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
@@ -978,8 +978,7 @@ Deno.test("authorizeOrReject: explicit deny returns denied error frame", async (
     testPrincipal,
   );
 
-  await new Promise((r) => setTimeout(r, 0));
-  assertEquals(mock.sent.length, 1);
+  await waitFor(() => mock.sent.length >= 1, "deny error frame sent");
   const msg = parseSent(mock);
   assertEquals(msg.type, "error");
   assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
@@ -1007,8 +1006,7 @@ Deno.test("authorizeOrReject: resolvedUserNames replaces raw ID in error message
     principal,
   );
 
-  await new Promise((r) => setTimeout(r, 0));
-  assertEquals(mock.sent.length, 1);
+  await waitFor(() => mock.sent.length >= 1, "resolved-name error frame sent");
   const msg = parseSent(mock);
   assertEquals(msg.type, "error");
   assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
@@ -1036,8 +1034,7 @@ Deno.test("authorizeOrReject: falls back to raw ID when resolvedUserNames absent
     principal,
   );
 
-  await new Promise((r) => setTimeout(r, 0));
-  assertEquals(mock.sent.length, 1);
+  await waitFor(() => mock.sent.length >= 1, "raw-id error frame sent");
   const msg = parseSent(mock);
   assertEquals(msg.type, "error");
   const errorMessage = String((msg.error as Record<string, unknown>).message);
@@ -1718,8 +1715,10 @@ Deno.test("authorizeOrReject: data.get rejected without read grant", async () =>
     testPrincipal,
   );
 
-  await new Promise((r) => setTimeout(r, 0));
-  assertEquals(mock.sent.length, 1);
+  await waitFor(
+    () => mock.sent.length >= 1,
+    "data.get unauthorized frame sent",
+  );
   const msg = parseSent(mock);
   assertEquals(msg.type, "error");
   assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
@@ -1995,7 +1994,10 @@ Deno.test("authorizeOrReject: admin on access:* grants data.get (superuser)", as
     testPrincipal,
   );
 
-  await new Promise((r) => setTimeout(r, 0));
+  await waitFor(
+    () => mock.sent.length >= 1,
+    "data.get superuser response sent",
+  );
   const unauthorizedErrors = mock.sent
     .map((s) => JSON.parse(s))
     .filter((m) =>

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -1701,7 +1701,7 @@ Deno.test("validateServerRequest accepts report.type.search", () => {
 
 // ── Authorization: new request types ────────────────────────────────────
 
-Deno.test("authorizeOrReject: data.get rejected without read grant", () => {
+Deno.test("authorizeOrReject: data.get rejected without read grant", async () => {
   const mock = createMockSocket();
   const active = new Map<string, AbortController>();
   const ctx = makeCtx(modeTokenConfig, []);
@@ -1718,6 +1718,7 @@ Deno.test("authorizeOrReject: data.get rejected without read grant", () => {
     testPrincipal,
   );
 
+  await new Promise((r) => setTimeout(r, 0));
   assertEquals(mock.sent.length, 1);
   const msg = parseSent(mock);
   assertEquals(msg.type, "error");
@@ -1972,7 +1973,7 @@ Deno.test("authorizeOrReject: audit.timeline rejected without read grant", () =>
   );
 });
 
-Deno.test("authorizeOrReject: admin on access:* grants data.get (superuser)", () => {
+Deno.test("authorizeOrReject: admin on access:* grants data.get (superuser)", async () => {
   const mock = createMockSocket();
   const active = new Map<string, AbortController>();
   const grant = makeGrant({
@@ -1994,6 +1995,7 @@ Deno.test("authorizeOrReject: admin on access:* grants data.get (superuser)", ()
     testPrincipal,
   );
 
+  await new Promise((r) => setTimeout(r, 0));
   const unauthorizedErrors = mock.sent
     .map((s) => JSON.parse(s))
     .filter((m) =>

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -631,7 +631,7 @@ Deno.test("authorizeOrReject: null principal rejected in token mode", () => {
 
 // ── Authorization: authorized request succeeds ────────────────────────────
 
-Deno.test("authorizeOrReject: authorized workflow.run proceeds", () => {
+Deno.test("authorizeOrReject: authorized workflow.run proceeds", async () => {
   const mock = createMockSocket();
   const active = new Map<string, AbortController>();
   const grant = makeGrant({
@@ -653,6 +653,7 @@ Deno.test("authorizeOrReject: authorized workflow.run proceeds", () => {
     testPrincipal,
   );
 
+  await waitFor(() => mock.sent.length >= 1, "workflow.run response sent");
   // Should not get an unauthorized error — the request proceeds to the handler
   for (const sent of mock.sent) {
     const msg = JSON.parse(sent);

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -545,6 +545,10 @@ const stubRepoContext = {
     listTypes: () => Promise.resolve([]),
     listByType: () => Promise.resolve([]),
   },
+  workflowRepo: {
+    findByName: () => Promise.resolve(null),
+    findById: () => Promise.resolve(null),
+  },
 } as unknown as ConnectionContext["repoContext"];
 
 const stubRepoDir = await Deno.makeTempDir({ prefix: "swamp_conn_test_" });
@@ -662,7 +666,7 @@ Deno.test("authorizeOrReject: authorized workflow.run proceeds", () => {
 
 // ── Authorization: unauthorized request gets error frame ──────────────────
 
-Deno.test("authorizeOrReject: unauthorized workflow.run returns error frame", () => {
+Deno.test("authorizeOrReject: unauthorized workflow.run returns error frame", async () => {
   const mock = createMockSocket();
   const active = new Map<string, AbortController>();
   const ctx = makeCtx(modeTokenConfig, []);
@@ -679,6 +683,7 @@ Deno.test("authorizeOrReject: unauthorized workflow.run returns error frame", ()
     testPrincipal,
   );
 
+  await new Promise((r) => setTimeout(r, 0));
   assertEquals(mock.sent.length, 1);
   const msg = parseSent(mock);
   assertEquals(msg.type, "error");
@@ -940,7 +945,7 @@ Deno.test("authorizeOrReject: explicit deny beats admin on access:*", () => {
   assertStringIncludes(errorMessage, "explicitly denied");
 });
 
-Deno.test("authorizeOrReject: explicit deny returns denied error frame", () => {
+Deno.test("authorizeOrReject: explicit deny returns denied error frame", async () => {
   const mock = createMockSocket();
   const active = new Map<string, AbortController>();
   const grants: Grant[] = [
@@ -973,6 +978,7 @@ Deno.test("authorizeOrReject: explicit deny returns denied error frame", () => {
     testPrincipal,
   );
 
+  await new Promise((r) => setTimeout(r, 0));
   assertEquals(mock.sent.length, 1);
   const msg = parseSent(mock);
   assertEquals(msg.type, "error");
@@ -981,7 +987,7 @@ Deno.test("authorizeOrReject: explicit deny returns denied error frame", () => {
   assertStringIncludes(errorMessage, "explicitly denied");
 });
 
-Deno.test("authorizeOrReject: resolvedUserNames replaces raw ID in error message", () => {
+Deno.test("authorizeOrReject: resolvedUserNames replaces raw ID in error message", async () => {
   const mock = createMockSocket();
   const active = new Map<string, AbortController>();
   const opaqueId = "699e486007f77116ebf44bd2";
@@ -1001,6 +1007,7 @@ Deno.test("authorizeOrReject: resolvedUserNames replaces raw ID in error message
     principal,
   );
 
+  await new Promise((r) => setTimeout(r, 0));
   assertEquals(mock.sent.length, 1);
   const msg = parseSent(mock);
   assertEquals(msg.type, "error");
@@ -1010,7 +1017,7 @@ Deno.test("authorizeOrReject: resolvedUserNames replaces raw ID in error message
   assertEquals(errorMessage.includes(opaqueId), false);
 });
 
-Deno.test("authorizeOrReject: falls back to raw ID when resolvedUserNames absent", () => {
+Deno.test("authorizeOrReject: falls back to raw ID when resolvedUserNames absent", async () => {
   const mock = createMockSocket();
   const active = new Map<string, AbortController>();
   const opaqueId = "699e486007f77116ebf44bd2";
@@ -1029,6 +1036,7 @@ Deno.test("authorizeOrReject: falls back to raw ID when resolvedUserNames absent
     principal,
   );
 
+  await new Promise((r) => setTimeout(r, 0));
   assertEquals(mock.sent.length, 1);
   const msg = parseSent(mock);
   assertEquals(msg.type, "error");

--- a/src/serve/handlers/data_handlers.ts
+++ b/src/serve/handlers/data_handlers.ts
@@ -74,6 +74,21 @@ import {
   send,
   sendError,
 } from "./shared.ts";
+import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
+
+export async function resolveDataFields(
+  definitionRepo: DefinitionRepository,
+  modelIdOrName: string,
+): Promise<Record<string, unknown>> {
+  const fields: Record<string, unknown> = { name: modelIdOrName };
+  const result = await findDefinitionByIdOrName(definitionRepo, modelIdOrName);
+  if (result) {
+    fields.name = result.definition.name;
+    const tags = result.definition.tags;
+    if (tags && Object.keys(tags).length > 0) fields.tags = tags;
+  }
+  return fields;
+}
 
 export async function handleDataGet(
   socket: WebSocket,
@@ -84,8 +99,9 @@ export async function handleDataGet(
   principal: Principal | null,
 ): Promise<void> {
   const resourceName = payload.modelIdOrName ?? "*";
-  const dataFields: Record<string, unknown> = {};
-  if (payload.modelIdOrName) dataFields.name = payload.modelIdOrName;
+  const dataFields = resourceName !== "*"
+    ? await resolveDataFields(ctx.repoContext.definitionRepo, resourceName)
+    : {};
   if (
     !authorizeOrReject(socket, requestId, principal, "read", {
       kind: "data",
@@ -219,8 +235,9 @@ export async function handleDataList(
   principal: Principal | null,
 ): Promise<void> {
   const resourceName = payload.modelIdOrName ?? "*";
-  const listFields: Record<string, unknown> = {};
-  if (payload.modelIdOrName) listFields.name = payload.modelIdOrName;
+  const listFields = resourceName !== "*"
+    ? await resolveDataFields(ctx.repoContext.definitionRepo, resourceName)
+    : {};
   if (
     !authorizeOrReject(socket, requestId, principal, "read", {
       kind: "data",
@@ -361,11 +378,15 @@ export async function handleDataVersions(
   principal: Principal | null,
 ): Promise<void> {
   const resourceName = payload.modelIdOrName;
+  const versionFields = await resolveDataFields(
+    ctx.repoContext.definitionRepo,
+    resourceName,
+  );
   if (
     !authorizeOrReject(socket, requestId, principal, "read", {
       kind: "data",
       name: resourceName,
-      fields: { name: resourceName },
+      fields: versionFields,
     }, ctx)
   ) return;
 
@@ -423,11 +444,15 @@ export async function handleDataDelete(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  const deleteFields = await resolveDataFields(
+    ctx.repoContext.definitionRepo,
+    payload.modelIdOrName,
+  );
   if (
     !authorizeOrReject(socket, requestId, principal, "write", {
       kind: "data",
       name: payload.modelIdOrName,
-      fields: { name: payload.modelIdOrName },
+      fields: deleteFields,
     }, ctx)
   ) return;
 
@@ -486,11 +511,15 @@ export async function handleDataRename(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  const renameFields = await resolveDataFields(
+    ctx.repoContext.definitionRepo,
+    payload.modelIdOrName,
+  );
   if (
     !authorizeOrReject(socket, requestId, principal, "write", {
       kind: "data",
       name: payload.modelIdOrName,
-      fields: { name: payload.modelIdOrName },
+      fields: renameFields,
     }, ctx)
   ) return;
 

--- a/src/serve/handlers/data_handlers.ts
+++ b/src/serve/handlers/data_handlers.ts
@@ -81,11 +81,18 @@ export async function resolveDataFields(
   modelIdOrName: string,
 ): Promise<Record<string, unknown>> {
   const fields: Record<string, unknown> = { name: modelIdOrName };
-  const result = await findDefinitionByIdOrName(definitionRepo, modelIdOrName);
-  if (result) {
-    fields.name = result.definition.name;
-    const tags = result.definition.tags;
-    if (tags && Object.keys(tags).length > 0) fields.tags = tags;
+  try {
+    const result = await findDefinitionByIdOrName(
+      definitionRepo,
+      modelIdOrName,
+    );
+    if (result) {
+      fields.name = result.definition.name;
+      const tags = result.definition.tags;
+      if (tags && Object.keys(tags).length > 0) fields.tags = tags;
+    }
+  } catch {
+    // Fall back to name-only fields on lookup failure
   }
   return fields;
 }

--- a/src/serve/handlers/data_handlers_test.ts
+++ b/src/serve/handlers/data_handlers_test.ts
@@ -1,0 +1,74 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { resolveDataFields } from "./data_handlers.ts";
+import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
+
+function makeDefinitionRepo(
+  definitions: Map<string, { name: string; tags?: Record<string, string> }>,
+): DefinitionRepository {
+  return {
+    findByNameGlobal: (name: string) => {
+      const def = definitions.get(name);
+      if (!def) return Promise.resolve(null);
+      return Promise.resolve({
+        type: { normalized: "test/type" },
+        definition: { name: def.name, tags: def.tags, id: "test-id" },
+      });
+    },
+    findById: () => Promise.resolve(null),
+    listTypes: () => Promise.resolve([]),
+    listByType: () => Promise.resolve([]),
+  } as unknown as DefinitionRepository;
+}
+
+Deno.test("resolveDataFields: returns tags when model has them", async () => {
+  const repo = makeDefinitionRepo(
+    new Map([["tagged-model", {
+      name: "tagged-model",
+      tags: { env: "prod" },
+    }]]),
+  );
+
+  const fields = await resolveDataFields(repo, "tagged-model");
+
+  assertEquals(fields.name, "tagged-model");
+  assertEquals(fields.tags, { env: "prod" });
+});
+
+Deno.test("resolveDataFields: omits tags when model has none", async () => {
+  const repo = makeDefinitionRepo(
+    new Map([["plain-model", { name: "plain-model" }]]),
+  );
+
+  const fields = await resolveDataFields(repo, "plain-model");
+
+  assertEquals(fields.name, "plain-model");
+  assertEquals(fields.tags, undefined);
+});
+
+Deno.test("resolveDataFields: falls back to name-only when model not found", async () => {
+  const repo = makeDefinitionRepo(new Map());
+
+  const fields = await resolveDataFields(repo, "missing-model");
+
+  assertEquals(fields.name, "missing-model");
+  assertEquals(fields.tags, undefined);
+});

--- a/src/serve/handlers/data_handlers_test.ts
+++ b/src/serve/handlers/data_handlers_test.ts
@@ -72,3 +72,17 @@ Deno.test("resolveDataFields: falls back to name-only when model not found", asy
   assertEquals(fields.name, "missing-model");
   assertEquals(fields.tags, undefined);
 });
+
+Deno.test("resolveDataFields: falls back to name-only when repo throws", async () => {
+  const repo = {
+    findByNameGlobal: () => Promise.reject(new Error("PermissionDenied")),
+    findById: () => Promise.reject(new Error("PermissionDenied")),
+    listTypes: () => Promise.resolve([]),
+    listByType: () => Promise.resolve([]),
+  } as unknown as DefinitionRepository;
+
+  const fields = await resolveDataFields(repo, "erroring-model");
+
+  assertEquals(fields.name, "erroring-model");
+  assertEquals(fields.tags, undefined);
+});

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -144,12 +144,16 @@ export async function resolveWorkflowFields(
   idOrName: string,
 ): Promise<Record<string, unknown>> {
   const fields: Record<string, unknown> = { name: idOrName };
-  const workflow = await workflowRepo.findByName(idOrName) ??
-    await workflowRepo.findById(createWorkflowId(idOrName));
-  if (workflow) {
-    fields.name = workflow.name;
-    const tags = workflow.tags;
-    if (tags && Object.keys(tags).length > 0) fields.tags = tags;
+  try {
+    const workflow = await workflowRepo.findByName(idOrName) ??
+      await workflowRepo.findById(createWorkflowId(idOrName));
+    if (workflow) {
+      fields.name = workflow.name;
+      const tags = workflow.tags;
+      if (tags && Object.keys(tags).length > 0) fields.tags = tags;
+    }
+  } catch {
+    // Fall back to name-only fields on lookup failure
   }
   return fields;
 }

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -134,9 +134,25 @@ import {
   validateTriggerOverrideEntry,
   writeServeConfigFile,
 } from "../serve_config.ts";
+import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 
 const logger = getSwampLogger(["serve", "connection"]);
 const DEFAULT_BUFFER_CAPACITY = 10_000;
+
+export async function resolveWorkflowFields(
+  workflowRepo: WorkflowRepository,
+  idOrName: string,
+): Promise<Record<string, unknown>> {
+  const fields: Record<string, unknown> = { name: idOrName };
+  const workflow = await workflowRepo.findByName(idOrName) ??
+    await workflowRepo.findById(createWorkflowId(idOrName));
+  if (workflow) {
+    fields.name = workflow.name;
+    const tags = workflow.tags;
+    if (tags && Object.keys(tags).length > 0) fields.tags = tags;
+  }
+  return fields;
+}
 
 export async function handleWorkflowRun(
   socket: WebSocket,
@@ -146,11 +162,15 @@ export async function handleWorkflowRun(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  const workflowFields = await resolveWorkflowFields(
+    ctx.repoContext.workflowRepo,
+    payload.workflowIdOrName,
+  );
   if (
     !authorizeOrReject(socket, requestId, principal, "run", {
       kind: "workflow",
       name: payload.workflowIdOrName,
-      fields: { name: payload.workflowIdOrName },
+      fields: workflowFields,
     }, ctx)
   ) return;
 
@@ -487,11 +507,15 @@ export async function handleWorkflowGet(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  const workflowFields = await resolveWorkflowFields(
+    ctx.repoContext.workflowRepo,
+    payload.workflowIdOrName,
+  );
   if (
     !authorizeOrReject(socket, requestId, principal, "read", {
       kind: "workflow",
       name: payload.workflowIdOrName,
-      fields: {},
+      fields: workflowFields,
     }, ctx)
   ) return;
 
@@ -542,11 +566,15 @@ export async function handleWorkflowHistoryGet(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  const workflowFields = await resolveWorkflowFields(
+    ctx.repoContext.workflowRepo,
+    payload.workflowIdOrName,
+  );
   if (
     !authorizeOrReject(socket, requestId, principal, "read", {
       kind: "workflow",
       name: payload.workflowIdOrName,
-      fields: {},
+      fields: workflowFields,
     }, ctx)
   ) return;
 
@@ -606,11 +634,15 @@ export async function handleWorkflowHistoryLogs(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  const workflowFields = await resolveWorkflowFields(
+    ctx.repoContext.workflowRepo,
+    payload.runIdOrWorkflow,
+  );
   if (
     !authorizeOrReject(socket, requestId, principal, "read", {
       kind: "workflow",
       name: payload.runIdOrWorkflow,
-      fields: {},
+      fields: workflowFields,
     }, ctx)
   ) return;
 
@@ -851,11 +883,15 @@ export async function handleWorkflowApprove(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  const workflowFields = await resolveWorkflowFields(
+    ctx.repoContext.workflowRepo,
+    payload.workflowIdOrName,
+  );
   if (
     !authorizeOrReject(socket, requestId, principal, "run", {
       kind: "workflow",
       name: payload.workflowIdOrName,
-      fields: {},
+      fields: workflowFields,
     }, ctx)
   ) return;
 
@@ -920,11 +956,15 @@ export async function handleWorkflowReject(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  const workflowFields = await resolveWorkflowFields(
+    ctx.repoContext.workflowRepo,
+    payload.workflowIdOrName,
+  );
   if (
     !authorizeOrReject(socket, requestId, principal, "run", {
       kind: "workflow",
       name: payload.workflowIdOrName,
-      fields: {},
+      fields: workflowFields,
     }, ctx)
   ) return;
 
@@ -990,11 +1030,15 @@ export async function handleWorkflowResume(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  const workflowFields = await resolveWorkflowFields(
+    ctx.repoContext.workflowRepo,
+    payload.workflowIdOrName,
+  );
   if (
     !authorizeOrReject(socket, requestId, principal, "run", {
       kind: "workflow",
       name: payload.workflowIdOrName,
-      fields: { name: payload.workflowIdOrName },
+      fields: workflowFields,
     }, ctx)
   ) return;
 
@@ -1353,7 +1397,7 @@ export async function handleWorkflowCreate(
     !authorizeOrReject(socket, requestId, principal, "write", {
       kind: "workflow",
       name: payload.name,
-      fields: {},
+      fields: { name: payload.name },
     }, ctx)
   ) return;
 
@@ -1399,11 +1443,15 @@ export async function handleWorkflowDelete(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  const workflowFields = await resolveWorkflowFields(
+    ctx.repoContext.workflowRepo,
+    payload.workflowIdOrName,
+  );
   if (
     !authorizeOrReject(socket, requestId, principal, "write", {
       kind: "workflow",
       name: payload.workflowIdOrName,
-      fields: {},
+      fields: workflowFields,
     }, ctx)
   ) return;
 
@@ -1451,11 +1499,15 @@ export async function handleWorkflowEdit(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  const workflowFields = await resolveWorkflowFields(
+    ctx.repoContext.workflowRepo,
+    payload.workflowIdOrName,
+  );
   if (
     !authorizeOrReject(socket, requestId, principal, "write", {
       kind: "workflow",
       name: payload.workflowIdOrName,
-      fields: {},
+      fields: workflowFields,
     }, ctx)
   ) return;
 
@@ -1507,11 +1559,15 @@ export async function handleWorkflowValidate(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  const resourceName = payload?.workflowIdOrName ?? "*";
+  const workflowFields = resourceName !== "*"
+    ? await resolveWorkflowFields(ctx.repoContext.workflowRepo, resourceName)
+    : {};
   if (
     !authorizeOrReject(socket, requestId, principal, "read", {
       kind: "workflow",
-      name: payload?.workflowIdOrName ?? "*",
-      fields: {},
+      name: resourceName,
+      fields: workflowFields,
     }, ctx)
   ) return;
 
@@ -1563,11 +1619,15 @@ export async function handleWorkflowEvaluate(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  const resourceName = payload?.workflowIdOrName ?? "*";
+  const workflowFields = resourceName !== "*"
+    ? await resolveWorkflowFields(ctx.repoContext.workflowRepo, resourceName)
+    : {};
   if (
     !authorizeOrReject(socket, requestId, principal, "read", {
       kind: "workflow",
-      name: payload?.workflowIdOrName ?? "*",
-      fields: {},
+      name: resourceName,
+      fields: workflowFields,
     }, ctx)
   ) return;
 
@@ -1622,11 +1682,15 @@ export async function handleWorkflowTriggerSet(
   _controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  const workflowFields = await resolveWorkflowFields(
+    ctx.repoContext.workflowRepo,
+    payload.workflowName,
+  );
   if (
     !authorizeOrReject(socket, requestId, principal, "write", {
       kind: "workflow",
       name: payload.workflowName,
-      fields: {},
+      fields: workflowFields,
     }, ctx)
   ) return;
 
@@ -1668,11 +1732,15 @@ export async function handleWorkflowTriggerGet(
   _controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  const workflowFields = await resolveWorkflowFields(
+    ctx.repoContext.workflowRepo,
+    payload.workflowName,
+  );
   if (
     !authorizeOrReject(socket, requestId, principal, "read", {
       kind: "workflow",
       name: payload.workflowName,
-      fields: {},
+      fields: workflowFields,
     }, ctx)
   ) return;
 
@@ -1728,11 +1796,15 @@ export async function handleWorkflowTriggerRemove(
   _controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
+  const workflowFields = await resolveWorkflowFields(
+    ctx.repoContext.workflowRepo,
+    payload.workflowName,
+  );
   if (
     !authorizeOrReject(socket, requestId, principal, "write", {
       kind: "workflow",
       name: payload.workflowName,
-      fields: {},
+      fields: workflowFields,
     }, ctx)
   ) return;
 

--- a/src/serve/handlers/workflow_handlers_test.ts
+++ b/src/serve/handlers/workflow_handlers_test.ts
@@ -1,0 +1,88 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { resolveWorkflowFields } from "./workflow_handlers.ts";
+import { Workflow } from "../../domain/workflows/workflow.ts";
+import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
+
+function makeWorkflowRepo(
+  workflows: Map<string, Workflow>,
+): WorkflowRepository {
+  return {
+    findByName: (name: string) => Promise.resolve(workflows.get(name) ?? null),
+    findById: () => Promise.resolve(null),
+    findAll: () => Promise.resolve([]),
+    save: () => Promise.resolve(),
+    delete: () => Promise.resolve(),
+  } as unknown as WorkflowRepository;
+}
+
+Deno.test("resolveWorkflowFields: returns tags when workflow has them", async () => {
+  const wf = Workflow.create({
+    name: "tagged-workflow",
+    tags: { env: "staging", team: "ops" },
+  });
+  const repo = makeWorkflowRepo(new Map([["tagged-workflow", wf]]));
+
+  const fields = await resolveWorkflowFields(repo, "tagged-workflow");
+
+  assertEquals(fields.name, "tagged-workflow");
+  assertEquals(fields.tags, { env: "staging", team: "ops" });
+});
+
+Deno.test("resolveWorkflowFields: omits tags when workflow has none", async () => {
+  const wf = Workflow.create({ name: "plain-workflow" });
+  const repo = makeWorkflowRepo(new Map([["plain-workflow", wf]]));
+
+  const fields = await resolveWorkflowFields(repo, "plain-workflow");
+
+  assertEquals(fields.name, "plain-workflow");
+  assertEquals(fields.tags, undefined);
+});
+
+Deno.test("resolveWorkflowFields: falls back to name-only when workflow not found", async () => {
+  const repo = makeWorkflowRepo(new Map());
+
+  const fields = await resolveWorkflowFields(repo, "missing-workflow");
+
+  assertEquals(fields.name, "missing-workflow");
+  assertEquals(fields.tags, undefined);
+});
+
+Deno.test("resolveWorkflowFields: falls back to findById when findByName returns null", async () => {
+  const wf = Workflow.create({
+    id: "abc-123",
+    name: "id-workflow",
+    tags: { env: "prod" },
+  });
+  const repo = {
+    findByName: () => Promise.resolve(null),
+    findById: (id: unknown) =>
+      Promise.resolve(String(id) === "abc-123" ? wf : null),
+    findAll: () => Promise.resolve([]),
+    save: () => Promise.resolve(),
+    delete: () => Promise.resolve(),
+  } as unknown as WorkflowRepository;
+
+  const fields = await resolveWorkflowFields(repo, "abc-123");
+
+  assertEquals(fields.name, "id-workflow");
+  assertEquals(fields.tags, { env: "prod" });
+});

--- a/src/serve/handlers/workflow_handlers_test.ts
+++ b/src/serve/handlers/workflow_handlers_test.ts
@@ -86,3 +86,18 @@ Deno.test("resolveWorkflowFields: falls back to findById when findByName returns
   assertEquals(fields.name, "id-workflow");
   assertEquals(fields.tags, { env: "prod" });
 });
+
+Deno.test("resolveWorkflowFields: falls back to name-only when repo throws", async () => {
+  const repo = {
+    findByName: () => Promise.reject(new Error("PermissionDenied")),
+    findById: () => Promise.reject(new Error("PermissionDenied")),
+    findAll: () => Promise.resolve([]),
+    save: () => Promise.resolve(),
+    delete: () => Promise.resolve(),
+  } as unknown as WorkflowRepository;
+
+  const fields = await resolveWorkflowFields(repo, "erroring-workflow");
+
+  assertEquals(fields.name, "erroring-workflow");
+  assertEquals(fields.tags, undefined);
+});


### PR DESCRIPTION
## Summary

- Workflow handlers passed only `{ name: ... }` or `fields: {}` to `authorizeOrReject`, so CEL grant conditions referencing `tags.*` always failed closed — silently denying access even when the workflow carried matching tags
- Data handlers had the same gap — `tags` from model definitions never reached the authorization context
- Both are now resolved by pre-authorization definition lookups that populate `name` and `tags` in the authorization fields, matching the pattern model handlers already used

## Changes

- **`src/serve/handlers/workflow_handlers.ts`** — Add `resolveWorkflowFields` helper (findByName-then-findById, with try/catch fallback) and wire it into all 15 per-workflow handlers
- **`src/serve/handlers/data_handlers.ts`** — Add `resolveDataFields` helper (findDefinitionByIdOrName, with try/catch fallback) and wire it into all 5 per-model data handlers
- **`src/serve/handlers/workflow_handlers_test.ts`** (new) — 5 unit tests for `resolveWorkflowFields`: tags present, tags empty, not found, findById fallback, and error catch path
- **`src/serve/handlers/data_handlers_test.ts`** (new) — 4 unit tests for `resolveDataFields`: tags present, no tags, not found, and error catch path
- **`src/serve/connection_test.ts`** — Add `workflowRepo` stubs to `stubRepoContext`; make 7 authorization tests async with `waitFor` for async pre-authorization resolution

Closes swamp-club#1871
Closes swamp-club#1873

## Test plan

- [x] `resolveWorkflowFields` returns tags when workflow has them
- [x] `resolveWorkflowFields` omits tags when workflow has none
- [x] `resolveWorkflowFields` falls back to name-only when workflow not found
- [x] `resolveWorkflowFields` falls back to name-only when repo throws
- [x] `resolveDataFields` returns tags when model has them
- [x] `resolveDataFields` omits tags when model has none
- [x] `resolveDataFields` falls back to name-only when model not found
- [x] `resolveDataFields` falls back to name-only when repo throws
- [x] All 197 existing connection_test.ts authorization tests pass
- [x] Build verification: lint, fmt, type-check, tests, compile all pass
- [x] Code review and adversarial review pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MDf3YDGCzjwxCfQ6GeRt2