### PR TITLE
fix(serve): populate ns and resolve auth fields for cancel/run.attach (swamp-club#1873)

### DIFF
--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -42,6 +42,7 @@ import {
   handleDataVersions,
   handleRunGc,
   handleSummarise,
+  resolveDataFields,
 } from "./handlers/data_handlers.ts";
 import {
   handleModelCreate,
@@ -84,6 +85,7 @@ import {
   handleWorkflowTriggerRemove,
   handleWorkflowTriggerSet,
   handleWorkflowValidate,
+  resolveWorkflowFields,
 } from "./handlers/workflow_handlers.ts";
 import {
   handleVaultAnnotate,
@@ -1364,23 +1366,35 @@ export function handleMessage(
   const request: ServerRequest = validated;
 
   if (request.type === "cancel") {
-    const controller = activeRequests.get(request.id);
-    if (controller) {
-      controller.abort();
+    const pendingController = activeRequests.get(request.id);
+    if (pendingController) {
+      pendingController.abort();
       return;
     }
     const run = ctx.activeRunRegistry?.get(request.id);
     if (run) {
       const resourceKind = run.kind === "method-run" ? "model" : "workflow";
-      if (
-        authorizeOrReject(socket, request.id, principal, "run", {
-          kind: resourceKind,
-          name: run.resourceName,
-          fields: {},
-        }, ctx)
-      ) {
-        ctx.activeRunRegistry!.cancel(request.id);
-      }
+      resolveRunFields(ctx, resourceKind, run.resourceName).then(
+        (cancelFields) => {
+          if (
+            authorizeOrReject(socket, request.id, principal, "run", {
+              kind: resourceKind,
+              name: run.resourceName,
+              fields: cancelFields,
+            }, ctx)
+          ) {
+            ctx.activeRunRegistry!.cancel(request.id);
+          }
+        },
+      ).catch((error: unknown) => {
+        logger.error(
+          "Failed to resolve fields for cancel {requestId}: {error}",
+          {
+            requestId: request.id,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      });
     }
     return;
   }
@@ -2473,6 +2487,27 @@ export function handleMessage(
 
 // ── Run attach handler ───────────────────────────────────────────────
 
+async function resolveRunFields(
+  ctx: ConnectionContext,
+  resourceKind: "model" | "workflow",
+  resourceName: string,
+): Promise<Record<string, unknown>> {
+  try {
+    if (resourceKind === "model") {
+      return await resolveDataFields(
+        ctx.repoContext.definitionRepo,
+        resourceName,
+      );
+    }
+    return await resolveWorkflowFields(
+      ctx.repoContext.workflowRepo,
+      resourceName,
+    );
+  } catch {
+    return { name: resourceName };
+  }
+}
+
 async function handleRunAttach(
   socket: WebSocket,
   ctx: ConnectionContext,
@@ -2492,11 +2527,16 @@ async function handleRunAttach(
         const resourceKind = result.record.runKind === "method-run"
           ? "model"
           : "workflow";
+        const remoteFields = await resolveRunFields(
+          ctx,
+          resourceKind,
+          result.record.resourceName,
+        );
         if (
           !authorizeOrReject(socket, requestId, principal, "run", {
             kind: resourceKind,
             name: result.record.resourceName,
-            fields: {},
+            fields: remoteFields,
           }, ctx)
         ) return;
 
@@ -2539,11 +2579,16 @@ async function handleRunAttach(
   }
 
   const resourceKind = run.kind === "method-run" ? "model" : "workflow";
+  const localFields = await resolveRunFields(
+    ctx,
+    resourceKind,
+    run.resourceName,
+  );
   if (
     !authorizeOrReject(socket, requestId, principal, "run", {
       kind: resourceKind,
       name: run.resourceName,
-      fields: {},
+      fields: localFields,
     }, ctx)
   ) return;
 

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -1372,30 +1372,26 @@ export function handleMessage(
       return;
     }
     const run = ctx.activeRunRegistry?.get(request.id);
-    if (run) {
-      const resourceKind = run.kind === "method-run" ? "model" : "workflow";
-      resolveRunFields(ctx, resourceKind, run.resourceName).then(
-        (cancelFields) => {
-          if (
-            authorizeOrReject(socket, request.id, principal, "run", {
-              kind: resourceKind,
-              name: run.resourceName,
-              fields: cancelFields,
-            }, ctx)
-          ) {
-            ctx.activeRunRegistry!.cancel(request.id);
-          }
-        },
-      ).catch((error: unknown) => {
-        logger.error(
-          "Failed to resolve fields for cancel {requestId}: {error}",
-          {
-            requestId: request.id,
-            error: error instanceof Error ? error.message : String(error),
-          },
-        );
-      });
-    }
+    if (!run) return;
+
+    const cancelController = new AbortController();
+    activeRequests.set(request.id, cancelController);
+
+    const cancelTask = handleCancelRun(
+      socket,
+      ctx,
+      request.id,
+      run,
+      principal,
+    );
+    cancelTask
+      .catch((error: unknown) => {
+        logger.error("Unhandled request error for {requestId}: {error}", {
+          requestId: request.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      })
+      .finally(() => activeRequests.delete(request.id));
     return;
   }
 
@@ -2486,6 +2482,30 @@ export function handleMessage(
 }
 
 // ── Run attach handler ───────────────────────────────────────────────
+
+async function handleCancelRun(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  run: import("./active_run_registry.ts").ActiveRun,
+  principal: Principal | null,
+): Promise<void> {
+  const resourceKind = run.kind === "method-run" ? "model" : "workflow";
+  const cancelFields = await resolveRunFields(
+    ctx,
+    resourceKind,
+    run.resourceName,
+  );
+  if (
+    authorizeOrReject(socket, requestId, principal, "run", {
+      kind: resourceKind,
+      name: run.resourceName,
+      fields: cancelFields,
+    }, ctx)
+  ) {
+    ctx.activeRunRegistry!.cancel(requestId);
+  }
+}
 
 async function resolveRunFields(
   ctx: ConnectionContext,

--- a/src/serve/handlers/data_handlers.ts
+++ b/src/serve/handlers/data_handlers.ts
@@ -63,6 +63,7 @@ import type {
   SummarisePayload,
 } from "../protocol.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
 import { findLatestItemsFromCatalog } from "../../infrastructure/persistence/catalog_search_adapter.ts";
 import type { Principal } from "../../domain/access/principal.ts";
 import {
@@ -88,6 +89,8 @@ export async function resolveDataFields(
     );
     if (result) {
       fields.name = result.definition.name;
+      const ns = ModelType.getUserNamespace(result.type.normalized);
+      if (ns) fields.ns = ns;
       const tags = result.definition.tags;
       if (tags && Object.keys(tags).length > 0) fields.tags = tags;
     }

--- a/src/serve/handlers/data_handlers_test.ts
+++ b/src/serve/handlers/data_handlers_test.ts
@@ -22,14 +22,17 @@ import { resolveDataFields } from "./data_handlers.ts";
 import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
 
 function makeDefinitionRepo(
-  definitions: Map<string, { name: string; tags?: Record<string, string> }>,
+  definitions: Map<
+    string,
+    { name: string; tags?: Record<string, string>; type?: string }
+  >,
 ): DefinitionRepository {
   return {
     findByNameGlobal: (name: string) => {
       const def = definitions.get(name);
       if (!def) return Promise.resolve(null);
       return Promise.resolve({
-        type: { normalized: "test/type" },
+        type: { normalized: def.type ?? "test/type" },
         definition: { name: def.name, tags: def.tags, id: "test-id" },
       });
     },
@@ -71,6 +74,36 @@ Deno.test("resolveDataFields: falls back to name-only when model not found", asy
 
   assertEquals(fields.name, "missing-model");
   assertEquals(fields.tags, undefined);
+});
+
+Deno.test("resolveDataFields: returns ns from user namespace type", async () => {
+  const repo = makeDefinitionRepo(
+    new Map([["ns-model", {
+      name: "ns-model",
+      tags: { env: "prod" },
+      type: "@myns/model-type",
+    }]]),
+  );
+
+  const fields = await resolveDataFields(repo, "ns-model");
+
+  assertEquals(fields.name, "ns-model");
+  assertEquals(fields.ns, "myns");
+  assertEquals(fields.tags, { env: "prod" });
+});
+
+Deno.test("resolveDataFields: omits ns for non-namespaced type", async () => {
+  const repo = makeDefinitionRepo(
+    new Map([["plain-type-model", {
+      name: "plain-type-model",
+      type: "command/shell",
+    }]]),
+  );
+
+  const fields = await resolveDataFields(repo, "plain-type-model");
+
+  assertEquals(fields.name, "plain-type-model");
+  assertEquals(fields.ns, undefined);
 });
 
 Deno.test("resolveDataFields: falls back to name-only when repo throws", async () => {


### PR DESCRIPTION
## Summary

- `resolveDataFields` now populates `ns` from the model type namespace via
  `ModelType.getUserNamespace()`, so CEL grant conditions referencing `ns`
  evaluate correctly for data resources
- `handleRunAttach` resolves authorization fields (name, tags, ns) for both
  local and remote run paths instead of passing `fields: {}`
- Cancel handler resolves authorization fields asynchronously via
  `resolveRunFields` instead of passing `fields: {}`, so CEL grant conditions
  on tags/ns work for cancel operations
- Added `resolveRunFields` helper that delegates to `resolveDataFields` or
  `resolveWorkflowFields` based on resource kind

Follow-up to #2300 which fixed tags for data/workflow handlers but left `ns`
and the connection.ts secondary handlers (`cancel`, `run.attach`) unpopulated.

Closes swamp-club#1873

## Test plan

- [x] `resolveDataFields` returns `ns` from user namespace type (`@myns/type` → `ns: "myns"`)
- [x] `resolveDataFields` omits `ns` for non-namespaced types (`command/shell`)
- [x] All 6 `data_handlers_test.ts` tests pass (4 existing + 2 new)
- [x] All 197 `connection_test.ts` tests pass
- [x] Reproduction test confirms `ns` is now populated and CEL conditions work
- [x] Build verification: lint, fmt, type-check, tests, compile all pass
- [x] Code review, adversarial review, UX review all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)