### PR TITLE
fix(serve): replicate grant/group data across HA cluster instances

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -204,6 +204,7 @@ import {
   sweepStaleRecords,
   sweepTokenConsistency,
 } from "../../serve/boot_reconciliation.ts";
+import { AccessDataPoller } from "../../serve/access_data_poller.ts";
 import { ConfigPoller } from "../../serve/config_poller.ts";
 
 import {
@@ -1423,6 +1424,7 @@ export const serveCommand = new Command()
     });
 
     let configPoller: ConfigPoller | null = null;
+    let accessDataPoller: AccessDataPoller | null = null;
     let repoMarker = null;
     try {
       const markerRepo = new RepoMarkerRepository();
@@ -2426,6 +2428,16 @@ export const serveCommand = new Command()
         policySnapshotLoader,
       });
       await grantsDirectoryPoller.start();
+    }
+
+    if (syncService) {
+      accessDataPoller = new AccessDataPoller({
+        syncService,
+        policySnapshotLoader,
+        catalogInvalidate: () => repoContext.catalogStore.invalidate(),
+        namespace: serveNamespace,
+      });
+      accessDataPoller.start();
     }
 
     const cancelRegistry = new RunCancelRegistry();
@@ -4022,6 +4034,9 @@ export const serveCommand = new Command()
       }
       if (grantsDirectoryPoller) {
         await grantsDirectoryPoller.stop();
+      }
+      if (accessDataPoller) {
+        await accessDataPoller.stop();
       }
       if (configPoller) {
         await configPoller.stop();

--- a/src/serve/access_data_poller.ts
+++ b/src/serve/access_data_poller.ts
@@ -1,0 +1,111 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getLogger } from "@logtape/logtape";
+import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
+import type { PolicySnapshotLoader } from "../domain/access/policy_snapshot_loader.ts";
+
+const logger = getLogger(["swamp", "serve", "access-data-poller"]);
+
+const DEFAULT_ACCESS_DATA_POLL_INTERVAL_MS = 30_000;
+
+const ACCESS_DATA_SUBDIRS = [
+  "data/swamp/grant",
+  "data/swamp/group",
+  "data/@swamp/grant",
+  "data/@swamp/group",
+] as const;
+
+export interface AccessDataPollerOptions {
+  syncService: DatastoreSyncService;
+  policySnapshotLoader: PolicySnapshotLoader;
+  catalogInvalidate: () => void;
+  pollIntervalMs?: number;
+  namespace?: string;
+}
+
+export class AccessDataPoller {
+  readonly #syncService: DatastoreSyncService;
+  readonly #policySnapshotLoader: PolicySnapshotLoader;
+  readonly #catalogInvalidate: () => void;
+  readonly #pollIntervalMs: number;
+  readonly #namespace?: string;
+  #timer: ReturnType<typeof setInterval> | null = null;
+  #pendingPull: Promise<void> = Promise.resolve();
+  #pulling = false;
+
+  constructor(options: AccessDataPollerOptions) {
+    this.#syncService = options.syncService;
+    this.#policySnapshotLoader = options.policySnapshotLoader;
+    this.#catalogInvalidate = options.catalogInvalidate;
+    this.#pollIntervalMs = options.pollIntervalMs ??
+      DEFAULT_ACCESS_DATA_POLL_INTERVAL_MS;
+    this.#namespace = options.namespace;
+  }
+
+  start(): void {
+    if (this.#timer) return;
+    this.#timer = setInterval(() => {
+      this.#poll();
+    }, this.#pollIntervalMs);
+    Deno.unrefTimer(this.#timer);
+    const intervalSec = this.#pollIntervalMs / 1000;
+    logger.info`Access data poller started (interval: ${intervalSec}s)`;
+  }
+
+  async stop(): Promise<void> {
+    if (this.#timer) {
+      clearInterval(this.#timer);
+      this.#timer = null;
+    }
+    await this.#pendingPull;
+  }
+
+  #poll(): void {
+    if (this.#pulling) return;
+
+    this.#pendingPull = this.#pendingPull.then(() =>
+      this.#pullAndReloadPolicy()
+    );
+  }
+
+  async #pullAndReloadPolicy(): Promise<void> {
+    this.#pulling = true;
+    try {
+      const result = await this.#syncService.pullChanged({
+        subdirs: [...ACCESS_DATA_SUBDIRS],
+        namespace: this.#namespace,
+      });
+      const count = typeof result === "number" ? result : 0;
+      if (count > 0) {
+        logger
+          .info`Access data poller: ${count} file(s) updated, reloading policy snapshot`;
+        this.#catalogInvalidate();
+        await this.#policySnapshotLoader.load();
+      }
+    } catch (error) {
+      logger
+        .warn`Access data poller pull failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`;
+    } finally {
+      this.#pulling = false;
+    }
+  }
+}

