### PR TITLE
fix(serve): push grant/group mutations to shared datastore for HA replication

### DIFF
--- a/src/cli/commands/access_grant.ts
+++ b/src/cli/commands/access_grant.ts
@@ -292,6 +292,20 @@ const accessGrantCreateCommand = new Command()
             },
           );
         }
+      } else if (syncService) {
+        try {
+          await syncService.markDirty();
+          await syncService.pushChanged();
+        } catch (pushError) {
+          ctx.logger.warn(
+            "Failed to push changes to remote datastore: {error}",
+            {
+              error: pushError instanceof Error
+                ? pushError.message
+                : String(pushError),
+            },
+          );
+        }
       }
     }
   });

--- a/src/cli/commands/access_group.ts
+++ b/src/cli/commands/access_group.ts
@@ -194,6 +194,20 @@ async function runGroupMethod(
           },
         );
       }
+    } else if (syncService) {
+      try {
+        await syncService.markDirty();
+        await syncService.pushChanged();
+      } catch (pushError) {
+        ctx.logger.warn(
+          "Failed to push changes to remote datastore: {error}",
+          {
+            error: pushError instanceof Error
+              ? pushError.message
+              : String(pushError),
+          },
+        );
+      }
     }
   }
 }

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -730,10 +730,19 @@ export async function handleAccessReload(
     }
 
     if (ctx.syncService) {
+      const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+        ? ctx.datastoreConfig.namespace
+        : undefined;
       try {
-        const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
-          ? ctx.datastoreConfig.namespace
-          : undefined;
+        await ctx.syncService.markDirty();
+        await ctx.syncService.pushChanged({ namespace });
+      } catch (error) {
+        logger
+          .warn`Remote access data push failed, proceeding with local reload: ${
+          error instanceof Error ? error.message : String(error)
+        }`;
+      }
+      try {
         const pulled = await ctx.syncService.pullChanged({
           subdirs: [...ACCESS_DATA_SUBDIRS],
           namespace,

--- a/src/serve/handlers/access_handlers_test.ts
+++ b/src/serve/handlers/access_handlers_test.ts
@@ -181,8 +181,12 @@ Deno.test("handleAccessCheck: null principal evaluates with empty groups", async
 function createMockSyncService(): {
   service: DatastoreSyncService;
   pullCalls: DatastoreSyncOptions[];
+  pushCalls: DatastoreSyncOptions[];
+  markDirtyCalls: DatastoreSyncOptions[];
 } {
   const pullCalls: DatastoreSyncOptions[] = [];
+  const pushCalls: DatastoreSyncOptions[] = [];
+  const markDirtyCalls: DatastoreSyncOptions[] = [];
   const service: DatastoreSyncService = {
     pullChanged(
       options?: DatastoreSyncOptions,
@@ -190,12 +194,16 @@ function createMockSyncService(): {
       pullCalls.push(options ?? {});
       return Promise.resolve(0);
     },
-    pushChanged(): Promise<number | void> {
+    pushChanged(options?: DatastoreSyncOptions): Promise<number | void> {
+      pushCalls.push(options ?? {});
       return Promise.resolve(0);
     },
-    async markDirty(): Promise<void> {},
+    markDirty(options?: DatastoreSyncOptions): Promise<void> {
+      markDirtyCalls.push(options ?? {});
+      return Promise.resolve();
+    },
   };
-  return { service, pullCalls };
+  return { service, pullCalls, pushCalls, markDirtyCalls };
 }
 
 function createMockUnifiedDataRepo() {
@@ -257,6 +265,22 @@ Deno.test("handleAccessReload: pulls remote access data before loading snapshot 
 
   assertGreater(pullCalls.length, 0);
   assertEquals(pullCalls[0].subdirs, [...ACCESS_DATA_SUBDIRS]);
+
+  const response = JSON.parse(socket.sent[0]);
+  assertEquals(response.payload.success, true);
+});
+
+Deno.test("handleAccessReload: pushes reconciled grants to remote datastore before pulling", async () => {
+  const { service: syncService, pushCalls, pullCalls, markDirtyCalls } =
+    createMockSyncService();
+  const ctx = createReloadCtx(syncService);
+  const socket = createMockSocket();
+
+  await handleAccessReload(socket, ctx, "req-reload", null);
+
+  assertGreater(markDirtyCalls.length, 0);
+  assertGreater(pushCalls.length, 0);
+  assertGreater(pullCalls.length, 0);
 
   const response = JSON.parse(socket.sent[0]);
   assertEquals(response.payload.success, true);

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -249,6 +249,18 @@ export async function handleModelMethodRun(
       } else {
         await runMethod();
       }
+      if (ctx.syncService && !flushLocks) {
+        try {
+          await ctx.syncService.markDirty();
+          await ctx.syncService.pushChanged();
+        } catch (pushError) {
+          logger.warn("Failed to push changes to remote datastore: {error}", {
+            error: pushError instanceof Error
+              ? pushError.message
+              : String(pushError),
+          });
+        }
+      }
       await telemetry?.finish(null);
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") {
@@ -454,6 +466,18 @@ export async function handleModelMethodRun(
         await doRun();
       }
 
+      if (ctx.syncService && !flushLocks) {
+        try {
+          await ctx.syncService.markDirty();
+          await ctx.syncService.pushChanged();
+        } catch (pushError) {
+          logger.warn("Failed to push changes to remote datastore: {error}", {
+            error: pushError instanceof Error
+              ? pushError.message
+              : String(pushError),
+          });
+        }
+      }
       buffer.finish({ kind: "done" });
       await detachedTelemetry?.finish(null);
     } catch (error) {


### PR DESCRIPTION
## Summary

- Add `markDirty()` + `pushChanged()` after model method runs that bypass `acquireModelLocks` (direct type execution where the definition doesn't exist yet), fixing HA grant/group replication
- Add push before pull in `handleAccessReload` so file-based grant reconciliation propagates to the shared datastore
- Add push in local CLI grant create and group create paths when lock flush was skipped

Closes swamp-club#1882

## Context

PR #2305 added the **pull** half of HA grant replication (AccessDataPoller + handleAccessReload pull). But the **push** half was missing: `acquireModelLocks` is gated on `findDefinitionByIdOrName`, which returns null for direct type execution because the definition is auto-created inside `modelMethodRun`. With `preResult` null, `acquireModelLocks` is skipped entirely, and data is never pushed to the remote datastore.

This fix follows the established `markDirty` + `pushChanged` pattern already used by `handleModelCreate` and `handleModelDelete`.

## Test plan

- [x] Extended `access_handlers_test.ts` mock sync service to track push/markDirty calls
- [x] Added test verifying `handleAccessReload` pushes reconciled grants when syncService present
- [x] All 10851 existing tests pass
- [x] Verification workflow: lint, fmt, type-check, deps audit, compile, code review, adversarial review, UX review — all passed
- [ ] swamp-uat pinned characterization tests in `tests/cli/serve/access/ha_test.ts` should flip green

🤖 Generated with [Claude Code](https://claude.com/claude-code)