### PR TITLE
feat(model): render description field in model get output

### DIFF
--- a/src/libswamp/models/get.ts
+++ b/src/libswamp/models/get.ts
@@ -40,6 +40,7 @@ import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 export interface ModelGetData {
   id: string;
   name: string;
+  description?: string;
   type: string;
   version: number;
   tags: Record<string, string>;
@@ -132,6 +133,7 @@ export async function* modelGet(
       const data: ModelGetData = {
         id: definition.id,
         name: definition.name,
+        description: definition.description,
         type: modelType.normalized,
         version: definition.version,
         tags: definition.tags,

--- a/src/libswamp/models/get_test.ts
+++ b/src/libswamp/models/get_test.ts
@@ -78,6 +78,7 @@ Deno.test("modelGet yields resolving -> completed with model data on success", a
       data: {
         id: "def-1",
         name: "my-model",
+        description: undefined,
         type: "aws/s3-bucket",
         version: 3,
         tags: { env: "prod" },
@@ -89,6 +90,22 @@ Deno.test("modelGet yields resolving -> completed with model data on success", a
       },
     },
   ]);
+});
+
+Deno.test("modelGet: surfaces description when definition has one", async () => {
+  const deps = makeDeps({
+    lookupResult: {
+      definition: { ...testDefinition, description: "A test model" },
+      type: testModelType,
+    },
+    modelDef: undefined,
+  });
+
+  const events = await collect<ModelGetEvent>(
+    modelGet(createLibSwampContext(), deps, "my-model"),
+  );
+
+  assertEquals(completedData(events).description, "A test model");
 });
 
 Deno.test("modelGet: surfaces autoCreated flag when lookup returns it", async () => {

--- a/src/presentation/output/model_get_output_test.ts
+++ b/src/presentation/output/model_get_output_test.ts
@@ -34,6 +34,11 @@ const testData: ModelGetData = {
   globalArguments: { message: "Hello World" },
 };
 
+const testDataWithDescription: ModelGetData = {
+  ...testData,
+  description: "An echo model for testing",
+};
+
 Deno.test("renderModelGet with json mode outputs valid JSON", () => {
   const logs: string[] = [];
   const originalLog = console.log;
@@ -70,6 +75,63 @@ Deno.test("renderModelGet JSON includes tags and attributes", () => {
 
 Deno.test("renderModelGet with log mode does not throw", () => {
   renderModelGet(testData, "log");
+});
+
+Deno.test("renderModelGet JSON includes description when set", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelGet(testDataWithDescription, "json");
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.description, "An echo model for testing");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderModelGet JSON omits description when undefined", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelGet(testData, "json");
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.description, undefined);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderModelGet log mode shows description when set", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelGet(testDataWithDescription, "log");
+    const combined = stripAnsiCode(logs.join("\n"));
+    assertStringIncludes(combined, "Description:");
+    assertStringIncludes(combined, "An echo model for testing");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderModelGet log mode omits description when undefined", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelGet(testData, "log");
+    const combined = stripAnsiCode(logs.join("\n"));
+    assertEquals(combined.includes("Description:"), false);
+  } finally {
+    console.log = originalLog;
+  }
 });
 
 Deno.test("renderModelGet log mode shows model details", () => {

--- a/src/presentation/renderers/model_get.ts
+++ b/src/presentation/renderers/model_get.ts
@@ -120,9 +120,16 @@ class LogModelGetRenderer implements Renderer<ModelGetEvent> {
         const data = e.data;
         const lines = [
           `${bold(cyan("Name:"))} ${bold(data.name)} ${dim(`(${data.type})`)}`,
+        ];
+
+        if (data.description) {
+          lines.push(`${bold(cyan("Description:"))} ${data.description}`);
+        }
+
+        lines.push(
           `${bold(cyan("ID:"))} ${dim(data.id)}`,
           `${bold(cyan("Version:"))} ${data.version}`,
-        ];
+        );
 
         if (data.autoCreated) {
           lines.push(`${bold(cyan("Auto-created:"))} ${dim("yes")}`);


### PR DESCRIPTION
## Summary

- Thread the `description` field — added to `DefinitionData` in #1842 — through `ModelGetData` and into both log and JSON renderers so users see it in `model get` output
- Added `description?: string` to `ModelGetData` interface, populated from `definition.description` in `modelGet()`
- Log mode renders description below the Name line when present; JSON mode includes it automatically

Closes swamp-club#1846

## Test plan

- [x] Unit tests for `description` in JSON output (present and absent)
- [x] Unit tests for `description` in log output (present and absent)
- [x] Updated exact-equality assertion in `get_test.ts` for new field
- [x] Added test for `description` propagation through `modelGet()` generator
- [x] All existing tests pass unchanged
- [x] Verification: lint, fmt, type-check, tests, compile, code review all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)