### PR TITLE
feat(serve): support direct type execution (@type) with --server

### DIFF
--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -225,16 +225,6 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
       methodName: string,
       definitionNameArg?: string,
     ) {
-      const server = resolveServeUrl(options.server as string | undefined);
-      if (server) {
-        await runMethodViaServer(
-          { ...options, server },
-          modelOrType,
-          methodName,
-          { isDirectExecution: modelOrType.startsWith("@") },
-        );
-        return;
-      }
       const isDirectExecution = modelOrType.startsWith("@");
 
       if (isDirectExecution && !definitionNameArg) {
@@ -249,6 +239,17 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
         ? definitionNameArg!
         : modelOrType;
       const definitionName = isDirectExecution ? definitionNameArg : undefined;
+
+      const server = resolveServeUrl(options.server as string | undefined);
+      if (server) {
+        await runMethodViaServer(
+          { ...options, server },
+          modelIdOrName,
+          methodName,
+          { typeArg, definitionName },
+        );
+        return;
+      }
       const ctx = createContext(options as GlobalOptions, [
         "model",
         "method",
@@ -544,20 +545,13 @@ async function runMethodViaServer(
   options: AnyOptions,
   modelIdOrName: string,
   methodName: string,
-  info: { isDirectExecution: boolean },
+  info: { typeArg?: string; definitionName?: string },
 ): Promise<void> {
   const ctx = createContext(options as GlobalOptions, [
     "model",
     "method",
     "run",
   ]);
-
-  if (info.isDirectExecution) {
-    throw new UserError(
-      "Direct type execution (@type) is not supported with --server yet — " +
-        "run against an existing model name instead",
-    );
-  }
   const stdinContent = options.stdin ? await readStdin() : null;
   let stdinItems: Record<string, unknown>[] | null = null;
   if (stdinContent !== null) {
@@ -620,6 +614,8 @@ async function runMethodViaServer(
             inputs: inputSets[i],
             lastEvaluated: options.lastEvaluated as boolean,
             runtimeTags,
+            typeArg: info.typeArg,
+            definitionName: info.definitionName,
             skipAllReports: options.skipReports as boolean | undefined,
             skipReportNames: options.skipReport as string[] | undefined,
             skipReportLabels: options.skipReportLabel as

--- a/src/cli/commands/model_method_run_test.ts
+++ b/src/cli/commands/model_method_run_test.ts
@@ -163,3 +163,105 @@ Deno.test({
     assertEquals(await runMethodRunAgainst({ status: "succeeded" }), 0);
   },
 });
+
+/**
+ * Captures the payload sent over the WebSocket by the --server path.
+ */
+function payloadCapturingServer(): {
+  url: string;
+  shutdown: () => Promise<void>;
+  payload: () => Record<string, unknown> | undefined;
+} {
+  let captured: Record<string, unknown> | undefined;
+  const server = Deno.serve(
+    { port: 0, hostname: "127.0.0.1", onListen: () => {} },
+    (req) => {
+      const { socket, response } = Deno.upgradeWebSocket(req);
+      socket.onmessage = (message) => {
+        const request = JSON.parse(message.data as string) as {
+          id: string;
+          payload: Record<string, unknown>;
+        };
+        captured = request.payload;
+        socket.send(JSON.stringify({
+          type: "event",
+          id: request.id,
+          event: { kind: "completed", run: { status: "succeeded" } },
+        }));
+        socket.send(JSON.stringify({ type: "done", id: request.id }));
+      };
+      return response;
+    },
+  );
+  return {
+    url: `ws://127.0.0.1:${server.addr.port}`,
+    shutdown: () => server.shutdown(),
+    payload: () => captured,
+  };
+}
+
+Deno.test({
+  name:
+    "modelMethodRunCommand: direct type execution sends typeArg and definitionName to server",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = payloadCapturingServer();
+    try {
+      const { modelMethodRunCommand } = await import("./model_method_run.ts");
+      const root = new Command()
+        .globalType("model_name", new ModelNameType())
+        .globalOption("--json", "JSON output")
+        .command("run", modelMethodRunCommand);
+      await root.parse([
+        "run",
+        "@swamp/echo",
+        "echo",
+        "my-def",
+        "--json",
+        "--server",
+        server.url,
+        "--token",
+        "test.token",
+      ]);
+      const payload = server.payload();
+      assertEquals(payload?.typeArg, "@swamp/echo");
+      assertEquals(payload?.definitionName, "my-def");
+      assertEquals(payload?.modelIdOrName, "my-def");
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "modelMethodRunCommand: direct type execution without definition name rejects before server call",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const { modelMethodRunCommand } = await import("./model_method_run.ts");
+    const root = new Command()
+      .globalType("model_name", new ModelNameType())
+      .globalOption("--json", "JSON output")
+      .command("run", modelMethodRunCommand);
+    try {
+      await root.parse([
+        "run",
+        "@swamp/echo",
+        "echo",
+        "--json",
+        "--server",
+        "ws://localhost:9999",
+        "--token",
+        "test.token",
+      ]);
+      throw new Error("expected UserError");
+    } catch (err) {
+      assertStringIncludes(
+        (err as Error).message,
+        "Direct type execution requires a definition name",
+      );
+    }
+  },
+});


### PR DESCRIPTION
## Summary

- Remove the client-side guard in `runMethodViaServer()` that blocked direct type execution (`@type`) with `--server`
- Wire `typeArg` and `definitionName` through in the server payload
- Move definition name validation before the server branch so users get a clear error locally

The server-side infrastructure already supported this — protocol types, validation schema, handler, deps factory, and authorization were all wired up. The change is purely client-side.

Closes swamp-club#1719

## Test plan

- [x] Unit test: direct type execution sends `typeArg` and `definitionName` in server payload
- [x] Unit test: missing definition name rejects before server call
- [x] All 10,852 existing tests pass
- [x] Type check, lint, fmt pass
- [x] Binary compiles and smoke test passes
- [x] Code review: pass
- [x] UX review: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>