### PR TITLE
fix(serve): pass namespace to pushChanged in method-run and CLI access commands (swamp-club#1883)

### DIFF
--- a/src/cli/commands/access_grant.ts
+++ b/src/cli/commands/access_grant.ts
@@ -58,6 +58,7 @@ import {
   validateServerRepoExclusivity,
 } from "./access_helpers.ts";
 import type { ModelMethodRunEvent } from "../../libswamp/mod.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import {
   requestServerResponse,
   resolveServerToken,
@@ -293,9 +294,12 @@ const accessGrantCreateCommand = new Command()
           );
         }
       } else if (syncService) {
+        const namespace = isCustomDatastoreConfig(datastoreConfig)
+          ? datastoreConfig.namespace
+          : undefined;
         try {
           await syncService.markDirty();
-          await syncService.pushChanged();
+          await syncService.pushChanged({ namespace });
         } catch (pushError) {
           ctx.logger.warn(
             "Failed to push changes to remote datastore: {error}",

--- a/src/cli/commands/access_group.ts
+++ b/src/cli/commands/access_group.ts
@@ -59,6 +59,7 @@ import {
   validateServerRepoExclusivity,
 } from "./access_helpers.ts";
 import type { ModelMethodRunEvent } from "../../libswamp/mod.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import {
   requestServerResponse,
   resolveServerToken,
@@ -195,9 +196,12 @@ async function runGroupMethod(
         );
       }
     } else if (syncService) {
+      const namespace = isCustomDatastoreConfig(datastoreConfig)
+        ? datastoreConfig.namespace
+        : undefined;
       try {
         await syncService.markDirty();
-        await syncService.pushChanged();
+        await syncService.pushChanged({ namespace });
       } catch (pushError) {
         ctx.logger.warn(
           "Failed to push changes to remote datastore: {error}",

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -97,6 +97,7 @@ import { modelRegistry } from "../../domain/models/model.ts";
 import { RegistryCapacityError } from "../active_run_registry.ts";
 import { RunEventBuffer } from "../run_event_buffer.ts";
 import { deleteActiveRun, writeActiveRun } from "../active_run_tracker.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import {
   authorizeOrReject,
   type ConnectionContext,
@@ -250,9 +251,12 @@ export async function handleModelMethodRun(
         await runMethod();
       }
       if (ctx.syncService && !flushLocks) {
+        const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+          ? ctx.datastoreConfig.namespace
+          : undefined;
         try {
           await ctx.syncService.markDirty();
-          await ctx.syncService.pushChanged();
+          await ctx.syncService.pushChanged({ namespace });
         } catch (pushError) {
           logger.warn("Failed to push changes to remote datastore: {error}", {
             error: pushError instanceof Error
@@ -467,9 +471,12 @@ export async function handleModelMethodRun(
       }
 
       if (ctx.syncService && !flushLocks) {
+        const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+          ? ctx.datastoreConfig.namespace
+          : undefined;
         try {
           await ctx.syncService.markDirty();
-          await ctx.syncService.pushChanged();
+          await ctx.syncService.pushChanged({ namespace });
         } catch (pushError) {
           logger.warn("Failed to push changes to remote datastore: {error}", {
             error: pushError instanceof Error


### PR DESCRIPTION
## Summary

PR #2308 added `markDirty()` + `pushChanged()` calls to propagate grant/group
mutations to the shared datastore for HA replication. However, the four new push
sites omitted the `{ namespace }` option required by namespace-bound datastores,
causing a silent "Namespace mismatch" error that swallowed every immediate push.

This meant grant/group mutations never propagated to peers until an explicit
`swamp access reload` — defeating the purpose of the immediate push.

The fix extracts `namespace` from `ctx.datastoreConfig` via
`isCustomDatastoreConfig()` — the same pattern already used correctly in
`handleAccessReload` from the same PR — and passes it to `pushChanged()` at all
four sites:

- `src/serve/handlers/model_handlers.ts` — both `handleModelMethodRun` push
  blocks (streaming and non-streaming paths)
- `src/cli/commands/access_grant.ts` — CLI grant create local push
- `src/cli/commands/access_group.ts` — CLI group method local push

## Test Plan

- Verification workflow passed: lint, fmt, type-check, tests, compile, deps
  audit, code review, adversarial review, UX review (16/17 steps, 1 skipped
  by guard)
- swamp-uat HA test (`tests/cli/serve/access/ha_test.ts`) characterizes the
  failure and will flip when this fix lands
- Attestation posted to swamp-club

Closes swamp-club#1883