### PR TITLE
fix(issue): reject repository URLs with invisible characters (swamp-club#1864)

### DIFF
--- a/src/domain/extensions/extension_manifest.ts
+++ b/src/domain/extensions/extension_manifest.ts
@@ -89,7 +89,14 @@ const ExtensionManifestSchemaV1 = z.object({
     message: "Version must be valid CalVer format: YYYY.MM.DD.MICRO",
   }),
   description: z.string().optional(),
-  repository: z.string().url().optional(),
+  repository: z.string().url().refine(
+    // deno-lint-ignore no-control-regex
+    (u) => !/[\x00-\x1f]/.test(u),
+    {
+      message:
+        "Repository URL must not contain ASCII control characters (tabs, newlines, etc.)",
+    },
+  ).optional(),
   paths: PathsConfigSchema.optional(),
   workflows: z.array(safePathString).optional(),
   models: z.array(safePathString).optional(),

--- a/src/domain/extensions/extension_manifest_test.ts
+++ b/src/domain/extensions/extension_manifest_test.ts
@@ -565,3 +565,19 @@ models:
   const error = assertThrows(() => parseExtensionManifest(yaml));
   assertStringIncludes((error as Error).message, "paths");
 });
+
+Deno.test("parseExtensionManifest: rejects repository URL with control characters", () => {
+  const yaml = `
+manifestVersion: 1
+name: "@myuser/myext"
+version: "2026.02.26.1"
+repository: "https://github.com/f\tveronezzi/repo"
+models:
+  - foo.ts
+`;
+  const error = assertThrows(() => parseExtensionManifest(yaml));
+  assertStringIncludes(
+    (error as Error).message,
+    "control characters",
+  );
+});

--- a/src/domain/extensions/repository_url.ts
+++ b/src/domain/extensions/repository_url.ts
@@ -48,6 +48,8 @@ const URL_BODY_TRUNCATION_SUFFIX = "\n\n…(body truncated; see terminal output)
  * surfaces the right guidance.
  */
 export function parseRepositoryUrl(url: string): ParsedRepositoryUrl {
+  rejectInvisibleCharacters(url);
+
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -167,4 +169,30 @@ function extractOwnerRepo(parsed: URL): string | undefined {
   const segments = cleaned.split("/").filter((s) => s.length > 0);
   if (segments.length < 2) return undefined;
   return `${segments[0]}/${segments[1]}`;
+}
+
+// deno-lint-ignore no-control-regex
+const INVISIBLE_CHAR_PATTERN = /[\x00-\x08\x0b\x0c\x0e-\x1f\t\n\r]/;
+
+/**
+ * Rejects repository URLs that contain ASCII control characters. The WHATWG
+ * URL parser silently strips tabs (U+0009) and newlines (U+000A, U+000D),
+ * which corrupts the extracted owner/repo — e.g. `f\tveronezzi` becomes
+ * `fveronezzi` after `new URL()` drops the tab.
+ */
+function rejectInvisibleCharacters(url: string): void {
+  const match = INVISIBLE_CHAR_PATTERN.exec(url);
+  if (match) {
+    const codePoint = match[0].codePointAt(0)!;
+    const position = match.index;
+    throw new UserError(
+      `Repository URL contains an invisible character ` +
+        `(U+${codePoint.toString(16).toUpperCase().padStart(4, "0")} ` +
+        `at position ${position}): "${url}". ` +
+        `This corrupts issue routing. The extension publisher needs to ` +
+        `fix the \`repository\` field in their manifest.yaml and re-push. ` +
+        `As a workaround, file the issue directly via ` +
+        `\`gh issue create --repo <owner>/<repo>\`.`,
+    );
+  }
 }

--- a/src/domain/extensions/repository_url_test.ts
+++ b/src/domain/extensions/repository_url_test.ts
@@ -178,3 +178,43 @@ Deno.test("buildGithubSecuritySettingsUrl: shape", () => {
     "https://github.com/adam/cfgmgmt/settings/security_analysis",
   );
 });
+
+Deno.test("parseRepositoryUrl: rejects URL with tab in owner name", () => {
+  assertThrows(
+    () =>
+      parseRepositoryUrl(
+        "https://github.com/f\tveronezzi/swamp-extensions",
+      ),
+    UserError,
+    "invisible character",
+  );
+});
+
+Deno.test("parseRepositoryUrl: rejects URL with newline", () => {
+  assertThrows(
+    () =>
+      parseRepositoryUrl(
+        "https://github.com/owner\n/repo",
+      ),
+    UserError,
+    "invisible character",
+  );
+});
+
+Deno.test("parseRepositoryUrl: rejects URL with carriage return", () => {
+  assertThrows(
+    () =>
+      parseRepositoryUrl(
+        "https://github.com/owner\r/repo",
+      ),
+    UserError,
+    "invisible character",
+  );
+});
+
+Deno.test("parseRepositoryUrl: accepts normal URL without invisible chars", () => {
+  const parsed = parseRepositoryUrl(
+    "https://github.com/ftveronezzi/swamp-extensions",
+  );
+  assertEquals(parsed.ownerRepo, "ftveronezzi/swamp-extensions");
+});


### PR DESCRIPTION
## Summary

- The WHATWG URL parser (`new URL()`) silently strips ASCII tab characters from input, which corrupts the `ownerRepo` extracted from extension manifest repository URLs — e.g. a tab in the owner name causes `ftveronezzi` to become `fveronezzi`
- Added a guard in `parseRepositoryUrl` that detects control characters before URL parsing and throws a clear `UserError` with the code point, position, and actionable guidance
- Added a Zod refinement on the manifest schema's `repository` field to reject control characters at push time, preventing bad data from entering the registry

## Test plan

- [x] Unit tests for `parseRepositoryUrl` with tab, newline, CR, and normal URL
- [x] Unit test for manifest schema rejecting repository URL with control chars
- [x] All existing dispatcher tests pass (no regressions)
- [x] Full verification: build 9/9, reviews pass (code-review + adversarial)

Fixes swamp-club#1864

🤖 Generated with [Claude Code](https://claude.com/claude-code)