--- a/src/serve/access_data_poller.ts
+++ b/src/serve/access_data_poller.ts
@@ -25,12 +25,12 @@ const logger = getLogger(["swamp", "serve", "access-data-poller"]);
 
 const DEFAULT_ACCESS_DATA_POLL_INTERVAL_MS = 30_000;
 
-const ACCESS_DATA_SUBDIRS = [
+export const ACCESS_DATA_SUBDIRS: readonly string[] = [
   "data/swamp/grant",
   "data/swamp/group",
   "data/@swamp/grant",
   "data/@swamp/group",
-] as const;
+];
 
 export interface AccessDataPollerOptions {
   syncService: DatastoreSyncService;
@@ -49,6 +49,7 @@ export class AccessDataPoller {
   #timer: ReturnType<typeof setInterval> | null = null;
   #pendingPull: Promise<void> = Promise.resolve();
   #pulling = false;
+  #needsReload = false;
 
   constructor(options: AccessDataPollerOptions) {
     this.#syncService = options.syncService;
@@ -97,7 +98,11 @@ export class AccessDataPoller {
         logger
           .info`Access data poller: ${count} file(s) updated, reloading policy snapshot`;
         this.#catalogInvalidate();
+        this.#needsReload = true;
+      }
+      if (this.#needsReload) {
         await this.#policySnapshotLoader.load();
+        this.#needsReload = false;
       }
     } catch (error) {
       logger

--- a/src/serve/access_data_poller.ts
+++ b/src/serve/access_data_poller.ts
@@ -106,7 +106,7 @@ export class AccessDataPoller {
       }
     } catch (error) {
       logger
-        .warn`Access data poller pull failed: ${
+        .warn`Access data poller cycle failed: ${
         error instanceof Error ? error.message : String(error)
       }`;
     } finally {

--- a/src/serve/access_data_poller_test.ts
+++ b/src/serve/access_data_poller_test.ts
@@ -313,6 +313,43 @@ Deno.test("AccessDataPoller: stop on never-started poller is a no-op", async () 
   assertEquals(sync.pullCalls.length, 0);
 });
 
+Deno.test("AccessDataPoller: retries policy reload on next tick if load fails", async () => {
+  let loadCallCount = 0;
+  let shouldFail = true;
+  const sync = createMockSyncService({ pullResult: 2 });
+  const loader: MockPolicySnapshotLoader = {
+    loadCalls: 0,
+    load(): Promise<void> {
+      loadCallCount++;
+      if (shouldFail && loadCallCount === 1) {
+        return Promise.reject(new Error("transient failure"));
+      }
+      loader.loadCalls++;
+      return Promise.resolve();
+    },
+  };
+  const { state, catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new AccessDataPoller({
+    syncService: sync,
+    policySnapshotLoader: loader as unknown as PolicySnapshotLoader,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  // First tick: pull returns 2 (changes), load fails
+  await waitFor(() => loadCallCount >= 1, "first load attempt");
+  // Second tick: pull returns 2 (still returning changes), load succeeds
+  shouldFail = false;
+  sync.pullResult = 0;
+  await waitFor(() => loader.loadCalls >= 1, "successful reload after retry");
+  await poller.stop();
+
+  assertGreater(loader.loadCalls, 0);
+  assertGreater(state.catalogInvalidateCalls, 0);
+});
+
 Deno.test("AccessDataPoller: can be restarted after stop", async () => {
   const sync = createMockSyncService();
   const loader = createMockPolicySnapshotLoader();

--- a/src/serve/access_data_poller_test.ts
+++ b/src/serve/access_data_poller_test.ts
@@ -1,0 +1,341 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertGreater } from "@std/assert";
+import { AccessDataPoller } from "./access_data_poller.ts";
+import type {
+  DatastoreSyncOptions,
+  DatastoreSyncService,
+} from "../domain/datastore/datastore_sync_service.ts";
+import type { PolicySnapshotLoader } from "../domain/access/policy_snapshot_loader.ts";
+import { waitFor } from "@swamp-club/swamp-testing";
+
+interface MockSyncService extends DatastoreSyncService {
+  pullCalls: DatastoreSyncOptions[];
+  pullResult: number | void;
+  pullDelay: number;
+  pullError: Error | null;
+}
+
+function createMockSyncService(
+  overrides: Partial<
+    Pick<MockSyncService, "pullResult" | "pullDelay" | "pullError">
+  > = {},
+): MockSyncService {
+  const mock: MockSyncService = {
+    pullCalls: [],
+    pullResult: overrides.pullResult ?? 0,
+    pullDelay: overrides.pullDelay ?? 0,
+    pullError: overrides.pullError ?? null,
+    async pullChanged(options?: DatastoreSyncOptions): Promise<number | void> {
+      mock.pullCalls.push(options ?? {});
+      if (mock.pullDelay > 0) {
+        await new Promise<void>((r) => setTimeout(r, mock.pullDelay));
+      }
+      if (mock.pullError) {
+        throw mock.pullError;
+      }
+      return mock.pullResult;
+    },
+    pushChanged(): Promise<number | void> {
+      return Promise.resolve(0);
+    },
+    async markDirty(): Promise<void> {},
+  };
+  return mock;
+}
+
+interface MockPolicySnapshotLoader {
+  loadCalls: number;
+  load(): Promise<void>;
+}
+
+function createMockPolicySnapshotLoader(): MockPolicySnapshotLoader {
+  const mock: MockPolicySnapshotLoader = {
+    loadCalls: 0,
+    async load(): Promise<void> {
+      mock.loadCalls++;
+    },
+  };
+  return mock;
+}
+
+function createCallbackTrackers() {
+  const state = { catalogInvalidateCalls: 0 };
+  return {
+    state,
+    catalogInvalidate: () => {
+      state.catalogInvalidateCalls++;
+    },
+  };
+}
+
+Deno.test("AccessDataPoller: start and stop lifecycle completes cleanly", async () => {
+  const sync = createMockSyncService();
+  const loader = createMockPolicySnapshotLoader();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new AccessDataPoller({
+    syncService: sync,
+    policySnapshotLoader: loader as unknown as PolicySnapshotLoader,
+    catalogInvalidate,
+    pollIntervalMs: 50,
+  });
+
+  poller.start();
+  await new Promise<void>((r) => setTimeout(r, 10));
+  await poller.stop();
+});
+
+Deno.test("AccessDataPoller: pullChanged is called with grant and group subdirs", async () => {
+  const sync = createMockSyncService();
+  const loader = createMockPolicySnapshotLoader();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new AccessDataPoller({
+    syncService: sync,
+    policySnapshotLoader: loader as unknown as PolicySnapshotLoader,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 1, "at least one pull");
+  await poller.stop();
+
+  const call = sync.pullCalls[0];
+  assertEquals(call.subdirs, [
+    "data/swamp/grant",
+    "data/swamp/group",
+    "data/@swamp/grant",
+    "data/@swamp/group",
+  ]);
+});
+
+Deno.test("AccessDataPoller: namespace is passed through to pullChanged", async () => {
+  const sync = createMockSyncService();
+  const loader = createMockPolicySnapshotLoader();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new AccessDataPoller({
+    syncService: sync,
+    policySnapshotLoader: loader as unknown as PolicySnapshotLoader,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+    namespace: "test-namespace",
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 1, "at least one pull");
+  await poller.stop();
+
+  assertEquals(sync.pullCalls[0].namespace, "test-namespace");
+});
+
+Deno.test("AccessDataPoller: reloads policy and invalidates catalog when pullChanged returns count > 0", async () => {
+  const sync = createMockSyncService({ pullResult: 3 });
+  const loader = createMockPolicySnapshotLoader();
+  const { state, catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new AccessDataPoller({
+    syncService: sync,
+    policySnapshotLoader: loader as unknown as PolicySnapshotLoader,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => loader.loadCalls >= 1, "policy reload");
+  await poller.stop();
+
+  assertGreater(loader.loadCalls, 0);
+  assertGreater(state.catalogInvalidateCalls, 0);
+});
+
+Deno.test("AccessDataPoller: does not reload policy when pullChanged returns 0", async () => {
+  const sync = createMockSyncService({ pullResult: 0 });
+  const loader = createMockPolicySnapshotLoader();
+  const { state, catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new AccessDataPoller({
+    syncService: sync,
+    policySnapshotLoader: loader as unknown as PolicySnapshotLoader,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 2, "at least two pulls");
+  await poller.stop();
+
+  assertEquals(loader.loadCalls, 0);
+  assertEquals(state.catalogInvalidateCalls, 0);
+});
+
+Deno.test("AccessDataPoller: does not reload policy when pullChanged returns void", async () => {
+  const sync = createMockSyncService({ pullResult: undefined });
+  const loader = createMockPolicySnapshotLoader();
+  const { state, catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new AccessDataPoller({
+    syncService: sync,
+    policySnapshotLoader: loader as unknown as PolicySnapshotLoader,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 2, "at least two pulls");
+  await poller.stop();
+
+  assertEquals(loader.loadCalls, 0);
+  assertEquals(state.catalogInvalidateCalls, 0);
+});
+
+Deno.test("AccessDataPoller: survives pullChanged throwing an error", async () => {
+  const sync = createMockSyncService({
+    pullError: new Error("network timeout"),
+  });
+  const loader = createMockPolicySnapshotLoader();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new AccessDataPoller({
+    syncService: sync,
+    policySnapshotLoader: loader as unknown as PolicySnapshotLoader,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 2, "at least two pulls");
+  await poller.stop();
+
+  assertGreater(sync.pullCalls.length, 1);
+});
+
+Deno.test("AccessDataPoller: serializes pulls — skips tick while pulling", async () => {
+  const sync = createMockSyncService({ pullDelay: 100 });
+  const loader = createMockPolicySnapshotLoader();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new AccessDataPoller({
+    syncService: sync,
+    policySnapshotLoader: loader as unknown as PolicySnapshotLoader,
+    catalogInvalidate,
+    pollIntervalMs: 20,
+  });
+
+  poller.start();
+  await new Promise<void>((r) => setTimeout(r, 200));
+  await poller.stop();
+
+  assertEquals(sync.pullCalls.length <= 3, true);
+});
+
+Deno.test("AccessDataPoller: double start does not create duplicate timers", async () => {
+  const sync = createMockSyncService();
+  const loader = createMockPolicySnapshotLoader();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new AccessDataPoller({
+    syncService: sync,
+    policySnapshotLoader: loader as unknown as PolicySnapshotLoader,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  poller.start();
+
+  await waitFor(() => sync.pullCalls.length >= 2, "at least two pulls");
+  const countAfterDoubleStart = sync.pullCalls.length;
+  await poller.stop();
+
+  assertEquals(countAfterDoubleStart <= 5, true);
+});
+
+Deno.test("AccessDataPoller: stop awaits pending pull before returning", async () => {
+  let pullCompleted = false;
+  const sync = createMockSyncService({ pullDelay: 80 });
+  const originalPull = sync.pullChanged.bind(sync);
+  sync.pullChanged = async (options?: DatastoreSyncOptions) => {
+    const result = await originalPull(options);
+    pullCompleted = true;
+    return result;
+  };
+
+  const loader = createMockPolicySnapshotLoader();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new AccessDataPoller({
+    syncService: sync,
+    policySnapshotLoader: loader as unknown as PolicySnapshotLoader,
+    catalogInvalidate,
+    pollIntervalMs: 20,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 1, "at least one pull");
+  await poller.stop();
+
+  assertEquals(pullCompleted, true);
+});
+
+Deno.test("AccessDataPoller: stop on never-started poller is a no-op", async () => {
+  const sync = createMockSyncService();
+  const loader = createMockPolicySnapshotLoader();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new AccessDataPoller({
+    syncService: sync,
+    policySnapshotLoader: loader as unknown as PolicySnapshotLoader,
+    catalogInvalidate,
+  });
+
+  await poller.stop();
+  assertEquals(sync.pullCalls.length, 0);
+});
+
+Deno.test("AccessDataPoller: can be restarted after stop", async () => {
+  const sync = createMockSyncService();
+  const loader = createMockPolicySnapshotLoader();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new AccessDataPoller({
+    syncService: sync,
+    policySnapshotLoader: loader as unknown as PolicySnapshotLoader,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 1, "at least one pull");
+  await poller.stop();
+
+  const countAfterFirstRun = sync.pullCalls.length;
+
+  poller.start();
+  await waitFor(
+    () => sync.pullCalls.length > countAfterFirstRun,
+    "pulls resume after restart",
+  );
+  await poller.stop();
+
+  assertGreater(sync.pullCalls.length, countAfterFirstRun);
+});

--- a/src/serve/access_data_poller_test.ts
+++ b/src/serve/access_data_poller_test.ts
@@ -69,8 +69,9 @@ interface MockPolicySnapshotLoader {
 function createMockPolicySnapshotLoader(): MockPolicySnapshotLoader {
   const mock: MockPolicySnapshotLoader = {
     loadCalls: 0,
-    async load(): Promise<void> {
+    load(): Promise<void> {
       mock.loadCalls++;
+      return Promise.resolve();
     },
   };
   return mock;

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -730,16 +730,24 @@ export async function handleAccessReload(
     }
 
     if (ctx.syncService) {
-      const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
-        ? ctx.datastoreConfig.namespace
-        : undefined;
-      const pulled = await ctx.syncService.pullChanged({
-        subdirs: [...ACCESS_DATA_SUBDIRS],
-        namespace,
-      });
-      if (typeof pulled === "number" && pulled > 0) {
-        logger.info`Pulled ${pulled} access data file(s) from remote datastore`;
-        ctx.repoContext.catalogStore.invalidate();
+      try {
+        const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+          ? ctx.datastoreConfig.namespace
+          : undefined;
+        const pulled = await ctx.syncService.pullChanged({
+          subdirs: [...ACCESS_DATA_SUBDIRS],
+          namespace,
+        });
+        if (typeof pulled === "number" && pulled > 0) {
+          logger
+            .info`Pulled ${pulled} access data file(s) from remote datastore`;
+          ctx.repoContext.catalogStore.invalidate();
+        }
+      } catch (error) {
+        logger
+          .warn`Remote access data pull failed, proceeding with local reload: ${
+          error instanceof Error ? error.message : String(error)
+        }`;
       }
     }
 

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -22,6 +22,8 @@
  */
 
 import { join } from "@std/path";
+import { ACCESS_DATA_SUBDIRS } from "../access_data_poller.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import type {
   AccessCanIPayload,
   AccessCheckPayload,
@@ -728,13 +730,12 @@ export async function handleAccessReload(
     }
 
     if (ctx.syncService) {
+      const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+        ? ctx.datastoreConfig.namespace
+        : undefined;
       const pulled = await ctx.syncService.pullChanged({
-        subdirs: [
-          "data/swamp/grant",
-          "data/swamp/group",
-          "data/@swamp/grant",
-          "data/@swamp/group",
-        ],
+        subdirs: [...ACCESS_DATA_SUBDIRS],
+        namespace,
       });
       if (typeof pulled === "number" && pulled > 0) {
         logger.info`Pulled ${pulled} access data file(s) from remote datastore`;

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -727,6 +727,21 @@ export async function handleAccessReload(
       });
     }
 
+    if (ctx.syncService) {
+      const pulled = await ctx.syncService.pullChanged({
+        subdirs: [
+          "data/swamp/grant",
+          "data/swamp/group",
+          "data/@swamp/grant",
+          "data/@swamp/group",
+        ],
+      });
+      if (typeof pulled === "number" && pulled > 0) {
+        logger.info`Pulled ${pulled} access data file(s) from remote datastore`;
+        ctx.repoContext.catalogStore.invalidate();
+      }
+    }
+
     const snapshotResult = await ctx.policySnapshotLoader.loadWithCounts();
 
     logger

--- a/src/serve/handlers/access_handlers_test.ts
+++ b/src/serve/handlers/access_handlers_test.ts
@@ -17,8 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
-import { handleAccessCheck } from "./access_handlers.ts";
+import { assertEquals, assertGreater } from "@std/assert";
+import { handleAccessCheck, handleAccessReload } from "./access_handlers.ts";
 import { type ConnectionContext, setConnectionCollectives } from "./shared.ts";
 import type { AccessCheckPayload } from "../protocol.ts";
 import type {
@@ -29,6 +29,10 @@ import type {
 import type { Action } from "../../domain/access/action.ts";
 import type { Principal } from "../../domain/access/principal.ts";
 import type { PolicySnapshotLoader } from "../../domain/access/policy_snapshot_loader.ts";
+import type {
+  DatastoreSyncOptions,
+  DatastoreSyncService,
+} from "../../domain/datastore/datastore_sync_service.ts";
 
 interface CapturedExplainCall {
   principal: AccessPrincipal;
@@ -169,4 +173,101 @@ Deno.test("handleAccessCheck: null principal evaluates with empty groups", async
   assertEquals(calls[0].principal.principal, { kind: "user", id: "anyone" });
   assertEquals(calls[0].principal.collectives, []);
   assertEquals(calls[0].principal.groups, []);
+});
+
+function createMockSyncService(): {
+  service: DatastoreSyncService;
+  pullCalls: DatastoreSyncOptions[];
+} {
+  const pullCalls: DatastoreSyncOptions[] = [];
+  const service: DatastoreSyncService = {
+    async pullChanged(
+      options?: DatastoreSyncOptions,
+    ): Promise<number | void> {
+      pullCalls.push(options ?? {});
+      return 0;
+    },
+    pushChanged(): Promise<number | void> {
+      return Promise.resolve(0);
+    },
+    async markDirty(): Promise<void> {},
+  };
+  return { service, pullCalls };
+}
+
+function createMockUnifiedDataRepo() {
+  return {
+    findAllForType() {
+      return Promise.resolve([]);
+    },
+    getContent() {
+      return Promise.resolve(null);
+    },
+  };
+}
+
+function createReloadCtx(
+  syncService?: DatastoreSyncService,
+): ConnectionContext {
+  let loadCalled = false;
+  return {
+    repoDir: "/tmp/test-reload-nonexistent",
+    repoContext: {
+      catalogStore: { invalidate() {} },
+      eventBus: { subscribe() {} },
+      definitionRepo: { save() {} },
+      unifiedDataRepo: createMockUnifiedDataRepo(),
+    } as unknown as ConnectionContext["repoContext"],
+    datastoreConfig: {} as ConnectionContext["datastoreConfig"],
+    datastoreResolver: {} as ConnectionContext["datastoreResolver"],
+    syncService,
+    policySnapshotLoader: {
+      async loadWithCounts() {
+        loadCalled = true;
+        return { grantCount: 0, groupCount: 0 };
+      },
+      get _loadCalled() {
+        return loadCalled;
+      },
+    } as unknown as PolicySnapshotLoader,
+    authConfig: {
+      mode: "none" as const,
+      admins: [],
+      allowedCollectives: [],
+      allowedUsers: [],
+      oauthProvider: "",
+      groupsField: "collectives",
+      restrictedModelTypes: [],
+      restrictedCommands: [],
+    },
+  };
+}
+
+Deno.test("handleAccessReload: pulls remote access data before loading snapshot when syncService present", async () => {
+  const { service: syncService, pullCalls } = createMockSyncService();
+  const ctx = createReloadCtx(syncService);
+  const socket = createMockSocket();
+
+  await handleAccessReload(socket, ctx, "req-reload", null);
+
+  assertGreater(pullCalls.length, 0);
+  assertEquals(pullCalls[0].subdirs, [
+    "data/swamp/grant",
+    "data/swamp/group",
+    "data/@swamp/grant",
+    "data/@swamp/group",
+  ]);
+
+  const response = JSON.parse(socket.sent[0]);
+  assertEquals(response.payload.success, true);
+});
+
+Deno.test("handleAccessReload: works without syncService (local-only mode)", async () => {
+  const ctx = createReloadCtx(undefined);
+  const socket = createMockSocket();
+
+  await handleAccessReload(socket, ctx, "req-reload", null);
+
+  const response = JSON.parse(socket.sent[0]);
+  assertEquals(response.payload.success, true);
 });

--- a/src/serve/handlers/access_handlers_test.ts
+++ b/src/serve/handlers/access_handlers_test.ts
@@ -181,11 +181,11 @@ function createMockSyncService(): {
 } {
   const pullCalls: DatastoreSyncOptions[] = [];
   const service: DatastoreSyncService = {
-    async pullChanged(
+    pullChanged(
       options?: DatastoreSyncOptions,
     ): Promise<number | void> {
       pullCalls.push(options ?? {});
-      return 0;
+      return Promise.resolve(0);
     },
     pushChanged(): Promise<number | void> {
       return Promise.resolve(0);
@@ -222,9 +222,9 @@ function createReloadCtx(
     datastoreResolver: {} as ConnectionContext["datastoreResolver"],
     syncService,
     policySnapshotLoader: {
-      async loadWithCounts() {
+      loadWithCounts() {
         loadCalled = true;
-        return { grantCount: 0, groupCount: 0 };
+        return Promise.resolve({ grantCount: 0, groupCount: 0 });
       },
       get _loadCalled() {
         return loadCalled;

--- a/src/serve/handlers/access_handlers_test.ts
+++ b/src/serve/handlers/access_handlers_test.ts
@@ -33,6 +33,7 @@ import type {
   DatastoreSyncOptions,
   DatastoreSyncService,
 } from "../../domain/datastore/datastore_sync_service.ts";
+import { ACCESS_DATA_SUBDIRS } from "../access_data_poller.ts";
 
 interface CapturedExplainCall {
   principal: AccessPrincipal;
@@ -80,7 +81,9 @@ function createCtx(
   return {
     repoDir: "/tmp/test",
     repoContext: {} as ConnectionContext["repoContext"],
-    datastoreConfig: {} as ConnectionContext["datastoreConfig"],
+    datastoreConfig: {
+      type: "filesystem",
+    } as ConnectionContext["datastoreConfig"],
     datastoreResolver: {} as ConnectionContext["datastoreResolver"],
     policySnapshotLoader: {
       decisionService: service,
@@ -218,7 +221,9 @@ function createReloadCtx(
       definitionRepo: { save() {} },
       unifiedDataRepo: createMockUnifiedDataRepo(),
     } as unknown as ConnectionContext["repoContext"],
-    datastoreConfig: {} as ConnectionContext["datastoreConfig"],
+    datastoreConfig: {
+      type: "filesystem",
+    } as ConnectionContext["datastoreConfig"],
     datastoreResolver: {} as ConnectionContext["datastoreResolver"],
     syncService,
     policySnapshotLoader: {
@@ -251,12 +256,7 @@ Deno.test("handleAccessReload: pulls remote access data before loading snapshot 
   await handleAccessReload(socket, ctx, "req-reload", null);
 
   assertGreater(pullCalls.length, 0);
-  assertEquals(pullCalls[0].subdirs, [
-    "data/swamp/grant",
-    "data/swamp/group",
-    "data/@swamp/grant",
-    "data/@swamp/group",
-  ]);
+  assertEquals(pullCalls[0].subdirs, [...ACCESS_DATA_SUBDIRS]);
 
   const response = JSON.parse(socket.sent[0]);
   assertEquals(response.payload.success, true);


### PR DESCRIPTION
## Summary

- Add `syncService.pullChanged()` before policy snapshot reload in `handleAccessReload` so explicit reloads pull remote grant/group data from the shared datastore
- Create `AccessDataPoller` (following the `ConfigPoller` pattern) that periodically pulls grant/group data and triggers policy snapshot rebuilds when changes are detected
- Wire `AccessDataPoller` into serve boot when `syncService` is available, with proper shutdown cleanup

## Root cause

Grants created on one HA serve instance were invisible to other instances sharing the same datastore because:
1. `handleAccessReload` loaded the policy snapshot from the local data cache without pulling remote changes
2. `PolicySnapshotLoader`'s auto-reload was wired to an in-process `EventBus` that cannot see cross-instance writes

The grant data IS pushed to the shared remote datastore via the normal `acquireModelLocks` pull-lock-execute-push cycle — the receiving instance just never pulled it.

## Test plan

- [x] 13 unit tests for `AccessDataPoller` (lifecycle, subdirs, namespace, reload/no-reload, error resilience, retry on load failure, serialization, restart)
- [x] 2 unit tests for `handleAccessReload` pull-before-load behavior (with and without syncService)
- [x] Verification workflow: lint, fmt, type-check, tests (10837 passed), compile, code/adversarial/UX reviews all pass

Closes swamp-club#1876

🤖 Generated with [Claude Code](https://claude.com/claude-code)