### PR TITLE
fix(cli): use interactiveOutputMode in --server path to prevent TUI rendering in non-TTY pipes (swamp-club#1866)

### DIFF
--- a/src/cli/commands/model_method_history_search.ts
+++ b/src/cli/commands/model_method_history_search.ts
@@ -75,7 +75,9 @@ export async function modelMethodHistorySearchAction(
         payload: { query },
       },
     );
-    const renderer = createModelOutputSearchRenderer(ctx.outputMode);
+    const renderer = createModelOutputSearchRenderer(
+      interactiveOutputMode(ctx),
+    );
     await consumeStream(
       (async function* () {
         yield {

--- a/src/cli/commands/model_output_search.ts
+++ b/src/cli/commands/model_output_search.ts
@@ -101,7 +101,9 @@ export async function modelOutputSearchAction(
         payload: { query },
       },
     );
-    const renderer = createModelOutputSearchRenderer(ctx.outputMode);
+    const renderer = createModelOutputSearchRenderer(
+      interactiveOutputMode(ctx),
+    );
     await consumeStream(
       (async function* () {
         yield {

--- a/src/cli/commands/model_search.ts
+++ b/src/cli/commands/model_search.ts
@@ -96,7 +96,7 @@ export async function modelSearchAction(
         payload: { query, includeInternal },
       },
     );
-    const renderer = createModelSearchRenderer(ctx.outputMode);
+    const renderer = createModelSearchRenderer(interactiveOutputMode(ctx));
     renderer.handlers().completed({
       kind: "completed",
       data: response.data as unknown as ModelSearchData,

--- a/src/cli/commands/report_search.ts
+++ b/src/cli/commands/report_search.ts
@@ -171,7 +171,7 @@ export async function reportSearchAction(
       },
     );
     const renderer = createReportSearchRenderer(
-      ctx.outputMode,
+      interactiveOutputMode(ctx),
       query ?? "",
       undefined,
     );

--- a/src/cli/commands/report_type_search.ts
+++ b/src/cli/commands/report_type_search.ts
@@ -66,7 +66,7 @@ export async function reportTypeSearchAction(
         payload: { query },
       },
     );
-    const renderer = createReportTypeSearchRenderer(ctx.outputMode);
+    const renderer = createReportTypeSearchRenderer(interactiveOutputMode(ctx));
     renderer.handlers().completed({
       kind: "completed",
       data: response.data as unknown as ReportTypeSearchData,

--- a/src/cli/commands/workflow_search.ts
+++ b/src/cli/commands/workflow_search.ts
@@ -87,7 +87,7 @@ export async function workflowSearchAction(
         payload: { query },
       },
     );
-    const renderer = createWorkflowSearchRenderer(ctx.outputMode);
+    const renderer = createWorkflowSearchRenderer(interactiveOutputMode(ctx));
     renderer.handlers().completed({
       kind: "completed",
       data: response.data as unknown as WorkflowSearchData,


### PR DESCRIPTION
## Summary

- Six `--server` search commands used `ctx.outputMode` (which only checks `--json`) instead of `interactiveOutputMode(ctx)` (which also checks `Deno.stdin.isTerminal()`), causing the interactive TUI picker to render into pipes and captured output
- Changed `model_search.ts`, `workflow_search.ts`, `report_search.ts`, `model_output_search.ts`, `model_method_history_search.ts`, and `report_type_search.ts` to use `interactiveOutputMode(ctx)` in their `--server` code path, matching the local path and the 6 other search commands that already handle this correctly

Closes swamp-club#1866

## Test plan

- [x] `deno check` — all 6 modified files type-check clean
- [x] `deno fmt` — all files formatted
- [x] `deno lint` — no issues
- [x] `deno run test` — 10811 passed, 0 failed
- [x] `deno compile` — binary compiles and smoke-checks pass
- [x] Code review — VERDICT: pass
- [x] Attestation posted to swamp-club

🤖 Generated with [Claude Code](https://claude.com/claude-code)